### PR TITLE
Fix DataSourceBrowserService HTTP 500 on malformed em.locale

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -519,7 +519,14 @@ public class DataSourceBrowserService {
       }
       else {
          String locstr = SreeEnv.getProperty("em.locale");
-         locale = Catalog.parseLocale(locstr);
+
+         try {
+            locale = Catalog.parseLocale(locstr);
+         }
+         catch(Exception e) {
+            LOG.warn("Invalid em.locale property value: {}", locstr, e);
+            locale = null;
+         }
       }
 
       return locale == null ? Locale.getDefault() : locale;

--- a/core/src/test/java/inetsoft/util/CatalogTest.java
+++ b/core/src/test/java/inetsoft/util/CatalogTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins Catalog.parseLocale's existing contract, including the fact that it throws for
+ * shapes other than a bare 2-char code or exactly language_COUNTRY (underscore at
+ * index 2). Callers such as DataSourceBrowserService.getLocale must handle this throw
+ * themselves -- parseLocale's throwing behavior is intentionally left unchanged.
+ */
+@Tag("core")
+class CatalogTest {
+   @Test
+   void parseLocale_null_returnsNull() {
+      assertNull(Catalog.parseLocale(null));
+   }
+
+   @Test
+   void parseLocale_empty_returnsNull() {
+      assertNull(Catalog.parseLocale(""));
+   }
+
+   @Test
+   void parseLocale_languageOnly_parses() {
+      assertEquals(Locale.of("en", ""), Catalog.parseLocale("en"));
+   }
+
+   @Test
+   void parseLocale_languageAndCountry_parses() {
+      assertEquals(Locale.of("en", "US"), Catalog.parseLocale("en_US"));
+   }
+
+   @Test
+   void parseLocale_hyphenatedForm_throws() {
+      assertThrows(RuntimeException.class, () -> Catalog.parseLocale("en-US"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/portal/data/DataSourceBrowserServiceTest.java
+++ b/core/src/test/java/inetsoft/web/portal/data/DataSourceBrowserServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.portal.data;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.sync.RenameTransformHandler;
+import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.uql.util.Config;
+import inetsoft.web.admin.content.repository.RepositoryObjectService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression coverage for the em.locale crash: a malformed em.locale value (one
+ * Catalog.parseLocale rejects) must not break data-source browsing for a non-SRPrincipal
+ * caller -- getLocale must catch the parse failure and fall back to the default locale.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class DataSourceBrowserServiceTest {
+   @Mock private SecurityEngine securityEngine;
+   @Mock private RepositoryObjectService repositoryObjectService;
+   @Mock private XRepository repository;
+   @Mock private DataSourceService dataSourceService;
+   @Mock private DataSourceRegistry dataSourceRegistry;
+   @Mock private Config uqlConfig;
+   @Mock private RenameTransformHandler renameTransformHandler;
+   @Mock private Principal principal;
+
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private DataSourceBrowserService service;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvStatic = mockStatic(SreeEnv.class);
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("em.locale")).thenReturn("en-US");
+
+      service = new DataSourceBrowserService(securityEngine, repositoryObjectService, repository,
+                                              dataSourceService, dataSourceRegistry, uqlConfig,
+                                              renameTransformHandler);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   @Test
+   void getDataSources_malformedEmLocale_doesNotThrow() throws Exception {
+      when(dataSourceRegistry.getSubDataSourceNames("/folder", false)).thenReturn(new ArrayList<>());
+      when(dataSourceRegistry.getSubfolderNames("/folder")).thenReturn(new ArrayList<>());
+
+      assertDoesNotThrow(
+         () -> assertEquals(0, service.getDataSources("/folder", false, null, principal).size()));
+   }
+
+   @Test
+   void getAllSubDataSources_malformedEmLocale_doesNotThrow() throws Exception {
+      when(dataSourceRegistry.getSubDataSourceNames("/folder", true)).thenReturn(new ArrayList<>());
+      when(dataSourceRegistry.getSubfolderNames("/folder", true)).thenReturn(new ArrayList<>());
+
+      assertDoesNotThrow(
+         () -> assertEquals(0, service.getAllSubDataSources("/folder", principal).size()));
+   }
+}


### PR DESCRIPTION
## Root cause

`Catalog.parseLocale` (`core/src/main/java/inetsoft/util/Catalog.java:263-280`) throws
an uncaught `RuntimeException` for any non-empty locale string that isn't a bare
2-character code or exactly `language_COUNTRY` (underscore at index 2) -- for example
the hyphenated BCP-47/HTTP `Accept-Language` form `"en-US"`, a 3-letter language code
like `"eng_US"`, or a bare word like `"english"`.

`DataSourceBrowserService.getLocale` (`core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java:514-526`)
calls `Catalog.parseLocale(SreeEnv.getProperty("em.locale"))` directly with no
try/catch for any caller whose `Principal` is not an `SRPrincipal`. This method is
called unconditionally at the top of `getDataSources`, `getAllSubDataSources`, and
`getSearchDataSources` (which itself calls `getAllSubDataSources`), so a malformed
`em.locale` property value breaks data-source browsing for that caller.

Both real controller entry points (`DataSourceController`, `WizDatabaseController`)
are covered by a Spring `@ControllerAdvice` catch-all, so this surfaces as a clean
HTTP 500 JSON response rather than an application crash -- but the feature is
genuinely broken for the affected caller, with no fallback to a usable default
locale.

`SRPrincipal` callers are unaffected because `AuthenticationService.updateLocale`
already wraps the same `Catalog.parseLocale` call in try/catch when populating
`SRPrincipal`'s locale field at login, so a malformed source value never reaches the
field `getLocale()` reads.

## Fix

Wrap the `Catalog.parseLocale` call in `DataSourceBrowserService.getLocale` in
try/catch, log a warning, and fall through to the method's existing
`locale == null ? Locale.getDefault() : locale` path -- the same pattern already used
at `LocalizationService.getSuffix`. `Catalog.parseLocale`'s throwing contract is left
unchanged: `AuthenticationService.updateLocale` genuinely depends on it (no
null-check before `setLocale`, so a non-throwing parseLocale would silently blank out
a previously-good stored locale on a malformed re-login).

## Testing

- Added `core/src/test/java/inetsoft/util/CatalogTest.java`, pinning
  `Catalog.parseLocale`'s existing contract (`null`/empty -> `null`, `"en"` and
  `"en_US"` parse, `"en-US"` throws).
- Added `core/src/test/java/inetsoft/web/portal/data/DataSourceBrowserServiceTest.java`,
  mocking `SreeEnv.getProperty("em.locale")` to return `"en-US"` and calling
  `getDataSources`/`getAllSubDataSources` with a non-`SRPrincipal` principal --
  confirms no exception and a sane (default-locale-based) result.

Ran via a single-module offline reactor build:
```
./mvnw -o -pl core -am test -Dtest=CatalogTest,DataSourceBrowserServiceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
```
`Tests run: 7, Failures: 0, Errors: 0`. The test log also shows the new warning being
logged exactly as intended (`Invalid em.locale property value: en-US`).

Found via the property-documentation corpus's own defect audit; no Redmine issue
filed for this one.