### PR TITLE
Fix: getThreadPool() breaks on invalid scheduleTask.thread.count

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -1680,6 +1680,7 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
                         "thread count property (scheduleTask.thread.count): " +
                         SreeEnv.getProperty("scheduleTask.thread.count") +
                         ", using default", ex);
+            hcount = scount * 2;
          }
 
          threadPool = Executors.newFixedThreadPool(hcount, new GroupedThreadFactory());

--- a/core/src/test/java/inetsoft/sree/schedule/ScheduleTaskTest.java
+++ b/core/src/test/java/inetsoft/sree/schedule/ScheduleTaskTest.java
@@ -46,10 +46,13 @@ import org.xml.sax.InputSource;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.StringReader;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -146,6 +149,38 @@ public class ScheduleTaskTest {
       assertEquals(Long.parseLong(shipped), ScheduleTask.DEFAULT_TASK_TIMEOUT,
                    "DEFAULT_TASK_TIMEOUT must track schedule.task.timeout in " +
                    "defaults.properties so the fallback does not silently change the timeout");
+   }
+
+   // --- getThreadPool ---
+
+   @Test
+   void getThreadPoolFallsBackToDefaultCapacityWhenThreadCountIsNotANumber() throws Exception {
+      // threadPool is a cached static singleton (double-checked locking); reset it so the
+      // parse/creation block actually runs instead of returning a pool from another test.
+      Field poolField = ScheduleTask.class.getDeclaredField("threadPool");
+      poolField.setAccessible(true);
+      poolField.set(null, null);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty(eq("scheduleTask.thread.count"), any(String.class)))
+            .thenReturn("not-a-number");
+         sreeEnv.when(() -> SreeEnv.getProperty(eq("scheduleTask.thread.count")))
+            .thenReturn("not-a-number");
+
+         Method getThreadPool = ScheduleTask.class.getDeclaredMethod("getThreadPool");
+         getThreadPool.setAccessible(true);
+         ExecutorService pool = (ExecutorService) getThreadPool.invoke(null);
+
+         assertTrue(pool instanceof ThreadPoolExecutor,
+                    "getThreadPool() is expected to return a fixed thread pool");
+         assertTrue(((ThreadPoolExecutor) pool).getMaximumPoolSize() > 0,
+                    "An invalid scheduleTask.thread.count must fall back to a non-zero pool " +
+                    "size instead of silently caching a dead (0-thread) executor");
+      }
+      finally {
+         ScheduleTask.shutdownThreadPool();
+         poolField.set(null, null);
+      }
    }
 
    @Test


### PR DESCRIPTION
## Root cause

`ScheduleTask.getThreadPool()` (`core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java:1658-1690`) declares `int hcount = 0;` and only reassigns it inside the `try` around `Integer.parseInt(val)`. The `catch(Exception ex)` block only logs "using default" - it never actually resets `hcount` to a default, despite the log message's claim.

## Actual runtime behavior (corrected from the diagnosis/refutation)

Both the original diagnosis and its refutation pass assumed `Executors.newFixedThreadPool(0, ...)` silently produces a "dead" zero-thread pool that queues submissions forever, and that this dead pool then gets **permanently cached** in the `private static ExecutorService threadPool` field for the life of the JVM (reasoning that the caller's `wait(1000)` loop would then time out after `schedule.task.timeout`, or hang forever if that property is configured `<= 0`).

I verified this against a live JVM (via the regression test below) and that assumption is wrong: `Executors.newFixedThreadPool(0, ...)` throws `IllegalArgumentException` immediately (`maximumPoolSize <= 0` fails the `ThreadPoolExecutor` constructor's validation) - it does not return a pool at all. Because the exception is thrown *before* the `threadPool = Executors.newFixedThreadPool(...)` assignment on the line below, **the static field is never cached when this bug fires**. So the actual behavior is:

- `ScheduleTask.run()` (line 645, `getThreadPool().submit(r)`) throws `IllegalArgumentException` immediately for the very first action of the task - no wait loop, no timeout, no hang.
- Since `threadPool` stays `null`, the double-checked-locking guard never short-circuits, so **every subsequent scheduled task run re-attempts the same broken parse and fails again**, indefinitely, until the property is corrected (a JVM restart does not help, since the property itself is still broken).

This is a different (and simpler) failure mode than "dead pool + optional hang," but the same root cause and the same fix: reset `hcount` before the pool is constructed so the `IllegalArgumentException` is never triggered.

## Fix

Reset `hcount` to `scount * 2` (the exact same default expression already used as the property lookup's own fallback string two lines above) inside the `catch` block - mirroring the pattern `getTaskTimeout()` already uses correctly for `schedule.task.timeout`.

## Testing

Added `ScheduleTaskTest#getThreadPoolFallsBackToDefaultCapacityWhenThreadCountIsNotANumber`, which mocks `SreeEnv.getProperty("scheduleTask.thread.count", ...)` to return a non-numeric value, resets the cached static `threadPool` field via reflection so the parse/creation block actually runs, invokes the private `getThreadPool()` via reflection, and asserts the resulting pool has `getMaximumPoolSize() > 0`.

- Verified the test fails without the fix (`IllegalArgumentException` propagates out, confirming the corrected root-cause analysis above).
- Verified the test (and the full `ScheduleTaskTest` suite, 29/29) passes with the fix.
- Ran via: `./mvnw -o -pl core -am test -Dtest=ScheduleTaskTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)