### PR TITLE
Withhold server.save.locations from admin-chat property reads (plaintext password exposure)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -272,7 +272,7 @@ public class AdminPropertyCatalog {
          return false;
       }
 
-      return isEncryptedCredential(lower) ||
+      return isEncryptedCredential(lower) || COMPOSITE_SECRET_PROPERTIES.contains(lower) ||
          lower.contains("password") || lower.contains("secret") ||
          lower.contains("credential") || lower.endsWith(".key") || lower.startsWith("license.");
    }
@@ -392,6 +392,28 @@ public class AdminPropertyCatalog {
     */
    private static final Set<String> CONFIRMED_NOT_SECRET = Set.of(
       "enable.changepassword", "sso.rsa.public.key", "google.maps.key");
+
+   /**
+    * Properties whose stored value is a composite of several fields - some secret, some not -
+    * joined into a single string, so the binary {@link #isSecret}/read gate is the only sound
+    * granularity: there is no per-field redactor in this generic, name/value-string catalog (one
+    * exists for {@code server.save.locations} specifically, in {@code ServerPathInfoModel.Builder},
+    * but it is wired to the structured Enterprise Manager schedule-configuration screen, not this
+    * generic admin-chat property path).
+    *
+    * <p>Deliberately NOT in {@link #ENCRYPTED_CREDENTIALS}: that set's contract is a single value
+    * written whole with {@code SreeEnv.setPassword}, so admin-chat can safely round-trip it through
+    * {@code setPassword}. {@code server.save.locations} is written with a plain
+    * {@code SreeEnv.setProperty} by {@code SchedulerConfigurationService.setServerLocations} as
+    * {@code path|label|username|password} segments joined by {@code ;} - one property, several
+    * server-save locations, each with its own credential. Routing it through
+    * {@code ENCRYPTED_CREDENTIALS} would make admin-chat's write path call
+    * {@code SreeEnv.setPassword("server.save.locations", <arbitrary caller string>)}, replacing
+    * every configured location with a single encrypted opaque value instead of encrypting one
+    * field of one location.
+    */
+   private static final Set<String> COMPOSITE_SECRET_PROPERTIES = Set.of(
+      "server.save.locations");
 
    private static final String RESOURCE = "admin-property-catalog.json";
    private final List<CatalogEntry> entries;

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
@@ -276,6 +276,30 @@ class AdminPropertyCatalogTest {
       assertTrue(AdminPropertyCatalog.isSecret("log.fluentd.security.sharedKey"));
    }
 
+   @Test
+   void withholdsServerSaveLocationsEvenThoughNeitherTheNamePatternNorEncryptedCredentialCoversIt() {
+      // SchedulerConfigurationService.setServerLocations embeds a plaintext password as the
+      // fourth pipe-delimited field of a "path|label|username|password" segment when the operator
+      // types credentials directly, and writes the whole "server.save.locations" property with a
+      // plain SreeEnv.setProperty. The name matches none of the five isSecret substrings/suffixes
+      // and is not a single encrypted value, so it belongs in neither the name test nor
+      // ENCRYPTED_CREDENTIALS - only the dedicated COMPOSITE_SECRET_PROPERTIES withhold list.
+      assertFalse(matchesTheNamePattern("server.save.locations"),
+                  "the point of this test is that the NAME does not match - if it now does, the "
+                  + "union below is no longer what covers it");
+      assertFalse(AdminPropertyCatalog.isEncryptedCredential("server.save.locations"),
+                  "server.save.locations is a multi-location composite value, not a single "
+                  + "credential admin-chat can round-trip through SreeEnv.setPassword");
+      assertTrue(AdminPropertyCatalog.isSecret("server.save.locations"),
+                 "server.save.locations can embed a plaintext password and must not be read back "
+                 + "through admin-chat");
+   }
+
+   @Test
+   void withholdsServerSaveLocationsWhateverCasingTheCallerUses() {
+      assertTrue(AdminPropertyCatalog.isSecret("Server.Save.Locations"));
+   }
+
    /**
     * The pre-#76006 predicate, kept here so a test can assert that a name is covered by the
     * writer half of the union rather than by the name half. Deliberately a copy: if


### PR DESCRIPTION
## Root cause

`SchedulerConfigurationService.setServerLocations` (`core/src/main/java/inetsoft/web/admin/schedule/SchedulerConfigurationService.java:298-354`) stores each server-save location as `path|label|username|password` in a single `server.save.locations` property, joined with `;` for multiple locations, written with a plain `SreeEnv.setProperty` — the password is embedded verbatim in the clear whenever an operator types a username/password directly instead of referencing a stored credential (`useCredential()==false`).

`AdminPropertyCatalog.isSecret("server.save.locations")` (`core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java:264-278`) returned `false`: the name matches none of the `password`/`secret`/`credential`/`.key`/`license.*` shape tests, and the property isn't in `ENCRYPTED_CREDENTIALS` (that allow-list is for single values written whole via `SreeEnv.setPassword`) or `CONFIRMED_NOT_SECRET`. It's also absent from `admin-property-catalog.json` entirely — an uncatalogued property, which the class javadoc says stays readable.

`AdminPropertiesController.view()` (line 116, `String stored = secret ? null : SreeEnv.getProperty(name.key(), false, false);`) therefore forwards the raw, password-embedded value to admin-chat's generic property read endpoint (`GET /api/wiz/v1/admin/properties[/{name}]`), gated only by ordinary site-admin auth — no additional privilege boundary for credential material.

**Concrete exposure evidence:** the actual MCP tool that surfaces this endpoint to the model — `plugin/admin/src/tools/readTools.ts` in the `stylebi-wiz` repo (`get_property`/`list_properties`) — calls this same REST path and returns the JSON response verbatim as the tool result. That tool's own description string tells the calling model explicitly that secret properties "can never be READ through admin-chat," naming the seven `ENCRYPTED_CREDENTIALS` entries. `server.save.locations` was exactly the kind of property that promise is supposed to cover, but wasn't — a real off-host egress of a plaintext password to a model provider, not just a hypothetical.

## Fix

Added a new purpose-built `COMPOSITE_SECRET_PROPERTIES` withhold-only set (currently just `server.save.locations`) in `AdminPropertyCatalog.java`, unioned into `isSecret()` only — **not** into `isEncryptedCredential()`. Deliberately not `ENCRYPTED_CREDENTIALS`: that set's write path (`AdminChangeService`) calls `SreeEnv.setPassword(name.key(), <caller's literal string>)`, which would replace the *entire* multi-location composite value with a single encrypted opaque string on any admin-chat write — corrupting every configured location's path/label/username, not encrypting one password field.

This makes `server.save.locations`: `isSecret=true`, `isEncryptedCredential=false` (unchanged). `AdminPropertiesController.view()` now takes the existing generic "secret pattern... neither read nor changed" branch — no new wording needed. As an intended side effect (not scope creep — confirmed during refutation), `AdminChangePlanService`'s `isSecret && !credential` check now also refuses admin-chat writes to this property, closing an equivalent plaintext-write path that is open today.

**Note on existing masking:** a per-field redactor for this exact property *does* already exist — `Util.PLACEHOLDER_PASSWORD` + `ServerPathInfoModel.Builder.from()` — but it's wired to the structured, typed Enterprise Manager schedule-configuration screen (`ScheduleService.getServerLocations`), not the generic name/value-string `AdminPropertyCatalog`/`AdminPropertiesController` path this bug is about. Reaching into that schedule-specific DTO from the generic catalog would couple two unrelated subsystems for one property; blanket withhold via the existing binary `isSecret` gate is the minimal, correctly-scoped fix here, matching how `password.encryption.key`/`jwt.signing.key`/`sso.rsa.private.key` are already treated.

## Testing

Added two tests to `core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java`, following the exact `#76006` pattern already established in that file:
- `withholdsServerSaveLocationsEvenThoughNeitherTheNamePatternNorEncryptedCredentialCoversIt` — asserts the name does NOT match the copied name-shape predicate and is NOT `isEncryptedCredential`, but `isSecret(...)` IS `true`.
- `withholdsServerSaveLocationsWhateverCasingTheCallerUses` — casing variant (`Server.Save.Locations`).

Ran `./mvnw -o -pl core -am test -Dtest=AdminPropertyCatalogTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`: `Tests run: 29, Failures: 0, Errors: 0` (27 pre-existing + 2 new), full `core` module build succeeded.