### PR TITLE
feat(admin-chat): providers area -- authentication/authorization provider management

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/providers/AdminProviderController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/AdminProviderController.java
@@ -1,0 +1,189 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.security.*;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * REST controller for the providers admin-plugin area (01-spec.md section 10). Placed in
+ * {@code community/core}, not {@code enterprise/}, the one transport decision this area makes
+ * differently from every prior area -- direct consequence of there being no Public API layer for
+ * providers and the shared admin-chat scaffolding + {@code AuthenticationProviderService}/
+ * {@code AuthorizationProviderService} all already living in {@code community/core} (section 0).
+ *
+ * <p>{@code @Secured} names {@code settings/security/provider}, the same resource string the real EM
+ * controllers ({@code AuthenticationProviderController}/{@code AuthorizationProviderController}) use.
+ * Per section 4a/10, this is not "inherited protection" the way it is for every prior area -- neither
+ * service makes any {@code checkPermission} call on any mutating method, so there is nothing to
+ * bypass in the first place; the sole real gate is {@code AdminAiCallerGuard}+
+ * {@code OrganizationManager.isSiteAdmin}, added purely for consistency with every prior area's
+ * belt-and-suspenders posture and to keep this area visible to any tooling that enumerates
+ * {@code @Secured} endpoints.
+ */
+@RestController
+public class AdminProviderController {
+   @Autowired
+   public AdminProviderController(AuthenticationProviderService authenticationProviderService,
+                                  AuthorizationProviderService authorizationProviderService,
+                                  ProviderChangePlanService planService,
+                                  ProviderChangesetApplyService applyService)
+   {
+      this.authenticationProviderService = authenticationProviderService;
+      this.authorizationProviderService = authorizationProviderService;
+      this.planService = planService;
+      this.applyService = applyService;
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/providers/authentication")
+   public SecurityProviderStatusList listAuthenticationProviders(Principal user) {
+      requireSiteAdmin(user);
+      return authenticationProviderService.getProviderListModel();
+   }
+
+   /** Existence is pre-checked against {@link #listAuthenticationProviders} before the potentially
+    * NPE-prone {@code getAuthenticationProvider} is ever called (01-spec.md section 2 -- a real,
+    * found tool-input-robustness gap in the underlying service on an unresolved name, confirmed by
+    * reading {@code AuthenticationProviderService.getAuthenticationProvider} directly; this area's
+    * own tool layer never calls it on a miss). */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/providers/authentication/{name}")
+   public AuthenticationProviderModel getAuthenticationProvider(@PathVariable("name") String name,
+                                                                 Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      requireExists(name, authenticationProviderService.getProviderListModel().providers());
+      return authenticationProviderService.getAuthenticationProvider(name);
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/providers/authorization")
+   public SecurityProviderStatusList listAuthorizationProviders(Principal user) {
+      requireSiteAdmin(user);
+      return authorizationProviderService.getProviderListModel();
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/providers/authorization/{name}")
+   public AuthorizationProviderModel getAuthorizationProvider(@PathVariable("name") String name,
+                                                               Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      requireExists(name, authorizationProviderService.getProviderListModel().providers());
+      return authorizationProviderService.getAuthorizationProvider(name);
+   }
+
+   /**
+    * Resolves a provider change plan (create/delete, either or both chains) without mutating
+    * anything. See {@code AdminAiController#preview} for the shape this mirrors.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/providers/preview")
+   public ResolvedPlan preview(@RequestBody ProviderChangePlanRequest req, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return planService.resolve(req, user);
+   }
+
+   /**
+    * Applies a reviewed provider change plan. Every verb in this area requires a Tier-2 backup
+    * (01-spec.md section 4/6/7 -- unconditional), taken synchronously inside
+    * {@link ProviderChangesetApplyService#apply} before any mutation.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/providers/apply")
+   public ProviderApplyResult apply(@RequestBody ProviderApplyRequest req, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return applyService.apply(req, user);
+   }
+
+   /** Same rationale and shape as {@code AdminAiController#requireSiteAdmin} -- see there. */
+   private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
+      }
+   }
+
+   /** 01-spec.md section 2/3: a structured 404-shaped error naming the id, resolved via the list,
+    * never via the NPE-prone {@code getAuthenticationProvider} on a raw miss. Raw-name match only
+    * (03-reconcile.md Addition 1), matching {@link ProviderChangePlanService}'s own resolution rule. */
+   private static void requireExists(String name, java.util.List<SecurityProviderStatus> providers) {
+      for(SecurityProviderStatus p : providers) {
+         if(p.name().equals(name)) {
+            return;
+         }
+      }
+
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+         "not found: no provider named \"" + name + "\" in this chain");
+   }
+
+   @ExceptionHandler(IllegalArgumentException.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleIllegalArgument(IllegalArgumentException ex) {
+      return Map.of("status", "failed", "error", String.valueOf(ex.getMessage()));
+   }
+
+   @ExceptionHandler(AdminChangesetApplyService.PlanHashMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handlePlanHashMismatch(
+      AdminChangesetApplyService.PlanHashMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
+   private final AuthenticationProviderService authenticationProviderService;
+   private final AuthorizationProviderService authorizationProviderService;
+   private final ProviderChangePlanService planService;
+   private final ProviderChangesetApplyService applyService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyOutcome.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyOutcome.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+/**
+ * Outcome of one attempted provider change -- identical shape to the shared
+ * {@code inetsoft.web.admin.ai.ApplyOutcome} plus one field, {@code advisory}, matching
+ * {@code IdentityApplyOutcome}'s own "replicate, don't generalize" precedent (01-spec.md section 6).
+ *
+ * @param advisory non-error, non-null-only-when-relevant disclosure the caller must relay to the
+ *                 human verbatim, never summarized away (01-spec.md section 6/11): the
+ *                 "restored at the end of the chain, not its original position" notice on a
+ *                 delete-rollback for either chain.
+ */
+public record ProviderApplyOutcome(String property, String before, String after, String status,
+                                   String error, String advisory)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyRequest.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Request body for {@code POST /api/wiz/v1/admin/providers/apply}: a plan request plus the hash
+ * from {@code preview}. The Tier-2 backup (01-spec.md section 6/7 -- unconditional for every verb
+ * in this area) is taken synchronously inside {@link ProviderChangesetApplyService#apply}, under the
+ * freshly generated transaction id used for the resulting {@link ProviderApplyResult}/audit trail --
+ * matching every prior area's own apply-request shape. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProviderApplyRequest extends ProviderChangePlanRequest {
+   public String getPlanHash() { return planHash; }
+   public void setPlanHash(String v) { this.planHash = v; }
+   public String getReviewOutcome() { return reviewOutcome; }
+   public void setReviewOutcome(String v) { this.reviewOutcome = v; }
+
+   private String planHash, reviewOutcome;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyResult.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyResult.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import inetsoft.web.admin.ai.RollbackFailure;
+
+import java.util.List;
+
+/**
+ * Result of applying a whole provider changeset -- identical shape to the shared
+ * {@code inetsoft.web.admin.ai.ApplyResult} except {@code results} carries
+ * {@link ProviderApplyOutcome}. {@code rollbackFailures} reuses the shared {@code RollbackFailure}
+ * unmodified.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ProviderApplyResult(String transactionId, String status, String backupRef,
+                                  List<ProviderApplyOutcome> results,
+                                  List<RollbackFailure> rollbackFailures)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChain.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChain.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+/**
+ * The two independent, ordered provider chains this area administers (01-spec.md section 1).
+ * Deliberately no abbreviation aliasing at the Java layer (unlike verb) -- "auth" is genuinely
+ * ambiguous between the two full words, so a caller-supplied abbreviation must fail loud rather than
+ * be silently guessed (01-spec.md section 11).
+ */
+public enum ProviderChain {
+   AUTHENTICATION("authentication"),
+   AUTHORIZATION("authorization");
+
+   ProviderChain(String label) {
+      this.label = label;
+   }
+
+   public String label() {
+      return label;
+   }
+
+   private final String label;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Request body for {@code POST /api/wiz/v1/admin/providers/preview}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProviderChangePlanRequest {
+   public String getTask() { return task; }
+   public void setTask(String v) { this.task = v; }
+   public List<ProviderChangeRequest> getChanges() { return changes; }
+   public void setChanges(List<ProviderChangeRequest> v) { this.changes = v; }
+
+   private String task;
+   private List<ProviderChangeRequest> changes;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
@@ -142,7 +142,7 @@ public class ProviderChangePlanService {
          }
 
          String proposed = ProviderProjection.projectFileProvider(name);
-         return new PlanChange(key, null, null, proposed, AdminChangeRecord.RISK_HIGH,
+         return new PlanChange(key, NOT_ORG_SCOPED, null, proposed, AdminChangeRecord.RISK_HIGH,
                                AdminChangeRecord.SCOPE_STORAGE, true,
                                "create " + chain.label() + " provider " + name + " (FILE)");
       }
@@ -157,7 +157,7 @@ public class ProviderChangePlanService {
          requireLdapSpec(label, spec);
          requireLdapMultiTenantAllowed(label);
          String proposed = ProviderProjection.projectLdapSpec(name, spec);
-         return new PlanChange(key, null, null, proposed, AdminChangeRecord.RISK_HIGH,
+         return new PlanChange(key, NOT_ORG_SCOPED, null, proposed, AdminChangeRecord.RISK_HIGH,
                                AdminChangeRecord.SCOPE_STORAGE, true,
                                "create authentication provider " + name + " (LDAP)");
       }
@@ -250,7 +250,7 @@ public class ProviderChangePlanService {
          requireDeletableAuthenticationType(label, model.providerType());
          requireAuthenticationDeletePreflight(label, name, user);
          String before = ProviderProjection.projectAuthenticationProvider(model);
-         return new PlanChange(key, null, before, null, AdminChangeRecord.RISK_HIGH,
+         return new PlanChange(key, NOT_ORG_SCOPED, before, null, AdminChangeRecord.RISK_HIGH,
                                AdminChangeRecord.SCOPE_STORAGE, true,
                                "delete authentication provider " + name);
       }
@@ -259,7 +259,7 @@ public class ProviderChangePlanService {
       requireDeletableAuthorizationType(label, model.providerType());
       requireAuthorizationDeletePreflight(label, name);
       String before = ProviderProjection.projectAuthorizationProvider(model);
-      return new PlanChange(key, null, before, null, AdminChangeRecord.RISK_HIGH,
+      return new PlanChange(key, NOT_ORG_SCOPED, before, null, AdminChangeRecord.RISK_HIGH,
                             AdminChangeRecord.SCOPE_STORAGE, true,
                             "delete authorization provider " + name);
    }
@@ -546,6 +546,12 @@ public class ProviderChangePlanService {
 
    private static final char SEP = (char) 0x1f;
    private static final String NULL_MARKER = String.valueOf((char) 0x01);
+   /** Provider configuration is deployment-wide, not org-scoped (01-spec.md section 1/5) -- every
+    * {@link PlanChange} this service builds passes this in place of a bare {@code null} literal so
+    * the omission reads as deliberate, not an oversight. See 03-reconcile.md's {@code orgId}
+    * resolution for why a sentinel string was considered and rejected in favor of {@code null}
+    * (nothing downstream requires non-null, confirmed by 04-build-java.md). */
+   private static final String NOT_ORG_SCOPED = null;
    private final AuthenticationProviderService authenticationProviderService;
    private final AuthorizationProviderService authorizationProviderService;
    private final SecurityEngine securityEngine;

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
@@ -1,0 +1,552 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.security.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Resolves a requested list of provider changes into a {@link ResolvedPlan} and hashes it -- the
+ * providers analog of {@code inetsoft.web.admin.ai.AdminChangePlanService} and (within this run)
+ * {@code ScheduleChangePlanService}/{@code PermissionChangePlanService}/
+ * {@code IdentityChangePlanService}, replicated rather than shared (01-spec.md section 6,
+ * carry-forward item 5 -- now a fourth structural-area data point).
+ *
+ * <p>Wraps {@link AuthenticationProviderService}/{@link AuthorizationProviderService} directly --
+ * there is no Public API (*ApiService) layer for providers (01-spec.md section 0). Never calls
+ * either service's own {@code getProviderByName} (01-spec.md section 2/03-reconcile.md Addition 1:
+ * the two services resolve a name differently -- the authentication side also matches a
+ * catalog-translated display string, the authorization side does not); this service's own name
+ * resolution is raw-name-only, against {@link AuthenticationProviderService#getProviderListModel()}/
+ * {@link AuthorizationProviderService#getProviderListModel()}, for both chains uniformly.
+ */
+@Component
+public class ProviderChangePlanService {
+   @Autowired
+   public ProviderChangePlanService(AuthenticationProviderService authenticationProviderService,
+                                    AuthorizationProviderService authorizationProviderService,
+                                    SecurityEngine securityEngine)
+   {
+      this.authenticationProviderService = authenticationProviderService;
+      this.authorizationProviderService = authorizationProviderService;
+      this.securityEngine = securityEngine;
+   }
+
+   /**
+    * Resolves and hashes a plan. Performs no mutation, but does perform live reads (the current
+    * provider list for every chain touched, plus one {@code get*} per delete, to capture
+    * {@code currentValue}).
+    *
+    * @throws IllegalArgumentException with a field-named message on a blank task, an empty change
+    *                                 list, an unrecognized verb/chain/providerType, a field illegal
+    *                                 for the resolved verb, a create whose name already exists, a
+    *                                 delete whose name does not exist or targets a DATABASE/CUSTOM
+    *                                 provider, an LDAP create refused by the multi-tenant gate
+    *                                 (03-reconcile.md Addition 2), or a delete refused by either
+    *                                 self-lockout preflight (01-spec.md section 4).
+    */
+   public ResolvedPlan resolve(ProviderChangePlanRequest req, Principal user) throws Exception {
+      if(req == null || req.getTask() == null || req.getTask().trim().isEmpty()) {
+         throw new IllegalArgumentException("task: a non-empty description is required");
+      }
+
+      if(req.getChanges() == null || req.getChanges().isEmpty()) {
+         throw new IllegalArgumentException("changes: at least one change is required");
+      }
+
+      List<PlanChange> changes = new ArrayList<>();
+      Set<String> seenKeys = new HashSet<>();
+      Map<ProviderChain, String> chainProjections = new EnumMap<>(ProviderChain.class);
+      int index = 0;
+
+      for(ProviderChangeRequest change : req.getChanges()) {
+         String label = "changes[" + index++ + "]";
+
+         if(change == null) {
+            throw new IllegalArgumentException(label + ": must not be null");
+         }
+
+         String verb = requireVerb(label, change.getVerb());
+         ProviderChain chain = requireChain(label, change.getChain());
+         String name = requireNonBlank(label + ".name", change.getName());
+         chainProjections.computeIfAbsent(chain, this::currentChainProjection);
+         List<SecurityProviderStatus> currentList = currentProviderList(chain);
+
+         if(ProviderChangeRequest.VERB_CREATE.equals(verb)) {
+            String providerType = requireNonBlank(label + ".providerType", change.getProviderType());
+            changes.add(resolveCreate(label, chain, name, providerType, change.getSpec(),
+                                      currentList, seenKeys));
+            continue;
+         }
+
+         if(change.getProviderType() != null) {
+            throw new IllegalArgumentException(
+               label + ".providerType: not used for verb=delete; remove it or use verb=create");
+         }
+
+         if(change.getSpec() != null) {
+            throw new IllegalArgumentException(
+               label + ".spec: not used for verb=delete; remove it or use verb=create");
+         }
+
+         changes.add(resolveDelete(label, chain, name, user, currentList, seenKeys));
+      }
+
+      String task = req.getTask().trim();
+      return new ResolvedPlan(task, Collections.unmodifiableList(changes), true, true,
+                              hash(task, changes, chainProjections));
+   }
+
+   // ---------------------------------------------------------------- create
+
+   private PlanChange resolveCreate(String label, ProviderChain chain, String name,
+                                    String providerType, ProviderLdapSpec spec,
+                                    List<SecurityProviderStatus> currentList, Set<String> seenKeys)
+   {
+      String key = key(chain, name);
+      requireUnseen(label, key, seenKeys);
+      requireNameFree(label, currentList, name);
+
+      if("FILE".equalsIgnoreCase(providerType)) {
+         if(spec != null) {
+            throw new IllegalArgumentException(label + ".spec: not used for providerType=FILE");
+         }
+
+         String proposed = ProviderProjection.projectFileProvider(name);
+         return new PlanChange(key, null, null, proposed, AdminChangeRecord.RISK_HIGH,
+                               AdminChangeRecord.SCOPE_STORAGE, true,
+                               "create " + chain.label() + " provider " + name + " (FILE)");
+      }
+
+      if("LDAP".equalsIgnoreCase(providerType)) {
+         if(chain != ProviderChain.AUTHENTICATION) {
+            throw new IllegalArgumentException(
+               label + ".providerType: \"LDAP\" is only valid for chain=\"authentication\" " +
+               "(the authorization chain accepts only \"FILE\", 01-spec.md section 11)");
+         }
+
+         requireLdapSpec(label, spec);
+         requireLdapMultiTenantAllowed(label);
+         String proposed = ProviderProjection.projectLdapSpec(name, spec);
+         return new PlanChange(key, null, null, proposed, AdminChangeRecord.RISK_HIGH,
+                               AdminChangeRecord.SCOPE_STORAGE, true,
+                               "create authentication provider " + name + " (LDAP)");
+      }
+
+      if("DATABASE".equalsIgnoreCase(providerType) || "CUSTOM".equalsIgnoreCase(providerType)) {
+         throw new IllegalArgumentException(
+            label + ".providerType: \"" + providerType + "\" is excluded from this cut -- " +
+            "license-gating (DATABASE) and arbitrary-classloading (CUSTOM) risk this area does not " +
+            "yet solve for an admin-chat caller (01-spec.md section 1)");
+      }
+
+      throw new IllegalArgumentException(
+         label + ".providerType: must be \"FILE\" or \"LDAP\", got " + providerType);
+   }
+
+   private static void requireLdapSpec(String label, ProviderLdapSpec spec) {
+      if(spec == null) {
+         throw new IllegalArgumentException(label + ".spec: required for providerType=LDAP");
+      }
+
+      requireNonBlank(label + ".spec.ldapServer", spec.getLdapServer());
+
+      if(!"ACTIVE_DIRECTORY".equalsIgnoreCase(spec.getLdapServer()) &&
+         !"GENERIC".equalsIgnoreCase(spec.getLdapServer()))
+      {
+         throw new IllegalArgumentException(label + ".spec.ldapServer: must be \"ACTIVE_DIRECTORY\" " +
+            "or \"GENERIC\", got " + spec.getLdapServer());
+      }
+
+      requireNonBlank(label + ".spec.protocol", spec.getProtocol());
+      requireNonBlank(label + ".spec.hostName", spec.getHostName());
+
+      if(spec.getHostPort() == null) {
+         throw new IllegalArgumentException(label + ".spec.hostPort: required");
+      }
+
+      requireNonBlank(label + ".spec.rootDN", spec.getRootDN());
+      boolean useCredential = Boolean.TRUE.equals(spec.getUseCredential());
+
+      if(useCredential) {
+         requireNonBlank(label + ".spec.secretId", spec.getSecretId());
+
+         if(spec.getAdminID() != null || spec.getPassword() != null) {
+            throw new IllegalArgumentException(
+               label + ".spec: useCredential=true requires secretId, not adminID/password " +
+               "(01-spec.md section 11 -- a field belonging to the other mode is refused loud, not " +
+               "silently dropped)");
+         }
+      }
+      else {
+         requireNonBlank(label + ".spec.adminID", spec.getAdminID());
+         requireNonBlank(label + ".spec.password", spec.getPassword());
+
+         if(spec.getSecretId() != null) {
+            throw new IllegalArgumentException(
+               label + ".spec: useCredential=false (or unset) requires adminID/password, not " +
+               "secretId");
+         }
+      }
+   }
+
+   /** 03-reconcile.md Addition 2: {@code AuthenticationProviderService.getProviderFromModel}'s LDAP
+    * branch and {@code LdapAuthenticationProvider.checkParameters()} were both read directly in this
+    * pass (04-build-java.md) and neither enforces the multi-tenant restriction
+    * {@code getAuthenticationProvider} otherwise reports as {@code ldapProviderEnabled} for the EM
+    * frontend's benefit -- this area self-imposes it, mirroring {@code AuthenticationProviderService
+    * .java:116}'s own flag expression negated. */
+   private static void requireLdapMultiTenantAllowed(String label) {
+      if(LicenseManager.isEnterprise() && SUtil.isMultiTenant()) {
+         throw new IllegalArgumentException(
+            label + ".providerType: \"LDAP\" authentication providers are not available in a " +
+            "multi-tenant enterprise deployment (mirrors the EM UI's ldapProviderEnabled flag, " +
+            "which AuthenticationProviderService.getProviderFromModel itself does not enforce -- " +
+            "this area's own service does, 03-reconcile.md Addition 2)");
+      }
+   }
+
+   // ---------------------------------------------------------------- delete
+
+   private PlanChange resolveDelete(String label, ProviderChain chain, String name, Principal user,
+                                    List<SecurityProviderStatus> currentList, Set<String> seenKeys)
+      throws Exception
+   {
+      String key = key(chain, name);
+      requireUnseen(label, key, seenKeys);
+      requireNameExists(label, currentList, name);
+
+      if(chain == ProviderChain.AUTHENTICATION) {
+         AuthenticationProviderModel model = authenticationProviderService.getAuthenticationProvider(name);
+         requireDeletableAuthenticationType(label, model.providerType());
+         requireAuthenticationDeletePreflight(label, name, user);
+         String before = ProviderProjection.projectAuthenticationProvider(model);
+         return new PlanChange(key, null, before, null, AdminChangeRecord.RISK_HIGH,
+                               AdminChangeRecord.SCOPE_STORAGE, true,
+                               "delete authentication provider " + name);
+      }
+
+      AuthorizationProviderModel model = authorizationProviderService.getAuthorizationProvider(name);
+      requireDeletableAuthorizationType(label, model.providerType());
+      requireAuthorizationDeletePreflight(label, name);
+      String before = ProviderProjection.projectAuthorizationProvider(model);
+      return new PlanChange(key, null, before, null, AdminChangeRecord.RISK_HIGH,
+                            AdminChangeRecord.SCOPE_STORAGE, true,
+                            "delete authorization provider " + name);
+   }
+
+   /** This area's own delete-target restriction (04-build-java.md): only FILE/LDAP, the types this
+    * area can itself create, may be deleted -- a DATABASE/CUSTOM provider pre-existing from EM is
+    * refused, because delete's rollback path would need to recreate it via the exact
+    * {@code getProviderFromModel}/{@code createCustomProvider} call chain 01-spec.md section 1
+    * excludes from creation for license-gating/classloading reasons. */
+   private static void requireDeletableAuthenticationType(String label, SecurityProviderType type) {
+      if(type != SecurityProviderType.FILE && type != SecurityProviderType.LDAP) {
+         throw new IllegalArgumentException(
+            label + ": provider is type " + type + ", not FILE or LDAP -- this area cannot delete " +
+            "a DATABASE/CUSTOM authentication provider (01-spec.md section 1's create-side " +
+            "exclusion applied symmetrically to delete's own rollback path, 04-build-java.md)");
+      }
+   }
+
+   private static void requireDeletableAuthorizationType(String label, SecurityProviderType type) {
+      if(type != SecurityProviderType.FILE) {
+         throw new IllegalArgumentException(
+            label + ": provider is type " + type + ", not FILE -- this area cannot delete a CUSTOM " +
+            "authorization provider (same reasoning as the authentication-chain DATABASE/CUSTOM " +
+            "exclusion, 04-build-java.md)");
+      }
+   }
+
+   /**
+    * 01-spec.md section 4, two independent checks, neither redundant with the other:
+    * <ol>
+    *   <li>Deployment-wide invariant, reproducing {@code AuthenticationProviderService
+    *       .providerHasSysAdmins}'s own predicate against a simulated post-removal chain (never
+    *       mutating the live chain).</li>
+    *   <li>Caller-specific: using the same simulated list, reproduce {@code AuthenticationChain
+    *       .isSystemAdministratorRole}'s "first provider that defines this role" resolution against
+    *       the calling principal's own JWT-baked roles ({@code ((XPrincipal) principal).getRoles()},
+    *       the same source {@code OrganizationManager.isSiteAdmin}'s own first, decisive branch
+    *       reads). This can fire even when check 1 passes -- the deployment as a whole may retain
+    *       system-administrator capability through a different provider/role while this specific
+    *       caller loses theirs.</li>
+    * </ol>
+    * {@code OrganizationManager.isSiteAdmin(Principal)} also has a second, fallback branch that
+    * re-reads the live user's stored roles via {@code SecurityProvider.getUser(...)} when the
+    * JWT-baked roles alone don't resolve to sys-admin (community/core/.../OrganizationManager.java:
+    * 125-140, read directly in this pass) -- this preflight does not reproduce that fallback branch,
+    * matching 01-spec.md section 4's own stated trace (JWT-baked roles only). Recorded as an
+    * open item in 04-build-java.md rather than silently expanding this preflight's scope beyond what
+    * was specified.
+    */
+   /** Package-visible so {@link ProviderChangesetApplyService} can re-run this exact check at apply
+    * time against the freshly-read live chain (01-spec.md section 6 step 2a: a concurrent change
+    * between preview and apply could alter which providers/roles remain even if the hash still
+    * happens to match for an unrelated reason -- belt-and-suspenders given the stakes). */
+   void requireAuthenticationDeletePreflight(String label, String name, Principal user) {
+      List<AuthenticationProvider> simulated = simulatedAuthenticationProviders(name);
+
+      if(simulated.stream().noneMatch(ProviderChangePlanService::providerHasSysAdmins)) {
+         throw new IllegalArgumentException(
+            label + ": deleting authentication provider \"" + name + "\" would leave the " +
+            "authentication chain with no remaining provider defining a system administrator role " +
+            "with a real member -- refused (01-spec.md section 4, reproducing " +
+            "AuthenticationProviderService.providerHasSysAdmins against the simulated post-removal " +
+            "chain)");
+      }
+
+      IdentityID[] callerRoles = callerRoles(user);
+
+      if(!callerRetainsSysAdmin(simulated, callerRoles)) {
+         throw new IllegalArgumentException(
+            label + ": deleting authentication provider \"" + name + "\" would resolve none of the " +
+            "calling session's own roles to system-administrator against the remaining chain -- " +
+            "applying this plan would lock the calling session out of every admin-chat area, not " +
+            "just this one (01-spec.md section 4). The deployment as a whole may retain " +
+            "system-administrator capability through a different provider/role/account even though " +
+            "this specific caller would not.");
+      }
+   }
+
+   private List<AuthenticationProvider> simulatedAuthenticationProviders(String name) {
+      List<AuthenticationProvider> current = securityEngine.getAuthenticationChain()
+         .map(AuthenticationChain::getProviders).orElseGet(List::of);
+      List<AuthenticationProvider> simulated = new ArrayList<>(current);
+      simulated.removeIf(p -> p.getProviderName().equals(name));
+      return simulated;
+   }
+
+   private static IdentityID[] callerRoles(Principal user) {
+      if(user instanceof XPrincipal xp) {
+         IdentityID[] roles = xp.getRoles();
+         return roles == null ? new IdentityID[0] : roles;
+      }
+
+      return new IdentityID[0];
+   }
+
+   private static boolean providerHasSysAdmins(AuthenticationProvider provider) {
+      return Arrays.stream(provider.getRoles())
+         .anyMatch(role -> provider.isSystemAdministratorRole(role) &&
+                          provider.getRoleMembers(role).length > 0);
+   }
+
+   private static boolean callerRetainsSysAdmin(List<AuthenticationProvider> simulated,
+                                                IdentityID[] callerRoles)
+   {
+      for(IdentityID roleId : callerRoles) {
+         Optional<AuthenticationProvider> resolving = simulated.stream()
+            .filter(p -> p.getRole(roleId) != null)
+            .findFirst();
+
+         if(resolving.isPresent() && resolving.get().isSystemAdministratorRole(roleId)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   /** 01-spec.md section 4: a new, minimal floor this spec proposes -- no
+    * {@code providerHasSysAdmins}-equivalent guard exists for the authorization chain, and no
+    * caller-specific self-lockout applies to it (a wiz principal's own gate never consults the
+    * authorization chain, section 4's own risk framing) -- so this is a floor, not a two-part
+    * preflight. */
+   /** Package-visible for the same apply-time re-check reason as
+    * {@link #requireAuthenticationDeletePreflight}. */
+   void requireAuthorizationDeletePreflight(String label, String name) {
+      List<AuthorizationProvider> current = securityEngine.getAuthorizationChain()
+         .map(AuthorizationChain::getProviders).orElseGet(List::of);
+      List<AuthorizationProvider> simulated = new ArrayList<>(current);
+      simulated.removeIf(p -> p.getProviderName().equals(name));
+
+      if(simulated.isEmpty()) {
+         throw new IllegalArgumentException(
+            label + ": deleting authorization provider \"" + name + "\" would leave the " +
+            "authorization chain with zero remaining providers -- refused as a precautionary floor " +
+            "(01-spec.md section 4; AuthorizationChain's own checkPermission behavior on an empty " +
+            "chain was not traced to a specific line in this pass, section 14 item 3)");
+      }
+   }
+
+   // ---------------------------------------------------------------- name resolution (Addition 1)
+
+   /** 03-reconcile.md Addition 1: raw-name match only, for both chains, never
+    * {@code AuthenticationProviderService.getProviderByName}/
+    * {@code AuthorizationProviderService.getProviderByName} directly (confirmed in 04-build-java.md
+    * to resolve a name two different ways between the two services). */
+   private static boolean existsInList(List<SecurityProviderStatus> list, String name) {
+      for(SecurityProviderStatus s : list) {
+         if(s.name().equals(name)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private static void requireNameFree(String label, List<SecurityProviderStatus> list, String name) {
+      if(existsInList(list, name)) {
+         throw new IllegalArgumentException(
+            label + ".name: \"" + name + "\" already exists in this chain; use a different name, " +
+            "or delete it first if you intend to replace it (update is not supported yet)");
+      }
+   }
+
+   private static void requireNameExists(String label, List<SecurityProviderStatus> list, String name) {
+      if(!existsInList(list, name)) {
+         throw new IllegalArgumentException(label + ".name: \"" + name + "\" not found in this chain");
+      }
+   }
+
+   // ---------------------------------------------------------------- shared helpers
+
+   private List<SecurityProviderStatus> currentProviderList(ProviderChain chain) {
+      return chain == ProviderChain.AUTHENTICATION
+         ? authenticationProviderService.getProviderListModel().providers()
+         : authorizationProviderService.getProviderListModel().providers();
+   }
+
+   private String currentChainProjection(ProviderChain chain) {
+      if(chain == ProviderChain.AUTHENTICATION) {
+         return ProviderProjection.projectChain(
+            authenticationProviderService.getProviderListModel().providers(), true);
+      }
+
+      return ProviderProjection.projectChain(
+         authorizationProviderService.getProviderListModel().providers(), false);
+   }
+
+   static String requireVerb(String label, String verb) {
+      if(ProviderChangeRequest.VERB_CREATE.equals(verb) || ProviderChangeRequest.VERB_DELETE.equals(verb)) {
+         return verb;
+      }
+
+      throw new IllegalArgumentException(
+         label + ".verb: must be \"" + ProviderChangeRequest.VERB_CREATE + "\" or \"" +
+         ProviderChangeRequest.VERB_DELETE + "\", got " + String.valueOf(verb));
+   }
+
+   /** Deliberately case-insensitive/trimmed exact-label match, no abbreviation aliasing -- "auth" is
+    * genuinely ambiguous between the two full words (01-spec.md section 11). */
+   static ProviderChain requireChain(String label, String chain) {
+      if(chain != null) {
+         for(ProviderChain c : ProviderChain.values()) {
+            if(c.label().equalsIgnoreCase(chain.trim())) {
+               return c;
+            }
+         }
+      }
+
+      throw new IllegalArgumentException(
+         label + ".chain: must be \"authentication\" or \"authorization\", got " +
+         String.valueOf(chain));
+   }
+
+   static String requireNonBlank(String field, String value) {
+      if(value == null || value.trim().isEmpty()) {
+         throw new IllegalArgumentException(field + ": required");
+      }
+
+      return value.trim();
+   }
+
+   private static void requireUnseen(String label, String key, Set<String> seenKeys) {
+      if(!seenKeys.add(key)) {
+         throw new IllegalArgumentException(
+            label + ": duplicate entry for " + key + "; list each provider at most once");
+      }
+   }
+
+   static String key(ProviderChain chain, String name) {
+      return chain.label() + "|" + name;
+   }
+
+   /**
+    * SHA-256 over the canonical plan. Same field-order/control-character contract as every prior
+    * area's own {@code hash} method, extended with one input none of them needed: the whole-chain,
+    * order-sensitive projection for every chain touched by this plan (01-spec.md section 5) --
+    * captured once per chain, not stored in any {@link PlanChange} (whose two value slots are
+    * reserved for the narrower per-provider projection, section 5's own "hash's unit and
+    * verification's unit can differ" design, see 04-build-java.md). A concurrent create/delete/
+    * reorder on a touched chain changes that chain's projection, so {@code apply}'s fresh re-resolve
+    * produces a different hash and is refused via the existing 409 path -- no new conflict-handling
+    * code needed.
+    */
+   private static String hash(String task, List<PlanChange> changes,
+                              Map<ProviderChain, String> chainProjections)
+   {
+      StringBuilder canonical = new StringBuilder(task).append('\n');
+
+      for(ProviderChain chain : ProviderChain.values()) {
+         String projection = chainProjections.get(chain);
+
+         if(projection != null) {
+            canonical.append("chain:").append(chain.label()).append(SEP).append(projection).append(SEP);
+         }
+      }
+
+      for(PlanChange change : changes) {
+         canonical.append(change.property()).append(SEP)
+            .append(canonical(change.currentValue())).append(SEP)
+            .append(canonical(change.proposedValue())).append(SEP)
+            .append(change.risk()).append(SEP)
+            .append(change.snapshotScope()).append(SEP);
+      }
+
+      try {
+         byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+         StringBuilder hex = new StringBuilder(digest.length * 2);
+
+         for(byte b : digest) {
+            hex.append(String.format("%02x", b));
+         }
+
+         return hex.toString();
+      }
+      catch(NoSuchAlgorithmException e) {
+         throw new IllegalStateException("SHA-256 is required to hash a provider change plan", e);
+      }
+   }
+
+   private static String canonical(String value) {
+      return value == null ? NULL_MARKER : value;
+   }
+
+   private static final char SEP = (char) 0x1f;
+   private static final String NULL_MARKER = String.valueOf((char) 0x01);
+   private final AuthenticationProviderService authenticationProviderService;
+   private final AuthorizationProviderService authorizationProviderService;
+   private final SecurityEngine securityEngine;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangeRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangeRequest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * One requested provider change: create or delete one named entry in one chain (01-spec.md section
+ * 1/11). {@link ProviderChangePlanService#resolve} re-validates every field independently rather
+ * than trusting the caller, per this repo's CLAUDE.md tool-robustness rule -- verb/chain aliasing
+ * (if any) is the plugin (TypeScript) tool layer's job, matching
+ * {@code IdentityChangePlanService.requireVerb}/{@code requireUnitType}'s own precedent of
+ * exact-label-only validation in Java.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProviderChangeRequest {
+   public static final String VERB_CREATE = "create";
+   public static final String VERB_DELETE = "delete";
+
+   public String getVerb() { return verb; }
+   public void setVerb(String v) { this.verb = v; }
+
+   public String getChain() { return chain; }
+   public void setChain(String v) { this.chain = v; }
+
+   /** Required for both verbs: for {@code create}, the id the new provider will have; for
+    * {@code delete}, the existing provider's id. */
+   public String getName() { return name; }
+   public void setName(String v) { this.name = v; }
+
+   /** Required for {@code create} ({@code "FILE"} or, authentication-chain only, {@code "LDAP"});
+    * rejected for {@code delete} (01-spec.md section 11). */
+   public String getProviderType() { return providerType; }
+   public void setProviderType(String v) { this.providerType = v; }
+
+   /** Required for {@code providerType: "LDAP"}; rejected otherwise, including for {@code delete}. */
+   public ProviderLdapSpec getSpec() { return spec; }
+   public void setSpec(ProviderLdapSpec v) { this.spec = v; }
+
+   private String verb;
+   private String chain;
+   private String name;
+   private String providerType;
+   private ProviderLdapSpec spec;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
@@ -592,6 +592,9 @@ public class ProviderChangesetApplyService {
          record.setSnapshotScope(AdminChangeRecord.SCOPE_STORAGE);
          record.setBackupRef(backupRef);
          record.setReviewOutcome(reviewOutcome);
+         // organizationId is deliberately left unset: provider configuration is deployment-wide,
+         // not org-scoped (01-spec.md section 1/5), so there is no organization to attribute this
+         // change to -- not an oversight, mirrors ProviderChangePlanService.NOT_ORG_SCOPED.
          record.setUserName(user == null ? null : user.getName());
          record.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
          record.setServerHostName(Tool.getHost());

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
@@ -1,0 +1,667 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.util.Tool;
+import inetsoft.util.audit.*;
+import inetsoft.web.admin.ai.*;
+import inetsoft.web.admin.security.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.security.SecureRandom;
+import java.sql.Timestamp;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a whole provider changeset, all-or-nothing, and audits every attempt -- the providers
+ * analog of {@code inetsoft.web.admin.ai.AdminChangesetApplyService} and (within this run)
+ * {@code ScheduleChangesetApplyService}/{@code PermissionChangesetApplyService}/
+ * {@code IdentityChangesetApplyService}, replicated rather than shared (01-spec.md section 6,
+ * carry-forward item 5).
+ *
+ * <p>Every verb in this area is {@code snapshotScope: storage} unconditionally (01-spec.md section
+ * 4/7), so the Tier-2 backup is taken synchronously here, before any change is attempted.
+ */
+@Component
+public class ProviderChangesetApplyService {
+   @Autowired
+   public ProviderChangesetApplyService(ProviderChangePlanService planService,
+                                        AuthenticationProviderService authenticationProviderService,
+                                        AuthorizationProviderService authorizationProviderService,
+                                        AdminBackupService backupService)
+   {
+      this.planService = planService;
+      this.authenticationProviderService = authenticationProviderService;
+      this.authorizationProviderService = authorizationProviderService;
+      this.backupService = backupService;
+   }
+
+   /**
+    * Resolves, gates on the plan hash, backs up, then executes.
+    *
+    * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
+    *         (maps to HTTP 409) -- reused verbatim, per 01-spec.md section 6.
+    * @throws Exception if the Tier-2 backup itself fails, in which case nothing was applied.
+    */
+   public ProviderApplyResult apply(ProviderApplyRequest req, Principal user) throws Exception {
+      APPLY_LOCK.lock();
+
+      try {
+         ResolvedPlan plan = planService.resolve(req, user);
+
+         if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
+            throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
+         }
+
+         if(plan.requiresAgentSignoff() &&
+            (req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()))
+         {
+            throw new IllegalArgumentException(
+               "reviewOutcome: required because this changeset contains a high-risk change");
+         }
+
+         String txId = "provider-" + newIdSuffix();
+         String backupRef = plan.requiresStorageBackup() ? backupService.backup(txId) : null;
+         String reviewOutcome = req.getReviewOutcome();
+         List<ProviderApplyOutcome> results = new ArrayList<>();
+         List<Undo> undoable = new ArrayList<>();
+         List<RollbackFailure> unknownStateFailures = new ArrayList<>();
+         boolean failed = false;
+
+         List<ProviderChangeRequest> originals = req.getChanges();
+
+         for(int i = 0; i < plan.changes().size(); i++) {
+            PlanChange change = plan.changes().get(i);
+            ProviderChangeRequest original = originals.get(i);
+            String key = change.property();
+
+            try {
+               applyOne(txId, plan.task(), key, original, user, backupRef, reviewOutcome, results,
+                       undoable);
+            }
+            catch(Exception e) {
+               // A throw carries no verifiable before/after evidence for THIS change -- must never
+               // be treated as rolled back. Same rule every prior area's apply service follows.
+               results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                                    messageOf(e), null));
+               unknownStateFailures.add(new RollbackFailure(key,
+                  "state unknown: apply did not return a verifiable outcome (" + messageOf(e) + ")"));
+               failed = true;
+               break;
+            }
+
+            if(AdminChangeRecord.STATUS_FAILED.equals(lastStatus(results))) {
+               failed = true;
+               break;
+            }
+         }
+
+         if(!failed) {
+            return new ProviderApplyResult(txId, AdminChangesetApplyService.STATUS_APPLIED, backupRef,
+                                           Collections.unmodifiableList(results), null);
+         }
+
+         Map<String, String> rollbackAdvisories = new LinkedHashMap<>();
+         List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
+         failures.addAll(rollback(txId, plan.task(), undoable, backupRef, reviewOutcome, user,
+                                  rollbackAdvisories));
+         // Merge each rollback's own disclosure (the "restored at the end of the chain, not its
+         // original position" notice, 01-spec.md section 6/11) into that entry's ORIGINAL outcome
+         // record -- the advisory is a first-class field on the outcome the caller sees, not a log
+         // line only.
+         List<ProviderApplyOutcome> finalResults = results.stream()
+            .map(o -> mergeAdvisory(o, rollbackAdvisories.get(o.property())))
+            .collect(Collectors.toList());
+
+         if(failures.isEmpty()) {
+            return new ProviderApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLED_BACK,
+                                           backupRef, Collections.unmodifiableList(finalResults), null);
+         }
+
+         LOG.error("Provider changeset {} rollback failed; providers still changed: {}", txId,
+                  failures.stream().map(RollbackFailure::property).collect(Collectors.joining(", ")));
+         return new ProviderApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLBACK_FAILED,
+                                        backupRef, Collections.unmodifiableList(finalResults),
+                                        Collections.unmodifiableList(failures));
+      }
+      finally {
+         APPLY_LOCK.unlock();
+      }
+   }
+
+   private void applyOne(String txId, String task, String key, ProviderChangeRequest original,
+                         Principal user, String backupRef, String reviewOutcome,
+                         List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      ProviderChain chain = ProviderChangePlanService.requireChain("change", original.getChain());
+      String name = original.getName().trim();
+
+      if(ProviderChangeRequest.VERB_CREATE.equals(original.getVerb())) {
+         if(chain == ProviderChain.AUTHENTICATION) {
+            applyCreateAuthentication(txId, task, key, name, original, backupRef, reviewOutcome,
+                                     user, results, undoable);
+         }
+         else {
+            applyCreateAuthorization(txId, task, key, name, backupRef, reviewOutcome, user, results,
+                                    undoable);
+         }
+
+         return;
+      }
+
+      if(chain == ProviderChain.AUTHENTICATION) {
+         applyDeleteAuthentication(txId, task, key, name, backupRef, reviewOutcome, user, results,
+                                  undoable);
+      }
+      else {
+         applyDeleteAuthorization(txId, task, key, name, backupRef, reviewOutcome, user, results,
+                                 undoable);
+      }
+   }
+
+   // ---------------------------------------------------------------- create
+
+   private void applyCreateAuthentication(String txId, String task, String key, String name,
+                                          ProviderChangeRequest original, String backupRef,
+                                          String reviewOutcome, Principal user,
+                                          List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      AuthenticationProviderModel.Builder builder = AuthenticationProviderModel.builder()
+         .providerName(name);
+
+      if("LDAP".equalsIgnoreCase(original.getProviderType())) {
+         builder.providerType(SecurityProviderType.LDAP)
+            .ldapProviderModel(buildLdapModel(original.getSpec()));
+      }
+      else {
+         builder.providerType(SecurityProviderType.FILE);
+      }
+
+      authenticationProviderService.addAuthenticationProvider(builder.build(), name, user);
+
+      AuthenticationProviderModel after =
+         tryGet(() -> authenticationProviderService.getAuthenticationProvider(name),
+               list -> indexOfName(list, name) >= 0,
+               authenticationProviderService.getProviderListModel().providers());
+      boolean verified = after != null;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      String afterProjection = verified ? ProviderProjection.projectAuthenticationProvider(after) : null;
+      results.add(new ProviderApplyOutcome(key, null, afterProjection, status,
+                                           verified ? null : "provider not found after create", null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                null, afterProjection, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.createdAuthentication(key, name));
+      }
+   }
+
+   private void applyCreateAuthorization(String txId, String task, String key, String name,
+                                         String backupRef, String reviewOutcome, Principal user,
+                                         List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      AuthorizationProviderModel model = AuthorizationProviderModel.builder()
+         .providerName(name)
+         .providerType(SecurityProviderType.FILE)
+         .build();
+
+      authorizationProviderService.addAuthorizationProvider(model, name, user);
+
+      List<SecurityProviderStatus> afterList =
+         authorizationProviderService.getProviderListModel().providers();
+      boolean verified = indexOfName(afterList, name) >= 0;
+      AuthorizationProviderModel after =
+         verified ? authorizationProviderService.getAuthorizationProvider(name) : null;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      String afterProjection = verified ? ProviderProjection.projectAuthorizationProvider(after) : null;
+      results.add(new ProviderApplyOutcome(key, null, afterProjection, status,
+                                           verified ? null : "provider not found after create", null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                null, afterProjection, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.createdAuthorization(key, name));
+      }
+   }
+
+   private static LdapAuthenticationProviderModel buildLdapModel(ProviderLdapSpec spec) {
+      boolean useCredential = Boolean.TRUE.equals(spec.getUseCredential());
+      return LdapAuthenticationProviderModel.builder()
+         .ldapServer(SecurityProviderType.valueOf(spec.getLdapServer().toUpperCase()))
+         .protocol(spec.getProtocol())
+         .hostName(spec.getHostName())
+         .hostPort(spec.getHostPort())
+         .rootDN(spec.getRootDN())
+         .useCredential(useCredential)
+         .adminID(spec.getAdminID())
+         .secretId(spec.getSecretId())
+         .password(spec.getPassword())
+         .userFilter(spec.getUserFilter())
+         .userBase(spec.getUserBase())
+         .userAttr(spec.getUserAttr())
+         .mailAttr(spec.getMailAttr())
+         .groupFilter(spec.getGroupFilter())
+         .groupBase(spec.getGroupBase())
+         .groupAttr(spec.getGroupAttr())
+         .roleFilter(spec.getRoleFilter())
+         .roleBase(spec.getRoleBase())
+         .roleAttr(spec.getRoleAttr())
+         .userRoleFilter(spec.getUserRoleFilter())
+         .roleRoleFilter(spec.getRoleRoleFilter())
+         .groupRoleFilter(spec.getGroupRoleFilter())
+         .startTls(spec.getStartTls())
+         .searchTree(Boolean.TRUE.equals(spec.getSearchTree()))
+         .sysAdminRoles(spec.getSysAdminRoles() == null ? null :
+                       spec.getSysAdminRoles().toArray(new String[0]))
+         .build();
+   }
+
+   // ---------------------------------------------------------------- delete
+
+   /**
+    * 01-spec.md section 1/6's single most safety-critical mechanical detail, confirmed directly in
+    * this pass against {@code removeAuthenticationProvider(int index, ...)}'s own signature
+    * (04-build-java.md): index is resolved fresh, from the name, against the chain as read AT APPLY
+    * TIME -- never a preview-captured index, since the chain is a live list any concurrent EM session
+    * can also mutate. The section 4 preflight is re-run here too (step 2a), against this same
+    * freshly-read state, not merely trusted from preview.
+    */
+   private void applyDeleteAuthentication(String txId, String task, String key, String name,
+                                          String backupRef, String reviewOutcome, Principal user,
+                                          List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      AuthenticationProviderModel before = authenticationProviderService.getAuthenticationProvider(name);
+      String beforeProjection = ProviderProjection.projectAuthenticationProvider(before);
+      planService.requireAuthenticationDeletePreflight("apply." + key, name, user);
+      int index = indexOfName(authenticationProviderService.getProviderListModel().providers(), name);
+
+      if(index < 0) {
+         results.add(new ProviderApplyOutcome(key, beforeProjection, null,
+                                              AdminChangeRecord.STATUS_FAILED,
+                                              "provider not found at apply time (concurrent change)",
+                                              null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                   beforeProjection, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome,
+                   user);
+         return;
+      }
+
+      authenticationProviderService.removeAuthenticationProvider(index, name, user);
+
+      boolean verified = indexOfName(authenticationProviderService.getProviderListModel().providers(),
+                                     name) < 0;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      results.add(new ProviderApplyOutcome(key, beforeProjection, null, status,
+                                           verified ? null : "provider still present after delete",
+                                           null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                beforeProjection, null, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.deletedAuthentication(key, name, before));
+      }
+   }
+
+   private void applyDeleteAuthorization(String txId, String task, String key, String name,
+                                         String backupRef, String reviewOutcome, Principal user,
+                                         List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      AuthorizationProviderModel before = authorizationProviderService.getAuthorizationProvider(name);
+      String beforeProjection = ProviderProjection.projectAuthorizationProvider(before);
+      planService.requireAuthorizationDeletePreflight("apply." + key, name);
+      int index = indexOfName(authorizationProviderService.getProviderListModel().providers(), name);
+
+      if(index < 0) {
+         results.add(new ProviderApplyOutcome(key, beforeProjection, null,
+                                              AdminChangeRecord.STATUS_FAILED,
+                                              "provider not found at apply time (concurrent change)",
+                                              null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                   beforeProjection, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome,
+                   user);
+         return;
+      }
+
+      authorizationProviderService.removeAuthorizationProvider(index, name, user);
+
+      boolean verified = indexOfName(authorizationProviderService.getProviderListModel().providers(),
+                                     name) < 0;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      results.add(new ProviderApplyOutcome(key, beforeProjection, null, status,
+                                           verified ? null : "provider still present after delete",
+                                           null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                beforeProjection, null, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.deletedAuthorization(key, name, before));
+      }
+   }
+
+   // ---------------------------------------------------------------- rollback
+
+   private List<RollbackFailure> rollback(String txId, String task, List<Undo> undoable,
+                                          String backupRef, String reviewOutcome, Principal user,
+                                          Map<String, String> advisories)
+   {
+      List<RollbackFailure> failures = new ArrayList<>();
+
+      for(int i = undoable.size() - 1; i >= 0; i--) {
+         Undo undo = undoable.get(i);
+
+         try {
+            switch(undo.kind) {
+            case CREATED_AUTHENTICATION:
+               rollbackCreatedAuthentication(txId, task, undo, backupRef, reviewOutcome, user,
+                                            failures);
+               break;
+            case CREATED_AUTHORIZATION:
+               rollbackCreatedAuthorization(txId, task, undo, backupRef, reviewOutcome, user,
+                                           failures);
+               break;
+            case DELETED_AUTHENTICATION:
+               rollbackDeletedAuthentication(txId, task, undo, backupRef, reviewOutcome, user,
+                                            failures, advisories);
+               break;
+            case DELETED_AUTHORIZATION:
+               rollbackDeletedAuthorization(txId, task, undo, backupRef, reviewOutcome, user,
+                                           failures, advisories);
+               break;
+            }
+         }
+         catch(Exception e) {
+            failures.add(new RollbackFailure(undo.key, messageOf(e)));
+         }
+      }
+
+      return failures;
+   }
+
+   private static ProviderApplyOutcome mergeAdvisory(ProviderApplyOutcome outcome,
+                                                      String rollbackAdvisory)
+   {
+      if(rollbackAdvisory == null) {
+         return outcome;
+      }
+
+      String combined = outcome.advisory() == null ? rollbackAdvisory :
+         outcome.advisory() + " | " + rollbackAdvisory;
+      return new ProviderApplyOutcome(outcome.property(), outcome.before(), outcome.after(),
+                                      outcome.status(), outcome.error(), combined);
+   }
+
+   private void rollbackCreatedAuthentication(String txId, String task, Undo undo, String backupRef,
+                                              String reviewOutcome, Principal user,
+                                              List<RollbackFailure> failures)
+      throws Exception
+   {
+      int index = indexOfName(authenticationProviderService.getProviderListModel().providers(),
+                              undo.name);
+
+      if(index < 0) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of create could not find the provider to remove (already gone)"));
+         return;
+      }
+
+      authenticationProviderService.removeAuthenticationProvider(index, undo.name, user);
+      boolean verified = indexOfName(authenticationProviderService.getProviderListModel().providers(),
+                                     undo.name) < 0;
+      writeAudit(txId, task, undo.key, ActionRecord.ACTION_NAME_DELETE,
+                AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                backupRef, reviewOutcome, user);
+
+      if(!verified) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of create reported the provider as still present after delete"));
+      }
+   }
+
+   private void rollbackCreatedAuthorization(String txId, String task, Undo undo, String backupRef,
+                                             String reviewOutcome, Principal user,
+                                             List<RollbackFailure> failures)
+      throws Exception
+   {
+      int index = indexOfName(authorizationProviderService.getProviderListModel().providers(),
+                              undo.name);
+
+      if(index < 0) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of create could not find the provider to remove (already gone)"));
+         return;
+      }
+
+      authorizationProviderService.removeAuthorizationProvider(index, undo.name, user);
+      boolean verified = indexOfName(authorizationProviderService.getProviderListModel().providers(),
+                                     undo.name) < 0;
+      writeAudit(txId, task, undo.key, ActionRecord.ACTION_NAME_DELETE,
+                AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                backupRef, reviewOutcome, user);
+
+      if(!verified) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of create reported the provider as still present after delete"));
+      }
+   }
+
+   /**
+    * Recreates a deleted authentication provider from its captured before-DTO -- a partial inverse
+    * (01-spec.md section 4/6): {@code addAuthenticationProvider} has no insert-at-index form, so the
+    * provider comes back at the END of the chain, not its original position, disclosed here as a
+    * first-class advisory, never buried in free text.
+    *
+    * <p>For an LDAP provider created with a literal (non-{@code useCredential}) bind password, this
+    * recreate is expected to fail: the real password is never captured on read (masked to
+    * {@code Util.PLACEHOLDER_PASSWORD}, section 9), and {@code replacePlaceholderWithPassword}'s
+    * substitution only fires for an edit ({@code model.oldName() != null}), never for this recreate.
+    * The literal placeholder string is passed through as-is; the server's own
+    * {@code checkParameters()} live-bind safety net (already relied on per section 13) throws on the
+    * bad credential, which surfaces here as an ordinary {@link RollbackFailure} -- the existing
+    * "never routine, needs manual intervention" contract, not a silent partial success. A
+    * {@code useCredential: true} (secretId-referenced) LDAP provider is unaffected: {@code secretId}
+    * is not secret-classified and is captured/echoed verbatim (section 9), so that flavor recreates a
+    * fully working provider. See 04-build-java.md for the full trace.
+    */
+   private void rollbackDeletedAuthentication(String txId, String task, Undo undo, String backupRef,
+                                              String reviewOutcome, Principal user,
+                                              List<RollbackFailure> failures,
+                                              Map<String, String> advisories)
+      throws Exception
+   {
+      authenticationProviderService.addAuthenticationProvider(undo.beforeAuthentication, undo.name,
+                                                              user);
+      boolean verified = indexOfName(authenticationProviderService.getProviderListModel().providers(),
+                                     undo.name) >= 0;
+      String advisory = verified
+         ? "provider restored at the END of the chain, not its original position -- addProvider has " +
+           "no insert-at-index form; if resolution order matters for this provider (order determines " +
+           "which provider's role definitions win, 01-spec.md section 4), an operator may need a " +
+           "follow-up reorder through EM, this area has no reorder tool in this cut"
+         : null;
+      writeAudit(txId, task, undo.key, ActionRecord.ACTION_NAME_CREATE,
+                AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                backupRef, reviewOutcome, user);
+
+      if(!verified) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of delete reported the provider as still missing after re-create"));
+      }
+      else {
+         advisories.put(undo.key, advisory);
+      }
+   }
+
+   private void rollbackDeletedAuthorization(String txId, String task, Undo undo, String backupRef,
+                                             String reviewOutcome, Principal user,
+                                             List<RollbackFailure> failures,
+                                             Map<String, String> advisories)
+      throws Exception
+   {
+      authorizationProviderService.addAuthorizationProvider(undo.beforeAuthorization, undo.name, user);
+      boolean verified = indexOfName(authorizationProviderService.getProviderListModel().providers(),
+                                     undo.name) >= 0;
+      String advisory = verified
+         ? "provider restored at the END of the chain, not its original position -- addProvider has " +
+           "no insert-at-index form; this area has no reorder tool in this cut"
+         : null;
+      writeAudit(txId, task, undo.key, ActionRecord.ACTION_NAME_CREATE,
+                AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                backupRef, reviewOutcome, user);
+
+      if(!verified) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of delete reported the provider as still missing after re-create"));
+      }
+      else {
+         advisories.put(undo.key, advisory);
+      }
+   }
+
+   // ---------------------------------------------------------------- shared helpers
+
+   @FunctionalInterface
+   private interface Getter<T> {
+      T get() throws Exception;
+   }
+
+   /** Returns {@code null} if the create is not verified in the fresh list, otherwise the value from
+    * {@code getter}. Avoids calling {@code getAuthenticationProvider} on a name that a concurrent
+    * failure left absent (section 2's NPE-avoidance discipline, applied here even though a
+    * just-created name should always resolve). */
+   private static <T> T tryGet(Getter<T> getter, java.util.function.Predicate<List<SecurityProviderStatus>> present,
+                               List<SecurityProviderStatus> list) throws Exception
+   {
+      return present.test(list) ? getter.get() : null;
+   }
+
+   private static int indexOfName(List<SecurityProviderStatus> list, String name) {
+      for(int i = 0; i < list.size(); i++) {
+         if(list.get(i).name().equals(name)) {
+            return i;
+         }
+      }
+
+      return -1;
+   }
+
+   private void writeAudit(String txId, String task, String key, String actionRecordName,
+                           String adminAction, String before, String after, String status,
+                           String backupRef, String reviewOutcome, Principal user)
+   {
+      try {
+         AdminChangeRecord record = new AdminChangeRecord();
+         record.setTransactionId(txId);
+         record.setTaskDescription(task);
+         record.setProperty(key);
+         record.setObjectType(ActionRecord.OBJECT_TYPE_SECURITY_PROVIDER);
+         record.setBeforeValue(before);
+         record.setAfterValue(after);
+         record.setAction(adminAction);
+         record.setStatus(status);
+         record.setRiskLevel(AdminChangeRecord.RISK_HIGH);
+         record.setSnapshotScope(AdminChangeRecord.SCOPE_STORAGE);
+         record.setBackupRef(backupRef);
+         record.setReviewOutcome(reviewOutcome);
+         record.setUserName(user == null ? null : user.getName());
+         record.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
+         record.setServerHostName(Tool.getHost());
+         Audit.getInstance().auditAdminChange(record, user);
+      }
+      catch(Exception auditFailure) {
+         // An audit write must never replace the real outcome -- same rule every prior area's apply
+         // service follows.
+         LOG.error("Failed to write provider admin change audit record for transaction {}", txId,
+                   auditFailure);
+      }
+   }
+
+   private static String lastStatus(List<ProviderApplyOutcome> results) {
+      return results.isEmpty() ? null : results.get(results.size() - 1).status();
+   }
+
+   private static String messageOf(Exception e) {
+      return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+   }
+
+   private static String newIdSuffix() {
+      return String.format("%016x", RANDOM.nextLong());
+   }
+
+   /** One undo descriptor built during apply, replayed in reverse by {@link #rollback}. */
+   private static final class Undo {
+      enum Kind { CREATED_AUTHENTICATION, CREATED_AUTHORIZATION, DELETED_AUTHENTICATION,
+                  DELETED_AUTHORIZATION }
+
+      static Undo createdAuthentication(String key, String name) {
+         return new Undo(Kind.CREATED_AUTHENTICATION, key, name, null, null);
+      }
+
+      static Undo createdAuthorization(String key, String name) {
+         return new Undo(Kind.CREATED_AUTHORIZATION, key, name, null, null);
+      }
+
+      static Undo deletedAuthentication(String key, String name, AuthenticationProviderModel before) {
+         return new Undo(Kind.DELETED_AUTHENTICATION, key, name, before, null);
+      }
+
+      static Undo deletedAuthorization(String key, String name, AuthorizationProviderModel before) {
+         return new Undo(Kind.DELETED_AUTHORIZATION, key, name, null, before);
+      }
+
+      private Undo(Kind kind, String key, String name, AuthenticationProviderModel beforeAuthentication,
+                  AuthorizationProviderModel beforeAuthorization)
+      {
+         this.kind = kind;
+         this.key = key;
+         this.name = name;
+         this.beforeAuthentication = beforeAuthentication;
+         this.beforeAuthorization = beforeAuthorization;
+      }
+
+      final Kind kind;
+      final String key;
+      final String name;
+      final AuthenticationProviderModel beforeAuthentication;
+      final AuthorizationProviderModel beforeAuthorization;
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(ProviderChangesetApplyService.class);
+   private static final SecureRandom RANDOM = new SecureRandom();
+   /** Serializes the entire body of {@link #apply} -- same rationale and same JVM-local-only
+    * limitation as every prior area's own lock. */
+   private static final ReentrantLock APPLY_LOCK = new ReentrantLock();
+   private final ProviderChangePlanService planService;
+   private final AuthenticationProviderService authenticationProviderService;
+   private final AuthorizationProviderService authorizationProviderService;
+   private final AdminBackupService backupService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderLdapSpec.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderLdapSpec.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * The field set for {@code chain: "authentication"}, {@code providerType: "LDAP"} creates
+ * (01-spec.md section 11) -- the only provider type in this cut with any configuration beyond a
+ * name (FILE has none). Field names mirror {@link inetsoft.web.admin.security.LdapAuthenticationProviderModel}
+ * one for one so {@link ProviderChangesetApplyService} can build that model directly.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProviderLdapSpec {
+   /** {@code "ACTIVE_DIRECTORY"} or {@code "GENERIC"}, required. */
+   public String getLdapServer() { return ldapServer; }
+   public void setLdapServer(String v) { this.ldapServer = v; }
+
+   public String getProtocol() { return protocol; }
+   public void setProtocol(String v) { this.protocol = v; }
+
+   public String getHostName() { return hostName; }
+   public void setHostName(String v) { this.hostName = v; }
+
+   public Integer getHostPort() { return hostPort; }
+   public void setHostPort(Integer v) { this.hostPort = v; }
+
+   public String getRootDN() { return rootDN; }
+   public void setRootDN(String v) { this.rootDN = v; }
+
+   /** Default {@code false}. {@code true} requires {@link #getSecretId()}, not
+    * {@link #getAdminID()}/{@link #getPassword()} -- cross-validated, not silently ignored
+    * (01-spec.md section 11). */
+   public Boolean getUseCredential() { return useCredential; }
+   public void setUseCredential(Boolean v) { this.useCredential = v; }
+
+   public String getAdminID() { return adminID; }
+   public void setAdminID(String v) { this.adminID = v; }
+
+   /** Never echoed back in a plan/audit/hash-mismatch response -- only a presence token
+    * (01-spec.md section 9). */
+   public String getPassword() { return password; }
+   public void setPassword(String v) { this.password = v; }
+
+   /** Opaque vault pointer, not secret-classified itself (01-spec.md section 9) -- echoed freely. */
+   public String getSecretId() { return secretId; }
+   public void setSecretId(String v) { this.secretId = v; }
+
+   public String getUserFilter() { return userFilter; }
+   public void setUserFilter(String v) { this.userFilter = v; }
+
+   public String getUserBase() { return userBase; }
+   public void setUserBase(String v) { this.userBase = v; }
+
+   public String getUserAttr() { return userAttr; }
+   public void setUserAttr(String v) { this.userAttr = v; }
+
+   public String getMailAttr() { return mailAttr; }
+   public void setMailAttr(String v) { this.mailAttr = v; }
+
+   public String getGroupFilter() { return groupFilter; }
+   public void setGroupFilter(String v) { this.groupFilter = v; }
+
+   public String getGroupBase() { return groupBase; }
+   public void setGroupBase(String v) { this.groupBase = v; }
+
+   public String getGroupAttr() { return groupAttr; }
+   public void setGroupAttr(String v) { this.groupAttr = v; }
+
+   public String getRoleFilter() { return roleFilter; }
+   public void setRoleFilter(String v) { this.roleFilter = v; }
+
+   public String getRoleBase() { return roleBase; }
+   public void setRoleBase(String v) { this.roleBase = v; }
+
+   public String getRoleAttr() { return roleAttr; }
+   public void setRoleAttr(String v) { this.roleAttr = v; }
+
+   public String getUserRoleFilter() { return userRoleFilter; }
+   public void setUserRoleFilter(String v) { this.userRoleFilter = v; }
+
+   public String getRoleRoleFilter() { return roleRoleFilter; }
+   public void setRoleRoleFilter(String v) { this.roleRoleFilter = v; }
+
+   public String getGroupRoleFilter() { return groupRoleFilter; }
+   public void setGroupRoleFilter(String v) { this.groupRoleFilter = v; }
+
+   public Boolean getStartTls() { return startTls; }
+   public void setStartTls(Boolean v) { this.startTls = v; }
+
+   public Boolean getSearchTree() { return searchTree; }
+   public void setSearchTree(Boolean v) { this.searchTree = v; }
+
+   public List<String> getSysAdminRoles() { return sysAdminRoles; }
+   public void setSysAdminRoles(List<String> v) { this.sysAdminRoles = v; }
+
+   private String ldapServer;
+   private String protocol;
+   private String hostName;
+   private Integer hostPort;
+   private String rootDN;
+   private Boolean useCredential;
+   private String adminID;
+   private String password;
+   private String secretId;
+   private String userFilter;
+   private String userBase;
+   private String userAttr;
+   private String mailAttr;
+   private String groupFilter;
+   private String groupBase;
+   private String groupAttr;
+   private String roleFilter;
+   private String roleBase;
+   private String roleAttr;
+   private String userRoleFilter;
+   private String roleRoleFilter;
+   private String groupRoleFilter;
+   private Boolean startTls;
+   private Boolean searchTree;
+   private List<String> sysAdminRoles;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderProjection.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderProjection.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.web.admin.security.*;
+
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * Canonical string projections used two ways (01-spec.md section 5): the *whole-chain*, order-
+ * sensitive projection that feeds the plan hash (never stored in a {@code PlanChange} -- see
+ * {@link ProviderChangePlanService}'s own hash method), and the *narrower*, per-provider DTO
+ * projection that feeds {@code PlanChange.currentValue}/{@code proposedValue} and the audit
+ * before/after value. Password is never included as literal content (section 9) -- only a
+ * presence/absence token, so a plan whose only change is a different password still perturbs the
+ * hash without exposing the value or its length; {@code secretId} is not secret-classified and is
+ * projected verbatim.
+ */
+final class ProviderProjection {
+   private ProviderProjection() {
+   }
+
+   /**
+    * The whole-chain projection (section 5): name + "|" + type, in list order, no sort step --
+    * order is semantic (the resolution order {@code isSystemAdministratorRole} depends on, section
+    * 4), not an implementation artifact to normalize away. {@code withLdapFlag} folds the LDAP flag
+    * into "type" for the authentication chain (the authorization chain has no equivalent
+    * distinction available from {@link SecurityProviderStatus} alone, section 5).
+    */
+   static String projectChain(List<SecurityProviderStatus> providers, boolean withLdapFlag) {
+      StringBuilder sb = new StringBuilder();
+
+      for(SecurityProviderStatus p : providers) {
+         sb.append(p.name()).append('|')
+            .append(withLdapFlag ? (p.ldap() ? "LDAP" : "OTHER") : "-").append(';');
+      }
+
+      return sb.toString();
+   }
+
+   static String projectFileProvider(String name) {
+      StringBuilder sb = new StringBuilder();
+      append(sb, "name", name);
+      append(sb, "type", "FILE");
+      return sb.toString();
+   }
+
+   /** Used for a create's {@code proposedValue} (no live object yet) and mirrors
+    * {@link #projectLdapModel} field-for-field so the hash is comparable across preview and apply. */
+   static String projectLdapSpec(String name, ProviderLdapSpec spec) {
+      StringBuilder sb = new StringBuilder();
+      append(sb, "name", name);
+      append(sb, "type", "LDAP");
+      append(sb, "ldapServer", spec.getLdapServer());
+      append(sb, "protocol", spec.getProtocol());
+      append(sb, "hostName", spec.getHostName());
+      append(sb, "hostPort", String.valueOf(spec.getHostPort()));
+      append(sb, "rootDN", spec.getRootDN());
+      append(sb, "useCredential", String.valueOf(Boolean.TRUE.equals(spec.getUseCredential())));
+      append(sb, "adminID", spec.getAdminID());
+      append(sb, "secretId", spec.getSecretId());
+      append(sb, "password", isBlank(spec.getPassword()) ? "pw:unset" : "pw:set");
+      append(sb, "userFilter", spec.getUserFilter());
+      append(sb, "userBase", spec.getUserBase());
+      append(sb, "userAttr", spec.getUserAttr());
+      append(sb, "mailAttr", spec.getMailAttr());
+      append(sb, "groupFilter", spec.getGroupFilter());
+      append(sb, "groupBase", spec.getGroupBase());
+      append(sb, "groupAttr", spec.getGroupAttr());
+      append(sb, "roleFilter", spec.getRoleFilter());
+      append(sb, "roleBase", spec.getRoleBase());
+      append(sb, "roleAttr", spec.getRoleAttr());
+      append(sb, "userRoleFilter", spec.getUserRoleFilter());
+      append(sb, "roleRoleFilter", spec.getRoleRoleFilter());
+      append(sb, "groupRoleFilter", spec.getGroupRoleFilter());
+      append(sb, "startTls", String.valueOf(Boolean.TRUE.equals(spec.getStartTls())));
+      append(sb, "searchTree", String.valueOf(Boolean.TRUE.equals(spec.getSearchTree())));
+      appendSorted(sb, "sysAdminRoles", spec.getSysAdminRoles());
+      return sb.toString();
+   }
+
+   /** The read-back model always carries {@code Util.PLACEHOLDER_PASSWORD} for password, never the
+    * real value (section 9) -- projected as a presence token identically to {@link #projectLdapSpec},
+    * not as literal placeholder text, so the two are comparable across preview/apply. */
+   static String projectLdapModel(String name, LdapAuthenticationProviderModel m) {
+      StringBuilder sb = new StringBuilder();
+      append(sb, "name", name);
+      append(sb, "type", "LDAP");
+      append(sb, "ldapServer", String.valueOf(m.ldapServer()));
+      append(sb, "protocol", m.protocol());
+      append(sb, "hostName", m.hostName());
+      append(sb, "hostPort", String.valueOf(m.hostPort()));
+      append(sb, "rootDN", m.rootDN());
+      append(sb, "useCredential", String.valueOf(m.useCredential()));
+      append(sb, "adminID", m.adminID());
+      append(sb, "secretId", m.secretId());
+      append(sb, "password", isBlank(m.password()) ? "pw:unset" : "pw:set");
+      append(sb, "userFilter", m.userFilter());
+      append(sb, "userBase", m.userBase());
+      append(sb, "userAttr", m.userAttr());
+      append(sb, "mailAttr", m.mailAttr());
+      append(sb, "groupFilter", m.groupFilter());
+      append(sb, "groupBase", m.groupBase());
+      append(sb, "groupAttr", m.groupAttr());
+      append(sb, "roleFilter", m.roleFilter());
+      append(sb, "roleBase", m.roleBase());
+      append(sb, "roleAttr", m.roleAttr());
+      append(sb, "userRoleFilter", m.userRoleFilter());
+      append(sb, "roleRoleFilter", m.roleRoleFilter());
+      append(sb, "groupRoleFilter", m.groupRoleFilter());
+      append(sb, "startTls", String.valueOf(Boolean.TRUE.equals(m.startTls())));
+      append(sb, "searchTree", String.valueOf(m.searchTree()));
+      appendSorted(sb, "sysAdminRoles", m.sysAdminRoles() == null ? null : List.of(m.sysAdminRoles()));
+      return sb.toString();
+   }
+
+   /** {@code currentValue} for a delete, either chain (section 5/6/8) -- {@code null} if the model
+    * itself is {@code null} (never expected once existence has been confirmed via the chain list,
+    * but defensive rather than NPE-prone, section 2). Only FILE/LDAP are ever passed here --
+    * DATABASE/CUSTOM targets are refused before this is reached (section 1, this area's own
+    * delete-target restriction, see 04-build-java.md). */
+   static String projectAuthenticationProvider(AuthenticationProviderModel model) {
+      if(model == null) {
+         return null;
+      }
+
+      if(model.providerType() == SecurityProviderType.LDAP && model.ldapProviderModel() != null) {
+         return projectLdapModel(model.providerName(), model.ldapProviderModel());
+      }
+
+      return projectFileProvider(model.providerName());
+   }
+
+   /** {@code currentValue} for a delete, authorization chain -- only FILE is ever passed here (this
+    * area's own delete-target restriction excludes CUSTOM the same as DATABASE/CUSTOM on the
+    * authentication side). */
+   static String projectAuthorizationProvider(AuthorizationProviderModel model) {
+      if(model == null) {
+         return null;
+      }
+
+      return projectFileProvider(model.providerName());
+   }
+
+   private static void append(StringBuilder sb, String field, String value) {
+      sb.append(field).append('=').append(value == null ? "" : value).append(';');
+   }
+
+   private static void appendSorted(StringBuilder sb, String field, List<String> values) {
+      TreeSet<String> sorted = values == null ? new TreeSet<>() : new TreeSet<>(values);
+      sb.append(field).append('=').append(String.join(",", sorted)).append(';');
+   }
+
+   private static boolean isBlank(String s) {
+      return s == null || s.trim().isEmpty();
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.admin.ai.providers;
 
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.util.Identity;
@@ -26,6 +28,7 @@ import inetsoft.web.admin.security.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
@@ -203,6 +206,57 @@ class ProviderChangePlanServiceTest {
       stubEmptyAuthenticationChain(List.of());
       assertThrows(IllegalArgumentException.class,
          () -> service.resolve(request("task", List.of(change)), user));
+   }
+
+   // -------------------------------------------------------------------------
+   // 03-reconcile.md Addition 2 -- multi-tenant LDAP gating this area self-imposes, confirmed by
+   // this review (07-review-r1.md) to have had zero test coverage despite requireLdapMultiTenant
+   // Allowed existing in production code: LicenseManager.isEnterprise()/SUtil.isMultiTenant() are
+   // both static, so a mocked test run never previously touched this refusal branch (both statics
+   // resolve to their real, effectively-false values in a bare unit-test JVM by default -- every
+   // pre-existing successful LDAP-create test above was passing this gate incidentally, not because
+   // it was verified).
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnLdapCreateInMultiTenantEnterpriseDeployment() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("p1");
+      change.setProviderType("LDAP");
+      change.setSpec(ldapSpec());
+      stubEmptyAuthenticationChain(List.of());
+
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class);
+          MockedStatic<SUtil> sUtil = mockStatic(SUtil.class))
+      {
+         license.when(LicenseManager::isEnterprise).thenReturn(true);
+         sUtil.when(SUtil::isMultiTenant).thenReturn(true);
+
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> service.resolve(request("task", List.of(change)), user));
+         assertTrue(ex.getMessage().contains("multi-tenant"));
+      }
+   }
+
+   @Test void resolveAllowsLdapCreateWhenEnterpriseButNotMultiTenant() throws Exception {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("p1");
+      change.setProviderType("LDAP");
+      change.setSpec(ldapSpec());
+      stubEmptyAuthenticationChain(List.of());
+
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class);
+          MockedStatic<SUtil> sUtil = mockStatic(SUtil.class))
+      {
+         license.when(LicenseManager::isEnterprise).thenReturn(true);
+         sUtil.when(SUtil::isMultiTenant).thenReturn(false);
+
+         ResolvedPlan plan = service.resolve(request("task", List.of(change)), user);
+         assertEquals(1, plan.changes().size());
+      }
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
@@ -1,0 +1,524 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.util.Identity;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.security.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 1 (scope/providerType-chain cross-validation), section 2 (name resolution,
+ * raw-name-only per 03-reconcile.md Addition 1), section 4 (both self-lockout preflight checks),
+ * and section 5 (the whole-chain, order-sensitive hash input).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ProviderChangePlanServiceTest {
+   private static final IdentityID CALLER_ROLE = new IdentityID("Administrator", "host-org");
+
+   @Mock private AuthenticationProviderService authenticationProviderService;
+   @Mock private AuthorizationProviderService authorizationProviderService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private XPrincipal user;
+   private ProviderChangePlanService service;
+
+   @BeforeEach void setUp() {
+      service = new ProviderChangePlanService(authenticationProviderService,
+                                              authorizationProviderService, securityEngine);
+      lenient().when(user.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
+   }
+
+   // -------------------------------------------------------------------------
+   // basic request validation
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnBlankTask() {
+      ProviderChangePlanRequest req = request("  ", List.of(deleteAuth("p1")));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user))
+                    .getMessage().contains("task"));
+   }
+
+   @Test void resolveThrowsOnEmptyChanges() {
+      ProviderChangePlanRequest req = request("task", List.of());
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+   }
+
+   @Test void resolveThrowsOnUnrecognizedVerb() {
+      ProviderChangeRequest change = deleteAuth("p1");
+      change.setVerb("rename");
+      stubEmptyAuthenticationChain(List.of("p1"));
+      assertTrue(assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user)).getMessage().contains("verb"));
+   }
+
+   @Test void resolveThrowsOnAmbiguousChainAbbreviation() {
+      ProviderChangeRequest change = deleteAuth("p1");
+      change.setChain("auth");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("chain"));
+      assertTrue(ex.getMessage().contains("authentication"));
+      assertTrue(ex.getMessage().contains("authorization"));
+   }
+
+   @Test void resolveThrowsOnDuplicateEntries() {
+      stubEmptyAuthenticationChain(List.of());
+      ProviderChangeRequest c1 = createFile(ProviderChain.AUTHENTICATION, "p1");
+      ProviderChangeRequest c2 = createFile(ProviderChain.AUTHENTICATION, "p1");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(c1, c2)), user));
+      assertTrue(ex.getMessage().contains("duplicate"));
+   }
+
+   // -------------------------------------------------------------------------
+   // providerType/chain cross-validation (section 11)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnLdapForAuthorizationChain() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authorization");
+      change.setName("p1");
+      change.setProviderType("LDAP");
+      stubProviderList(authorizationProviderService, List.of());
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("providerType"));
+   }
+
+   @Test void resolveThrowsOnDatabaseProviderType() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("p1");
+      change.setProviderType("DATABASE");
+      stubEmptyAuthenticationChain(List.of());
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("excluded"));
+   }
+
+   @Test void resolveThrowsOnCustomProviderType() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authorization");
+      change.setName("p1");
+      change.setProviderType("CUSTOM");
+      stubProviderList(authorizationProviderService, List.of());
+      assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+   }
+
+   @Test void resolveThrowsOnUnrecognizedProviderType() {
+      ProviderChangeRequest change = createFile(ProviderChain.AUTHENTICATION, "p1");
+      change.setProviderType("SAML");
+      stubEmptyAuthenticationChain(List.of());
+      assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+   }
+
+   @Test void resolveThrowsOnSpecOnFileCreate() {
+      ProviderChangeRequest change = createFile(ProviderChain.AUTHENTICATION, "p1");
+      change.setSpec(new ProviderLdapSpec());
+      stubEmptyAuthenticationChain(List.of());
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("spec"));
+   }
+
+   @Test void resolveThrowsOnProviderTypeOnDelete() {
+      ProviderChangeRequest change = deleteAuth("p1");
+      change.setProviderType("FILE");
+      stubEmptyAuthenticationChain(List.of("p1"));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("providerType"));
+   }
+
+   @Test void resolveThrowsOnSpecOnDelete() {
+      ProviderChangeRequest change = deleteAuth("p1");
+      change.setSpec(ldapSpec());
+      stubEmptyAuthenticationChain(List.of("p1"));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("spec"));
+   }
+
+   @Test void resolveThrowsOnLdapUseCredentialWithPassword() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("p1");
+      change.setProviderType("LDAP");
+      ProviderLdapSpec spec = ldapSpec();
+      spec.setUseCredential(true);
+      spec.setSecretId("vault:1");
+      // password still set alongside useCredential=true -- illegal combination
+      change.setSpec(spec);
+      stubEmptyAuthenticationChain(List.of());
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("useCredential"));
+   }
+
+   @Test void resolveThrowsOnLdapMissingAdminIdWhenNotUsingCredential() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("p1");
+      change.setProviderType("LDAP");
+      ProviderLdapSpec spec = ldapSpec();
+      spec.setAdminID(null);
+      spec.setPassword(null);
+      change.setSpec(spec);
+      stubEmptyAuthenticationChain(List.of());
+      assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+   }
+
+   // -------------------------------------------------------------------------
+   // identity/existence (section 2)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnCreateNameAlreadyExists() {
+      stubEmptyAuthenticationChain(List.of("p1"));
+      ProviderChangeRequest change = createFile(ProviderChain.AUTHENTICATION, "p1");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("already exists"));
+   }
+
+   @Test void resolveThrowsOnDeleteNameNotFound() {
+      stubEmptyAuthenticationChain(List.of("other"));
+      ProviderChangeRequest change = deleteAuth("p1");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("not found"));
+   }
+
+   @Test void resolveDeleteNeverCallsGetProviderByNameOnEitherService() throws Exception {
+      // Two healthy (sys-admin-holding) providers so deleting one still passes both preflight
+      // checks via the other.
+      stubHealthyAuthenticationChainOf("p1", "p2");
+      when(authenticationProviderService.getAuthenticationProvider("p1"))
+         .thenReturn(fileModel("p1"));
+      service.resolve(request("task", List.of(deleteAuth("p1"))), user);
+      verify(authenticationProviderService, never()).getProviderByName(anyString());
+      verify(authorizationProviderService, never()).getProviderByName(anyString());
+   }
+
+   // -------------------------------------------------------------------------
+   // section 4 preflight -- authentication chain delete
+   // -------------------------------------------------------------------------
+
+   @Test void resolveAllowsAuthenticationDeleteWhenAnotherProviderKeepsSysAdmin() throws Exception {
+      // Two providers both recognize CALLER_ROLE as sys-admin -- deleting one leaves the other.
+      AuthenticationProvider keep = sysAdminProvider("keep");
+      AuthenticationProvider victim = sysAdminProvider("victim");
+      stubAuthenticationChain(List.of(keep, victim), List.of("keep", "victim"));
+      when(authenticationProviderService.getAuthenticationProvider("victim"))
+         .thenReturn(fileModel("victim"));
+
+      ResolvedPlan plan = service.resolve(request("task", List.of(deleteAuth("victim"))), user);
+      assertEquals(1, plan.changes().size());
+   }
+
+   @Test void resolveRefusesAuthenticationDeleteWhenNoProviderWouldRetainSysAdminMember() throws Exception {
+      // The only provider defining a sys-admin-with-a-member role is the one being deleted.
+      AuthenticationProvider victim = sysAdminProvider("victim");
+      AuthenticationProvider plain = plainProvider("plain");
+      stubAuthenticationChain(List.of(victim, plain), List.of("victim", "plain"));
+      when(authenticationProviderService.getAuthenticationProvider("victim"))
+         .thenReturn(fileModel("victim"));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(deleteAuth("victim"))), user));
+      assertTrue(ex.getMessage().contains("no remaining provider"));
+   }
+
+   @Test void resolveRefusesAuthenticationDeleteWhenCallersOwnRoleWouldNotResolve() throws Exception {
+      // The remaining provider retains SOME sys-admin (deployment-wide check 1 passes), but not one
+      // that resolves the CALLING principal's own role -- check 2 must still refuse.
+      IdentityID otherRole = new IdentityID("OtherAdmin", "host-org");
+      AuthenticationProvider victim = sysAdminProvider("victim"); // recognizes CALLER_ROLE
+      AuthenticationProvider keep = mock(AuthenticationProvider.class);
+      lenient().when(keep.getProviderName()).thenReturn("keep");
+      lenient().when(keep.getRoles()).thenReturn(new IdentityID[] { otherRole });
+      lenient().when(keep.getRole(otherRole)).thenReturn(mock(Role.class));
+      lenient().when(keep.getRole(CALLER_ROLE)).thenReturn(null);
+      lenient().when(keep.isSystemAdministratorRole(otherRole)).thenReturn(true);
+      lenient().when(keep.getRoleMembers(otherRole)).thenReturn(new Identity[] { mock(Identity.class) });
+
+      stubAuthenticationChain(List.of(victim, keep), List.of("victim", "keep"));
+      when(authenticationProviderService.getAuthenticationProvider("victim"))
+         .thenReturn(fileModel("victim"));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(deleteAuth("victim"))), user));
+      assertTrue(ex.getMessage().contains("lock the calling session out"));
+   }
+
+   @Test void resolveRefusesDeleteOfDatabaseTypedAuthenticationProvider() throws Exception {
+      stubHealthyAuthenticationChainOf("victim");
+      AuthenticationProviderModel dbModel = AuthenticationProviderModel.builder()
+         .providerName("victim").providerType(SecurityProviderType.DATABASE).build();
+      when(authenticationProviderService.getAuthenticationProvider("victim")).thenReturn(dbModel);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(deleteAuth("victim"))), user));
+      assertTrue(ex.getMessage().contains("DATABASE"));
+   }
+
+   // -------------------------------------------------------------------------
+   // section 4 preflight -- authorization chain delete (floor only)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveAllowsAuthorizationDeleteWhenAnotherProviderRemains() throws Exception {
+      AuthorizationProvider keep = mock(AuthorizationProvider.class);
+      lenient().when(keep.getProviderName()).thenReturn("keep");
+      AuthorizationProvider victim = mock(AuthorizationProvider.class);
+      lenient().when(victim.getProviderName()).thenReturn("victim");
+      AuthorizationChain chain = mock(AuthorizationChain.class);
+      when(chain.getProviders()).thenReturn(List.of(keep, victim));
+      when(securityEngine.getAuthorizationChain()).thenReturn(Optional.of(chain));
+      stubProviderList(authorizationProviderService, List.of("keep", "victim"));
+      when(authorizationProviderService.getAuthorizationProvider("victim"))
+         .thenReturn(authzFileModel("victim"));
+
+      ResolvedPlan plan = service.resolve(request("task", List.of(deleteAuthz("victim"))), user);
+      assertEquals(1, plan.changes().size());
+   }
+
+   @Test void resolveRefusesAuthorizationDeleteThatWouldEmptyTheChain() throws Exception {
+      AuthorizationProvider victim = mock(AuthorizationProvider.class);
+      lenient().when(victim.getProviderName()).thenReturn("victim");
+      AuthorizationChain chain = mock(AuthorizationChain.class);
+      when(chain.getProviders()).thenReturn(List.of(victim));
+      when(securityEngine.getAuthorizationChain()).thenReturn(Optional.of(chain));
+      stubProviderList(authorizationProviderService, List.of("victim"));
+      when(authorizationProviderService.getAuthorizationProvider("victim"))
+         .thenReturn(authzFileModel("victim"));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(deleteAuthz("victim"))), user));
+      assertTrue(ex.getMessage().contains("zero remaining"));
+   }
+
+   // -------------------------------------------------------------------------
+   // section 5 -- the whole-chain, order-sensitive hash
+   // -------------------------------------------------------------------------
+
+   @Test void hashIsStableAcrossTwoIdenticalResolutions() throws Exception {
+      stubHealthyAuthenticationChainOf("p1", "p2");
+      when(authenticationProviderService.getAuthenticationProvider("p2")).thenReturn(fileModel("p2"));
+
+      ResolvedPlan first = service.resolve(request("task", List.of(deleteAuth("p2"))), user);
+      ResolvedPlan second = service.resolve(request("task", List.of(deleteAuth("p2"))), user);
+      assertEquals(first.planHash(), second.planHash());
+   }
+
+   @Test void hashChangesWhenProviderOrderChangesButMembershipDoesNot() throws Exception {
+      // A create -- no preflight involved -- isolates the whole-chain projection's own order
+      // sensitivity (section 5) from the delete preflight's own membership requirements.
+      stubProviderList(authenticationProviderService, List.of("p1", "p2"));
+      ResolvedPlan first = service.resolve(
+         request("task", List.of(createFile(ProviderChain.AUTHENTICATION, "p3"))), user);
+
+      reset(authenticationProviderService);
+      stubProviderList(authenticationProviderService, List.of("p2", "p1"));
+      ResolvedPlan second = service.resolve(
+         request("task", List.of(createFile(ProviderChain.AUTHENTICATION, "p3"))), user);
+
+      assertNotEquals(first.planHash(), second.planHash());
+   }
+
+   @Test void hashChangesWhenAConcurrentProviderIsAddedToTheSameChain() throws Exception {
+      stubHealthyAuthenticationChainOf("p1", "p2");
+      when(authenticationProviderService.getAuthenticationProvider("p2")).thenReturn(fileModel("p2"));
+      ResolvedPlan first = service.resolve(request("task", List.of(deleteAuth("p2"))), user);
+
+      reset(securityEngine, authenticationProviderService);
+      stubHealthyAuthenticationChainOf("p1", "p2", "p3");
+      when(authenticationProviderService.getAuthenticationProvider("p2")).thenReturn(fileModel("p2"));
+      ResolvedPlan second = service.resolve(request("task", List.of(deleteAuth("p2"))), user);
+
+      assertNotEquals(first.planHash(), second.planHash());
+   }
+
+   @Test void passwordNeverAppearsInAHashProjectionString() {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("p1");
+      change.setProviderType("LDAP");
+      ProviderLdapSpec spec = ldapSpec();
+      spec.setPassword("s3cr3t-literal-value");
+      change.setSpec(spec);
+      stubEmptyAuthenticationChain(List.of());
+
+      ResolvedPlan plan;
+      try {
+         plan = service.resolve(request("task", List.of(change)), user);
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+
+      for(PlanChange pc : plan.changes()) {
+         assertFalse(String.valueOf(pc.proposedValue()).contains("s3cr3t-literal-value"));
+      }
+
+      assertFalse(plan.planHash().contains("s3cr3t-literal-value"));
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private AuthenticationProvider sysAdminProvider(String name) {
+      AuthenticationProvider p = mock(AuthenticationProvider.class);
+      lenient().when(p.getProviderName()).thenReturn(name);
+      lenient().when(p.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
+      lenient().when(p.getRole(CALLER_ROLE)).thenReturn(mock(Role.class));
+      lenient().when(p.isSystemAdministratorRole(CALLER_ROLE)).thenReturn(true);
+      lenient().when(p.getRoleMembers(CALLER_ROLE)).thenReturn(new Identity[] { mock(Identity.class) });
+      return p;
+   }
+
+   private AuthenticationProvider plainProvider(String name) {
+      AuthenticationProvider p = mock(AuthenticationProvider.class);
+      lenient().when(p.getProviderName()).thenReturn(name);
+      lenient().when(p.getRoles()).thenReturn(new IdentityID[0]);
+      lenient().when(p.getRole(any())).thenReturn(null);
+      return p;
+   }
+
+   private void stubAuthenticationChain(List<AuthenticationProvider> providers, List<String> names) {
+      AuthenticationChain chain = mock(AuthenticationChain.class);
+      lenient().when(chain.getProviders()).thenReturn(providers);
+      lenient().when(securityEngine.getAuthenticationChain()).thenReturn(Optional.of(chain));
+      stubProviderList(authenticationProviderService, names);
+   }
+
+   /** A two-provider chain, both recognizing {@link #CALLER_ROLE} as sys-admin, so any single
+    * delete's preflight passes by default. */
+   private void stubHealthyAuthenticationChainOf(String... names) {
+      List<AuthenticationProvider> providers = new java.util.ArrayList<>();
+
+      for(String name : names) {
+         providers.add(sysAdminProvider(name));
+      }
+
+      stubAuthenticationChain(providers, List.of(names));
+   }
+
+   private void stubEmptyAuthenticationChain(List<String> names) {
+      lenient().when(securityEngine.getAuthenticationChain()).thenReturn(Optional.empty());
+      stubProviderList(authenticationProviderService, names);
+   }
+
+   private static void stubProviderList(AuthenticationProviderService svc, List<String> names) {
+      SecurityProviderStatusList.Builder builder = SecurityProviderStatusList.builder();
+
+      for(String name : names) {
+         builder.addProviders(SecurityProviderStatus.builder()
+            .name(name).label(name).cacheEnabled(false).cacheAge(0).loading(false).build());
+      }
+
+      lenient().when(svc.getProviderListModel()).thenReturn(builder.build());
+   }
+
+   private static void stubProviderList(AuthorizationProviderService svc, List<String> names) {
+      SecurityProviderStatusList.Builder builder = SecurityProviderStatusList.builder();
+
+      for(String name : names) {
+         builder.addProviders(SecurityProviderStatus.builder()
+            .name(name).label(name).cacheEnabled(false).cacheAge(0).loading(false).build());
+      }
+
+      lenient().when(svc.getProviderListModel()).thenReturn(builder.build());
+   }
+
+   private static AuthenticationProviderModel fileModel(String name) {
+      return AuthenticationProviderModel.builder()
+         .providerName(name).providerType(SecurityProviderType.FILE).build();
+   }
+
+   private static AuthorizationProviderModel authzFileModel(String name) {
+      return AuthorizationProviderModel.builder()
+         .providerName(name).providerType(SecurityProviderType.FILE).build();
+   }
+
+   private static ProviderLdapSpec ldapSpec() {
+      ProviderLdapSpec spec = new ProviderLdapSpec();
+      spec.setLdapServer("GENERIC");
+      spec.setProtocol("ldap");
+      spec.setHostName("ldap.example.com");
+      spec.setHostPort(389);
+      spec.setRootDN("dc=example,dc=com");
+      spec.setAdminID("cn=admin");
+      spec.setPassword("initial-password");
+      return spec;
+   }
+
+   private static ProviderChangeRequest createFile(ProviderChain chain, String name) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain(chain.label());
+      change.setName(name);
+      change.setProviderType("FILE");
+      return change;
+   }
+
+   private static ProviderChangeRequest deleteAuth(String name) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("delete");
+      change.setChain("authentication");
+      change.setName(name);
+      return change;
+   }
+
+   private static ProviderChangeRequest deleteAuthz(String name) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("delete");
+      change.setChain("authorization");
+      change.setName(name);
+      return change;
+   }
+
+   private static ProviderChangePlanRequest request(String task, List<ProviderChangeRequest> changes) {
+      ProviderChangePlanRequest req = new ProviderChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
@@ -1,0 +1,400 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.util.Identity;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.ai.AdminBackupService;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.security.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 6 (apply/rollback per verb, both chains) and section 7 (the Tier-2 backup,
+ * unconditional for this whole area, taken synchronously before any mutation). Backs
+ * {@link AuthenticationProviderService}/{@link AuthorizationProviderService} with a small in-memory
+ * fake chain (mutated by the mocked add/remove calls) so verification/rollback assertions reflect
+ * real state transitions rather than a fixed stub.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ProviderChangesetApplyServiceTest {
+   private static final IdentityID CALLER_ROLE = new IdentityID("Administrator", "host-org");
+
+   @Mock private AuthenticationProviderService authenticationProviderService;
+   @Mock private AuthorizationProviderService authorizationProviderService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private AdminBackupService backupService;
+   @Mock private XPrincipal user;
+
+   private final List<String> authChainNames = new ArrayList<>();
+   private final Map<String, AuthenticationProviderModel> authModels = new HashMap<>();
+   private final List<String> authzChainNames = new ArrayList<>();
+   private final Map<String, AuthorizationProviderModel> authzModels = new HashMap<>();
+
+   private ProviderChangePlanService planService;
+   private ProviderChangesetApplyService service;
+
+   @BeforeEach void setUp() throws Exception {
+      planService = new ProviderChangePlanService(authenticationProviderService,
+                                                  authorizationProviderService, securityEngine);
+      service = new ProviderChangesetApplyService(planService, authenticationProviderService,
+                                                  authorizationProviderService, backupService);
+
+      lenient().when(user.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
+      lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
+      wireAuthenticationFake();
+      wireAuthorizationFake();
+   }
+
+   // -------------------------------------------------------------------------
+   // success
+   // -------------------------------------------------------------------------
+
+   @Test void appliesACreateFileAuthenticationProviderAndReportsApplied() throws Exception {
+      var result = service.apply(applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1")),
+                                 user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertEquals("admin-snapshot/ref", result.backupRef());
+      assertNull(result.rollbackFailures());
+      assertEquals(1, result.results().size());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, result.results().get(0).status());
+      assertTrue(authChainNames.contains("p1"));
+      verify(backupService).backup(anyString());
+   }
+
+   @Test void appliesACreateFileAuthorizationProviderAndReportsApplied() throws Exception {
+      var result = service.apply(
+         applyRequest("create p1", createFile(ProviderChain.AUTHORIZATION, "p1")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertTrue(authzChainNames.contains("p1"));
+   }
+
+   @Test void appliesADeleteAuthenticationProviderAndReportsAppliedWithNoAdvisory() throws Exception {
+      seedHealthyAuthentication("keep", "victim");
+
+      var result = service.apply(applyRequest("delete victim", deleteAuth("victim")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertFalse(authChainNames.contains("victim"));
+      assertNull(result.results().get(0).advisory());
+   }
+
+   @Test void appliesAnLdapAuthenticationCreateBuildingTheModelFromSpec() throws Exception {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain("authentication");
+      change.setName("ldap1");
+      change.setProviderType("LDAP");
+      change.setSpec(ldapSpec());
+
+      var result = service.apply(applyRequest("create ldap1", change), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertEquals(SecurityProviderType.LDAP, authModels.get("ldap1").providerType());
+   }
+
+   @Test void nChangePlanSpanningBothChainsAppliesAllAndReportsTwoOutcomes() throws Exception {
+      var result = service.apply(applyRequest("create both",
+         createFile(ProviderChain.AUTHENTICATION, "a1"), createFile(ProviderChain.AUTHORIZATION, "z1")),
+         user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertEquals(2, result.results().size());
+      assertTrue(authChainNames.contains("a1"));
+      assertTrue(authzChainNames.contains("z1"));
+   }
+
+   // -------------------------------------------------------------------------
+   // throw mid-apply -> rollback / rollback-failed (section 6, "fails by throwing")
+   // -------------------------------------------------------------------------
+
+   @Test void throwMidApplyRollsBackEarlierChangeButReportsRollbackFailedForTheUnknownState()
+      throws Exception
+   {
+      // change 2's own add throws -- its state is unknown and must never be reported as rolled
+      // back, even though change 1's own rollback succeeds (section 6/2.5 of the guide).
+      doThrow(new RuntimeException("simulated race: duplicate name"))
+         .when(authenticationProviderService)
+         .addAuthenticationProvider(argThat(m -> m != null && "p2".equals(m.providerName())),
+                                    eq("p2"), eq(user));
+
+      var result = service.apply(applyRequest("create p1 then p2",
+         createFile(ProviderChain.AUTHENTICATION, "p1"), createFile(ProviderChain.AUTHENTICATION, "p2")),
+         user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertNotNull(result.rollbackFailures());
+      assertTrue(result.rollbackFailures().stream()
+         .anyMatch(f -> f.property().contains("p2") && f.error().contains("state unknown")));
+      // change 1 was still rolled back correctly, disclosed via its own outcome/state, even though
+      // the OVERALL status is rollback-failed because of change 2's unknown state.
+      assertFalse(authChainNames.contains("p1"));
+   }
+
+   @Test void undoRunsNewestFirst() throws Exception {
+      doThrow(new RuntimeException("boom"))
+         .when(authenticationProviderService)
+         .addAuthenticationProvider(argThat(m -> m != null && "p3".equals(m.providerName())),
+                                    eq("p3"), eq(user));
+
+      service.apply(applyRequest("create p1, p2, p3",
+         createFile(ProviderChain.AUTHENTICATION, "p1"), createFile(ProviderChain.AUTHENTICATION, "p2"),
+         createFile(ProviderChain.AUTHENTICATION, "p3")), user);
+
+      InOrder inOrder = inOrder(authenticationProviderService);
+      inOrder.verify(authenticationProviderService).removeAuthenticationProvider(anyInt(), eq("p2"),
+                                                                                 eq(user));
+      inOrder.verify(authenticationProviderService).removeAuthenticationProvider(anyInt(), eq("p1"),
+                                                                                 eq(user));
+   }
+
+   @Test void anUndoThatItselfFailsIsReportedAlongsideTheUnknownStateFailure() throws Exception {
+      doThrow(new RuntimeException("boom"))
+         .when(authenticationProviderService)
+         .addAuthenticationProvider(argThat(m -> m != null && "p2".equals(m.providerName())),
+                                    eq("p2"), eq(user));
+      doThrow(new RuntimeException("rollback also fails"))
+         .when(authenticationProviderService)
+         .removeAuthenticationProvider(anyInt(), eq("p1"), eq(user));
+
+      var result = service.apply(applyRequest("create p1 then p2",
+         createFile(ProviderChain.AUTHENTICATION, "p1"), createFile(ProviderChain.AUTHENTICATION, "p2")),
+         user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      Set<String> failedKeys = result.rollbackFailures().stream()
+         .map(f -> f.property()).collect(Collectors.toSet());
+      assertTrue(failedKeys.stream().anyMatch(k -> k.contains("p1")));
+      assertTrue(failedKeys.stream().anyMatch(k -> k.contains("p2")));
+   }
+
+   // -------------------------------------------------------------------------
+   // delete-rollback's mandatory "restored at end, not original position" advisory
+   // -------------------------------------------------------------------------
+
+   @Test void deleteRollbackDisclosesTheRestoredAtEndAdvisoryAsAFirstClassField() throws Exception {
+      seedHealthyAuthentication("keep", "victim");
+      doThrow(new RuntimeException("boom"))
+         .when(authenticationProviderService)
+         .addAuthenticationProvider(argThat(m -> m != null && "boom".equals(m.providerName())),
+                                    eq("boom"), eq(user));
+
+      var result = service.apply(applyRequest("delete victim then create boom",
+         deleteAuth("victim"), createFile(ProviderChain.AUTHENTICATION, "boom")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      var victimOutcome = result.results().stream()
+         .filter(o -> o.property().contains("victim")).findFirst().orElseThrow();
+      assertNotNull(victimOutcome.advisory());
+      assertTrue(victimOutcome.advisory().contains("END of the chain"));
+      assertTrue(authChainNames.contains("victim")); // recreated by rollback
+   }
+
+   // -------------------------------------------------------------------------
+   // index resolved fresh at apply time, never a preview-captured index (section 1/6)
+   // -------------------------------------------------------------------------
+
+   @Test void deleteResolvesIndexFreshByNameNotAPreviewCapturedIndex() throws Exception {
+      seedHealthyAuthentication("x", "y", "victim"); // victim is at index 2, not 0
+
+      service.apply(applyRequest("delete victim", deleteAuth("victim")), user);
+
+      verify(authenticationProviderService).removeAuthenticationProvider(eq(2), eq("victim"), eq(user));
+   }
+
+   // -------------------------------------------------------------------------
+   // hash / reviewOutcome gates (shared machinery, still worth one assertion per area)
+   // -------------------------------------------------------------------------
+
+   @Test void applyRefusesAStalePlanHash() throws Exception {
+      ProviderApplyRequest req = applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1"));
+      req.setPlanHash("not-the-real-hash");
+
+      assertThrows(AdminChangesetApplyService.PlanHashMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(authChainNames.isEmpty());
+   }
+
+   @Test void applyRefusesAMissingReviewOutcome() throws Exception {
+      ProviderChangePlanRequest planReq = request("create p1",
+         List.of(createFile(ProviderChain.AUTHENTICATION, "p1")));
+      ResolvedPlan plan = planService.resolve(planReq, user);
+      ProviderApplyRequest req = applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1"));
+      req.setPlanHash(plan.planHash());
+      req.setReviewOutcome("  ");
+
+      assertThrows(IllegalArgumentException.class, () -> service.apply(req, user));
+      assertTrue(authChainNames.isEmpty());
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private void seedHealthyAuthentication(String... names) {
+      for(String name : names) {
+         authChainNames.add(name);
+         authModels.put(name, AuthenticationProviderModel.builder()
+            .providerName(name).providerType(SecurityProviderType.FILE).build());
+      }
+   }
+
+   private AuthenticationProvider sysAdminProvider(String name) {
+      AuthenticationProvider p = mock(AuthenticationProvider.class);
+      lenient().when(p.getProviderName()).thenReturn(name);
+      lenient().when(p.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
+      lenient().when(p.getRole(CALLER_ROLE)).thenReturn(mock(Role.class));
+      lenient().when(p.isSystemAdministratorRole(CALLER_ROLE)).thenReturn(true);
+      lenient().when(p.getRoleMembers(CALLER_ROLE)).thenReturn(new Identity[] { mock(Identity.class) });
+      return p;
+   }
+
+   private void wireAuthenticationFake() throws Exception {
+      lenient().when(authenticationProviderService.getProviderListModel()).thenAnswer(inv -> {
+         SecurityProviderStatusList.Builder b = SecurityProviderStatusList.builder();
+
+         for(String n : authChainNames) {
+            b.addProviders(SecurityProviderStatus.builder()
+               .name(n).label(n).cacheEnabled(false).cacheAge(0).loading(false).build());
+         }
+
+         return b.build();
+      });
+      lenient().when(authenticationProviderService.getAuthenticationProvider(anyString()))
+         .thenAnswer(inv -> authModels.get((String) inv.getArgument(0)));
+      lenient().doAnswer(inv -> {
+         AuthenticationProviderModel model = inv.getArgument(0);
+         authChainNames.add(model.providerName());
+         authModels.put(model.providerName(), model);
+         return null;
+      }).when(authenticationProviderService).addAuthenticationProvider(any(), anyString(), any());
+      lenient().doAnswer(inv -> {
+         int idx = inv.getArgument(0);
+         String name = authChainNames.remove(idx);
+         authModels.remove(name);
+         return null;
+      }).when(authenticationProviderService).removeAuthenticationProvider(anyInt(), anyString(), any());
+
+      AuthenticationChain chain = mock(AuthenticationChain.class);
+      lenient().when(chain.getProviders()).thenAnswer(inv ->
+         authChainNames.stream().map(this::sysAdminProvider).collect(Collectors.toList()));
+      lenient().when(securityEngine.getAuthenticationChain()).thenReturn(Optional.of(chain));
+   }
+
+   private void wireAuthorizationFake() throws Exception {
+      lenient().when(authorizationProviderService.getProviderListModel()).thenAnswer(inv -> {
+         SecurityProviderStatusList.Builder b = SecurityProviderStatusList.builder();
+
+         for(String n : authzChainNames) {
+            b.addProviders(SecurityProviderStatus.builder()
+               .name(n).label(n).cacheEnabled(false).cacheAge(0).loading(false).build());
+         }
+
+         return b.build();
+      });
+      lenient().when(authorizationProviderService.getAuthorizationProvider(anyString()))
+         .thenAnswer(inv -> authzModels.get((String) inv.getArgument(0)));
+      lenient().doAnswer(inv -> {
+         AuthorizationProviderModel model = inv.getArgument(0);
+         authzChainNames.add(model.providerName());
+         authzModels.put(model.providerName(), model);
+         return null;
+      }).when(authorizationProviderService).addAuthorizationProvider(any(), anyString(), any());
+      lenient().doAnswer(inv -> {
+         int idx = inv.getArgument(0);
+         String name = authzChainNames.remove(idx);
+         authzModels.remove(name);
+         return null;
+      }).when(authorizationProviderService).removeAuthorizationProvider(anyInt(), anyString(), any());
+
+      AuthorizationChain chain = mock(AuthorizationChain.class);
+      lenient().when(chain.getProviders()).thenAnswer(inv ->
+         authzChainNames.stream().map(n -> {
+            AuthorizationProvider p = mock(AuthorizationProvider.class);
+            lenient().when(p.getProviderName()).thenReturn(n);
+            return p;
+         }).collect(Collectors.toList()));
+      lenient().when(securityEngine.getAuthorizationChain()).thenReturn(Optional.of(chain));
+   }
+
+   private static ProviderLdapSpec ldapSpec() {
+      ProviderLdapSpec spec = new ProviderLdapSpec();
+      spec.setLdapServer("GENERIC");
+      spec.setProtocol("ldap");
+      spec.setHostName("ldap.example.com");
+      spec.setHostPort(389);
+      spec.setRootDN("dc=example,dc=com");
+      spec.setAdminID("cn=admin");
+      spec.setPassword("initial-password");
+      return spec;
+   }
+
+   private static ProviderChangeRequest createFile(ProviderChain chain, String name) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("create");
+      change.setChain(chain.label());
+      change.setName(name);
+      change.setProviderType("FILE");
+      return change;
+   }
+
+   private static ProviderChangeRequest deleteAuth(String name) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("delete");
+      change.setChain("authentication");
+      change.setName(name);
+      return change;
+   }
+
+   private static ProviderChangePlanRequest request(String task, List<ProviderChangeRequest> changes) {
+      ProviderChangePlanRequest req = new ProviderChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+
+   private ProviderApplyRequest applyRequest(String task, ProviderChangeRequest... changes)
+      throws Exception
+   {
+      List<ProviderChangeRequest> list = List.of(changes);
+      ResolvedPlan plan = planService.resolve(request(task, list), user);
+      ProviderApplyRequest req = new ProviderApplyRequest();
+      req.setTask(task);
+      req.setChanges(list);
+      req.setPlanHash(plan.planHash());
+      req.setReviewOutcome("looks safe");
+      return req;
+   }
+}


### PR DESCRIPTION
## Summary

Lands Track C.4 (admin-chat providers area) production code for real. This branch existed
standalone against `stylebi` for a while but was never actually opened as a PR here -- only
`stylebi-enterprise#694` bumped the `community` submodule gitlink straight to this branch's tip
commit, so this code has never run `stylebi`'s own CI or gone through a real PR review gate. This
PR corrects that.

- `ProviderChangePlanService`/`ProviderChangesetApplyService` (preview/apply for create+delete of
  authentication and authorization providers, both chains), `AdminProviderController`, and
  supporting DTOs/projections -- all under `community/core/.../web/admin/ai/providers/` (13 new
  files, purely additive, no existing file touched).
- Scope is deliberately restricted to create/delete of FILE/LDAP (authentication) and FILE
  (authorization) providers -- DATABASE/CUSTOM excluded, no edit/reorder verb exposed.
- Self-imposed multi-tenant LDAP creation gate (the server itself doesn't enforce this;
  `ProviderChangePlanService.requireLdapMultiTenantAllowed` does), covered by dedicated tests.
- Self-lockout preflight for authentication-provider delete, independently traced against
  `OrganizationManager.isSiteAdmin`/`AuthenticationChain.isSystemAdministratorRole` and confirmed
  to match exactly.
- Secrets are never exposed: password fields are hash-projected (`"pw:set"`/`"pw:unset"`) or come
  back as `Util.PLACEHOLDER_PASSWORD` from the live read-model; asserted against a literal secret
  value in test, not just field presence.

Already reviewed once informally during the original build; full record at
`docs/teams/2026-08-26-track-c4-providers/07-review-r1.md` in `stylebi-wiz` (not this repo). This
PR's own CI is the first time this diff runs `stylebi`'s real build/test/security gates.

## Test plan

- [x] `./mvnw -pl core test -o -Dtest="ProviderChangePlanServiceTest,ProviderChangesetApplyServiceTest"`
      from `community/` -- 41/41 passing, independently re-run after rebasing onto current
      `stylebi-wiz-main-rebase`.
- [x] Rebased cleanly onto current `stylebi-wiz-main-rebase` tip, zero conflicts.
- [x] Diff scope verified additive-only: 13 new files, 2944 insertions, 0 deletions, 0 modified
      existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)