### PR TITLE
Bug #76038, reposition tab children when bottomTabs toggles in mobile preview

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfo.java
@@ -423,8 +423,10 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
 
    /**
     * Scaled-space counterpart of {@link #repositionForBottomTabs}. Lets a
-    * runtime script toggle take effect immediately in layout previews. Tab
-    * moves; children stay. No-op in master view (no scaledPosition).
+    * runtime script toggle take effect immediately in layout previews. The
+    * tab bar re-anchors to the children's extent, and children are then
+    * re-flushed against the tab bar's new position -- mirroring the
+    * master-pixel-space loop below. No-op in master view (no scaledPosition).
     */
    public static void repositionForBottomTabsInScaledSpace(TabVSAssemblyInfo tabInfo,
                                                            Viewsheet vs,
@@ -469,6 +471,44 @@ public class TabVSAssemblyInfo extends ContainerVSAssemblyInfo {
 
       if(newTabY != tabScaledPos.y) {
          tabInfo.setScaledPosition(new Point(tabScaledPos.x, newTabY));
+      }
+
+      // Re-flush each child against the (possibly just-moved) tab bar. With a single
+      // child this is a no-op (the tab was anchored to that same child's extent), but
+      // with multiple children of differing heights, a child that isn't the tallest/
+      // shortest (the one defining the extent) would otherwise keep the scaled Y a
+      // prior full applyScale() pass computed for the OLD bottomTabs value -- e.g. a
+      // short Text child stays pinned near the old top-tabs position instead of
+      // following the tab bar to the bottom, until the next full refresh recalculates
+      // it (Bug #76038).
+      for(String childName : children) {
+         VSAssembly child = (VSAssembly) vs.getAssembly(childName);
+
+         if(child == null) {
+            continue;
+         }
+
+         VSAssemblyInfo childInfo = child.getVSAssemblyInfo();
+         Point childScaledPos = childInfo.getLayoutPosition(true);
+         Dimension childScaledSize = childInfo.getLayoutSize(true);
+
+         if(childScaledPos == null || childScaledSize == null) {
+            continue;
+         }
+
+         int childHeight = getBottomTabChildHeight(childInfo, childScaledSize);
+
+         if(childHeight == 0) {
+            continue;
+         }
+
+         int newChildY = toBottomTabs
+            ? newTabY - childHeight   // bottom edge flush with tab bar top
+            : newTabY + tabHeight;    // top edge flush with tab bar bottom
+
+         if(newChildY != childScaledPos.y) {
+            childInfo.setScaledPosition(new Point(childScaledPos.x, newChildY));
+         }
       }
    }
 

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/TabVSAssemblyInfoTest.java
@@ -225,6 +225,44 @@ class TabVSAssemblyInfoTest {
    }
 
    @Test
+   void repositionForBottomTabsInScaledSpaceReflowsShorterChildWithTabBar() {
+      Viewsheet vs = Mockito.mock(Viewsheet.class);
+
+      // tall child defines the tab bar's new anchor: bottom = 24 + 200 = 224
+      SelectionListVSAssemblyInfo tallChildInfo = new SelectionListVSAssemblyInfo();
+      tallChildInfo.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      tallChildInfo.setScaledPosition(new Point(50, 24));
+      tallChildInfo.setScaledSize(new Dimension(200, 200));
+      VSAssembly tallChild = Mockito.mock(VSAssembly.class);
+      when(tallChild.getVSAssemblyInfo()).thenReturn(tallChildInfo);
+      when(vs.getAssembly("Tall1")).thenReturn(tallChild);
+
+      // short text child baked at the same top-tabs position (y=24) as the tall child,
+      // but with a much smaller height -- it does not define the extent
+      TextVSAssemblyInfo shortChildInfo = new TextVSAssemblyInfo();
+      shortChildInfo.setScaledPosition(new Point(50, 24));
+      shortChildInfo.setScaledSize(new Dimension(200, 40));
+      VSAssembly shortChild = Mockito.mock(VSAssembly.class);
+      when(shortChild.getVSAssemblyInfo()).thenReturn(shortChildInfo);
+      when(vs.getAssembly("Text1")).thenReturn(shortChild);
+
+      TabVSAssemblyInfo tabInfo = new TabVSAssemblyInfo();
+      tabInfo.setAssemblies(new String[]{"Tall1", "Text1"});
+      tabInfo.setScaledPosition(new Point(50, 0));
+      tabInfo.setScaledSize(new Dimension(200, 24));
+
+      TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabInfo, vs, true);
+
+      // tab bar anchors to the tall child's bottom
+      assertEquals(224, tabInfo.getLayoutPosition(true).y);
+      // tall child already flush -- unchanged
+      assertEquals(24, tallChildInfo.getLayoutPosition(true).y);
+      // Bug #76038: short child must follow the tab bar (224 - 40 = 184), not stay at
+      // its old top-tabs y=24
+      assertEquals(184, shortChildInfo.getLayoutPosition(true).y);
+   }
+
+   @Test
    void getBottomTabChildHeightReturnsPixelHeightForNonDropdown() {
       SelectionListVSAssemblyInfo info = new SelectionListVSAssemblyInfo();
       info.setShowTypeValue(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);


### PR DESCRIPTION
## Summary

In a mobile/device-layout preview, a Tab assembly's `bottomTabs` property toggled at runtime via script (e.g. `Tab1.bottomTabs = RadioButton1.selectedObject`) moved the tab bar to its new position immediately, but left the tab's children at their old scaled position. With a single tab child this was invisible; with multiple children of differing heights, a child not defining the tab's new anchor (e.g. a short Text object) stayed pinned near its old position until a full page refresh recomputed everything.

## Root Cause

`TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace()` (called from `TabVSAScriptable.setBottomTabs()` to give immediate visual feedback in the scaled/mobile-preview coordinate space) repositioned only the tab bar's own `scaledPosition`. Its master-pixel-space sibling, `repositionForBottomTabs()`, already has a per-child reposition loop for the equivalent (non-scaled) case, but the scaled-space version never got one — its doc comment even said "Tab moves; children stay," which matches the reported symptom exactly.

## Fix

Added a loop to `repositionForBottomTabsInScaledSpace()` that re-flushes every child's scaled position against the tab bar's new position, mirroring the existing per-child loop in `repositionForBottomTabs()` and reusing the same `getBottomTabChildHeight()` helper for dropdown/labeled-input height handling.

## Test Plan

- Added `repositionForBottomTabsInScaledSpaceReflowsShorterChildWithTabBar` — a multi-child scenario (tall + short child) verifying the short child now follows the tab bar to its new scaled Y instead of staying at its old position. Hand-verified the arithmetic and confirmed via code review that this test fails without the fix.
- Ran `TabVSAScriptableTest` (12/12 pass) — exercises the sole production call site (`TabVSAScriptable.setBottomTabs()`) and its master-pixel-space multi-child analog, confirming no regression to the existing (unscaled) behavior.
- `mvn clean install -pl core -am -DskipTests` builds clean.
- User confirmed the fix resolves the reported issue against the attached test asset.

Fixes Redmine #76038.