### PR TITLE
feat(admin-chat): presentation settings area -- 16 sub-model catalog, update-only (Track C.5 area 3)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/AdminPresentationController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/AdminPresentationController.java
@@ -1,0 +1,183 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * REST controller for the presentation admin-plugin area (01-spec.md section 10). Placed in
+ * {@code community/core}, not {@code enterprise/} -- {@code PresentationSettingsController} and all
+ * 16 sub-services live entirely in {@code community/core} with no enterprise Public API layer at all
+ * (01-spec.md section 10), the same "no Public API layer" community-tier shape this run's own
+ * {@code AdminClusterController}/{@code AdminLicensingController} already establish.
+ *
+ * <p>Never calls {@code PresentationSettingsController} itself -- wraps the 16 sub-services directly
+ * (01-spec.md section 4a): that controller's own {@code @Secured} gate is checkPermission-mediated
+ * and therefore inert for a wiz-tagged caller (section 4a), so the real, only gate for this new area
+ * is {@link #requireSiteAdmin}, matching {@code AdminLicensingController.requireSiteAdmin}'s exact
+ * shape. The {@code @Secured} annotations below reuse the real controller's own resource string as
+ * belt-and-suspenders visibility to any tooling that enumerates {@code @Secured} endpoints -- not a
+ * load-bearing check (section 4a).
+ */
+@RestController
+public class AdminPresentationController {
+   @Autowired
+   public AdminPresentationController(PresentationSettingsAccess access,
+                                      PresentationChangePlanService planService,
+                                      PresentationChangesetApplyService applyService)
+   {
+      this.access = access;
+      this.planService = planService;
+      this.applyService = applyService;
+   }
+
+   /**
+    * Reads one sub-model (when {@code subModel} is given) or all 16 (when omitted) -- mirroring
+    * {@code getSettings}'s own full-builder response (01-spec.md section 3). {@code scope} is
+    * required, no default. {@code webMap.mapboxToken}/{@code googleKey} are masked
+    * (01-spec.md section 9) regardless of which is requested.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/presentation/settings",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/presentation/settings")
+   public PresentationGetResult getSettings(
+      @RequestParam("scope") String scope,
+      @RequestParam(value = "subModel", required = false) String subModelKey, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      boolean global = requireScopeParam(scope);
+      Map<String, JsonNode> subModels = new LinkedHashMap<>();
+
+      if(subModelKey == null) {
+         for(PresentationSubModel subModel : PresentationSubModel.values()) {
+            subModels.put(subModel.key(), projectedRead(subModel, user, global));
+         }
+      }
+      else {
+         PresentationSubModel subModel = PresentationSubModel.require(subModelKey);
+         subModels.put(subModel.key(), projectedRead(subModel, user, global));
+      }
+
+      return new PresentationGetResult(global ? "global" : "organization", subModels);
+   }
+
+   /**
+    * Resolves a presentation change plan (16-sub-model catalog, {@code update} verb only) without
+    * mutating anything. See {@code AdminAiController#preview} for the shape this mirrors.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/presentation/settings",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/presentation/preview")
+   public ResolvedPlan preview(@RequestBody PresentationChangePlanRequest req, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return planService.resolve(req, user);
+   }
+
+   /**
+    * Applies a reviewed presentation change plan. Every plan requires a Tier-2 backup
+    * (01-spec.md section 4/6/7/11 -- unconditional), taken synchronously inside
+    * {@link PresentationChangesetApplyService#apply} before any mutation.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/presentation/settings",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/presentation/apply")
+   public PresentationApplyResult apply(@RequestBody PresentationApplyRequest req, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return applyService.apply(req, user);
+   }
+
+   private JsonNode projectedRead(PresentationSubModel subModel, Principal user, boolean global)
+      throws Exception
+   {
+      JsonNode node = PresentationJson.toNode(access.read(subModel, user, global));
+      return subModel == PresentationSubModel.WEB_MAP
+         ? PresentationJson.maskWebMapSecrets(node) : node;
+   }
+
+   private static boolean requireScopeParam(String scope) {
+      if(scope == null) {
+         throw new IllegalArgumentException(
+            "scope: required, must be \"global\" or \"organization\"");
+      }
+
+      String trimmed = scope.trim();
+
+      if(PresentationChangeRequest.SCOPE_GLOBAL.equalsIgnoreCase(trimmed)) {
+         return true;
+      }
+
+      if(PresentationChangeRequest.SCOPE_ORGANIZATION.equalsIgnoreCase(trimmed)) {
+         return false;
+      }
+
+      throw new IllegalArgumentException(
+         "scope: must be \"global\" or \"organization\", got \"" + scope + "\"");
+   }
+
+   /** Same rationale and shape as {@code AdminLicensingController#requireSiteAdmin} -- see there. */
+   private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
+      }
+   }
+
+   @ExceptionHandler(IllegalArgumentException.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleIllegalArgument(IllegalArgumentException ex) {
+      return Map.of("status", "failed", "error", String.valueOf(ex.getMessage()));
+   }
+
+   @ExceptionHandler(AdminChangesetApplyService.PlanHashMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handlePlanHashMismatch(
+      AdminChangesetApplyService.PlanHashMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
+   private final PresentationSettingsAccess access;
+   private final PresentationChangePlanService planService;
+   private final PresentationChangesetApplyService applyService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyOutcome.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyOutcome.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+/**
+ * Outcome of one attempted presentation sub-model change -- area-local (not the shared
+ * {@code inetsoft.web.admin.ai.ApplyOutcome}) only insofar as {@code advisory} is added, matching
+ * {@code LicenseApplyOutcome}'s own "replicate, don't generalize" precedent. {@code before}/
+ * {@code after} are JSON text (the same projection {@link PresentationChangePlanService} puts in
+ * {@code PlanChange.currentValue}/{@code proposedValue}, webMap-masked where applicable) -- kept as
+ * {@code String}, matching the shared record's own field type, per this build's deviation from
+ * 01-spec.md Flagged Decision 5 (see {@link PresentationChangePlanService}'s own javadoc).
+ *
+ * @param property  composite {@code <subModel>:<scope>} key, e.g. {@code "lookAndFeel:global"}.
+ * @param advisory  non-error, non-null-only-when-relevant disclosure the caller must relay to the
+ *                  human verbatim -- currently only used for the storage-scope non-compensable
+ *                  notice (01-spec.md section 6).
+ */
+public record PresentationApplyOutcome(String property, String before, String after, String status,
+                                       String error, String advisory)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyRequest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request body for {@code POST /api/wiz/v1/admin/presentation/apply}. {@code
+ * acknowledgeIrreversibleUpdate} must be exactly {@code true} whenever the freshly re-resolved plan
+ * contains any of the 4 storage-scope sub-models ({@code lookAndFeel}/{@code welcomePage}/
+ * {@code loginBanner}/{@code portalIntegration}) -- those have no live inverse in this cut and are
+ * gated the same way an irreversible delete is gated elsewhere in this program (01-spec.md section 6).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PresentationApplyRequest extends PresentationChangePlanRequest {
+   public String getPlanHash() {
+      return planHash;
+   }
+
+   public void setPlanHash(String v) {
+      this.planHash = v;
+   }
+
+   public String getReviewOutcome() {
+      return reviewOutcome;
+   }
+
+   public void setReviewOutcome(String v) {
+      this.reviewOutcome = v;
+   }
+
+   public Boolean getAcknowledgeIrreversibleUpdate() {
+      return acknowledgeIrreversibleUpdate;
+   }
+
+   public void setAcknowledgeIrreversibleUpdate(Boolean v) {
+      this.acknowledgeIrreversibleUpdate = v;
+   }
+
+   private String planHash;
+   private String reviewOutcome;
+   private Boolean acknowledgeIrreversibleUpdate;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyResult.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyResult.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import inetsoft.web.admin.ai.RollbackFailure;
+
+import java.util.List;
+
+/**
+ * Result of applying a whole presentation changeset -- identical shape to the shared
+ * {@code inetsoft.web.admin.ai.ApplyResult} except {@code results} carries
+ * {@link PresentationApplyOutcome}. {@code rollbackFailures} reuses the shared {@code RollbackFailure}
+ * unmodified.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PresentationApplyResult(String transactionId, String status, String backupRef,
+                                      List<PresentationApplyOutcome> results,
+                                      List<RollbackFailure> rollbackFailures)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanRequest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Request body for {@code POST /api/wiz/v1/admin/presentation/preview}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PresentationChangePlanRequest {
+   public String getTask() {
+      return task;
+   }
+
+   public void setTask(String v) {
+      this.task = v;
+   }
+
+   public List<PresentationChangeRequest> getChanges() {
+      return changes;
+   }
+
+   public void setChanges(List<PresentationChangeRequest> v) {
+      this.changes = v;
+   }
+
+   private String task;
+   private List<PresentationChangeRequest> changes;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
@@ -1,0 +1,401 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.sree.security.OrganizationManager;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Resolves a requested list of presentation sub-model changes into a {@link ResolvedPlan} and hashes
+ * it -- the presentation analog of {@code inetsoft.web.admin.ai.AdminChangePlanService} and (within
+ * this run) {@code LicenseChangePlanService}/{@code ClusterChangePlanService}, replicated rather than
+ * shared (01-spec.md section 6, matching every prior area's own "replicate, don't generalize"
+ * precedent).
+ *
+ * <p><b>Deviation from 01-spec.md's Flagged Decision 5, recorded here per this build's own reporting
+ * duty.</b> The spec recommends area-local, object-typed {@code PresentationPlanChange}/
+ * {@code PresentationResolvedPlan} records instead of the shared String-typed
+ * {@code PlanChange}/{@code ResolvedPlan}, reasoning that forcing a compound sub-model value through
+ * a {@code String} is "needless double-serialization". That reasoning was sound against the one
+ * precedent the spec had read (C.4's {@code ProviderApplyOutcome}), but this pin also contains two
+ * more recent, actually-shipped community-tier areas the spec did not have: {@code
+ * ClusterChangePlanService} and {@code LicenseChangePlanService}, both of which reuse the shared
+ * {@code PlanChange}/{@code ResolvedPlan} unmodified and JSON-serialize into the existing {@code
+ * String} fields, reserving an area-local record only for the {@code ApplyOutcome} shape (adding one
+ * field, {@code advisory}, in licensing's case). Reusing the shared plan types here matches that
+ * (more current) established pattern, avoids a parallel {@code PlanHashMismatchException}/{@code
+ * ResolvedPlan} type family, and lets this area reuse {@code AdminChangesetApplyService.
+ * PlanHashMismatchException} and its controller-level 409 handling verbatim, the same way cluster and
+ * licensing both do. See {@link PresentationApplyOutcome} for where an area-local record IS still
+ * needed (the apply side, to keep {@code before}/{@code after} as nested JSON rather than an escaped
+ * string).
+ */
+@Component
+public class PresentationChangePlanService {
+   @Autowired
+   public PresentationChangePlanService(PresentationSettingsAccess access) {
+      this.access = access;
+   }
+
+   /**
+    * Resolves and hashes a plan. Performs no mutation, but does perform a live read of every named
+    * sub-model's current value.
+    *
+    * @throws IllegalArgumentException with a field-named message on a blank task, an empty change
+    *         list, an unrecognized verb/subModel/scope, a duplicate sub-model+scope pair, an
+    *         unrecognized {@code spec} field, {@code scope: "organization"} for a global-only
+    *         sub-model, an unsafe {@code lookAndFeel} file name, a secret {@code webMap} field, or a
+    *         {@code portalIntegration.tabs} array that omits a current tab.
+    */
+   public ResolvedPlan resolve(PresentationChangePlanRequest req, Principal principal)
+      throws Exception
+   {
+      List<ResolvedChange> resolved = resolveEntries(req, principal);
+      List<PlanChange> changes = new ArrayList<>();
+
+      for(ResolvedChange entry : resolved) {
+         changes.add(entry.planChange());
+      }
+
+      String task = req.getTask().trim();
+      List<PlanChange> immutableChanges = Collections.unmodifiableList(changes);
+      return new ResolvedPlan(task, immutableChanges, true, true, hash(task, immutableChanges));
+   }
+
+   /**
+    * Same resolution {@link #resolve} performs, but also returns the actual proposed model object
+    * (not just its JSON projection) for each change, so {@link PresentationChangesetApplyService} can
+    * pass it straight to {@link PresentationSettingsAccess#write} without re-deriving it a second way.
+    * Package-visible, mirroring {@code ProviderChangePlanService}'s own preflight-methods-reused-at-
+    * apply-time shape.
+    */
+   List<ResolvedChange> resolveEntries(PresentationChangePlanRequest req, Principal principal)
+      throws Exception
+   {
+      if(req == null || req.getTask() == null || req.getTask().trim().isEmpty()) {
+         throw new IllegalArgumentException("task: a non-empty description is required");
+      }
+
+      if(req.getChanges() == null || req.getChanges().isEmpty()) {
+         throw new IllegalArgumentException("changes: at least one change is required");
+      }
+
+      List<ResolvedChange> result = new ArrayList<>();
+      Set<String> seen = new HashSet<>();
+      int index = 0;
+
+      for(PresentationChangeRequest raw : req.getChanges()) {
+         String label = "changes[" + index++ + "]";
+
+         if(raw == null) {
+            throw new IllegalArgumentException(label + ": must not be null");
+         }
+
+         requireVerb(label, raw.getVerb());
+         PresentationSubModel subModel = requireSubModel(label, raw.getSubModel());
+         boolean global = requireScope(label, subModel, raw.getScope());
+         requireUnseen(label, subModel, global, seen);
+
+         JsonNode spec = requireSpecObject(label, raw.getSpec());
+         requireKnownFields(label, subModel, spec);
+
+         Object currentModel = access.read(subModel, principal, global);
+         JsonNode currentNode = PresentationJson.toNode(currentModel);
+
+         if(subModel == PresentationSubModel.PORTAL_INTEGRATION) {
+            requireWholeTabList(label, spec, currentNode);
+         }
+
+         if(subModel == PresentationSubModel.LOOK_AND_FEEL) {
+            spec = sanitizeLookAndFeelFileNames(label, spec);
+         }
+
+         if(subModel == PresentationSubModel.WEB_MAP) {
+            requireNoSecretFields(label, spec);
+         }
+
+         JsonNode mergedNode = PresentationJson.merge(currentNode, spec);
+         Object proposedModel;
+
+         try {
+            proposedModel = PresentationJson.toModel(mergedNode, subModel.modelClass());
+         }
+         catch(Exception e) {
+            throw new IllegalArgumentException(
+               label + ".spec: does not produce a valid \"" + subModel.key() + "\" value (" +
+               e.getMessage() + ")", e);
+         }
+
+         String orgId = global ? null :
+            OrganizationManager.getInstance().getCurrentOrgID();
+         String scopeLabel = global ? PresentationChangeRequest.SCOPE_GLOBAL :
+            PresentationChangeRequest.SCOPE_ORGANIZATION;
+         String property = subModel.key() + ":" + scopeLabel;
+
+         PlanChange planChange = new PlanChange(
+            property, orgId, projectedValue(subModel, currentNode),
+            projectedValue(subModel, mergedNode), subModel.risk(), subModel.scope(), true,
+            "update " + subModel.key() + " (" + scopeLabel + " scope)");
+
+         result.add(new ResolvedChange(subModel, global, currentModel, proposedModel, planChange));
+      }
+
+      return result;
+   }
+
+   // ---------------------------------------------------------------- validation helpers
+
+   static void requireVerb(String label, String verb) {
+      if(verb == null || !PresentationChangeRequest.VERB_UPDATE.equalsIgnoreCase(verb.trim())) {
+         throw new IllegalArgumentException(
+            label + ".verb: must be \"update\" -- presentation sub-models cannot be created or " +
+            "destroyed, got " + verb);
+      }
+   }
+
+   static PresentationSubModel requireSubModel(String label, String subModel) {
+      if(subModel == null) {
+         throw new IllegalArgumentException(label + ".subModel: required");
+      }
+
+      try {
+         return PresentationSubModel.require(subModel);
+      }
+      catch(IllegalArgumentException e) {
+         throw new IllegalArgumentException(label + "." + e.getMessage());
+      }
+   }
+
+   static boolean requireScope(String label, PresentationSubModel subModel, String scope) {
+      if(scope == null) {
+         throw new IllegalArgumentException(
+            label + ".scope: required, must be \"global\" or \"organization\"");
+      }
+
+      String trimmed = scope.trim();
+      boolean global;
+
+      if(PresentationChangeRequest.SCOPE_GLOBAL.equalsIgnoreCase(trimmed)) {
+         global = true;
+      }
+      else if(PresentationChangeRequest.SCOPE_ORGANIZATION.equalsIgnoreCase(trimmed)) {
+         global = false;
+      }
+      else {
+         throw new IllegalArgumentException(
+            label + ".scope: must be \"global\" or \"organization\", got \"" + scope + "\"");
+      }
+
+      if(!global && subModel.globalOnly()) {
+         throw new IllegalArgumentException(
+            label + ".scope: \"" + subModel.key() + "\" has no organization-scoped layer -- it is " +
+            "global-only. \"organization\" always means the calling principal's own organization, " +
+            "never a different org, and this sub-model does not have a separate per-organization " +
+            "value at all.");
+      }
+
+      return global;
+   }
+
+   private static void requireUnseen(String label, PresentationSubModel subModel, boolean global,
+                                      Set<String> seen)
+   {
+      String key = subModel.key() + ":" + global;
+
+      if(!seen.add(key)) {
+         throw new IllegalArgumentException(
+            label + ": duplicate entry for \"" + subModel.key() + "\" (" +
+            (global ? "global" : "organization") + " scope); list each sub-model/scope pair once");
+      }
+   }
+
+   private static JsonNode requireSpecObject(String label, JsonNode spec) {
+      if(spec == null || spec.isNull() || !spec.isObject() || spec.isEmpty()) {
+         throw new IllegalArgumentException(
+            label + ".spec: required, must be a non-empty object naming only the fields being " +
+            "changed");
+      }
+
+      return spec;
+   }
+
+   private static void requireKnownFields(String label, PresentationSubModel subModel, JsonNode spec) {
+      Set<String> valid = subModel.fieldNames();
+      Iterator<String> names = spec.fieldNames();
+
+      while(names.hasNext()) {
+         String field = names.next();
+
+         if(!valid.contains(field)) {
+            throw new IllegalArgumentException(
+               label + ".spec." + field + ": not a field of \"" + subModel.key() + "\" -- valid " +
+               "fields are " + valid);
+         }
+      }
+   }
+
+   /** 03-reconcile.md Addition 2: {@code portalIntegration.tabs} must always be every current tab, in
+    * full -- {@code PortalIntegrationViewSettingsService.setModel} both indexes into the live tab list
+    * by a caller-echoed {@code originalIndex} with no bounds/identity check AND does a whole-list
+    * replace underneath, so a shorter {@code tabs} array would silently drop the missing tabs. */
+   private static void requireWholeTabList(String label, JsonNode spec, JsonNode current) {
+      JsonNode tabs = spec.get("tabs");
+
+      if(tabs == null) {
+         return;
+      }
+
+      if(!tabs.isArray()) {
+         throw new IllegalArgumentException(label + ".spec.tabs: must be an array");
+      }
+
+      JsonNode currentTabs = current.get("tabs");
+      int currentCount = currentTabs == null ? 0 : currentTabs.size();
+
+      if(tabs.size() != currentCount) {
+         throw new IllegalArgumentException(
+            label + ".spec.tabs: must include every current tab (" + currentCount + "), not a " +
+            "partial list -- got " + tabs.size() + " entries. portalIntegration.tabs is a " +
+            "whole-list replace underneath (PortalIntegrationViewSettingsService.setModel); a " +
+            "shorter list would silently drop the tabs left out, not leave them unchanged.");
+      }
+   }
+
+   /** 03-reconcile.md Addition 1: {@code lookAndFeel}'s org-scoped CSS-upload path
+    * ({@code LookAndFeelService.setViewsheet}) writes a caller-supplied file name straight to
+    * {@code DataSpace} with no validation of its own; the extension suffix on {@code setLogo}/
+    * {@code setFavicon} has the same gap in miniature. Normalizes to a safe basename (the natural
+    * "pasted a full path" LLM mistake) and refuses loud only when nothing safe remains. */
+   private static JsonNode sanitizeLookAndFeelFileNames(String label, JsonNode spec) {
+      ObjectNode copy = spec.deepCopy();
+
+      for(String fileField : List.of("logoFile", "faviconFile", "viewsheetFile")) {
+         JsonNode file = copy.get(fileField);
+
+         if(file != null && file.isObject() && file.hasNonNull("name")) {
+            String sanitized =
+               sanitizeBaseName(label + ".spec." + fileField + ".name", file.get("name").asText());
+            ((ObjectNode) file).put("name", sanitized);
+         }
+      }
+
+      return copy;
+   }
+
+   private static String sanitizeBaseName(String label, String raw) {
+      String normalized = raw.replace('\\', '/');
+      int idx = normalized.lastIndexOf('/');
+      String base = (idx >= 0 ? normalized.substring(idx + 1) : normalized).trim();
+
+      if(base.isEmpty() || base.equals(".") || base.equals("..") || base.contains("..")) {
+         throw new IllegalArgumentException(
+            label + ": \"" + raw + "\" is not a safe file name -- once any path is stripped it " +
+            "must not be blank or still contain \"..\" (lookAndFeel's org-scoped upload path " +
+            "writes this name to storage verbatim; see 03-reconcile.md Addition 1)");
+      }
+
+      return base;
+   }
+
+   /** 01-spec.md section 9: {@code webMap.mapboxToken}/{@code googleKey} are treated as
+    * secret-classified for this area even though the underlying service returns them in the clear --
+    * refused outright in a write {@code spec} (matching {@code AdminPropertyCatalog.isSecret}'s own
+    * "refuse to change a secret through admin-chat" treatment), masked on every read (see
+    * {@link #projectedValue}). */
+   private static void requireNoSecretFields(String label, JsonNode spec) {
+      for(String secret : PresentationJson.WEB_MAP_SECRET_FIELDS) {
+         if(spec.has(secret)) {
+            throw new IllegalArgumentException(
+               label + ".spec." + secret + ": secret-classified third-party API keys cannot be " +
+               "set through admin-chat (01-spec.md section 9) -- change it through Enterprise " +
+               "Manager instead");
+         }
+      }
+   }
+
+   /** Package-visible so {@link PresentationChangesetApplyService} can compute the identical
+    * before/after projection when verifying a write's read-back, instead of re-deriving its own. */
+   static String projectedValue(PresentationSubModel subModel, JsonNode node) {
+      JsonNode projected = subModel == PresentationSubModel.WEB_MAP
+         ? PresentationJson.maskWebMapSecrets(node) : node;
+      return PresentationJson.writeString(projected);
+   }
+
+   // ---------------------------------------------------------------- hash
+
+   /** SHA-256 over the canonical plan, same field-order/control-character-free contract as every
+    * other area's own {@code hash} method. Package-visible so {@link PresentationChangesetApplyService}
+    * can recompute the identical hash from the same {@link ResolvedChange#planChange()} list
+    * {@link #resolveEntries} already produced, instead of resolving the whole plan a second time. */
+   static String hash(String task, List<PlanChange> changes) {
+      StringBuilder canonical = new StringBuilder(task).append('\n');
+
+      for(PlanChange change : changes) {
+         canonical.append(change.property()).append(SEP)
+            .append(canonicalValue(change.orgId())).append(SEP)
+            .append(canonicalValue(change.currentValue())).append(SEP)
+            .append(canonicalValue(change.proposedValue())).append(SEP)
+            .append(change.risk()).append(SEP)
+            .append(change.snapshotScope()).append(SEP);
+      }
+
+      try {
+         byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+         StringBuilder hex = new StringBuilder(digest.length * 2);
+
+         for(byte b : digest) {
+            hex.append(String.format("%02x", b));
+         }
+
+         return hex.toString();
+      }
+      catch(NoSuchAlgorithmException e) {
+         throw new IllegalStateException("SHA-256 is required to hash a presentation change plan", e);
+      }
+   }
+
+   private static String canonicalValue(String value) {
+      return value == null ? NULL_MARKER : value;
+   }
+
+   private static final char SEP = (char) 0x1f;
+   private static final String NULL_MARKER = String.valueOf((char) 0x01);
+   private final PresentationSettingsAccess access;
+
+   /** One resolved change: the sub-model/scope it targets, its current and ready-to-write proposed
+    * model objects, and the {@link PlanChange} record describing it -- returned by
+    * {@link #resolveEntries} so {@link PresentationChangesetApplyService} can write
+    * {@link #proposedModel()} (and, on rollback, write {@link #currentModel()} back) directly instead
+    * of re-deriving either from JSON a second time. */
+   record ResolvedChange(PresentationSubModel subModel, boolean global, Object currentModel,
+                         Object proposedModel, PlanChange planChange)
+   {
+   }
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangeRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangeRequest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * One requested sub-model change: {@code update} one of the 16 sub-models by short name
+ * (01-spec.md section 5/11). {@code scope} is deliberately {@code "global"|"organization"}, never an
+ * {@code orgId} -- the underlying controller has no way to target a different org's settings at all
+ * (01-spec.md section 1); a caller-invented {@code orgId} field would be accepted by nothing
+ * underneath and silently ignored, exactly the trap CLAUDE.md's tool-misuse section names.
+ *
+ * <p>{@code spec} is a partial-field object, merged onto the sub-model's current value
+ * ({@link PresentationChangePlanService}) -- except {@code viewsheetToolbar.options} and
+ * {@code portalIntegration.tabs}, which must always be the whole list (01-spec.md section 5,
+ * 03-reconcile.md Addition 2).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PresentationChangeRequest {
+   public static final String VERB_UPDATE = "update";
+   public static final String SCOPE_GLOBAL = "global";
+   public static final String SCOPE_ORGANIZATION = "organization";
+
+   public String getVerb() {
+      return verb;
+   }
+
+   public void setVerb(String v) {
+      this.verb = v;
+   }
+
+   public String getSubModel() {
+      return subModel;
+   }
+
+   public void setSubModel(String v) {
+      this.subModel = v;
+   }
+
+   public String getScope() {
+      return scope;
+   }
+
+   public void setScope(String v) {
+      this.scope = v;
+   }
+
+   public JsonNode getSpec() {
+      return spec;
+   }
+
+   public void setSpec(JsonNode v) {
+      this.spec = v;
+   }
+
+   private String verb;
+   private String subModel;
+   private String scope;
+   private JsonNode spec;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
@@ -1,0 +1,289 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import inetsoft.util.Tool;
+import inetsoft.util.audit.ActionRecord;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.util.audit.Audit;
+import inetsoft.web.admin.ai.AdminBackupService;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.RollbackFailure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.security.SecureRandom;
+import java.sql.Timestamp;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a whole presentation changeset, all-or-nothing, and audits every attempt -- the
+ * presentation analog of {@code inetsoft.web.admin.ai.AdminChangesetApplyService} and (within this
+ * run) {@code LicenseChangesetApplyService}/{@code ClusterChangesetApplyService}, replicated rather
+ * than shared (01-spec.md section 6).
+ *
+ * <p><b>Two rollback classes, matching 01-spec.md section 4/6's value/storage split.</b> The 12
+ * value-scope sub-models have a real live inverse: the {@code currentModel} object
+ * {@link PresentationChangePlanService#resolveEntries} captured before the write is simply written
+ * back. The 4 storage-scope sub-models ({@code lookAndFeel}/{@code welcomePage}/{@code loginBanner}/
+ * {@code portalIntegration}) have none in this cut -- a successful storage-scope write is never
+ * undone; if a later change in the same apply fails, that earlier success is reported as an
+ * unconditional {@link RollbackFailure} (recovery is the Tier-2 backup, not a compensating write),
+ * so the overall status is honestly {@code rollback-failed} rather than a {@code rolled-back} that
+ * would be a lie about what's actually still on disk.
+ */
+@Component
+public class PresentationChangesetApplyService {
+   @Autowired
+   public PresentationChangesetApplyService(PresentationChangePlanService planService,
+                                            PresentationSettingsAccess access,
+                                            AdminBackupService backupService)
+   {
+      this.planService = planService;
+      this.access = access;
+      this.backupService = backupService;
+   }
+
+   /**
+    * Resolves fresh, gates on the plan hash, {@code reviewOutcome} (always required -- this area's
+    * plan is always high risk, 01-spec.md section 11), and {@code acknowledgeIrreversibleUpdate}
+    * (required exactly when the freshly re-resolved plan touches a storage-scope sub-model), backs
+    * up, then executes.
+    *
+    * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
+    *         (maps to HTTP 409).
+    * @throws Exception if the Tier-2 backup itself fails, in which case nothing was applied.
+    */
+   public PresentationApplyResult apply(PresentationApplyRequest req, Principal user) throws Exception {
+      APPLY_LOCK.lock();
+
+      try {
+         List<PresentationChangePlanService.ResolvedChange> resolved =
+            planService.resolveEntries(req, user);
+         List<PlanChange> planChanges = new ArrayList<>();
+
+         for(PresentationChangePlanService.ResolvedChange entry : resolved) {
+            planChanges.add(entry.planChange());
+         }
+
+         String task = req.getTask().trim();
+         String currentHash = PresentationChangePlanService.hash(task, planChanges);
+
+         if(req.getPlanHash() == null || !currentHash.equals(req.getPlanHash())) {
+            throw new AdminChangesetApplyService.PlanHashMismatchException(
+               new inetsoft.web.admin.ai.ResolvedPlan(task, planChanges, true, true, currentHash));
+         }
+
+         if(req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()) {
+            throw new IllegalArgumentException(
+               "reviewOutcome: required -- every presentation change plan is high risk " +
+               "(01-spec.md section 11)");
+         }
+
+         boolean touchesStorage = resolved.stream().anyMatch(e -> e.subModel().isStorageScope());
+
+         if(touchesStorage && !Boolean.TRUE.equals(req.getAcknowledgeIrreversibleUpdate())) {
+            throw new IllegalArgumentException(
+               "acknowledgeIrreversibleUpdate: must be true because this changeset touches a " +
+               "storage-scope sub-model (lookAndFeel/welcomePage/loginBanner/portalIntegration), " +
+               "which has no live rollback in this cut (01-spec.md section 6)");
+         }
+
+         String txId = "pres-" + newIdSuffix();
+         String backupRef = backupService.backup(txId);
+         String reviewOutcome = req.getReviewOutcome();
+         List<PresentationApplyOutcome> results = new ArrayList<>();
+         List<PresentationChangePlanService.ResolvedChange> undoableValue = new ArrayList<>();
+         List<PresentationChangePlanService.ResolvedChange> appliedStorage = new ArrayList<>();
+         List<RollbackFailure> unknownStateFailures = new ArrayList<>();
+         boolean failed = false;
+
+         for(PresentationChangePlanService.ResolvedChange entry : resolved) {
+            String key = entry.planChange().property();
+            String before = entry.planChange().currentValue();
+            String expectedAfter = entry.planChange().proposedValue();
+
+            try {
+               access.write(entry.subModel(), entry.proposedModel(), user, entry.global());
+               String actualAfter = PresentationChangePlanService.projectedValue(
+                  entry.subModel(), PresentationJson.toNode(
+                     access.read(entry.subModel(), user, entry.global())));
+               boolean verified = expectedAfter.equals(actualAfter);
+               String status = verified
+                  ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+               results.add(new PresentationApplyOutcome(key, before, actualAfter, status,
+                  verified ? null : "value did not read back as written", null));
+               writeAudit(txId, task, key, entry, AdminChangeRecord.ACTION_APPLY, before, actualAfter, status,
+                         backupRef, reviewOutcome, user);
+
+               if(!verified) {
+                  failed = true;
+                  break;
+               }
+
+               if(entry.subModel().isStorageScope()) {
+                  appliedStorage.add(entry);
+               }
+               else {
+                  undoableValue.add(entry);
+               }
+            }
+            catch(Exception e) {
+               // A throw carries no verifiable before/after evidence for THIS change -- must never
+               // be treated as rolled back, same rule every prior area's apply service follows.
+               results.add(new PresentationApplyOutcome(key, before, null,
+                  AdminChangeRecord.STATUS_FAILED, messageOf(e), null));
+               unknownStateFailures.add(new RollbackFailure(key,
+                  "state unknown: apply did not return a verifiable outcome (" + messageOf(e) + ")"));
+               writeAudit(txId, task, key, entry, AdminChangeRecord.ACTION_APPLY, before, null,
+                         AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+               failed = true;
+               break;
+            }
+         }
+
+         if(!failed) {
+            return new PresentationApplyResult(txId, AdminChangesetApplyService.STATUS_APPLIED,
+               backupRef, Collections.unmodifiableList(results), null);
+         }
+
+         List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
+
+         // Storage-scope successes that happened before the failure: no live inverse exists in this
+         // cut (01-spec.md section 4/6) -- unconditionally reported, never silently left out of the
+         // response, so the operator knows recovery for these means restoring the Tier-2 backup.
+         for(PresentationChangePlanService.ResolvedChange applied : appliedStorage) {
+            failures.add(new RollbackFailure(applied.planChange().property(),
+               "storage-scope sub-model update cannot be rolled back in this cut (01-spec.md " +
+               "section 4/6) -- recovery requires restoring the Tier-2 backup for transaction " +
+               txId + " (backupRef: " + backupRef + ")"));
+         }
+
+         failures.addAll(rollback(txId, task, undoableValue, backupRef, reviewOutcome, user));
+
+         String status = failures.isEmpty()
+            ? AdminChangesetApplyService.STATUS_ROLLED_BACK
+            : AdminChangesetApplyService.STATUS_ROLLBACK_FAILED;
+
+         if(!failures.isEmpty()) {
+            LOG.error("Presentation changeset {} rollback failed; sub-models still changed: {}", txId,
+                     failures.stream().map(RollbackFailure::property).collect(Collectors.joining(", ")));
+         }
+
+         return new PresentationApplyResult(txId, status, backupRef,
+            Collections.unmodifiableList(results),
+            failures.isEmpty() ? null : Collections.unmodifiableList(failures));
+      }
+      finally {
+         APPLY_LOCK.unlock();
+      }
+   }
+
+   /** Undoes verified value-scope changes newest-first, attempting all of them and collecting any
+    * failures -- never called for a storage-scope entry (see {@link #apply}). */
+   private List<RollbackFailure> rollback(String txId, String task,
+                                          List<PresentationChangePlanService.ResolvedChange> undoable,
+                                          String backupRef, String reviewOutcome, Principal user)
+   {
+      List<RollbackFailure> failures = new ArrayList<>();
+
+      for(int i = undoable.size() - 1; i >= 0; i--) {
+         PresentationChangePlanService.ResolvedChange entry = undoable.get(i);
+         String key = entry.planChange().property();
+         String expectedBefore = entry.planChange().currentValue();
+
+         try {
+            access.write(entry.subModel(), entry.currentModel(), user, entry.global());
+            String restoredValue = PresentationChangePlanService.projectedValue(
+               entry.subModel(), PresentationJson.toNode(
+                  access.read(entry.subModel(), user, entry.global())));
+            boolean verified = expectedBefore.equals(restoredValue);
+            writeAudit(txId, task, key, entry, AdminChangeRecord.ACTION_ROLLBACK, null, restoredValue,
+                      verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                      backupRef, reviewOutcome, user);
+
+            if(!verified) {
+               failures.add(new RollbackFailure(key,
+                  "rollback reported the value as not restored to its pre-apply state"));
+            }
+         }
+         catch(Exception e) {
+            failures.add(new RollbackFailure(key, messageOf(e)));
+         }
+      }
+
+      return failures;
+   }
+
+   private void writeAudit(String txId, String task, String key,
+                           PresentationChangePlanService.ResolvedChange entry, String adminAction,
+                           String before, String after, String status, String backupRef,
+                           String reviewOutcome, Principal user)
+   {
+      try {
+         AdminChangeRecord record = new AdminChangeRecord();
+         record.setTransactionId(txId);
+         record.setTaskDescription(task);
+         record.setProperty(key);
+         record.setObjectType(ActionRecord.OBJECT_TYPE_EMPROPERTY);
+         record.setBeforeValue(before);
+         record.setAfterValue(after);
+         record.setAction(adminAction);
+         record.setStatus(status);
+         record.setRiskLevel(entry.subModel().risk());
+         record.setSnapshotScope(entry.subModel().scope());
+         record.setBackupRef(backupRef);
+         record.setReviewOutcome(reviewOutcome);
+         record.setOrganizationId(entry.global() ? null :
+            inetsoft.sree.security.OrganizationManager.getInstance().getCurrentOrgID());
+         record.setUserName(user == null ? null : user.getName());
+         record.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
+         record.setServerHostName(Tool.getHost());
+         Audit.getInstance().auditAdminChange(record, user);
+      }
+      catch(Exception auditFailure) {
+         // An audit write must never replace the real outcome -- same rule every prior area's apply
+         // service follows.
+         LOG.error("Failed to write presentation admin change audit record for transaction {}", txId,
+                   auditFailure);
+      }
+   }
+
+   private static String messageOf(Exception e) {
+      return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+   }
+
+   private static String newIdSuffix() {
+      return String.format("%016x", RANDOM.nextLong());
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(PresentationChangesetApplyService.class);
+   private static final SecureRandom RANDOM = new SecureRandom();
+   /** Serializes the entire body of {@link #apply} -- same rationale and same JVM-local-only
+    * limitation as every prior area's own lock. */
+   private static final ReentrantLock APPLY_LOCK = new ReentrantLock();
+   private final PresentationChangePlanService planService;
+   private final PresentationSettingsAccess access;
+   private final AdminBackupService backupService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationGetResult.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationGetResult.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Map;
+
+/**
+ * Response for {@code GET /api/wiz/v1/admin/presentation/settings} -- one entry per requested
+ * sub-model, keyed by short name (all 16 when {@code subModel} was omitted, exactly one otherwise).
+ * {@code webMap.mapboxToken}/{@code googleKey} are masked (01-spec.md section 9).
+ */
+public record PresentationGetResult(String scope, Map<String, JsonNode> subModels) {
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationJson.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationJson.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Small Jackson-tree helpers shared by {@link PresentationSubModel} (field-name introspection) and
+ * {@link PresentationChangePlanService} (JSON projection/merge/masking) -- kept in one place so both
+ * use the identical {@link ObjectMapper} configuration rather than two independently-constructed
+ * ones drifting apart.
+ *
+ * <p>A plain (non-enum) class deliberately, so {@link #MAPPER} initializes before
+ * {@link PresentationSubModel}'s enum constants can call {@link #fieldNames} from their own
+ * constructors -- referencing this class triggers its static initialization first, avoiding the
+ * "enum constants run before the rest of the enum's own static fields" ordering hazard a shared
+ * static field inside the enum itself would hit.
+ */
+final class PresentationJson {
+   private PresentationJson() {
+   }
+
+   static final ObjectMapper MAPPER = new ObjectMapper();
+
+   /** The caller-visible-when-non-blank field name test used for {@code webMap}'s two secret-classified
+    * fields (01-spec.md section 9) -- masked on every read/projection, refused outright in a write
+    * {@code spec} (see {@code PresentationChangePlanService.requireNoSecretFields}). */
+   static final Set<String> WEB_MAP_SECRET_FIELDS = Set.of("mapboxToken", "googleKey");
+   static final String SECRET_MASK = "********";
+
+   /** The exact JSON property names Jackson would (de)serialize for {@code modelClass}, i.e. the
+    * complete, valid {@code spec} field set for one sub-model -- mechanically derived from the model
+    * interface itself so it can never drift from what the interface actually declares (the same
+    * failure mode the two dead {@code PresentationSettingsModel} fields are proof of).
+    *
+    * <p>Reflection over the interface's own no-arg instance methods, not Jackson's {@code
+    * BeanDescription} introspection -- {@code getSerializationConfig().introspect(...)} on the bare
+    * interface type does not follow {@code @JsonSerialize(as = ImmutableXModel.class)} to the
+    * generated Immutables class, and returns no properties at all for these fluent-accessor
+    * interfaces (confirmed: every field name below matches the interface method name verbatim, no
+    * {@code get}/{@code is} prefix to strip, exactly what every {@code getModel}/{@code setModel}
+    * body already reads/writes under). */
+   static Set<String> fieldNames(Class<?> modelClass) {
+      Set<String> names = new LinkedHashSet<>();
+
+      for(Method method : modelClass.getMethods()) {
+         if(method.getParameterCount() == 0 && !Modifier.isStatic(method.getModifiers()) &&
+            method.getDeclaringClass() != Object.class)
+         {
+            names.add(method.getName());
+         }
+      }
+
+      return names;
+   }
+
+   static JsonNode toNode(Object model) {
+      return MAPPER.valueToTree(model);
+   }
+
+   static <T> T toModel(JsonNode node, Class<T> modelClass) throws JsonProcessingException {
+      return MAPPER.treeToValue(node, modelClass);
+   }
+
+   /** Shallow overlay: every top-level field present in {@code spec} replaces the same field in
+    * {@code current} wholesale (never deep-merged) -- correct both for scalar fields and for the two
+    * list-valued fields this area has ({@code viewsheetToolbar.options}, {@code portalIntegration.
+    * tabs}), which 01-spec.md section 5 and 03-reconcile.md Addition 2 both require to be replaced as
+    * a whole, never patched element-by-element. */
+   static JsonNode merge(JsonNode current, JsonNode spec) {
+      ObjectNode merged = current.deepCopy();
+      Iterator<Map.Entry<String, JsonNode>> fields = spec.fields();
+
+      while(fields.hasNext()) {
+         Map.Entry<String, JsonNode> field = fields.next();
+         merged.set(field.getKey(), field.getValue());
+      }
+
+      return merged;
+   }
+
+   /** Masks {@code webMap.mapboxToken}/{@code googleKey} to a fixed placeholder wherever a value is
+    * about to be shown to a caller (a GET response, or a plan/audit {@code before}/{@code after}
+    * projection) -- never used on the node that is about to be deserialized back into a model and
+    * written, only on display copies (01-spec.md section 9, "refuse to return ... the real value"). */
+   static JsonNode maskWebMapSecrets(JsonNode node) {
+      ObjectNode copy = node.deepCopy();
+
+      for(String field : WEB_MAP_SECRET_FIELDS) {
+         JsonNode value = copy.get(field);
+
+         if(value != null && value.isTextual() && !value.asText().isEmpty()) {
+            copy.put(field, SECRET_MASK);
+         }
+      }
+
+      return copy;
+   }
+
+   static String writeString(JsonNode node) {
+      try {
+         return MAPPER.writeValueAsString(node);
+      }
+      catch(JsonProcessingException e) {
+         throw new IllegalStateException("failed to serialize a presentation sub-model value", e);
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationSettingsAccess.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationSettingsAccess.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import inetsoft.web.admin.general.WebMapSettingsService;
+import inetsoft.web.admin.presentation.*;
+import inetsoft.web.admin.presentation.model.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.EnumMap;
+
+/**
+ * Bridges the 16-entry {@link PresentationSubModel} catalog to the real sub-services
+ * {@code PresentationSettingsController} itself wraps -- never calls the controller (same "wrap the
+ * service layer, not the EM controller" decision C.4 made for providers, 01-spec.md section 4a).
+ *
+ * <p>Each of the 16 real services has a slightly different {@code getModel}/{@code setModel} shape
+ * (some take a {@link Principal}, some don't; {@code fontMapping}/{@code ai} take no scope boolean at
+ * all) -- normalized here, once, into one uniform {@code (Principal, boolean) -> Object} /
+ * {@code (Object, Principal, boolean) -> void} pair per sub-model, so the plan/apply services never
+ * need to know which of the 16 shapes they are calling.
+ */
+@Component
+public class PresentationSettingsAccess {
+   @Autowired
+   public PresentationSettingsAccess(
+      PresentationFormatsSettingsService formats,
+      PresentationDashboardSettingsService dashboard,
+      PresentationToolbarSettingsService toolbar,
+      LookAndFeelService lookAndFeel,
+      WelcomePageService welcomePage,
+      PresentationLoginBannerSettingsService loginBanner,
+      PortalIntegrationViewSettingsService portalIntegration,
+      PresentationPdfGenerationSettingsService pdfGeneration,
+      ExportMenuSettingsService exportMenu,
+      PresentationFontMappingSettingsService fontMapping,
+      ShareSettingsService share,
+      PresentationComposerMessageSettingsService composerMessage,
+      PresentationTimeSettingsService time,
+      PresentationDataSourceVisibilitySettingsService dataSourceVisibility,
+      WebMapSettingsService webMap,
+      AISettingsService ai)
+   {
+      adapters = new EnumMap<>(PresentationSubModel.class);
+
+      adapters.put(PresentationSubModel.FORMATS, new Adapter(
+         (principal, global) -> formats.getModel(global),
+         (model, principal, global) ->
+            formats.setModel((PresentationFormatsSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.DASHBOARD, new Adapter(
+         (principal, global) -> dashboard.getModel(global),
+         (model, principal, global) ->
+            dashboard.setModel((PresentationDashboardSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.VIEWSHEET_TOOLBAR, new Adapter(
+         (principal, global) -> toolbar.getViewsheetOptions(global),
+         (model, principal, global) ->
+            toolbar.setViewsheetOptions((PresentationViewsheetToolbarOptionsModel) model, global)));
+
+      adapters.put(PresentationSubModel.LOOK_AND_FEEL, new Adapter(
+         lookAndFeel::getModel,
+         (model, principal, global) ->
+            lookAndFeel.setModel((LookAndFeelSettingsModel) model, principal, global)));
+
+      adapters.put(PresentationSubModel.WELCOME_PAGE, new Adapter(
+         (principal, global) -> welcomePage.getModel(global),
+         (model, principal, global) ->
+            welcomePage.setModel((WelcomePageSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.LOGIN_BANNER, new Adapter(
+         (principal, global) -> loginBanner.getModel(global),
+         (model, principal, global) ->
+            loginBanner.setModel((PresentationLoginBannerSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.PORTAL_INTEGRATION, new Adapter(
+         portalIntegration::getModel,
+         (model, principal, global) ->
+            portalIntegration.setModel((PortalIntegrationSettingsModel) model, principal, global)));
+
+      adapters.put(PresentationSubModel.PDF_GENERATION, new Adapter(
+         (principal, global) -> pdfGeneration.getModel(global),
+         (model, principal, global) ->
+            pdfGeneration.setModel((PresentationPdfGenerationSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.EXPORT_MENU, new Adapter(
+         (principal, global) -> exportMenu.getExportMenuSettings(global),
+         (model, principal, global) ->
+            exportMenu.setExportMenuSettings((PresentationExportMenuSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.FONT_MAPPING, new Adapter(
+         (principal, global) -> fontMapping.getModel(),
+         (model, principal, global) ->
+            fontMapping.setModel((PresentationFontMappingSettingsModel) model)));
+
+      adapters.put(PresentationSubModel.SHARE, new Adapter(
+         (principal, global) -> share.getModel(global),
+         (model, principal, global) ->
+            share.setModel((PresentationShareSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.COMPOSER_MESSAGE, new Adapter(
+         (principal, global) -> composerMessage.getModel(global),
+         (model, principal, global) ->
+            composerMessage.setModel((PresentationComposerMessageSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.TIME, new Adapter(
+         (principal, global) -> time.getModel(global),
+         (model, principal, global) ->
+            time.setModel((PresentationTimeSettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.DATA_SOURCE_VISIBILITY, new Adapter(
+         (principal, global) -> dataSourceVisibility.getModel(global),
+         (model, principal, global) -> dataSourceVisibility
+            .setModel((PresentationDataSourceVisibilitySettingsModel) model, global)));
+
+      adapters.put(PresentationSubModel.WEB_MAP, new Adapter(
+         (principal, global) -> webMap.getModel(global),
+         (model, principal, global) ->
+            webMap.setModel((inetsoft.web.admin.general.model.WebMapSettingsModel) model, principal,
+                            global)));
+
+      adapters.put(PresentationSubModel.AI, new Adapter(
+         (principal, global) -> ai.getModel(),
+         (model, principal, global) -> ai.setModel((PresentationAISettingsModel) model)));
+   }
+
+   /** Reads the current value of one sub-model, in whichever of the 16 real shapes it actually has. */
+   public Object read(PresentationSubModel subModel, Principal principal, boolean global)
+      throws Exception
+   {
+      return adapters.get(subModel).reader.read(principal, global);
+   }
+
+   /** Writes a fully-resolved (never partial) sub-model value -- callers must merge a partial
+    * {@code spec} onto a fresh {@link #read} result themselves before calling this (the real
+    * {@code setModel} methods all expect a complete object, none accept a patch). */
+   public void write(PresentationSubModel subModel, Object model, Principal principal, boolean global)
+      throws Exception
+   {
+      adapters.get(subModel).writer.write(model, principal, global);
+   }
+
+   @FunctionalInterface
+   private interface Reader {
+      Object read(Principal principal, boolean global) throws Exception;
+   }
+
+   @FunctionalInterface
+   private interface Writer {
+      void write(Object model, Principal principal, boolean global) throws Exception;
+   }
+
+   private record Adapter(Reader reader, Writer writer) {
+   }
+
+   private final EnumMap<PresentationSubModel, Adapter> adapters;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationSubModel.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationSubModel.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.general.model.WebMapSettingsModel;
+import inetsoft.web.admin.presentation.model.*;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The closed, compile-time-known catalog of the 16 sub-models {@code PresentationSettingsController}
+ * actually wires (01-spec.md section 0/2) -- a hardcoded Java enum, not a JSON resource, matching
+ * {@code AdminProviderController}'s own sibling area's precedent for a small closed unit set
+ * (01-spec.md "Flagged decisions" item 1). Deliberately excludes the two dead
+ * {@code PresentationSettingsModel} fields ({@code reportToolbarOptionsModel},
+ * {@code reportViewerSettingsModel} -- declared on the model, never read/written by the real
+ * controller, 01-spec.md section 2).
+ *
+ * <p>An unrecognized name is a hard refusal everywhere this enum is resolved by key -- unlike
+ * properties' open-ended namespace, these 16 names ARE the entire namespace (01-spec.md section 2).
+ */
+public enum PresentationSubModel {
+   FORMATS("formats", PresentationFormatsSettingsModel.class,
+           AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   DASHBOARD("dashboard", PresentationDashboardSettingsModel.class,
+             AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   VIEWSHEET_TOOLBAR("viewsheetToolbar", PresentationViewsheetToolbarOptionsModel.class,
+                      AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   LOOK_AND_FEEL("lookAndFeel", LookAndFeelSettingsModel.class,
+                 AdminChangeRecord.SCOPE_STORAGE, AdminChangeRecord.RISK_HIGH, false),
+   WELCOME_PAGE("welcomePage", WelcomePageSettingsModel.class,
+                AdminChangeRecord.SCOPE_STORAGE, AdminChangeRecord.RISK_HIGH, false),
+   LOGIN_BANNER("loginBanner", PresentationLoginBannerSettingsModel.class,
+                AdminChangeRecord.SCOPE_STORAGE, AdminChangeRecord.RISK_HIGH, false),
+   PORTAL_INTEGRATION("portalIntegration", PortalIntegrationSettingsModel.class,
+                       AdminChangeRecord.SCOPE_STORAGE, AdminChangeRecord.RISK_HIGH, false),
+   PDF_GENERATION("pdfGeneration", PresentationPdfGenerationSettingsModel.class,
+                  AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   EXPORT_MENU("exportMenu", PresentationExportMenuSettingsModel.class,
+               AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   FONT_MAPPING("fontMapping", PresentationFontMappingSettingsModel.class,
+                AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, true),
+   SHARE("share", PresentationShareSettingsModel.class,
+         AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   COMPOSER_MESSAGE("composerMessage", PresentationComposerMessageSettingsModel.class,
+                     AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   TIME("time", PresentationTimeSettingsModel.class,
+        AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   DATA_SOURCE_VISIBILITY("dataSourceVisibility", PresentationDataSourceVisibilitySettingsModel.class,
+                           AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   WEB_MAP("webMap", WebMapSettingsModel.class,
+           AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, false),
+   AI("ai", PresentationAISettingsModel.class,
+      AdminChangeRecord.SCOPE_VALUE, AdminChangeRecord.RISK_LOW, true);
+
+   PresentationSubModel(String key, Class<?> modelClass, String scope, String risk,
+                         boolean globalOnly)
+   {
+      this.key = key;
+      this.modelClass = modelClass;
+      this.scope = scope;
+      this.risk = risk;
+      this.globalOnly = globalOnly;
+      this.fieldNames = PresentationJson.fieldNames(modelClass);
+   }
+
+   public String key() {
+      return key;
+   }
+
+   public Class<?> modelClass() {
+      return modelClass;
+   }
+
+   /** {@link AdminChangeRecord#SCOPE_VALUE} for a thin {@code SreeEnv} wrapper, or
+    * {@link AdminChangeRecord#SCOPE_STORAGE} for one of the 4 {@code DataSpace}-backed sub-models
+    * (01-spec.md section 4). */
+   public String scope() {
+      return scope;
+   }
+
+   /** {@link AdminChangeRecord#RISK_HIGH} for the 4 storage-scope sub-models, {@link
+    * AdminChangeRecord#RISK_LOW} for the other 12 (01-spec.md section 4). */
+   public String risk() {
+      return risk;
+   }
+
+   public boolean isStorageScope() {
+      return AdminChangeRecord.SCOPE_STORAGE.equals(scope);
+   }
+
+   /** {@code fontMapping}/{@code ai} -- the underlying sub-service takes no org-scope parameter at
+    * all, so {@code scope: "organization"} is refused rather than silently applied to the global
+    * layer (01-spec.md section 11). */
+   public boolean globalOnly() {
+      return globalOnly;
+   }
+
+   /** The exact set of {@code spec} field names this sub-model accepts (01-spec.md section 5) --
+    * mechanically derived from {@link #modelClass()}, see {@link PresentationJson#fieldNames}. */
+   public Set<String> fieldNames() {
+      return fieldNames;
+   }
+
+   /** Exact, case-sensitive match against the 16 names (01-spec.md section 11) -- no fuzzy/prefix
+    * matching, since a wrong guess here would silently target the wrong sub-model.
+    *
+    * @throws IllegalArgumentException naming all 16 valid values when {@code key} does not match. */
+   public static PresentationSubModel require(String key) {
+      for(PresentationSubModel subModel : values()) {
+         if(subModel.key.equals(key)) {
+            return subModel;
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "subModel: \"" + key + "\" is not one of the 16 recognized presentation sub-models (" +
+         allKeys() + ")");
+   }
+
+   public static String allKeys() {
+      return Arrays.stream(values()).map(PresentationSubModel::key)
+         .collect(Collectors.joining(", "));
+   }
+
+   private final String key;
+   private final Class<?> modelClass;
+   private final String scope;
+   private final String risk;
+   private final boolean globalOnly;
+   private final Set<String> fieldNames;
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
@@ -1,0 +1,436 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.general.model.WebMapSettingsModel;
+import inetsoft.web.admin.presentation.model.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * 01-spec.md section 0/2 (16-entry catalog, dead-field exclusion), section 4 (risk/scope split),
+ * section 5 (partial-{@code spec} merge, {@code viewsheetToolbar}/{@code portalIntegration.tabs}
+ * whole-list treatment), section 9 (webMap secret masking/refusal), section 11 (global-only refusal,
+ * verb/scope/subModel validation); 03-reconcile.md Addition 1 (lookAndFeel file name sanitization)
+ * and Addition 2 (portalIntegration.tabs whole-list enforcement).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PresentationChangePlanServiceTest {
+   @Mock
+   private PresentationSettingsAccess access;
+   private PresentationChangePlanService service;
+
+   private static final Principal PRINCIPAL = () -> "admin";
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   @BeforeEach
+   void setUp() {
+      service = new PresentationChangePlanService(access);
+   }
+
+   // ---------------------------------------------------------------- request builders
+
+   private static PresentationChangeRequest change(String subModel, String scope, ObjectNode spec) {
+      PresentationChangeRequest r = new PresentationChangeRequest();
+      r.setVerb("update");
+      r.setSubModel(subModel);
+      r.setScope(scope);
+      r.setSpec(spec);
+      return r;
+   }
+
+   private static PresentationChangePlanRequest request(String task, PresentationChangeRequest... changes) {
+      PresentationChangePlanRequest req = new PresentationChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(Arrays.asList(changes));
+      return req;
+   }
+
+   private static ObjectNode obj() {
+      return MAPPER.createObjectNode();
+   }
+
+   private void stub(PresentationSubModel subModel, Object current) throws Exception {
+      lenient().when(access.read(eq(subModel), any(), anyBoolean())).thenReturn(current);
+   }
+
+   // ---------------------------------------------------------------- minimal valid fixtures, one per sub-model
+
+   private static Object currentFor(PresentationSubModel subModel) {
+      switch(subModel) {
+      case FORMATS:
+         return PresentationFormatsSettingsModel.builder()
+            .dateFormat("MM/dd/yyyy").timeFormat("HH:mm").dateTimeFormat("MM/dd/yyyy HH:mm").build();
+      case DASHBOARD:
+         return PresentationDashboardSettingsModel.builder()
+            .enabled(true).tabsTop(false).drillTabsTop(false).build();
+      case VIEWSHEET_TOOLBAR:
+         return PresentationViewsheetToolbarOptionsModel.builder()
+            .options(List.of(ToolbarOption.builder().id("save").visible(true).enabled(true).build()))
+            .build();
+      case LOOK_AND_FEEL:
+         return LookAndFeelSettingsModel.builder()
+            .ascending(true).repositoryTree(true).expand(false)
+            .defaultLogo(true).defaultFavicon(true).defaultViewsheet(true).defaultFont(true)
+            .viewsheetCSSEntries(List.of()).vsEnabled(true).build();
+      case WELCOME_PAGE:
+         return WelcomePageSettingsModel.builder().type(0).source("").build();
+      case LOGIN_BANNER:
+         return PresentationLoginBannerSettingsModel.builder().bannerType("0").loginBanner("").build();
+      case PORTAL_INTEGRATION:
+         return PortalIntegrationSettingsModel.builder()
+            .tabs(List.of(
+               PortalTabModel.builder().name("Dashboard").label("Dashboard").uri("/dashboard")
+                  .visible(true).editable(false).originalIndex(0).build(),
+               PortalTabModel.builder().name("Report").label("Repository").uri("/report")
+                  .visible(true).editable(false).originalIndex(1).build()))
+            .help(true).preference(true).logout(true).search(true).dashboardAvailable(true)
+            .home(true).customLoadingText("").homeLink("").emHomeLink("").build();
+      case PDF_GENERATION:
+         return PresentationPdfGenerationSettingsModel.builder()
+            .compressText(true).compressImage(true).asciiOnly(false).mapSymbols(false)
+            .pdfEmbedCmap(false).pdfEmbedFont(false).browserEmbedPdf(false).pdfHyperlinks(true)
+            .build();
+      case EXPORT_MENU:
+         return PresentationExportMenuSettingsModel.builder()
+            .vsOptions(List.of(ExportMenuOption.builder().name("PDF").description("PDF").value(true)
+                                  .build()))
+            .vsEnabled(true).build();
+      case FONT_MAPPING:
+         return PresentationFontMappingSettingsModel.builder().fontMappings(List.of()).build();
+      case SHARE:
+         return PresentationShareSettingsModel.builder()
+            .emailEnabled(true).facebookEnabled(false).googleChatEnabled(false)
+            .linkedinEnabled(false).slackEnabled(false).twitterEnabled(false).linkEnabled(true)
+            .openGraphTitle("").openGraphDescription("").openGraphSiteName("").openGraphImageUrl("")
+            .build();
+      case COMPOSER_MESSAGE:
+         return PresentationComposerMessageSettingsModel.builder()
+            .worksheetCreateMessage("").worksheetEditMessage("").viewsheetCreateMessage("")
+            .viewsheetEditMessage("").build();
+      case TIME:
+         return PresentationTimeSettingsModel.builder().weekStart("Sunday").scheduleTime12Hours(true)
+            .build();
+      case DATA_SOURCE_VISIBILITY:
+         return PresentationDataSourceVisibilitySettingsModel.builder().build();
+      case WEB_MAP:
+         return WebMapSettingsModel.builder().service("mapbox").defaultOn(false)
+            .mapboxUser("user").mapboxToken("secret-token").mapboxStyle("streets")
+            .googleKey("secret-key").build();
+      case AI:
+         return PresentationAISettingsModel.builder().aiAssistantVisible(true)
+            .chatAppServerUrl("https://example.com").build();
+      default:
+         throw new IllegalStateException("unhandled sub-model in test fixture: " + subModel);
+      }
+   }
+
+   /** One valid, minimal partial {@code spec} per sub-model -- deliberately avoids the {@code tabs}/
+    * secret fields the dedicated Addition-1/Addition-2/section-9 tests cover on their own. */
+   private static ObjectNode specFor(PresentationSubModel subModel) {
+      ObjectNode spec = obj();
+
+      switch(subModel) {
+      case FORMATS -> spec.put("dateFormat", "yyyy-MM-dd");
+      case DASHBOARD -> spec.put("enabled", false);
+      case VIEWSHEET_TOOLBAR -> {
+         ArrayNode options = spec.putArray("options");
+         options.addObject().put("id", "save").put("visible", false).put("enabled", true);
+      }
+      case LOOK_AND_FEEL -> spec.put("expand", true);
+      case WELCOME_PAGE -> spec.put("type", 1);
+      case LOGIN_BANNER -> spec.put("bannerType", "1");
+      case PORTAL_INTEGRATION -> spec.put("help", false);
+      case PDF_GENERATION -> spec.put("compressText", false);
+      case EXPORT_MENU -> spec.put("vsEnabled", true);
+      case FONT_MAPPING -> spec.putArray("fontMappings");
+      case SHARE -> spec.put("emailEnabled", false);
+      case COMPOSER_MESSAGE -> spec.put("viewsheetCreateMessage", "hello");
+      case TIME -> spec.put("scheduleTime12Hours", false);
+      case DATA_SOURCE_VISIBILITY -> spec.putArray("hiddenDataSources");
+      case WEB_MAP -> spec.put("defaultOn", true);
+      case AI -> spec.put("aiAssistantVisible", false);
+      default -> throw new IllegalStateException("unhandled sub-model in test fixture: " + subModel);
+      }
+
+      return spec;
+   }
+
+   // ---------------------------------------------------------------- section 4: risk/scope, one per sub-model
+
+   @Test
+   void allSixteenSubModelsResolveToTheirDeclaredRiskAndScope() throws Exception {
+      for(PresentationSubModel subModel : PresentationSubModel.values()) {
+         stub(subModel, currentFor(subModel));
+         String scope = subModel.globalOnly() ? "global" : "organization";
+         PresentationChangePlanRequest req =
+            request("update " + subModel.key(), change(subModel.key(), scope, specFor(subModel)));
+
+         var plan = service.resolve(req, PRINCIPAL);
+
+         assertEquals(1, plan.changes().size(), subModel.key());
+         var planChange = plan.changes().get(0);
+         assertEquals(subModel.risk(), planChange.risk(), subModel.key() + " risk");
+         assertEquals(subModel.scope(), planChange.snapshotScope(), subModel.key() + " scope");
+         assertEquals(subModel.key() + ":" + scope, planChange.property(), subModel.key() + " property");
+         assertTrue(plan.requiresAgentSignoff());
+         assertTrue(plan.requiresStorageBackup());
+      }
+   }
+
+   @Test
+   void storageScopeSetIsExactlyTheFourExpectedSubModels() {
+      for(PresentationSubModel subModel : PresentationSubModel.values()) {
+         boolean expectedStorage = subModel == PresentationSubModel.LOOK_AND_FEEL
+            || subModel == PresentationSubModel.WELCOME_PAGE
+            || subModel == PresentationSubModel.LOGIN_BANNER
+            || subModel == PresentationSubModel.PORTAL_INTEGRATION;
+         assertEquals(expectedStorage, subModel.isStorageScope(), subModel.key());
+         assertEquals(expectedStorage ? AdminChangeRecord.RISK_HIGH : AdminChangeRecord.RISK_LOW,
+                      subModel.risk(), subModel.key());
+      }
+   }
+
+   // ---------------------------------------------------------------- section 2: dead fields / unrecognized names
+
+   @Test
+   void deadModelFieldsAreNotRecognizedSubModelNames() {
+      assertThrows(IllegalArgumentException.class,
+                  () -> PresentationSubModel.require("reportToolbarOptionsModel"));
+      assertThrows(IllegalArgumentException.class,
+                  () -> PresentationSubModel.require("reportViewerSettingsModel"));
+   }
+
+   @Test
+   void unrecognizedSubModelIsRefusedNamingAllSixteen() {
+      PresentationChangePlanRequest req =
+         request("t", change("notARealSubModel", "global", obj().put("x", 1)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("notARealSubModel"));
+      assertTrue(ex.getMessage().contains("lookAndFeel"));
+      assertTrue(ex.getMessage().contains("ai"));
+   }
+
+   // ---------------------------------------------------------------- section 11: fontMapping/ai global-only
+
+   @Test
+   void fontMappingRejectsOrganizationScope() throws Exception {
+      stub(PresentationSubModel.FONT_MAPPING, currentFor(PresentationSubModel.FONT_MAPPING));
+      PresentationChangePlanRequest req = request("t",
+         change("fontMapping", "organization", specFor(PresentationSubModel.FONT_MAPPING)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("global-only"));
+   }
+
+   @Test
+   void aiRejectsOrganizationScope() throws Exception {
+      stub(PresentationSubModel.AI, currentFor(PresentationSubModel.AI));
+      PresentationChangePlanRequest req =
+         request("t", change("ai", "organization", specFor(PresentationSubModel.AI)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("global-only"));
+   }
+
+   // ---------------------------------------------------------------- section 5: spec validation
+
+   @Test
+   void unknownSpecFieldIsRefusedNamingFieldAndSubModel() throws Exception {
+      stub(PresentationSubModel.FORMATS, currentFor(PresentationSubModel.FORMATS));
+      PresentationChangePlanRequest req = request("t",
+         change("formats", "organization", obj().put("notARealField", "x")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("notARealField"));
+      assertTrue(ex.getMessage().contains("formats"));
+   }
+
+   @Test
+   void verbOtherThanUpdateIsRefused() {
+      PresentationChangeRequest raw = change("formats", "organization", obj().put("dateFormat", "x"));
+      raw.setVerb("create");
+      PresentationChangePlanRequest req = request("t", raw);
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("update"));
+   }
+
+   @Test
+   void duplicateSubModelAndScopePairIsRefused() throws Exception {
+      stub(PresentationSubModel.FORMATS, currentFor(PresentationSubModel.FORMATS));
+      PresentationChangePlanRequest req = request("t",
+         change("formats", "organization", obj().put("dateFormat", "a")),
+         change("formats", "organization", obj().put("timeFormat", "b")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("duplicate"));
+   }
+
+   @Test
+   void sameSubModelDifferentScopeIsAllowed() throws Exception {
+      stub(PresentationSubModel.FORMATS, currentFor(PresentationSubModel.FORMATS));
+      PresentationChangePlanRequest req = request("t",
+         change("formats", "global", obj().put("dateFormat", "a")),
+         change("formats", "organization", obj().put("dateFormat", "b")));
+
+      var plan = service.resolve(req, PRINCIPAL);
+      assertEquals(2, plan.changes().size());
+   }
+
+   @Test
+   void emptySpecIsRefused() {
+      PresentationChangePlanRequest req = request("t", change("formats", "organization", obj()));
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+   }
+
+   @Test
+   void blankTaskIsRefused() {
+      PresentationChangePlanRequest req =
+         request("   ", change("formats", "organization", obj().put("dateFormat", "x")));
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+   }
+
+   @Test
+   void emptyChangesIsRefused() {
+      PresentationChangePlanRequest req = new PresentationChangePlanRequest();
+      req.setTask("t");
+      req.setChanges(List.of());
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+   }
+
+   // ---------------------------------------------------------------- 03-reconcile.md Addition 1: lookAndFeel file names
+
+   @Test
+   void lookAndFeelFileNameIsNormalizedToASafeBasename() throws Exception {
+      stub(PresentationSubModel.LOOK_AND_FEEL, currentFor(PresentationSubModel.LOOK_AND_FEEL));
+      ObjectNode spec = obj();
+      spec.putObject("viewsheetFile").put("name", "../../etc/passwd").put("content", "YWJj");
+      spec.put("defaultViewsheet", false);
+      PresentationChangePlanRequest req = request("t", change("lookAndFeel", "organization", spec));
+
+      var plan = service.resolve(req, PRINCIPAL);
+      String proposed = plan.changes().get(0).proposedValue();
+      assertTrue(proposed.contains("\"name\":\"passwd\""), proposed);
+      assertFalse(proposed.contains(".."), proposed);
+   }
+
+   @Test
+   void lookAndFeelFileNameThatIsOnlyDotsIsRefused() throws Exception {
+      stub(PresentationSubModel.LOOK_AND_FEEL, currentFor(PresentationSubModel.LOOK_AND_FEEL));
+      ObjectNode spec = obj();
+      spec.putObject("logoFile").put("name", "..").put("content", "YWJj");
+      spec.put("defaultLogo", false);
+      PresentationChangePlanRequest req = request("t", change("lookAndFeel", "organization", spec));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("logoFile"));
+   }
+
+   // ---------------------------------------------------------------- 03-reconcile.md Addition 2: portalIntegration.tabs
+
+   @Test
+   void portalIntegrationTabsMustIncludeEveryCurrentTab() throws Exception {
+      stub(PresentationSubModel.PORTAL_INTEGRATION, currentFor(PresentationSubModel.PORTAL_INTEGRATION));
+      ObjectNode spec = obj();
+      ArrayNode tabs = spec.putArray("tabs");
+      tabs.addObject().put("name", "Dashboard").put("label", "Dashboard").put("uri", "/dashboard")
+         .put("visible", false).put("editable", false).put("originalIndex", 0);
+      // current fixture has 2 tabs; this spec supplies only 1 -- must be refused.
+      PresentationChangePlanRequest req =
+         request("t", change("portalIntegration", "global", spec));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("tabs"));
+   }
+
+   @Test
+   void portalIntegrationWholeTabListIsAccepted() throws Exception {
+      stub(PresentationSubModel.PORTAL_INTEGRATION, currentFor(PresentationSubModel.PORTAL_INTEGRATION));
+      ObjectNode spec = obj();
+      ArrayNode tabs = spec.putArray("tabs");
+      tabs.addObject().put("name", "Dashboard").put("label", "Dashboard").put("uri", "/dashboard")
+         .put("visible", false).put("editable", false).put("originalIndex", 0);
+      tabs.addObject().put("name", "Report").put("label", "Repository").put("uri", "/report")
+         .put("visible", true).put("editable", false).put("originalIndex", 1);
+      PresentationChangePlanRequest req =
+         request("t", change("portalIntegration", "global", spec));
+
+      var plan = service.resolve(req, PRINCIPAL);
+      assertEquals(1, plan.changes().size());
+   }
+
+   // ---------------------------------------------------------------- section 9: webMap secrets
+
+   @Test
+   void webMapMapboxTokenCannotBeSetThroughSpec() throws Exception {
+      stub(PresentationSubModel.WEB_MAP, currentFor(PresentationSubModel.WEB_MAP));
+      PresentationChangePlanRequest req = request("t",
+         change("webMap", "organization", obj().put("mapboxToken", "new-secret")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("mapboxToken"));
+   }
+
+   @Test
+   void webMapGoogleKeyCannotBeSetThroughSpec() throws Exception {
+      stub(PresentationSubModel.WEB_MAP, currentFor(PresentationSubModel.WEB_MAP));
+      PresentationChangePlanRequest req = request("t",
+         change("webMap", "organization", obj().put("googleKey", "new-secret")));
+
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+   }
+
+   @Test
+   void webMapSecretsAreMaskedInThePlanProjection() throws Exception {
+      stub(PresentationSubModel.WEB_MAP, currentFor(PresentationSubModel.WEB_MAP));
+      PresentationChangePlanRequest req =
+         request("t", change("webMap", "organization", specFor(PresentationSubModel.WEB_MAP)));
+
+      var plan = service.resolve(req, PRINCIPAL);
+      String current = plan.changes().get(0).currentValue();
+      assertFalse(current.contains("secret-token"), current);
+      assertFalse(current.contains("secret-key"), current);
+      assertTrue(current.contains("********"), current);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
@@ -1,0 +1,259 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.uql.XPrincipal;
+import inetsoft.web.admin.ai.AdminBackupService;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.presentation.model.LookAndFeelSettingsModel;
+import inetsoft.web.admin.presentation.model.PresentationDashboardSettingsModel;
+import inetsoft.web.admin.presentation.model.PresentationFormatsSettingsModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 6 (apply/rollback per verb, echoed-hash gate), section 7 (unconditional Tier-2
+ * backup), section 11 ({@code reviewOutcome} always required, {@code acknowledgeIrreversibleUpdate}
+ * required exactly when a storage-scope sub-model is touched). {@code PresentationSettingsAccess} is
+ * mocked with an in-memory map so write-then-read-back verification and rollback assertions reflect
+ * real state transitions, matching {@code LicenseChangesetApplyServiceTest}'s own in-memory-fake
+ * pattern.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PresentationChangesetApplyServiceTest {
+   @Mock
+   private PresentationSettingsAccess access;
+   @Mock
+   private AdminBackupService backupService;
+   @Mock
+   private XPrincipal user;
+
+   private final Map<String, Object> state = new HashMap<>();
+   private PresentationChangePlanService planService;
+   private PresentationChangesetApplyService service;
+
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   @BeforeEach
+   void setUp() throws Exception {
+      planService = new PresentationChangePlanService(access);
+      service = new PresentationChangesetApplyService(planService, access, backupService);
+
+      lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
+
+      lenient().when(access.read(any(), any(), anyBoolean())).thenAnswer(inv -> {
+         PresentationSubModel subModel = inv.getArgument(0);
+         boolean global = inv.getArgument(2);
+         return state.get(stateKey(subModel, global));
+      });
+
+      lenient().doAnswer(inv -> {
+         PresentationSubModel subModel = inv.getArgument(0);
+         Object model = inv.getArgument(1);
+         boolean global = inv.getArgument(3);
+         state.put(stateKey(subModel, global), model);
+         return null;
+      }).when(access).write(any(), any(), any(), anyBoolean());
+   }
+
+   private static String stateKey(PresentationSubModel subModel, boolean global) {
+      return subModel.key() + ":" + global;
+   }
+
+   private void seed(PresentationSubModel subModel, boolean global, Object current) {
+      state.put(stateKey(subModel, global), current);
+   }
+
+   private static ObjectNode obj() {
+      return MAPPER.createObjectNode();
+   }
+
+   private static PresentationChangeRequest change(String subModel, String scope, ObjectNode spec) {
+      PresentationChangeRequest r = new PresentationChangeRequest();
+      r.setVerb("update");
+      r.setSubModel(subModel);
+      r.setScope(scope);
+      r.setSpec(spec);
+      return r;
+   }
+
+   private PresentationApplyRequest applyRequest(String task, String reviewOutcome,
+                                                 Boolean acknowledgeIrreversibleUpdate,
+                                                 PresentationChangeRequest... changes)
+      throws Exception
+   {
+      PresentationChangePlanRequest preview = new PresentationChangePlanRequest();
+      preview.setTask(task);
+      preview.setChanges(List.of(changes));
+      var plan = planService.resolve(preview, user);
+
+      PresentationApplyRequest apply = new PresentationApplyRequest();
+      apply.setTask(task);
+      apply.setChanges(List.of(changes));
+      apply.setPlanHash(plan.planHash());
+      apply.setReviewOutcome(reviewOutcome);
+      apply.setAcknowledgeIrreversibleUpdate(acknowledgeIrreversibleUpdate);
+      return apply;
+   }
+
+   private static PresentationFormatsSettingsModel formats(String dateFormat) {
+      return PresentationFormatsSettingsModel.builder()
+         .dateFormat(dateFormat).timeFormat("HH:mm").dateTimeFormat("MM/dd/yyyy HH:mm").build();
+   }
+
+   private static PresentationDashboardSettingsModel dashboard(boolean enabled) {
+      return PresentationDashboardSettingsModel.builder()
+         .enabled(enabled).tabsTop(false).drillTabsTop(false).build();
+   }
+
+   private static LookAndFeelSettingsModel lookAndFeel(boolean expand) {
+      return LookAndFeelSettingsModel.builder()
+         .ascending(true).repositoryTree(true).expand(expand)
+         .defaultLogo(true).defaultFavicon(true).defaultViewsheet(true).defaultFont(true)
+         .viewsheetCSSEntries(List.of()).vsEnabled(true).build();
+   }
+
+   // ---------------------------------------------------------------- applied
+
+   @Test
+   void applySucceedsForAValueScopeChange() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationApplyRequest req = applyRequest("t", "looks good", null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")));
+
+      var result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertEquals(1, result.results().size());
+      assertEquals("verified", result.results().get(0).status());
+      assertNull(result.rollbackFailures());
+      verify(backupService).backup(anyString());
+   }
+
+   @Test
+   void applyRefusesWithoutReviewOutcome() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationApplyRequest req = applyRequest("t", null, null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")));
+
+      assertThrows(IllegalArgumentException.class, () -> service.apply(req, user));
+   }
+
+   @Test
+   void applyRefusesAStaleHash() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationApplyRequest req = applyRequest("t", "ok", null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")));
+      req.setPlanHash("not-the-real-hash");
+
+      assertThrows(AdminChangesetApplyService.PlanHashMismatchException.class,
+                  () -> service.apply(req, user));
+   }
+
+   // ---------------------------------------------------------------- storage-scope acknowledgement gate
+
+   @Test
+   void applyRefusesStorageScopeChangeWithoutAcknowledgement() throws Exception {
+      seed(PresentationSubModel.LOOK_AND_FEEL, true, lookAndFeel(false));
+      PresentationApplyRequest req = applyRequest("t", "ok", null,
+         change("lookAndFeel", "global", obj().put("expand", true)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.apply(req, user));
+      assertTrue(ex.getMessage().contains("acknowledgeIrreversibleUpdate"));
+   }
+
+   @Test
+   void applyAllowsStorageScopeChangeWithAcknowledgement() throws Exception {
+      seed(PresentationSubModel.LOOK_AND_FEEL, true, lookAndFeel(false));
+      PresentationApplyRequest req = applyRequest("t", "ok", true,
+         change("lookAndFeel", "global", obj().put("expand", true)));
+
+      var result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+   }
+
+   // ---------------------------------------------------------------- rollback: value-scope
+
+   @Test
+   void applyRollsBackAnEarlierValueScopeChangeWhenALaterChangeFailsVerification() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      seed(PresentationSubModel.DASHBOARD, false, dashboard(true));
+
+      PresentationApplyRequest req = applyRequest("t", "ok", null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")),
+         change("dashboard", "organization", obj().put("enabled", false)));
+
+      // Simulate a mid-apply failure on the SECOND change only, via a clean (non-throwing)
+      // read-back mismatch rather than a thrown exception: a throw leaves that property's own
+      // state genuinely unknown and must always force rollback-failed (see the dedicated
+      // storage-scope/non-compensable test below for that case) -- a verified-false outcome is
+      // the only failure shape that can still legitimately end in rolled-back.
+      doAnswer(inv -> null)
+         .when(access).write(eq(PresentationSubModel.DASHBOARD), any(), any(), anyBoolean());
+
+      var result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      // formats was written, then rolled back to its original value.
+      Object restored = state.get(stateKey(PresentationSubModel.FORMATS, false));
+      assertEquals("MM/dd/yyyy", ((PresentationFormatsSettingsModel) restored).dateFormat());
+   }
+
+   // ---------------------------------------------------------------- rollback: storage-scope non-compensable
+
+   @Test
+   void applyReportsRollbackFailedWhenAStorageScopeChangeAlreadySucceededBeforeALaterFailure()
+      throws Exception
+   {
+      seed(PresentationSubModel.LOOK_AND_FEEL, true, lookAndFeel(false));
+      seed(PresentationSubModel.FORMATS, true, formats("MM/dd/yyyy"));
+
+      PresentationApplyRequest req = applyRequest("t", "ok", true,
+         change("lookAndFeel", "global", obj().put("expand", true)),
+         change("formats", "global", obj().put("dateFormat", "yyyy-MM-dd")));
+
+      doThrow(new RuntimeException("boom"))
+         .when(access).write(eq(PresentationSubModel.FORMATS), any(), any(), anyBoolean());
+
+      var result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertNotNull(result.rollbackFailures());
+      assertTrue(result.rollbackFailures().stream()
+                    .anyMatch(f -> f.property().startsWith("lookAndFeel:")));
+      // The storage-scope write itself is never undone -- still the new value.
+      Object stillApplied = state.get(stateKey(PresentationSubModel.LOOK_AND_FEEL, true));
+      assertTrue(((LookAndFeelSettingsModel) stillApplied).expand());
+   }
+}


### PR DESCRIPTION
## Summary

Adds the Java/community-tier surface for the admin-chat **Presentation settings** area (Track C.5
area 3): a hardcoded 16 sub-model catalog (`formats` through `ai`) with get/preview/apply endpoints
under `/api/wiz/v1/admin/presentation/**`, modeled on the `licensing` area's own shared
`PlanChange`/`ResolvedPlan`/`ApplyOutcome`/`ApplyResult` machinery (`inetsoft.web.admin.ai.*`).

Key safety properties:

- **Authorization**: `AdminAiCallerGuard.requireBearerAuthenticatedRequest()` +
  `OrganizationManager.isSiteAdmin(user)`, the same shape as every other community-tier admin-chat
  area (`AdminLicensingController`/`AdminProviderController`).
- **`webMap` secrets** (`mapboxToken`/`googleKey`): refused outright on any write `spec`
  (`requireNoSecretFields`), masked on every read/plan/audit projection
  (`PresentationJson.maskWebMapSecrets`) -- the real write path itself carries the unmasked live
  value through correctly (verified this does not repeat the data-sources area's own password
  overwrite bug).
- **`lookAndFeel` file-name sanitization**: strips any path prefix, refuses blank/dot-only/`..`
  results -- unconditional, stricter than the plugin's own client-side pre-check.
- **`portalIntegration.tabs` whole-list enforcement**: refuses any length mismatch (not just
  shorter) against a freshly re-read live tab count -- closes a silent whole-tab-list-drop hazard in
  the underlying `PortalIntegrationViewSettingsService.setModel`'s raw-index list replace.
- **Rollback**: 12 value-scope sub-models are compensated newest-first with write-then-read-back
  verification; the 4 storage-scope sub-models (file-backed, no compensating inverse) are never
  silently reported as rolled back if they already succeeded before a later failure -- forces
  `rollback-failed` instead, with a real state assertion (not just a status string) confirming the
  already-applied value is not misrepresented.

Known, accepted limitation (matching `licensing`/`cluster` in the same pin): the apply lock
(`PresentationChangesetApplyService.APPLY_LOCK`) is JVM-local (`ReentrantLock`), not the real
cluster-wide `SETTINGS_LOCK` -- a documented, non-blocking, program-wide limitation, not specific to
this area.

## Design chain

`docs/teams/2026-08-27-track-c5-presentation/00-charter.md` through `08-review-r1.md` (spec,
verify-plan, reconcile, build, verify, fix round, independent adversarial security review -- all
approved, no findings >= 8/10 severity, no build-blocking findings).

## Defects filed against underlying product code during this track's design/verify passes

- `stylebi#76360`
- `stylebi#76361`

## Test plan

- [x] `./mvnw -pl core test -o -Dtest="PresentationChangePlanServiceTest,PresentationChangesetApplyServiceTest"`
      -- 27/27 passing, 0 failures, 0 errors, BUILD SUCCESS.
- [x] `./mvnw -pl core -am test-compile -o` -- full module + dependencies compile clean.
- [x] Independently re-run in `08-review-r1.md`'s own adversarial pass -- same result.