### PR TITLE
Bug #75990, surface the permission-denied error when moving a schedule task in EM

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -458,10 +458,11 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
             this.http.post(TASKS_MOVE_URI, moveTaskFolderRequest).subscribe(() => {
                this.loadTasks();
             }, (error) => {
-               if(error.status == 403) {
-                  this.dialog.open(MessageDialog, this.setConfigs(`_#(js:Unauthorized)`,
-                     "_#(js:schedule.folder.moveTargetPermissionError)", MessageDialogType.ERROR));
-               }
+               const message = error.error != null && error.error.type == "MessageException" ?
+                  error.error.message : "Failed to move selected tasks";
+
+               this.dialog.open(MessageDialog, this.setConfigs(`_#(js:Error)`,
+                  message, MessageDialogType.ERROR));
             });
          }
       });


### PR DESCRIPTION
## Summary

Moving a schedule task in Enterprise Manager to a folder the user lacks WRITE
permission on correctly blocked the move server-side, but the EM UI's move
dialog just closed silently with no error shown to the user.

## Root Cause

`ScheduleTaskFolderService.moveScheduleItems()` throws a `MessageException`
when the destination folder lacks WRITE permission (added by the #75946 fix).
For EM's move-folder endpoint (`EMScheduleTaskFolderController`, package
`inetsoft.web.admin.schedule`), this exception is handled by
`AdminExceptionHandler`'s generic `Exception` fallback, which maps it to HTTP
**500**, not 403.

EM's `ScheduleTaskListComponent.moveTasks()` error handler only displayed a
message dialog when `error.status == 403`, so it never matched and nothing
was shown — even though the move was correctly rejected.

(Portal's equivalent move flow doesn't have this bug because its error
handler shows `error.error.message` regardless of status code.)

## Fix

Updated the EM `moveTasks()` error handler to show the server's specific
`MessageException` message (falling back to a generic message otherwise),
matching the existing pattern already used in the same file's `removeTasks()`
handler and in `repository-schedule-task-folder-settings-page.component.ts`.

## Test Plan

- [x] `ng build em` succeeds
- [x] `ng run em:test-tl` — all 818 tests pass (70 files), including the 35
      tests in `schedule-task-list.component.tl.spec.ts`
- [x] Code-reviewed (confirmed the fallback message doesn't misrepresent
      unrelated failures, matches established codebase convention)
- Manual repro: create a non-admin user with READ-only permission on a
  schedule folder, log in as that user in EM, attempt to move a task into
  that folder — a "permission denied" dialog with the specific server
  message now appears instead of the dialog silently closing.

Fixes Redmine #75990.