### PR TITLE
Bug #76173, remove the unreachable query.max.time timeout fallback

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -597,19 +597,6 @@ public abstract class AssetQuery extends PreAssetQuery {
 
       // runtime?
       if((mode & AssetQuerySandbox.RUNTIME_MODE) != 0) {
-         // try query max time
-         prop = SreeEnv.getProperty("query.max.time");
-
-         if(prop != null) {
-            try {
-               return Integer.parseInt(prop);
-            }
-            catch(Exception ex) {
-               LOG.warn("Invalid value for the query timeout (query.max.time): " +
-                  prop, ex);
-            }
-         }
-
          // 20 minutes for runtime
          return 1200;
       }


### PR DESCRIPTION
## Problem

`query.max.time` is read at exactly one place — `AssetQuery.getTimeout()` — as a fallback a stock install can never reach.

```java
String propName = (mode & AssetQuerySandbox.RUNTIME_MODE) != 0 ?
   "query.runtime.timeout" : "query.preview.timeout";
String prop = SreeEnv.getProperty(propName);

if(prop != null) {
   try {
      return Integer.parseInt(prop);   // <-- always returns here
   }
   ...
}

// runtime?
if((mode & AssetQuerySandbox.RUNTIME_MODE) != 0) {
   prop = SreeEnv.getProperty("query.max.time");   // <-- dead
```

`SreeEnv.getProperty(String)` resolves through `PropertiesEngine.internalProperties`, built as
`new DefaultProperties(prop, getDefaultProperties())` (`PropertiesEngine.java:502,507`) and chained to
`inetsoft/report/defaults.properties`. That file declares `query.runtime.timeout=0` (line 167), so the
read never returns `null`, `Integer.parseInt("0")` returns, and the branch below is unreachable.

Setting `query.runtime.timeout` to any value — including `0` — does not expose the fallback. Nor would
deleting the declaration: the EM **General → Performance** page writes `query.runtime.timeout` on every
save (`PerformanceSettingsService.java:39,59`), so a single save re-buries it permanently.

Design-time mode never reaches it at all — the branch is guarded on `RUNTIME_MODE`, and
`query.preview.timeout` is likewise declared (line 165).

## Why remove rather than rewire

`query.max.time` has no `defaults.properties` declaration, no EM control, and no documentation, so
nothing advertises it — but its name reads as *the* general query time limit, which is exactly what an
operator hunting for one would search for and set. They would see no change and no error, because
nothing is listening on any reachable path.

The fallback was not meant to be reachable. `query.runtime.timeout` is the live property: declared,
EM-exposed, and read by a second consumer (`Util.getQueryRuntimeTimeout()`, `Util.java:3152`) for the
legacy report-engine path. `query.max.time` is a superseded pre-open-source alias — `git log -S` touches
only `Initial commit`.

## Change

13 lines deleted from `AssetQuery.getTimeout()`: the `query.max.time` read and its `LOG.warn`. The
runtime branch now falls straight through to its existing `return 1200`. No other file needed touching.

Removal is behavior-safe: nothing can reach the branch today on any configuration a stock install can
produce.

## Note for reviewers (no change proposed)

While tracing this: with stock defaults in runtime mode `getTimeout()` returns `0`, and its caller
guards `if(timeout > 0)` before setting `XQuery.HINT_TIMEOUT` (`AssetQuery.java:3621-3625`) — so a stock
install applies no runtime query timeout at all. That is intended (`0` = no limit; the EM control uses
`Validators.min(0)`), but it does mean the surviving `return 1200` and `return 120` defaults are equally
unreachable. Left in place deliberately as fallbacks should a defaults declaration ever be removed.

## Testing

- `core` compiles cleanly.
- EM **General → Performance**: setting *Query Runtime Timeout* still aborts a slow viewsheet query at
  the configured value, confirming `query.runtime.timeout` resolves through `getTimeout()` →
  `XQuery.HINT_TIMEOUT`.
- *Query Design Time Timeout* still applies on worksheet preview (shared method, untouched branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
