### PR TITLE
Bug #76004, keep a date combobox on the day the user picked

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/model/VSComboBoxModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/VSComboBoxModel.java
@@ -66,7 +66,16 @@ public class VSComboBoxModel extends ListInputModel<ComboBoxVSAssembly> {
       }
 
       if(calendar && selectedObject instanceof Date) {
-         selectedObject = ((Date) selectedObject).getTime();
+         // a date has no time component. send it as a wall clock date string instead of an
+         // instant, otherwise the browser and java.util.Date may disagree on the time zone
+         // offset (historical offsets that are not a whole number of minutes) and shift the
+         // date by a day.
+         if(XSchema.DATE.equals(dataType)) {
+            selectedObject = new SimpleDateFormat("yyyy-MM-dd").format(selectedObject);
+         }
+         else {
+            selectedObject = ((Date) selectedObject).getTime();
+         }
       }
       // used entered value, don't convert to full date in serializer
       else if(editable && selectedObject instanceof Date) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -61,6 +61,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.awt.*;
 import java.security.Principal;
 import java.text.Format;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
@@ -161,7 +162,12 @@ public class VSInputService {
       Object selectedValue = event.value();
 
       try {
-         if(info.isCalendar() && selectedValue != null && !"".equals(selectedValue)) {
+         // a date is sent as a wall clock date string instead of an instant, and is
+         // converted in applySelection0() so that the submit button path gets it too
+         if(info.isCalendar() && isWallClockDate(info.getDataType(), selectedValue)) {
+            // not an instant, leave it alone
+         }
+         else if(info.isCalendar() && selectedValue != null && !"".equals(selectedValue)) {
             try {
                selectedValue = new Date(Long.parseLong(selectedValue.toString()));
             }
@@ -190,6 +196,39 @@ public class VSInputService {
       singleApplySelection(vsId, assemblyName, selectedValue, principal, dispatcher, linkUri);
 
       return null;
+   }
+
+   /**
+    * Check if the value is a wall clock date (yyyy-MM-dd), which is how the client sends the
+    * value of a date combobox. Such a value carries no time of day and no time zone, so it
+    * must not be treated as an instant.
+    */
+   private static boolean isWallClockDate(String dataType, Object value) {
+      return XSchema.DATE.equals(dataType) && value instanceof String &&
+         WALL_CLOCK_DATE.matcher((String) value).matches();
+   }
+
+   /**
+    * Convert a wall clock date string into the date it names, keeping the day exactly as
+    * picked. Both of the alternatives shift the day for a date inside a zone's Local Mean
+    * Time era: the browser resolves a zone offset through ICU, which models LMT, while
+    * java.util.Date reports a whole hour offset for the same instant, and CoreTool.parseDate
+    * splits the difference by parsing with LMT and truncating without it.
+    *
+    * @return the converted value, or the value unchanged if it is not a wall clock date.
+    */
+   private static Object convertWallClockDate(String dataType, Object value) {
+      if(!isWallClockDate(dataType, value)) {
+         return value;
+      }
+
+      try {
+         return java.sql.Date.valueOf(LocalDate.parse(value.toString()));
+      }
+      catch(Exception ex) {
+         LOG.debug("Not a valid date: {}", value, ex);
+         return value;
+      }
    }
 
    @ClusterWriteMethod
@@ -2804,7 +2843,15 @@ public class VSInputService {
 
       InputVSAssemblyInfo info = (InputVSAssemblyInfo) assembly.getVSAssemblyInfo();
       String type = assembly.getDataType();
-      Object obj = values == null || values.length == 0 ? null : Tool.getData(type, values[0]);
+
+      // don't write back into values[], it may alias the caller's array
+      Object firstValue = values == null || values.length == 0 ? null : values[0];
+
+      if(firstValue != null && info instanceof ComboBoxVSAssemblyInfo cinfo && cinfo.isCalendar()) {
+         firstValue = convertWallClockDate(type, firstValue);
+      }
+
+      Object obj = firstValue == null ? null : Tool.getData(type, firstValue);
 
       if(values !=null && values.length > 0 && obj == null && type.equals(CoreTool.BOOLEAN) && values[0].equals("")) {
          obj = "";
@@ -3851,5 +3898,6 @@ public class VSInputService {
    private final CoreLifecycleService coreLifecycleService;
    private final ViewsheetService viewsheetService;
    private final VSColumnHandler vsColumnHandler;
+   private static final Pattern WALL_CLOCK_DATE = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
    private static final Logger LOG = LoggerFactory.getLogger(VSInputService.class);
 }

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSComboBoxDateValueTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSComboBoxDateValueTest.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+/*
+ * Test strategy
+ *
+ * A calendar combobox whose data type is "date" has no time component. Its value used to travel
+ * to the server as epoch millis that the browser had moved into the server time zone. The
+ * browser resolves a zone offset through ICU, which models pre-1901 Local Mean Time, while
+ * java.util.Date/TimeZone report a whole hour offset for the same instant. For a date inside a
+ * zone's LMT era the two disagree by a few minutes, and truncating that instant to midnight
+ * turns the disagreement into a whole day: the user picked 1900-01-01 under Asia/Shanghai and
+ * the combobox came back showing 1899-12-31.
+ *
+ * The fix sends a wall clock "yyyy-MM-dd" string, which VSInputService turns straight into the
+ * java.sql.Date it names. Going through Tool.getData()'s string parse instead is NOT enough --
+ * CoreTool.parseDate() resolves LMT while the truncation that follows does not, so it loses the
+ * same day (pinned by [G2] below). That is a wider defect in CoreTool, left alone here.
+ *
+ * Surefire pins these tests to America/New_York (core/pom.xml argLine), whose LMT era ends in
+ * 1883, so 1880-01-01 stands in for the reported 1900-01-01 under Asia/Shanghai. The mechanism
+ * and the assertions are the same; only the zone's cutover year differs. (CoreTool.parseDate
+ * has an explicit special case for the literal "1900-01-01", which is why that one date happens
+ * to survive the string parse -- another sign this class of bug has been hit before.)
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] convertWallClockDate() keeps the day exactly as picked, for an LMT-era date and a
+ *      modern one, and yields a java.sql.Date that Tool.getData() then passes through
+ *      unchanged (no re-parse, no truncation).
+ * [G2] Pins the two paths this replaces -- an instant, and Tool.getData()'s own string parse --
+ *      both losing a day for an LMT-era date, so [G1] is not guarding a non-problem.
+ * [G3] isWallClockDate() accepts only a yyyy-MM-dd string on a "date" combobox; a millis
+ *      payload, a date/time string and the other date types still take the instant path.
+ * [G4] An impossible date that still matches the pattern is returned unchanged rather than
+ *      throwing out of the conversion.
+ */
+
+import inetsoft.uql.schema.XSchema;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class VSComboBoxDateValueTest {
+   /** A date inside the surefire time zone's Local Mean Time era. */
+   private static final String LMT_ERA_DATE = "1880-01-01";
+   /** What that date used to become. */
+   private static final String SHIFTED_DATE = "1879-12-31";
+
+   // [G1]
+   @ParameterizedTest
+   @ValueSource(strings = { LMT_ERA_DATE, "1900-01-01", "2025-12-31", "2024-05-06" })
+   void wallClockDateKeepsItsDay(String date) throws Exception {
+      Object converted = convertWallClockDate(XSchema.DATE, date);
+
+      assertInstanceOf(java.sql.Date.class, converted);
+      assertEquals(date, converted.toString());
+
+      // and Tool.getData() leaves an already typed java.sql.Date alone
+      assertEquals(date, Tool.getData(XSchema.DATE, converted).toString());
+   }
+
+   // [G2]
+   @Test
+   void bothReplacedPathsLoseADayForAnLmtEraDate() {
+      assertTrue(isInLmtEra(LMT_ERA_DATE),
+                 "the test date must sit in the zone's LMT era for this to be meaningful");
+
+      // what the browser used to send: the wall clock date resolved through ICU/java.time,
+      // which models the pre-1883 -04:56:02 offset that java.util.Date does not
+      long millis = startOfDayMillis(LMT_ERA_DATE);
+
+      assertEquals(SHIFTED_DATE, Tool.getData(XSchema.DATE, new Date(millis)).toString(),
+                   "pins the instant path the wall clock string replaces");
+      assertEquals(SHIFTED_DATE, Tool.getData(XSchema.DATE, LMT_ERA_DATE).toString(),
+                   "pins CoreTool.parseDate's own LMT/truncation split -- why the conversion "
+                      + "builds the java.sql.Date itself instead of handing over the string");
+   }
+
+   // [G3]
+   @Test
+   void onlyAWallClockDateStringIsConverted() throws Exception {
+      assertTrue(isWallClockDate(XSchema.DATE, LMT_ERA_DATE));
+      assertTrue(isWallClockDate(XSchema.DATE, "2025-12-31"));
+
+      // a millis payload still takes the instant path
+      assertFalse(isWallClockDate(XSchema.DATE, "1767110400000"));
+      assertFalse(isWallClockDate(XSchema.DATE, 1767110400000L));
+      // so does a date/time string, and anything empty or absent
+      assertFalse(isWallClockDate(XSchema.DATE, "2025-12-31 00:00:00"));
+      assertFalse(isWallClockDate(XSchema.DATE, ""));
+      assertFalse(isWallClockDate(XSchema.DATE, null));
+      // the other date types keep their existing handling
+      assertFalse(isWallClockDate(XSchema.TIME_INSTANT, "2025-12-31"));
+      assertFalse(isWallClockDate(XSchema.TIME, "2025-12-31"));
+
+      // a value that is not converted is handed on untouched
+      assertEquals("2025-12-31 00:00:00",
+                   convertWallClockDate(XSchema.DATE, "2025-12-31 00:00:00"));
+   }
+
+   // [G4]
+   @Test
+   void animpossibleDateIsReturnedUnchanged() throws Exception {
+      assertEquals("2025-02-30", convertWallClockDate(XSchema.DATE, "2025-02-30"));
+   }
+
+   private static boolean isInLmtEra(String date) {
+      long millis = startOfDayMillis(date);
+      ZoneId zone = ZoneId.of(TimeZone.getDefault().getID());
+
+      return TimeZone.getDefault().getOffset(millis) !=
+         zone.getRules().getOffset(Instant.ofEpochMilli(millis)).getTotalSeconds() * 1000L;
+   }
+
+   private static long startOfDayMillis(String date) {
+      return LocalDate.parse(date)
+         .atStartOfDay(ZoneId.of(TimeZone.getDefault().getID()))
+         .toInstant()
+         .toEpochMilli();
+   }
+
+   private static boolean isWallClockDate(String dataType, Object value) throws Exception {
+      return (Boolean) invoke("isWallClockDate", dataType, value);
+   }
+
+   private static Object convertWallClockDate(String dataType, Object value) throws Exception {
+      return invoke("convertWallClockDate", dataType, value);
+   }
+
+   private static Object invoke(String name, String dataType, Object value) throws Exception {
+      Method method = VSInputService.class
+         .getDeclaredMethod(name, String.class, Object.class);
+      method.setAccessible(true);
+
+      return method.invoke(null, dataType, value);
+   }
+}

--- a/web/projects/portal/src/app/vsobjects/objects/combo-box/vs-combo-box.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/combo-box/vs-combo-box.component.interaction.tl.spec.ts
@@ -619,4 +619,111 @@ describe("VSComboBox — Pass 1: Interaction", () => {
          expect(unsubSpy).toHaveBeenCalled();
       });
    });
+
+   // -- Group 16 - date-only value round trip ---------------------------------
+   //
+   // A combobox whose dataType is "date" has no time component. The value used to travel as
+   // epoch millis converted into the server timezone, and for a pre-1901 date the browser
+   // (ICU, which models Local Mean Time) and java.util.Date (whole hour offset) disagree on
+   // that offset by 5m43s for Asia/Shanghai, so 1900-01-01 came back as 1899-12-31 carrying a
+   // stale 00:05:43. That stale time then pushed the last allowed day past the max bound
+   // (midnight of that day) and raised a spurious "Invalid date range".
+   describe("Group 16 - date-only value round trip", () => {
+      function dateComboBox(overrides: any = {}) {
+         return createComboBoxComponent({
+            model: Object.assign({
+               calendar: true, dataType: "date", serverTZ: true,
+               serverTZID: "Asia/Shanghai", refresh: false,
+            }, overrides),
+         });
+      }
+
+      it("should send the picked day as a wall clock date string, not an instant", () => {
+         const { comp, formInputService, ngbModal } = dateComboBox();
+         comp.dropdown = { close: vi.fn() } as any;
+
+         comp.updateDate({ year: 1900, month: 1, day: 1 });
+
+         expect(ngbModal.open).not.toHaveBeenCalled();
+         expect(formInputService.addPendingValue).toHaveBeenCalledWith("Combo1", "1900-01-01");
+      });
+
+      it("should send the same date string whatever the server timezone is", () => {
+         const utc = dateComboBox({ serverTZID: "UTC" });
+         const shanghai = dateComboBox({ serverTZID: "Asia/Shanghai" });
+         utc.comp.dropdown = { close: vi.fn() } as any;
+         shanghai.comp.dropdown = { close: vi.fn() } as any;
+
+         utc.comp.updateDate({ year: 1900, month: 1, day: 1 });
+         shanghai.comp.updateDate({ year: 1900, month: 1, day: 1 });
+
+         expect(utc.formInputService.addPendingValue)
+            .toHaveBeenCalledWith("Combo1", "1900-01-01");
+         expect(shanghai.formInputService.addPendingValue)
+            .toHaveBeenCalledWith("Combo1", "1900-01-01");
+      });
+
+      it("should read a wall clock date back without shifting the day or keeping a time", () => {
+         const { comp } = dateComboBox({ selectedObject: "1900-01-01" });
+
+         expect(comp.selectedDate).toEqual({ year: 1900, month: 1, day: 1 });
+         expect(comp.hours).toBe(0);
+         expect(comp.minutes).toBe(0);
+         expect(comp.seconds).toBe(0);
+         expect(comp.meridian).toBe("AM");
+      });
+
+      it("should accept the configured max day even with a left over time of day", () => {
+         const { comp, formInputService, ngbModal } = dateComboBox({
+            minDate: "1900-01-01 00:00:00", maxDate: "2025-12-31 00:00:00",
+         });
+         comp.dropdown = { close: vi.fn() } as any;
+         // a time left over from a previously selected value
+         comp.hours = 12; comp.minutes = 5; comp.seconds = 43;
+
+         comp.updateDate({ year: 2025, month: 12, day: 31 });
+
+         expect(ngbModal.open).not.toHaveBeenCalled();
+         expect(comp.selectedDate).toEqual({ year: 2025, month: 12, day: 31 });
+         expect(formInputService.addPendingValue).toHaveBeenCalledWith("Combo1", "2025-12-31");
+      });
+
+      it("should accept the configured min day", () => {
+         const { comp, formInputService, ngbModal } = dateComboBox({
+            minDate: "1900-01-01 00:00:00", maxDate: "2025-12-31 00:00:00",
+         });
+         comp.dropdown = { close: vi.fn() } as any;
+
+         comp.updateDate({ year: 1900, month: 1, day: 1 });
+
+         expect(ngbModal.open).not.toHaveBeenCalled();
+         expect(formInputService.addPendingValue).toHaveBeenCalledWith("Combo1", "1900-01-01");
+      });
+
+      it("should still reject a day outside the configured range", () => {
+         const { comp, formInputService, ngbModal } = dateComboBox({
+            minDate: "1900-01-01 00:00:00", maxDate: "2025-12-31 00:00:00",
+         });
+         comp.dropdown = { close: vi.fn() } as any;
+
+         comp.updateDate({ year: 2026, month: 1, day: 1 });
+
+         expect(ngbModal.open).toHaveBeenCalled();
+         expect(comp.selectedDate).toBeFalsy();
+         expect(formInputService.addPendingValue).not.toHaveBeenCalled();
+      });
+
+      it("should keep sending epoch millis for a timeInstant combobox", () => {
+         const { comp, formInputService } = createComboBoxComponent({
+            model: { calendar: true, dataType: "timeInstant", refresh: false },
+         });
+         comp.dropdown = { close: vi.fn() } as any;
+         comp.hours = 10; comp.minutes = 0; comp.seconds = 0; comp.meridian = "AM";
+
+         comp.updateDate({ year: 2024, month: 5, day: 6 });
+
+         expect(formInputService.addPendingValue)
+            .toHaveBeenCalledWith("Combo1", new Date(2024, 4, 6, 10, 0, 0, 0).getTime());
+      });
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/combo-box/vs-combo-box.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/combo-box/vs-combo-box.component.ts
@@ -113,11 +113,7 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
       // don't lose user change if the value has not changed
       if(value.calendar && (valueChanged || !value.editable)) {
          if(value.selectedObject) {
-            let dayjsVal = dayjs(value.selectedObject);
-
-            if(value.serverTZ) {
-               dayjsVal = dayjs.tz(value.selectedObject, value.serverTZID);
-            }
+            const dayjsVal = this.parseSelectedObject(value);
 
             if(dayjsVal.isValid()) {
                const timeInstant = dayjsVal.toObject() as TimeInstant;
@@ -128,18 +124,25 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
                   day: timeInstant.date
                };
 
-               this.hours = timeInstant.hours;
-
-               if(this.hours > 12) {
-                  this.hours -= 12;
+               if(value.dataType == XSchema.DATE) {
+                  // a date has no time component
+                  this.hours = this.minutes = this.seconds = 0;
+                  this.meridian = "AM";
                }
-               else if(this.hours < 1) {
-                  this.hours = 12;
-               }
+               else {
+                  this.hours = timeInstant.hours;
 
-               this.minutes = timeInstant.minutes;
-               this.seconds = timeInstant.seconds;
-               this.meridian = timeInstant.hours >= 12 ? "PM" : "AM";
+                  if(this.hours > 12) {
+                     this.hours -= 12;
+                  }
+                  else if(this.hours < 1) {
+                     this.hours = 12;
+                  }
+
+                  this.minutes = timeInstant.minutes;
+                  this.seconds = timeInstant.seconds;
+                  this.meridian = timeInstant.hours >= 12 ? "PM" : "AM";
+               }
             }
 
          }
@@ -185,6 +188,7 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
    @ViewChild("second") secondRef: ElementRef;
    @ViewChild("meridianRef") meridianRef: ElementRef;
    @ViewChild(NgbDatepicker) dp: NgbDatepicker;
+   private static readonly SERVER_DATE_TIME_FORMAT: string = "YYYY-MM-DD HH:mm:ss";
    readonly defaultMinDate: NgbDateStruct = {year: 1900, month: 1, day: 1};
    readonly defaultMaxDate: NgbDateStruct = {year: 2050, month: 12, day: 31};
    minDate: NgbDateStruct = this.defaultMinDate;
@@ -371,7 +375,7 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
       this.hours = 0;
       this.minutes = 0;
       this.seconds = 0;
-      this.meridian == "AM";
+      this.meridian = "AM";
       this.selectedDate = null;
 
       if(this._model.refresh) {
@@ -387,6 +391,19 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
    }
 
    private isValidDate(date: any): boolean {
+      if(this.isDateOnly()) {
+         const minDay: NgbDateStruct = Tool.isEmpty(this.model.minDate)
+            ? this.defaultMinDate : this.getDate(this.model.minDate);
+         const maxDay: NgbDateStruct = Tool.isEmpty(this.model.maxDate)
+            ? this.defaultMaxDate : this.getDate(this.model.maxDate);
+
+         // a date has no time component, so only the day may take part in the comparison.
+         // otherwise a left over time (e.g. from a previously selected value) pushes the
+         // last allowed day past the max, which is the midnight of that same day.
+         return this.toDayNumber(date) >= this.toDayNumber(minDay) &&
+            this.toDayNumber(date) <= this.toDayNumber(maxDay);
+      }
+
       let min: Date = Tool.isEmpty(this.model.minDate)
          ? new Date(this.defaultMinDate.year, this.defaultMinDate.month - 1, this.defaultMinDate.day)
          : this.getTimeInstant(this.model.minDate);
@@ -436,21 +453,33 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
          return;
       }
 
-      let time = this.getDateTime(selectedDate).getTime();
+      // a date is sent as a wall clock date string so that it is parsed in the server
+      // timezone instead of being interpreted as an instant
+      const value = this.isDateOnly()
+         ? dayjs(this.getDateTime(selectedDate)).format(DateTypeFormatter.ISO_8601_DATE_FORMAT)
+         : this.getDateTime(selectedDate).getTime();
 
       if(this._model.refresh) {
-         const event = new VSInputSelectionEvent(this._model.absoluteName, time);
+         const event = new VSInputSelectionEvent(this._model.absoluteName, value);
          this.debounceService.debounce(
             `InputSelectionEvent.${this.model.absoluteName}`,
             (evt, socket) => socket.sendEvent("/events/comboBox/applySelection", evt),
             500, [event, this.socket]);
       }
       else {
-         this.formInputService.addPendingValue(this._model.absoluteName, time);
+         this.formInputService.addPendingValue(this._model.absoluteName, value);
       }
    }
 
    private getDateTime(selectedDate: any): Date {
+      // a date has no time component, so keep it as a plain local date. moving the instant
+      // into the server timezone can push it to the previous day, since the browser and
+      // java.util.Date disagree on historical offsets that are not a whole number of minutes
+      // (e.g. Asia/Shanghai was +08:05:43 before 1901).
+      if(this.isDateOnly()) {
+         return new Date(selectedDate.year, selectedDate.month - 1, selectedDate.day, 0, 0, 0, 0);
+      }
+
       let hours: number = this.hours;
 
       if (this.meridian == "AM" && this.hours == 12) {
@@ -500,8 +529,50 @@ export class VSComboBox extends NavigationComponent<VSComboBoxModel> implements 
    }
 
    getDate(str: string): NgbDateStruct {
+      // min/max are already formatted in the server timezone, so for a date they are read as
+      // a wall clock date. converting them again would move the bound by a day when the
+      // browser and the server are in different timezones.
+      if(this.isDateOnly()) {
+         let val = dayjs(str, VSComboBox.SERVER_DATE_TIME_FORMAT, true);
+
+         if(!val.isValid()) {
+            val = dayjs(str, DateTypeFormatter.ISO_8601_DATE_FORMAT, true);
+         }
+
+         if(val.isValid()) {
+            const instant = val.toObject() as TimeInstant;
+            return {year: instant.years, month: instant.months + 1, day: instant.date};
+         }
+      }
+
       let date: Date = this.getTimeInstant(str);
       return {year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()};
+   }
+
+   private isDateOnly(): boolean {
+      return !!this._model && this._model.dataType == XSchema.DATE;
+   }
+
+   private toDayNumber(date: NgbDateStruct): number {
+      return date.year * 10000 + date.month * 100 + date.day;
+   }
+
+   /**
+    * Parse the value sent by the server. A date is sent as a wall clock date string and must
+    * not be converted through a timezone. Other date types are sent as epoch millis.
+    */
+   private parseSelectedObject(value: VSComboBoxModel): dayjs.Dayjs {
+      if(value.dataType == XSchema.DATE) {
+         const dateVal = dayjs(value.selectedObject + "",
+                               DateTypeFormatter.ISO_8601_DATE_FORMAT, true);
+
+         if(dateVal.isValid()) {
+            return dateVal;
+         }
+      }
+
+      return value.serverTZ ? dayjs.tz(value.selectedObject, value.serverTZID)
+         : dayjs(value.selectedObject);
    }
 
    getTimeInstant(str: string) {


### PR DESCRIPTION
## Problem

Reported against a viewsheet with a single `date` calendar combobox:

1. Select `1900-01-01` → the value changes to `1899-12-31`.
2. Then select `2025-12-31` → `Invalid date range`. Selecting `2025-12-30` first and then `2025-12-31` works. Only happens the first time.

## Root cause

Both symptoms are one cascading defect.

`serverTZ` is forced on for `XSchema.DATE` (`VSComboBoxModel:49-52`) because a date has no time component, so the value travelled as **epoch millis moved into the server time zone**. `dayjs.tz` resolves the offset through ICU, which models pre-1901 Local Mean Time; the server reads the same instant with the legacy `java.util.Date`/`TimeZone` stack, which reports a whole hour offset. For `Asia/Shanghai`:

```
browser: 1900-01-01T00:00:00 -> -2209017943000   (+08:05:43, ICU / java.time)
server:  TimeZone.getOffset(-2209017943000) = +08:00
         new Date(-2209017943000) = Sun Dec 31 23:54:17 CST 1899
```

`CoreTool.getDateData()` then truncates with the deprecated `Date.setHours(0)`, turning 5m43s into a whole day → **1899-12-31**. That is symptom 1.

That value came back as millis, was re-read with `dayjs.tz` (LMT again), and left `selectedDate = {1899,12,31}` **plus a stale `hours=0/min=5/sec=43`**. `getDateTime()` reused that time for the next pick, and `isValidDate()` compared the resulting *instant* against the max bound's exact instant — midnight of the max day, while `ngb-datepicker`'s `[maxDate]` is day granular. So the max day was rejected once and accepted after any earlier day had cleared the stale time: exactly the reported "2025-12-30 then 2025-12-31 works / only the first time".

## Fix

For `XSchema.DATE` only — transfer a wall clock `yyyy-MM-dd` string instead of an instant, and compare the range by day.

- `vs-combo-box.component.ts` — send/receive a wall clock date string (no `dayjs.tz`), zero the time components, parse min/max as wall clock for both the picker bound and the validation bound, and compare day-only.
- `VSComboBoxModel.java` — a calendar `date` value goes out as `yyyy-MM-dd` rather than millis.
- `VSInputService.java` — converts a wall clock date string with `java.sql.Date.valueOf(LocalDate.parse(...))`, which `Tool.getData()` then passes through untouched.

`timeInstant` and `time` keep the existing millis + `serverTZ` path unchanged, and `CoreTool.getDateData()` is not modified.

Two notes on the shape of the server change:

- It **builds the `java.sql.Date` itself** rather than handing the string to `Tool.getData()`. Just passing the string through is not enough: `CoreTool.parseDate()` resolves LMT while the truncation that follows does not, so it loses the same day for any LMT-era date — `Tool.getData("date", "1880-01-01")` returns `1879-12-31` under `America/New_York`. Only the literal `"1900-01-01"` survives, via an explicit special case at `CoreTool:1855` — evidently a band-aid for this same bug class. That underlying `CoreTool` defect is wider than the combobox and is left alone here; it deserves its own issue.
- The conversion lives in `applySelection0()`, not `applySelection()`, so the **submit button** path (`OnClickService` → `multiApplySelection`) gets it too — that path bypasses `applySelection()` entirely.

Also fixes `clearCalendar()` leaving the meridian untouched (`this.meridian == "AM"` compared instead of assigning).

## Testing

- **New frontend tests** — `vs-combo-box.component.interaction.tl.spec.ts` Group 16 (7 tests). Reverting only the component makes **5 of 7 fail**, and the pre-fix run reproduces the reported symptoms directly: the dialog opens for `1900-01-01`, and `hours` is 12 where 0 is expected. Full combobox suite **99/99 pass**.
- **New backend test** — `VSComboBoxDateValueTest` (7 tests). Two of them *pin the old defect* (the instant path, and `Tool.getData()`'s own string parse, both losing a day for an LMT-era date) so the fix is not guarding a non-problem. Surefire pins `America/New_York`, whose LMT era ends in 1883, so `1880-01-01` stands in for the reported `1900-01-01` under `Asia/Shanghai` — same mechanism, different cutover year.
- `ExtendedDateFormatTest`, `ToolTest`, `ToolTimeFormatTest`, `ComboBoxVSAScriptableTest`, `ApplyParameterToInputTest` — all pass. `core` compiles.
- `vsobjects` standard specs **64/64 pass**. The full portal TL suite fails 24-28 files on `main` *before* this change (flaky membership run to run); no combobox file is in either failing set, and the set-difference files pass in isolation.
- Verified manually against a freshly built server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
