### PR TITLE
Bug #76178, do not overwrite INETSOFTENV_*-derived properties in StorageInitializer

### DIFF
--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -176,9 +176,11 @@ public class StorageInitializer implements Callable<Integer> {
                }
             }
 
-            service.put("schedule.auto.start", "false");
-            service.put("schedule.auto.stop", "false");
-            service.put("font.truetype.path", "/usr/share/fonts/truetype/;$(sree.home)/fonts");
+            // Container defaults, applied only when the operator has not supplied the property
+            // via an INETSOFTENV_* variable above -- the live environment always wins.
+            service.putIfAbsent("schedule.auto.start", "false");
+            service.putIfAbsent("schedule.auto.stop", "false");
+            service.putIfAbsent("font.truetype.path", "/usr/share/fonts/truetype/;$(sree.home)/fonts");
          }
       }
 

--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -179,7 +179,7 @@ public class StorageInitializer implements Callable<Integer> {
             // Container defaults, applied only when the operator has not supplied the property
             // via an INETSOFTENV_* variable above -- the live environment always wins.
             service.putIfAbsent("schedule.auto.start", "false");
-            service.putIfAbsent("schedule.auto.stop", "false");
+            service.putIfAbsent("schedule.auto.down", "false");
             service.putIfAbsent("font.truetype.path", "/usr/share/fonts/truetype/;$(sree.home)/fonts");
          }
       }


### PR DESCRIPTION
## Problem

`StorageInitializer.setProperties()` copies every `INETSOFTENV_*` environment variable into the `sreeProperties` store, printing `Set property <name>` for each, and then unconditionally wrote three fixed values:

```java
service.put("schedule.auto.start", "false");
service.put("schedule.auto.stop", "false");
service.put("font.truetype.path", "/usr/share/fonts/truetype/;$(sree.home)/fonts");
```

The hard-coded writes came after the loop, so they won. An operator who set `INETSOFTENV_SCHEDULE_AUTO_START`, `INETSOFTENV_SCHEDULE_AUTO_STOP` or `INETSOFTENV_FONT_TRUETYPE_PATH` got a log line claiming the property was set and a stored value that contradicted it — the log was actively misleading for anyone diagnosing why their variable had no effect.

The three default *values* are correct for the shipped container; the defect is precedence, not the values.

This is worse for the community edition than it first appears. The only override path today is the Groovy `properties {}` DSL block (`shell/.../SetupDelegate.groovy:42`), which runs in the `afterPropertiesSet` phase — *after* these puts — and the community entrypoint rejects `dsl` outright (`community/docker/src/main/docker/files/bin/entrypoint.sh:36-48`). So a community operator had no supported way to set these three on first init.

## Changes

Two commits, in `core/src/main/java/inetsoft/setup/StorageInitializer.java`.

### 1. `put` → `putIfAbsent`

Reuses the existing `PropertiesService.putIfAbsent()` (`PropertiesService.java:69`), which had no production caller until now, so the three values are applied only as defaults and the live environment wins. This matches the precedence the project already relies on in `e2e/tests/resources/restore-storage-backup.groovy:19-32`, which works around this same clobbering in the same phase with a comment that a stale stored value must not "silently win over the live environment".

Chosen over moving the writes above the loop because `putIfAbsent` is order-independent (it also preserves a value written by a `SetupExtension` in an earlier phase) and states the intent in the code rather than in write ordering.

This also makes the `Set property` line truthful without touching the logging.

### 2. `schedule.auto.stop` → `schedule.auto.down`

`schedule.auto.stop` is read nowhere — a repo-wide search finds it only at this write. It is absent from `defaults.properties` and from the EM property allowlist in `properties-tool.ts:48`.

The property the server actually reads is `schedule.auto.down`: `defaults.properties:186` defaults it to `true`, and `BaseInetsoftApplication.shutdownInetsoft()` reads it at `BaseInetsoftApplication.java:235` to decide whether to call `SUtil.stopScheduler()`. The evident intent of this line — that the server container must not drive the scheduler lifecycle — was therefore never achieved.

**⚠️ Behaviour change, worth calling out for release notes.** Server containers now skip `SUtil.stopScheduler()` on shutdown. This removes a cross-container shutdown attempt that, in a multi-server cluster sharing one scheduler container, could stop the scheduler when any single server restarts. Nothing breaks for anyone setting `INETSOFTENV_SCHEDULE_AUTO_STOP` today, since that was a no-op — but a single-container deployment that *wanted* the scheduler stopped on shutdown now needs `INETSOFTENV_SCHEDULE_AUTO_DOWN=true`, which is honored as of commit 1.

Kept as a separate commit so it can be reverted independently of the precedence fix.

## Regression analysis

Installs that set none of these variables are unaffected. The block is guarded by `if(!context.initialized())`, so on first initialisation the store holds nothing but what the environment loop just wrote, and `putIfAbsent` still applies all three defaults. `defaults.properties` is a separate layer read through `SreeEnv`, not the `sreeProperties` store, so it does not suppress these writes.

`StorageInitializer.setProperties` is the only setup-time writer of these three keys: no `StorageInitializer` subclass exists, and of the four `SetupExtension` implementations only `ExecuteScriptsExtension` overrides `afterPropertiesSet` (it writes no properties itself, only dispatching to Groovy scripts). No shipped image sets any `INETSOFTENV_*` variable itself, and no compose/Terraform artifact in the repo sets `FONT_TRUETYPE_PATH` or `SCHEDULE_AUTO_*`.

## Testing

`community/core` compiles clean. No automated test added: `setProperties()` is private and reads `System.getenv()` directly, so testing it would require extracting the loop into an injectable method — a refactor beyond this fix. If wanted as a follow-up, the harness to copy is `PropertiesServiceTest.java:49-84`.

Manual end-to-end verification requires a fresh storage volume, since the block only runs when storage is uninitialised. With `INETSOFTENV_FONT_TRUETYPE_PATH` set in the server service's `environment:`, confirm EM → Settings → Presentation → PDF Generation → *TrueType/CID Font Path* shows the environment value rather than the hard-coded default; then tear down, remove the variable, and confirm on a fresh volume that the default is still applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
