### PR TITLE
Bug #75965, underline table cells that have a row-level hyperlink

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.html
@@ -264,7 +264,7 @@
                       [wTooltip]="getTooltip(_cell, i)"
                       [cellAnnotations]="model.leftBottomAnnotations"
                       [class.selected-table-cell]="isSelected(_cell)"
-                      [class.hyperlink]="isHyperlink(_cell)"
+                      [class.hyperlink]="isHyperlink(_cell, i)"
                       [style.min-width.px]="tableCellDisplayWidth(j)"
                       [style.max-width.px]="tableCellDisplayWidth(j)"
                       [style.color]="_cell.vsFormatModel?.foreground"

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.interaction.tl.spec.ts
@@ -39,6 +39,7 @@
  *   Group 11 — isDraggable: header→true; non-header+viewer→false; resizeCol active→false
  *   Group 12 — clearFlyover: hasFlyover+force→sendFlyover+clears; no-op when condition fails
  *   Group 13 — onOpenHighlightDialog: 'table highlight' action emits model
+ *   Group 14 — isHyperlink/hasRowHyperlink: cell links, row links, form + indicator gates
  */
 
 import { Subject } from "rxjs";
@@ -600,6 +601,66 @@ describe("VSTable — Pass 1: Interaction", () => {
 
          expect(emitted).toHaveLength(1);
          expect(emitted[0]).toBe(comp.model);
+      });
+   });
+
+   // ── Group 14 — isHyperlink / hasRowHyperlink ─────────────────────────────
+   describe("Group 14 — isHyperlink / hasRowHyperlink", () => {
+      const ROW_LINK = { tooltip: "tip", label: "link", url: "www.baidu.com", linkType: 1 } as any;
+      const CELL_LINK = { tooltip: "cell", label: "c", url: "", linkType: 0 } as any;
+
+      it("should underline a cell that has its own hyperlinks", () => {
+         const { comp } = createTableComponent();
+
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [CELL_LINK], underline: true }))).toBe(true);
+      });
+
+      it("should underline a detail cell whose row has a row hyperlink (Bug: row hyperlink not underlined)", () => {
+         const { comp } = createTableComponent();
+         comp.rowHyperlinks = [ROW_LINK];
+
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [], underline: true }), 0)).toBe(true);
+      });
+
+      it("should not underline a row-hyperlink cell when no row index is supplied (header cells)", () => {
+         const { comp } = createTableComponent();
+         comp.rowHyperlinks = [ROW_LINK];
+
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [], underline: true }))).toBe(false);
+      });
+
+      it("should not underline a row without an entry in rowHyperlinks", () => {
+         const { comp } = createTableComponent();
+         comp.rowHyperlinks = [ROW_LINK, null];
+
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [], underline: true }), 1)).toBe(false);
+      });
+
+      it("should not underline when the hyperlink indicator is off (cell.underline false)", () => {
+         const { comp } = createTableComponent();
+         comp.rowHyperlinks = [ROW_LINK];
+
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [], underline: false }), 0)).toBe(false);
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [CELL_LINK], underline: false }), 0)).toBe(false);
+      });
+
+      it("should not underline on a form table", () => {
+         const { comp } = createTableComponent({ model: { form: true } });
+         comp.rowHyperlinks = [ROW_LINK];
+
+         expect(comp.isHyperlink(makeTableCell({ hyperlinks: [], underline: true }), 0)).toBe(false);
+      });
+
+      it("should report hasRowHyperlink only for rows with a link and a valid index", () => {
+         const { comp } = createTableComponent();
+
+         expect(comp.hasRowHyperlink(0)).toBe(false);
+
+         comp.rowHyperlinks = [ROW_LINK];
+
+         expect(comp.hasRowHyperlink(0)).toBe(true);
+         expect(comp.hasRowHyperlink(-1)).toBe(false);
+         expect(comp.hasRowHyperlink(5)).toBe(false);
       });
    });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/vs-table.component.ts
@@ -745,8 +745,13 @@ export class VSTable extends BaseTable<VSTableModel> implements OnInit, OnDestro
       return map && super.isColumnSelected(map.get(row), column);
    }
 
-   public isHyperlink(cell: BaseTableCellModel): boolean {
-      return cell.hyperlinks != null && cell.hyperlinks.length > 0 && !this.model.form && cell.underline;
+   public hasRowHyperlink(row: number): boolean {
+      return row > -1 && !!this.rowHyperlinks && !!this.rowHyperlinks[row];
+   }
+
+   public isHyperlink(cell: BaseTableCellModel, row: number = -1): boolean {
+      return (cell.hyperlinks != null && cell.hyperlinks.length > 0 || this.hasRowHyperlink(row)) &&
+         !this.model.form && cell.underline;
    }
 
    public selectTitle(event: MouseEvent): void {


### PR DESCRIPTION
## Problem

Opening viewsheet `hyperlink1` in the portal and hovering cell `12001` in the `Order` table shows the hyperlink tooltip (`tip`) but the cell text is **not underlined**.

This looked intermittent but is deterministic. In the reported asset, `<tableHyperlinkAttr>` is empty — the link is an **assembly-level row hyperlink**:

```xml
<Hyperlink ApplyToRow="true" Link="www.baidu.com" ToolTip="tip" LinkType="1">
```

Adding a **column** hyperlink underlines correctly, because that is a different code path. Only row hyperlinks were affected.

## Root cause

Row hyperlinks are sent to the client in a separate array, never attached to the cell model:

- `BaseTableService.getRowHyperlinks()` builds `LoadTableDataCommand.rowHyperlinks`, one entry per loaded row (null for header rows).
- `BaseTableCellModel.getHyperlinks()` only consults `VSTableLens.getCellHyperlink()`, which resolves column/cell and auto-drill links — it never sees `rowHyperlink`. So `cell.hyperlinks` is `null` for these cells.

On the client, the underline was keyed solely off `cell.hyperlinks`:

```ts
public isHyperlink(cell: BaseTableCellModel): boolean {
   return cell.hyperlinks != null && cell.hyperlinks.length > 0 && !this.model.form && cell.underline;
}
```

The row-hyperlink-aware members already existed and worked — they just did not affect styling: `getTooltip(cell, i)` (hence the visible "tip"), `rowHoverable()`, `rowLinkClicked()`, `linkClicked()`.

This has never worked in the Angular viewer; it is not a recent regression. The export path is the behavioral precedent and is already correct: `VSTableDataHelper.getHyperLink()` returns the row link for **every** column of a detail row and `HTMLTableHelper` writes `text-decoration:underline` for it. The viewer was the odd one out.

## Change

Frontend only, two files.

**`vs-table.component.ts`** — new `hasRowHyperlink(row)` helper; `isHyperlink()` takes an optional row index and ORs in the row hyperlink:

```ts
public hasRowHyperlink(row: number): boolean {
   return row > -1 && !!this.rowHyperlinks && !!this.rowHyperlinks[row];
}

public isHyperlink(cell: BaseTableCellModel, row: number = -1): boolean {
   return (cell.hyperlinks != null && cell.hyperlinks.length > 0 || this.hasRowHyperlink(row)) &&
      !this.model.form && cell.underline;
}
```

`row` is the `tableData` batch index, which is exactly how `rowHyperlinks` is indexed (both are assigned together in `loadTableData`), matching the existing `getTooltip(cell, i)` / `linkClicked($event, false, i)` convention.

**`vs-table.component.html`** — detail cell loop only: `[class.hyperlink]="isHyperlink(_cell, i)"`. The header binding is unchanged, since the server already stores `null` in `rowHyperlinks` for header rows and headers render from a separate `tableHeaders` table.

### Deliberately not changed

- **Java side** — folding the row link into `cell.hyperlinks` would break `rowLinkClicked()`, which deliberately distinguishes cell auto-drill links from the row link, and would push row links into the click dropdown menu.
- **`vs-table-cell.component.ts` (`isLinkedCell`)** — the `.hyperlink` class on the `<td>` inherits `text-decoration` into the cell text, so no new `@Input` on the shared cell component is needed. `vs-table-cell` is shared with crosstab and calc table.
- **`vs-crosstab` / `vs-calctable`** — `BaseTableService.getRowHyperlinks()` returns an empty array unless the assembly is a `TableVSAssembly` (and not embedded), so crosstabs and calc tables never receive row hyperlinks.
- **Form / embedded tables** — unaffected: excluded server-side via `!info.getFormValue()` and on the client by the retained `!this.model.form` guard.
- The `cell.underline` gate is retained, so the `hyperlink.indicator` property still suppresses the indicator.

## Testing

Added `Group 14 — isHyperlink / hasRowHyperlink` to `vs-table.component.interaction.tl.spec.ts` (7 cases): row link underlines the detail cell; header cells (no row index) do not; a row with no `rowHyperlinks` entry does not; `underline: false` does not; form tables do not; the existing cell-hyperlink case is unchanged; `hasRowHyperlink` index bounds.

All 7 pass. Reverting only the `isHyperlink` change makes **exactly one** fail — the bug-reproducing case — confirming the tests are not vacuous.

Also verified: `tsc --noEmit` on the spec-tl project is clean, ESLint on the changed files is clean, and the standard portal suite is unaffected.

Manually confirmed in a running server with the reported asset: detail cells are underlined, the `tip` tooltip still appears, and clicking a row still opens the link.

> [!NOTE]
> `vs-table.component.interaction.tl.spec.ts` is currently one of **26 portal TL spec files that fail at import on clean `main`** (`TypeError: Class extends value undefined` from `sort-column-event.ts:23`, a module-init/chunking issue in the `@angular/build:unit-test` builder). Confirmed pre-existing by stashing these changes and re-running. The new tests were therefore verified through the standard runner via a temporary copy. This is consistent with `CLAUDE.md` noting `test:portal:tl` is not yet wired to CI, and is tracked separately from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
