### PR TITLE
Fix ReportCache.calculateMaxThreads() zeroing the report-cache pool on malformed reportCache.thread.count

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/paging/ReportCache.java
+++ b/core/src/main/java/inetsoft/report/internal/paging/ReportCache.java
@@ -138,8 +138,8 @@ public class ReportCache implements Serializable {
     * @return  maximum number of threads
     */
    public static int calculateMaxThreads() {
-      int hcount = 0;
       int scount = calculateMaxActiveThreads();
+      int hcount = scount * 2;
       String val = SreeEnv.getProperty("reportCache.thread.count",
                                        (scount * 2) + "");
       try {

--- a/core/src/test/java/inetsoft/report/internal/paging/ReportCacheTest.java
+++ b/core/src/test/java/inetsoft/report/internal/paging/ReportCacheTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.internal.paging;
+
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+@Tag("core")
+class ReportCacheTest {
+   @Test
+   void calculateMaxThreadsFallsBackToDefaultOnMalformedValue() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("replet.cache.concurrency")).thenReturn(null);
+         sreeEnv.when(() -> SreeEnv.getProperty(eq("reportCache.thread.count"), anyString()))
+            .thenReturn("not-a-number");
+
+         int scount = ReportCache.calculateMaxActiveThreads();
+         int hcount = ReportCache.calculateMaxThreads();
+
+         assertEquals(scount * 2, hcount);
+      }
+   }
+
+   @Test
+   void calculateMaxThreadsUsesValidConfiguredValue() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("replet.cache.concurrency")).thenReturn(null);
+         sreeEnv.when(() -> SreeEnv.getProperty(eq("reportCache.thread.count"), anyString()))
+            .thenReturn("7");
+
+         int hcount = ReportCache.calculateMaxThreads();
+
+         assertEquals(7, hcount);
+      }
+   }
+}


### PR DESCRIPTION
## Root cause

`ReportCache.calculateMaxThreads()` initializes `hcount = 0`. When `SreeEnv.getProperty("reportCache.thread.count", ...)` returns a value that fails `Integer.parseInt` (e.g. a typo, a range string, or a blank templated value), the `catch` block only logs a warning — it never resets `hcount` to the computed default (`scount * 2`). The method then returns `0`.

That `0` is used as `hardLimit` in `new ThreadPool(scount, hcount, "ReportCache")` (constructor) and `threadpool.resize(scount, hcount)` (`resize()`). `ThreadPool`'s constructor sets `softLimit = Math.min(softLimit, hardLimit)`, so both limits collapse to `0`. `ThreadPool.checkThread()`'s guard `tcnt < hardLimit` (`0 < 0`) is then permanently false, so no worker thread is ever spawned — the report cache's pool silently accepts queued jobs via `add()` but never executes any of them for the life of the process, with only the one `LOG.warn` from the failed parse as a trace.

The sibling method `calculateMaxActiveThreads()` shows the intended pattern: it never lets a bad/absent value collapse below a safe default (`scount = temp > 0 ? temp : scount`, then `Math.max(scount, 1)`).

`reportCache.thread.count` has no dedicated Enterprise Manager field or `defaults.properties` entry, but it's read through the generic `SreeEnv`/`PropertiesEngine` mechanism (same as `sree.properties` and any generic property-editing path), so a malformed value is a realistic operator-error path, not merely a hypothetical.

## Fix

Compute `scount` first and initialize `hcount = scount * 2` (the same expression already used as the property's own default string) before the `try`, so a parse failure falls back to the documented default instead of `0`. Minimal, no behavior change for valid values.

## Testing

Added `core/src/test/java/inetsoft/report/internal/paging/ReportCacheTest.java` (no prior test coverage existed for this class):
- malformed `reportCache.thread.count` → `calculateMaxThreads()` returns `calculateMaxActiveThreads() * 2`, not `0`
- valid numeric value → still returns the parsed value (guards against a fix that overwrites `hcount` unconditionally after the `try`)

Ran `./mvnw.cmd -pl core -am test -Dtest=ReportCacheTest -o`: `Tests run: 2, Failures: 0, Errors: 0`, full `core` module build succeeded.