### PR TITLE
Bug #76044, expose the per-organization selected-theme pointer

### DIFF
--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesImpl.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesImpl.java
@@ -46,6 +46,10 @@ public class CustomThemesImpl implements XMLSerializable, AutoCloseable {
       return "default";
    }
 
+   public String getOrgSelectedTheme(String orgID) {
+      return "default";
+   }
+
    public String getGlobalSelectedTheme() {
       return "default";
    }

--- a/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomThemesManager.java
@@ -84,6 +84,14 @@ public class CustomThemesManager implements XMLSerializable, AutoCloseable {
       return impl.getOrgSelectedTheme();
    }
 
+   /**
+    * Gets the selected theme of the specified organization, rather than of the org that is
+    * current on this thread. Returns "default" when the organization has no theme selected.
+    */
+   public String getOrgSelectedTheme(String orgID) {
+      return impl.getOrgSelectedTheme(orgID);
+   }
+
    public void setGlobalSelectedTheme(String selectedTheme) {
       impl.setGlobalSelectedTheme(selectedTheme);
    }


### PR DESCRIPTION
## What

Adds a `getOrgSelectedTheme(String orgID)` overload to `CustomThemesManager` and its community fallback `CustomThemesImpl`, mirroring the existing `setOrgSelectedTheme(String)` / `setOrgSelectedTheme(String, String)` pair. The enterprise implementation already had the method — it was just `private`.

## Why

"Default for This Organization" is denormalized into three places: the authoritative `portal.org.selectedThemeId.<orgID>` SreeEnv pointer, `FSOrganization.theme`, and the theme's own `organizations` list. Several writers touch only a subset, so the membership list can drift out of agreement with the pointer.

The enterprise theme delete path (`ThemeService.removeTheme()`) currently derives the set of affected organizations from the membership list alone. To close that gap it needs to read the selected-theme pointer of an organization *other* than the one current on the thread — which is what this overload provides.

## Notes

- Community-side change only; no behavior change on its own. The enterprise consumer is in a companion PR (linked below once opened).
- Existing `CustomThemesManagerTest` passes (13/13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)