### PR TITLE
Bug #76069, reserve the built-in theme ID so a theme named "default" applies

### DIFF
--- a/core/src/main/java/inetsoft/sree/portal/CustomTheme.java
+++ b/core/src/main/java/inetsoft/sree/portal/CustomTheme.java
@@ -30,6 +30,30 @@ import java.util.*;
  */
 public final class CustomTheme implements XMLSerializable, Cloneable {
    /**
+    * The reserved theme identifier that denotes the built-in theme. It doubles as the sentinel
+    * written to the selected-theme pointers ({@code portal.org.selectedThemeId[.<orgID>]} and
+    * {@code Organization.theme}) to mean "no custom theme selected", so it must never be the ID
+    * of an installed custom theme: such a theme is stored and listed, but every consumer of the
+    * pointers reads it as "nothing selected" and the built-in theme is served instead.
+    *
+    * <p>Only the <em>ID</em> is reserved. A theme may still be <em>named</em> "default"; it is
+    * assigned a different ID.
+    */
+   public static final String DEFAULT_THEME_ID = "default";
+
+   /**
+    * Determines whether a theme identifier is reserved and therefore unavailable to a custom
+    * theme.
+    *
+    * @param id the theme identifier to test.
+    *
+    * @return {@code true} if the identifier is reserved.
+    */
+   public static boolean isReservedId(String id) {
+      return DEFAULT_THEME_ID.equals(id);
+   }
+
+   /**
     * Gets the display name of the theme.
     *
     * @return the theme name.

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.spec.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { AddThemeDialogComponent } from "./add-theme-dialog.component";
+
+describe("AddThemeDialogComponent", () => {
+   let dialogRef: any;
+
+   async function createComponent(data: any): Promise<ComponentFixture<AddThemeDialogComponent>> {
+      dialogRef = { close: vi.fn() };
+
+      await TestBed.resetTestingModule().configureTestingModule({
+         // the modal header resolves a help URL over HTTP on render; intercept it so the
+         // request does not escape the test as an unhandled error
+         imports: [NoopAnimationsModule, HttpClientTestingModule, AddThemeDialogComponent],
+         providers: [
+            { provide: MatDialogRef, useValue: dialogRef },
+            { provide: MAT_DIALOG_DATA, useValue: data }
+         ],
+         schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(AddThemeDialogComponent);
+      fixture.detectChanges();
+      TestBed.inject(HttpTestingController).match(() => true).forEach(r => r.flush(""));
+      return fixture;
+   }
+
+   // The id is derived from the name, so a free name is used verbatim.
+   it("should use the name as the id when it does not collide", async () => {
+      const fixture = await createComponent({ ids: ["other"], names: [] });
+      fixture.componentInstance.form.get("name").setValue("MyTheme");
+
+      fixture.componentInstance.commit();
+
+      expect(dialogRef.close).toHaveBeenCalledWith(
+         expect.objectContaining({ name: "MyTheme", id: "MyTheme" }));
+   });
+
+   // "default" is the built-in theme's id and doubles as the sentinel meaning "no custom theme
+   // selected", so a theme taking it would be stored and listed but never applied. The name is
+   // still the user's; only the id moves.
+   it("should not assign the reserved id to a theme named default", async () => {
+      const fixture = await createComponent({ ids: [], names: [] });
+      fixture.componentInstance.form.get("name").setValue("default");
+
+      fixture.componentInstance.commit();
+
+      expect(dialogRef.close).toHaveBeenCalledWith(
+         expect.objectContaining({ name: "default", id: "default1" }));
+   });
+
+   // The server also reports the reserved id as unavailable; the check must hold even when it
+   // does not, so a stale or failed /themes/ids response cannot reintroduce the collision.
+   it("should avoid the reserved id even when the server reports it", async () => {
+      const fixture = await createComponent({ ids: ["default"], names: [] });
+      fixture.componentInstance.form.get("name").setValue("default");
+
+      fixture.componentInstance.commit();
+
+      const arg = dialogRef.close.mock.calls[0][0];
+      expect(arg.id).not.toBe("default");
+   });
+
+   // An existing id still gets the counter treatment.
+   it("should make a colliding name unique", async () => {
+      const fixture = await createComponent({ ids: ["Theme"], names: [] });
+      fixture.componentInstance.form.get("name").setValue("Theme");
+
+      fixture.componentInstance.commit();
+
+      expect(dialogRef.close).toHaveBeenCalledWith(
+         expect.objectContaining({ name: "Theme", id: "Theme1" }));
+   });
+});

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/add-theme-dialog/add-theme-dialog.component.ts
@@ -37,6 +37,9 @@ import { NgIf } from "@angular/common";
     imports: [NgIf, ModalHeaderComponent, MatDialogContent, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatError, FileChooserComponent, MatIcon, MatSuffix, MatDialogActions, MatButton, MatDialogClose]
 })
 export class AddThemeDialogComponent implements OnInit {
+   /** Mirrors CustomTheme.DEFAULT_THEME_ID: the reserved ID of the built-in theme. */
+   private static readonly RESERVED_ID = "default";
+
    form: UntypedFormGroup;
    private ids: string[];
    private jar: FileData;
@@ -74,7 +77,11 @@ export class AddThemeDialogComponent implements OnInit {
    private createId(): string {
       const nameValue = this.form.get("name").value;
 
-      if(!this.ids.includes(nameValue)) {
+      // "default" is the reserved ID of the built-in theme and doubles as the sentinel meaning
+      // "no custom theme selected", so a theme that took it as its ID would be stored and listed
+      // but never applied. The server reserves it too; check it here as well so a stale or failed
+      // /themes/ids response cannot reintroduce the collision. The name is kept either way.
+      if(!this.ids.includes(nameValue) && nameValue !== AddThemeDialogComponent.RESERVED_ID) {
          return nameValue;
       }
 
@@ -87,7 +94,10 @@ export class AddThemeDialogComponent implements OnInit {
 
       let newId = base;
 
-      for(let counter = 1; !!this.ids.find(s => s == newId); counter++) {
+      for(let counter = 1;
+          !!this.ids.find(s => s == newId) || newId === AddThemeDialogComponent.RESERVED_ID;
+          counter++)
+      {
          newId = base + counter;
       }
 


### PR DESCRIPTION
## What

Reserves `"default"` as a theme **ID** so it can never be assigned to a custom theme. The theme **name** `default` remains perfectly legal — it just gets a different ID (`default1`).

Adds `CustomTheme.DEFAULT_THEME_ID` and `CustomTheme.isReservedId()` as the single definition of the sentinel, and teaches `AddThemeDialogComponent.createId()` to treat it as taken.

## Why

`"default"` is the ID of the built-in theme and simultaneously the sentinel written to the selected-theme pointers (`portal.org.selectedThemeId[.<orgID>]`, `Organization.theme`) to mean "no custom theme selected".

A new theme's ID is derived from its name — `createId()` returns the typed name verbatim unless it collides with an ID already in use. The collision list comes from `GET /api/em/settings/presentation/themes/ids`, which reports only *existing custom themes*. The reserved sentinel is not among them, so the name `default` passed straight through and the theme was persisted with `id == "default"`.

From there every consumer of the pointers read it as "nothing selected":

- `CustomThemesImpl.getSelectedTheme()` discarded the pointer and returned `"default"`.
- `isCustomThemeApplied()` returned `false`, so `theme-variables.css` was never even `<link>`ed into the portal.
- `isEMDarkTheme()` and `getScriptThemeCssPath()` short-circuited before consulting the theme.

Meanwhile `CustomThemeModel.applyDefaultFlags()` compares the theme's ID against `getOrgSelectedTheme()`/`getGlobalSelectedTheme()`, **both of which return the literal `"default"` when unset** — so EM reported both default checkboxes ticked while the portal rendered the built-in theme. That is the exact EM-vs-portal disagreement in the bug report.

Worth noting the resource layer would have worked fine: `GlobalStyleController` and `ThemeProtocolResolver` both match a custom theme with that ID. The break was entirely in selected-ID resolution above it, so the JAR was never requested.

## Approach

Reserve the ID rather than reject the name — no user-facing error and no new i18n string. The server reserves it too (companion enterprise PR), but checking it client-side as well means a stale or failed `/themes/ids` response cannot reintroduce the collision.

Both branches of `createId()` are covered: the fast path and the `base + counter` loop, which would otherwise have resolved straight back to `default`.

## Notes

- Community half of the fix. The enterprise PR reserves the ID server-side (`getThemesIds()`, `addTheme()`, the `updateTheme()` rename path) and depends on `DEFAULT_THEME_ID` landing here first — link below.
- **No migration** for themes already stored with `id == "default"`. They remain listed and deletable in EM, so delete-and-recreate is the recovery path.
- New `add-theme-dialog.component.spec.ts` (the component had no spec): 4 tests covering the ordinary path, the reserved name, the reserved name when the server *does* report it, and an ordinary collision.
- Full EM suite passes: 104 files / 371 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)