### PR TITLE
Fix format.time/format.date.time keyword styles (full/long/medium/short) rendering as date-only

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/StyleCore.java
+++ b/core/src/main/java/inetsoft/report/internal/StyleCore.java
@@ -78,14 +78,14 @@ public abstract class StyleCore extends AbstractAssetEngine
       String prop = SreeEnv.getProperty("format.date", "");
 
       if(!prop.equals("")) {
-         Format fmt = Tool.createDateFormat(prop, locale);
+         Format fmt = Tool.createDateFormat(prop, locale, CoreTool.DateFormatKind.DATE);
          this.formatmap.put(java.sql.Date.class, fmt);
       }
 
       prop = SreeEnv.getProperty("format.date.time", "");
 
       if(!prop.equals("")) {
-         Format fmt = Tool.createDateFormat(prop, locale);
+         Format fmt = Tool.createDateFormat(prop, locale, CoreTool.DateFormatKind.DATE_TIME);
          this.formatmap.put(Date.class, fmt);
          this.formatmap.put(java.sql.Timestamp.class, fmt);
       }
@@ -93,7 +93,7 @@ public abstract class StyleCore extends AbstractAssetEngine
       prop = SreeEnv.getProperty("format.time", "");
 
       if(!prop.equals("")) {
-         Format fmt = Tool.createDateFormat(prop, locale);
+         Format fmt = Tool.createDateFormat(prop, locale, CoreTool.DateFormatKind.TIME);
          this.formatmap.put(java.sql.Time.class, fmt);
       }
    }

--- a/core/src/main/java/inetsoft/util/CoreTool.java
+++ b/core/src/main/java/inetsoft/util/CoreTool.java
@@ -557,6 +557,12 @@ public class CoreTool {
    }
 
    /**
+    * The kind of date/time value a keyword style (FULL/LONG/MEDIUM/SHORT) should be
+    * resolved to by createDateFormat.
+    */
+   public enum DateFormatKind { DATE, TIME, DATE_TIME }
+
+   /**
     * Create an Extended version of the SimpleDateFormatter.
     * @return an instance of the ExtendedDateFormat.
     */
@@ -593,33 +599,59 @@ public class CoreTool {
    public static SimpleDateFormat createDateFormat(String pattern,
                      Locale locale)
    {
-      if(locale == null) {
+      return createDateFormat(pattern, locale, DateFormatKind.DATE);
+   }
+
+   /**
+    * Create an Extended version of the SimpleDateFormatter.
+    * @return an instance of the ExtendedDateFormat.
+    */
+   public static SimpleDateFormat createDateFormat(String pattern, Locale locale,
+                     DateFormatKind kind)
+   {
+      if(locale == null && kind == DateFormatKind.DATE) {
          return createDateFormat(pattern);
       }
 
       DateFormat fmt = null;
 
       if(pattern.equalsIgnoreCase("FULL")) {
-         fmt = DateFormat.getDateInstance(DateFormat.FULL, locale);
+         fmt = getStyledInstance(DateFormat.FULL, locale, kind);
       }
       else if(pattern.equalsIgnoreCase("LONG")) {
-         fmt = DateFormat.getDateInstance(DateFormat.LONG, locale);
+         fmt = getStyledInstance(DateFormat.LONG, locale, kind);
       }
       else if(pattern.equalsIgnoreCase("MEDIUM")) {
-         fmt = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
+         fmt = getStyledInstance(DateFormat.MEDIUM, locale, kind);
       }
       else if(pattern.equalsIgnoreCase("SHORT")) {
-         fmt = DateFormat.getDateInstance(DateFormat.SHORT, locale);
+         fmt = getStyledInstance(DateFormat.SHORT, locale, kind);
       }
       else if(pattern.equalsIgnoreCase("yyyy")) {
-         fmt = new SimpleDateFormat("yyyy", locale);
+         fmt = locale == null ? new SimpleDateFormat("yyyy") : new SimpleDateFormat("yyyy", locale);
       }
 
       if(fmt instanceof SimpleDateFormat) {
          return (SimpleDateFormat) fmt;
       }
 
-      return new ExtendedDateFormat(pattern, locale);
+      return locale == null ? new ExtendedDateFormat(pattern) : new ExtendedDateFormat(pattern, locale);
+   }
+
+   private static DateFormat getStyledInstance(int style, Locale locale, DateFormatKind kind) {
+      if(locale == null) {
+         return switch(kind) {
+            case DATE -> DateFormat.getDateInstance(style);
+            case TIME -> DateFormat.getTimeInstance(style);
+            case DATE_TIME -> DateFormat.getDateTimeInstance(style, style);
+         };
+      }
+
+      return switch(kind) {
+         case DATE -> DateFormat.getDateInstance(style, locale);
+         case TIME -> DateFormat.getTimeInstance(style, locale);
+         case DATE_TIME -> DateFormat.getDateTimeInstance(style, style, locale);
+      };
    }
 
    /**

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -2860,7 +2860,7 @@ public final class Tool extends CoreTool {
          }
 
          try {
-            dateFmt = Tool.createDateFormat(prop, locale);
+            dateFmt = Tool.createDateFormat(prop, locale, DateFormatKind.DATE);
             dateFmt.format(new Date());
          }
          catch(Exception ex) {
@@ -2945,7 +2945,7 @@ public final class Tool extends CoreTool {
          }
 
          try {
-            timeFmt = Tool.createDateFormat(prop, locale);
+            timeFmt = Tool.createDateFormat(prop, locale, DateFormatKind.TIME);
             timeFmt.format(new Date());
          }
          catch(Exception ex) {
@@ -2997,7 +2997,7 @@ public final class Tool extends CoreTool {
          }
 
          try {
-            datetimeFmt = Tool.createDateFormat(prop, locale);
+            datetimeFmt = Tool.createDateFormat(prop, locale, DateFormatKind.DATE_TIME);
             datetimeFmt.format(new Date());
          }
          catch(Exception ex) {

--- a/core/src/test/java/inetsoft/util/CoreToolTest.java
+++ b/core/src/test/java/inetsoft/util/CoreToolTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Tag("core")
+class CoreToolTest {
+   private static final Date NOW = new Date();
+   private static final Locale LOCALE = Locale.US;
+
+   @ParameterizedTest
+   @ValueSource(strings = { "full", "long", "medium", "short" })
+   void createDateFormatTimeKindProducesTimeInstance(String keyword) {
+      int style = styleFor(keyword);
+      SimpleDateFormat fmt = CoreTool.createDateFormat(keyword, LOCALE, CoreTool.DateFormatKind.TIME);
+
+      String actual = fmt.format(NOW);
+      String expectedTime = DateFormat.getTimeInstance(style, LOCALE).format(NOW);
+      String dateOnly = DateFormat.getDateInstance(style, LOCALE).format(NOW);
+
+      assertEquals(expectedTime, actual);
+      assertNotEquals(dateOnly, actual);
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "full", "long", "medium", "short" })
+   void createDateFormatDateTimeKindProducesDateTimeInstance(String keyword) {
+      int style = styleFor(keyword);
+      SimpleDateFormat fmt = CoreTool.createDateFormat(keyword, LOCALE, CoreTool.DateFormatKind.DATE_TIME);
+
+      String actual = fmt.format(NOW);
+      String expectedDateTime = DateFormat.getDateTimeInstance(style, style, LOCALE).format(NOW);
+      String dateOnly = DateFormat.getDateInstance(style, LOCALE).format(NOW);
+
+      assertEquals(expectedDateTime, actual);
+      assertNotEquals(dateOnly, actual);
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "full", "long", "medium", "short" })
+   void createDateFormatTimeKindWithNullLocaleProducesTimeInstance(String keyword) {
+      int style = styleFor(keyword);
+      SimpleDateFormat fmt = CoreTool.createDateFormat(keyword, null, CoreTool.DateFormatKind.TIME);
+
+      String actual = fmt.format(NOW);
+      String expectedTime = DateFormat.getTimeInstance(style).format(NOW);
+      String dateOnly = DateFormat.getDateInstance(style).format(NOW);
+
+      assertEquals(expectedTime, actual);
+      assertNotEquals(dateOnly, actual);
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "full", "long", "medium", "short" })
+   void createDateFormatOneArgOverloadStillProducesDateInstance(String keyword) {
+      int style = styleFor(keyword);
+      SimpleDateFormat fmt = CoreTool.createDateFormat(keyword);
+      assertEquals(DateFormat.getDateInstance(style).format(NOW), fmt.format(NOW));
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "full", "long", "medium", "short" })
+   void createDateFormatTwoArgOverloadStillProducesDateInstance(String keyword) {
+      int style = styleFor(keyword);
+      SimpleDateFormat fmt = CoreTool.createDateFormat(keyword, LOCALE);
+      assertEquals(DateFormat.getDateInstance(style, LOCALE).format(NOW), fmt.format(NOW));
+   }
+
+   private static int styleFor(String keyword) {
+      return switch(keyword.toLowerCase()) {
+         case "full" -> DateFormat.FULL;
+         case "long" -> DateFormat.LONG;
+         case "medium" -> DateFormat.MEDIUM;
+         case "short" -> DateFormat.SHORT;
+         default -> throw new IllegalArgumentException(keyword);
+      };
+   }
+}

--- a/core/src/test/java/inetsoft/util/ToolTest.java
+++ b/core/src/test/java/inetsoft/util/ToolTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.util;
 
+import inetsoft.sree.SreeEnv;
 import inetsoft.test.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -127,5 +131,40 @@ class ToolTest {
    @MethodSource("validDates")
    void validDate(String validDate) {
       assertTrue(Tool.isDate(validDate), String.format("Valid date failed date check: %s", validDate));
+   }
+
+   @Test
+   void getTimeFormatWithKeywordStyleProducesTimeComponent() {
+      String original = SreeEnv.getProperty("format.time");
+
+      try {
+         SreeEnv.setProperty("format.time", "full");
+         Date now = new Date();
+         SimpleDateFormat fmt = Tool.getTimeFormat();
+
+         assertEquals(DateFormat.getTimeInstance(DateFormat.FULL).format(now), fmt.format(now));
+         assertNotEquals(DateFormat.getDateInstance(DateFormat.FULL).format(now), fmt.format(now));
+      }
+      finally {
+         SreeEnv.setProperty("format.time", original);
+      }
+   }
+
+   @Test
+   void getDateTimeFormatWithKeywordStyleProducesDateAndTimeComponents() {
+      String original = SreeEnv.getProperty("format.date.time");
+
+      try {
+         SreeEnv.setProperty("format.date.time", "full");
+         Date now = new Date();
+         SimpleDateFormat fmt = Tool.getDateTimeFormat();
+
+         assertEquals(
+            DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL).format(now), fmt.format(now));
+         assertNotEquals(DateFormat.getDateInstance(DateFormat.FULL).format(now), fmt.format(now));
+      }
+      finally {
+         SreeEnv.setProperty("format.date.time", original);
+      }
    }
 }


### PR DESCRIPTION
## Root cause

Both overloads of `CoreTool.createDateFormat` (`core/src/main/java/inetsoft/util/CoreTool.java`) call `DateFormat.getDateInstance(...)` unconditionally for every `FULL`/`LONG`/`MEDIUM`/`SHORT` keyword branch. Neither overload has any parameter indicating whether the caller wants a date, time, or date-time instance.

Six call sites read `format.date`/`format.time`/`format.date.time` from `SreeEnv` and pass the raw property value straight into `createDateFormat` with no "kind" information:
- `Tool.getDateFormat`, `Tool.getTimeFormat`, `Tool.getDateTimeFormat`
- `StyleCore.refreshFormats()` (3 call sites, populating the report engine's type-to-format map)

Effect: setting `format.time` or `format.date.time` to one of the four keywords silently produces a **date-only** formatter with no time-of-day component — `format.time=full` and `format.date=full` become indistinguishable at format time.

## Fix

Added `CoreTool.DateFormatKind { DATE, TIME, DATE_TIME }` and a new `createDateFormat(String pattern, Locale locale, DateFormatKind kind)` overload that dispatches to `getDateInstance`/`getTimeInstance`/`getDateTimeInstance` accordingly. The two existing public signatures (`createDateFormat(String)`, `createDateFormat(String, Locale)`) keep their exact current behavior, delegating to the new overload with `kind = DateFormatKind.DATE` — this guarantees zero behavior change for the ~50+ other call sites in the codebase, none of which can reach the keyword branch with a non-DATE kind (they either pass literal `SimpleDateFormat` patterns or use the two old overloads, which are structurally locked to `DATE`).

Threaded the correct kind through the 6 call sites: `Tool.getDateFormat` → `DATE` (explicit, no behavior change), `Tool.getTimeFormat` → `TIME`, `Tool.getDateTimeFormat` → `DATE_TIME`; `StyleCore.refreshFormats()`'s three calls similarly.

`PresentationFormatsSettingsService.checkDateFormatPattern` was left unchanged — it already correctly accepts the four keywords for all three properties; the defect was never in what's allowed to be saved, only in what a saved keyword becomes at format-construction time.

## Testing

Added `core/src/test/java/inetsoft/util/CoreToolTest.java` (new file, no prior coverage existed):
- `createDateFormat(keyword, locale, TIME)` matches `DateFormat.getTimeInstance` and *differs* from `getDateInstance` for the same input (fails if the fix regresses to always-DATE) — same for `DATE_TIME`, and with a `null` locale.
- The two old public signatures (no `kind` argument) still produce a `DATE` instance identical to today's output.

Added two end-to-end cases to `core/src/test/java/inetsoft/util/ToolTest.java`: `Tool.getTimeFormat()`/`Tool.getDateTimeFormat()` with the corresponding `SreeEnv` property set to `"full"`, asserting the output matches the real time/date-time instance and differs from the date-only instance.

Ran `./mvnw.cmd -o -pl core -am test -Dtest=CoreToolTest,ToolTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`: `Tests run: 65, Failures: 0, Errors: 0` (20 in `CoreToolTest`, 45 in `ToolTest` including the 2 new cases), full `core` module build succeeded.

## Follow-up candidates (not folded into this PR)

Found while tracing every read site for these three properties — same defect class, different code paths, **not** reached through `CoreTool.createDateFormat`'s dispatch, so this fix doesn't touch them:
- `TableFormat.getFormat` (`core/src/main/java/inetsoft/report/internal/table/TableFormat.java:183-227`) already receives a `format` argument naming the column kind (`DATE_FORMAT`/`TIME_FORMAT`/`TIMEINSTANT_FORMAT`) but ignores it for its own inlined keyword branch, which always calls `getDateInstance`.
- ~9 call sites construct `new SimpleDateFormat(SreeEnv.getProperty("format.date.time"))` directly (bypassing `createDateFormat` entirely) — since `SimpleDateFormat`'s constructor treats its argument as a literal pattern, a keyword value like `"full"` throws `IllegalArgumentException` at construction time instead of producing a silently wrong result. Locations: `AutoSaveUtils.java:365`, `SheetService.java:96`, `RepositoryRecycleBinController.java:206,249`, `DataSpaceFileSettingsController.java:73`, `DataSourceStatusService.java:148`, `DataSetService.java:393,395,476,478`.