### PR TITLE
Bug #76005, disable scroll anchoring on tree containers to fix scrollbar jump

### DIFF
--- a/web/projects/portal/src/app/widget/tree/tree.component.scss
+++ b/web/projects/portal/src/app/widget/tree/tree.component.scss
@@ -63,6 +63,9 @@
     flex-grow: 1;
     //height: 100%;
     padding-left: 4px;
+    // disable scroll anchoring so resizing the virtual-scroll spacer divs on scroll doesn't
+    // trigger the browser to auto-adjust scrollTop, which caused runaway scroll jumps (76005)
+    overflow-anchor: none;
 
     &.vscrollable-always {
       overflow-y: auto;


### PR DESCRIPTION
## Summary

When a viewsheet has many assemblies, the Script tab's column tree (e.g. Properties > Script > Component/ComboBoxN) switches to a virtual-scroll rendering mode once the tree exceeds 500 nodes. Clicking the scrollbar's down arrow a second time, or scrolling with the mouse wheel, would cause the scrollbar to snap straight to the end of the list instead of scrolling incrementally.

## Root Cause

The virtual-scroll tree (`TreeComponent` with `useVirtualScroll` enabled, used by `virtual-scroll-tree` in the script pane) renders only a windowed subset of nodes, padded above/below by spacer `<div>`s whose heights are recalculated synchronously on every native `scroll` event (`calculateBounds()` in `tree.component.ts`), then applied immediately via `ChangeDetectorRef.detectChanges()`.

Because the spacer div above the visible content resizes synchronously in response to scrolling, Chrome's CSS scroll-anchoring feature detects the shift and auto-adjusts `scrollTop` to compensate. That adjustment fires another `scroll` event, which recalculates and resizes the spacer again — a feedback loop that snowballs the scroll position toward the end of the list.

This is a known pattern elsewhere in the codebase: `VirtualScrollTreeDatasource.restoreScrollTop()` is explicitly commented as a hack to work around "scroll anchoring type behavior", but it's only wired up for the binding tree, not this virtual-scroll-tree path. Disabling scroll anchoring via CSS (`overflow-anchor: none`) is the established fix used elsewhere for the same class of problem (`viewsheet-pane.component.scss`, `ws-details-table-data.component.scss`).

## Fix

Added `overflow-anchor: none;` to the shared `.tree-container` rule in `tree.component.scss`, the scrollable container used by every `TreeComponent` instance (virtual-scroll and non-virtual-scroll alike). This is a no-op for non-scrolling trees and only disables the browser's automatic scroll-position compensation, with no functional change to app logic.

## Test Plan

- `npm run build` (portal/em/elements/viewer-element) compiles clean.
- All tree-related test suites pass: `tree`/`virtual-scroll-tree` (271 tests) and `script-pane`/`vsassembly-script-pane` (39 tests).
- Manually reproduced the bug (viewsheet with many assemblies, Properties > Script tab, expand `Component/<assembly>`, click the scrollbar down arrow twice / mouse-wheel scroll) — scrolling now advances smoothly without jumping to the end.

Fixes Redmine #76005.