### PR TITLE
Fix SreeEnv.getInt/getLong/getBoolean returning stale values after property writes

### DIFF
--- a/core/src/main/java/inetsoft/sree/SreeEnv.java
+++ b/core/src/main/java/inetsoft/sree/SreeEnv.java
@@ -107,13 +107,7 @@ public class SreeEnv {
     */
    public static Integer getInt(String name) {
       String str = getProperty(name);
-      Integer val = null;
-
-      if(str != null) {
-         val = (Integer) cache.computeIfAbsent(name, key -> Integer.valueOf(str));
-      }
-
-      return val;
+      return str != null ? Integer.valueOf(str) : null;
    }
 
    /**
@@ -121,13 +115,7 @@ public class SreeEnv {
     */
    public static Long getLong(String name) {
       String str = getProperty(name);
-      Long val = null;
-
-      if(str != null) {
-         val = (Long) cache.computeIfAbsent(name, key -> Long.valueOf(str));
-      }
-
-      return val;
+      return str != null ? Long.valueOf(str) : null;
    }
 
    /**
@@ -135,13 +123,7 @@ public class SreeEnv {
     */
    public static Boolean getBoolean(String name) {
       String str = getProperty(name);
-      Boolean val = null;
-
-      if(str != null) {
-         val = (Boolean) cache.computeIfAbsent(name, key -> Boolean.valueOf(str));
-      }
-
-      return val;
+      return str != null ? Boolean.valueOf(str) : null;
    }
 
    /**
@@ -326,7 +308,6 @@ public class SreeEnv {
       return ConfigurationContext.getContext().getApplicationContext() != null;
    }
 
-   private static final Map<String, Object> cache = new ConcurrentHashMap<>(); // cached objects
    private static final Map<String, Font> fontMap = new ConcurrentHashMap<>();
 
    /**

--- a/core/src/test/java/inetsoft/sree/SreeEnvTest.java
+++ b/core/src/test/java/inetsoft/sree/SreeEnvTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree;
+
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * getInt/getLong/getBoolean must reflect the current property value on every call, not just
+ * the first one seen by a given accessor for a given property name (see the now-removed
+ * cache.computeIfAbsent memoization that made them stick to their first-parsed value forever).
+ */
+@Tag("core")
+class SreeEnvTest {
+   private MockedStatic<PropertiesEngine> propertiesEngineStatic;
+   private PropertiesEngine engine;
+   private final Map<String, String> properties = new HashMap<>();
+
+   @BeforeEach
+   void setUp() {
+      properties.clear();
+      engine = mock(PropertiesEngine.class);
+      when(engine.getProperty(anyString(), eq(false))).thenAnswer(
+         invocation -> properties.get(invocation.getArgument(0, String.class)));
+      doAnswer(invocation -> properties.put(
+         invocation.getArgument(0, String.class), invocation.getArgument(1, String.class)))
+         .when(engine).setProperty(anyString(), anyString());
+
+      propertiesEngineStatic = mockStatic(PropertiesEngine.class);
+      propertiesEngineStatic.when(PropertiesEngine::getInstance).thenReturn(engine);
+   }
+
+   @AfterEach
+   void tearDown() {
+      propertiesEngineStatic.close();
+   }
+
+   @Test
+   void getLong_reflectsPropertyChangeAfterFirstRead() {
+      SreeEnv.setProperty("some.long.prop", "10");
+      assertEquals(10L, SreeEnv.getLong("some.long.prop"));
+
+      SreeEnv.setProperty("some.long.prop", "20");
+      assertEquals(20L, SreeEnv.getLong("some.long.prop"));
+   }
+
+   @Test
+   void getInt_reflectsPropertyChangeAfterFirstRead() {
+      SreeEnv.setProperty("some.int.prop", "10");
+      assertEquals(10, SreeEnv.getInt("some.int.prop"));
+
+      SreeEnv.setProperty("some.int.prop", "20");
+      assertEquals(20, SreeEnv.getInt("some.int.prop"));
+   }
+
+   @Test
+   void getBoolean_reflectsPropertyChangeAfterFirstRead() {
+      SreeEnv.setProperty("some.boolean.prop", "true");
+      assertEquals(true, SreeEnv.getBoolean("some.boolean.prop"));
+
+      SreeEnv.setProperty("some.boolean.prop", "false");
+      assertEquals(false, SreeEnv.getBoolean("some.boolean.prop"));
+   }
+}


### PR DESCRIPTION
## Root cause

`SreeEnv.getInt`/`getLong`/`getBoolean` (`core/src/main/java/inetsoft/sree/SreeEnv.java`)
each re-read the property's current string via `getProperty(name)` on every call, but
resolved the typed return value through `cache.computeIfAbsent(name, key -> parse(str))`
against a `private static final Map<String, Object> cache` field that nothing ever
cleared. Per the `Map.computeIfAbsent` contract, the mapping function is never
re-invoked once a key is present, so the freshly-read string was silently discarded on
every call after the first. The first successful parse for a given property name wins
forever until process restart, regardless of any later `SreeEnv.setProperty` write to
that same property (which does update the string returned by plain
`SreeEnv.getProperty(name)` immediately -- only the typed accessors were stale).

Confirmed live blast radius: 3 call sites, all via `getLong`, all on per-request/
per-response paths reading admin-editable REST connector timeouts:
- `connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/HttpHandler.java` (`rest.query.timeout.minutes`)
- `connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/json/HttpResponseCache.java` (`rest.cache.timeout.millis`)
- `connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/json/HttpRestDataIteratorStrategy.java` (`rest.cache.timeout.millis`)

`getInt`/`getBoolean` have no current callers in the repo, but share the identical
defect against the same public API, so they're fixed too. `getFont` has the same
pattern against a separate `fontMap` field but is intentionally left untouched -- out
of scope for this fix.

## Fix

Parse the freshly-read string directly on every call instead of memoizing it through
`computeIfAbsent`. `getProperty` resolves through an in-memory `Properties` lookup
(no I/O), so this adds no meaningful cost -- the removed step was caching a primitive
parse, not an expensive lookup. Removed the now-unused `cache` field.

## Testing

Added `core/src/test/java/inetsoft/sree/SreeEnvTest.java`, covering `getInt`/`getLong`/
`getBoolean` reflecting a second `SreeEnv.setProperty` call for the same property name
-- the assertion that fails on the pre-fix code (stuck on the first-parsed value) and
passes after the fix.

Ran via a single-module offline reactor build:
```
./mvnw -o -pl core -am test -Dtest=SreeEnvTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
```
`Tests run: 3, Failures: 0, Errors: 0`.

Found via the property-documentation corpus's own defect audit; no Redmine issue
filed for this one.