### PR TITLE
Bug #76185, drop dead claim-attribute puts from validateSAMLAttributes

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
@@ -286,9 +286,10 @@ public class SSOSettingsService {
       settingsMap.put("onelogin.saml2.sp.entityid", model.spEntityId());
       settingsMap.put("onelogin.saml2.idp.x509cert", model.idpPublicKey());
       settingsMap.put("onelogin.saml2.idp.single_logout_service.url", model.idpLogoutUrl());
-      settingsMap.put("saml.roles.attribute", model.roleClaim());
-      settingsMap.put("saml.groups.attribute", model.groupClaim());
-      settingsMap.put("saml.orgID.attribute", model.orgIDClaim());
+      //the saml.*.attribute claim names are StyleBI's own and are not part of the java-saml
+      //settings vocabulary, so they cannot be checked here -- fromValues drops keys it does
+      //not recognise. Nothing validates a claim name anywhere; a wrong one saves cleanly and
+      //silently maps nothing at login (see SAMLFilter.ClaimNames).
       final Saml2Settings settings = new SettingsBuilder().fromValues(settingsMap).build();
       final List<String> errors = settings.checkSettings();
       final boolean valid = errors.isEmpty();


### PR DESCRIPTION
### Problem

`SSOSettingsService.validateSAMLAttributes` put nine entries into its settings map — the six real
`onelogin.saml2.*` settings plus `saml.roles.attribute`, `saml.groups.attribute` and
`saml.orgID.attribute` — then built a `Saml2Settings` via `SettingsBuilder.fromValues` and called
`checkSettings()`.

`Saml2Settings` has no member for any of the three claim attributes, and `fromValues` silently drops
keys it does not recognise, so those three puts had no effect on the validation result. Dead code
rather than a defect in behaviour — but it read as though the claim names were validated on save,
which is the opposite of what happens.

### Verification that the puts are inert

`javap` against `java-saml-core-3.0.0.jar`, the version on the compile classpath:

```
javap -classpath java-saml-core-3.0.0.jar com.onelogin.saml2.settings.Saml2Settings
  -> only allowRepeatAttributeName / trimAttributeValues match "attribute"; nothing matches "claim"

javap -classpath java-saml-core-3.0.0.jar -p com.onelogin.saml2.settings.SettingsBuilder
  -> the *_PROPERTY_KEY constants cover onelogin.saml2.* only; no claim/attribute key
```

### Change

Removed the three puts and left a comment recording that nothing validates a claim name, so the code
no longer implies a check it does not perform. The `SreeEnv.setProperty` calls that actually persist
the three properties are untouched.

No behaviour change: `checkSettings()` sees the same six settings and returns an identical error list.
`validateSAMLAttributes` is private with a single caller (`updateSSOSettings`), its `boolean` result is
unchanged for every input, and `settingsMap` is a local built and consumed in the same method.

### Why not validate the claim names instead

A non-empty check would reject working configurations. `SAMLFilter.ClaimNames.current()` reads all
three properties with **no default**, and each use is null-guarded — blank legitimately means "do not
map roles / groups / org". Validating against IdP metadata is not possible at this point either: no
metadata is fetched at save time, the admin hand-enters the certificate and URLs.

Also worth noting for whoever picks up the related ticket: **#76163 (name claim read without a null
guard) appears already fixed** — `SAMLFilter` now has a null guard, a blank-value guard and a
special-character check, each producing a distinct `claimError` recorded in the session audit record.

### Testing

- `./mvnw -pl core compile` — clean.
- `./mvnw -pl core test -Dtest=SSOSettingsControllerTest` — 2/2 pass (delegation-only coverage; it does
  not exercise `validateSAMLAttributes`). No new test added for a dead-code deletion with a provably
  identical result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
