### PR TITLE
Fix Bug #76341: resetSettings scope divergence from getSettings/applySettings

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PresentationSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PresentationSettingsController.java
@@ -275,14 +275,10 @@ public class PresentationSettingsController {
    public PresentationSettingsModel resetSettings(@RequestBody() PresentationSettingsModel model,
                                                   Principal principal) throws Exception
    {
-      SecurityProvider provider = securityEngine.getSecurityProvider();
-      boolean securityEnabled = !provider.isVirtual();
+      boolean securityEnabled = !securityEngine.getSecurityProvider().isVirtual();
       boolean globalSettings = OrganizationManager.getInstance().isSiteAdmin(principal) &&
-            (model.orgSettings() != null && !model.orgSettings()) || !securityEnabled;
-
-      if(!globalSettings && securityEnabled && !SUtil.isMultiTenant()) {
-         globalSettings = provider.checkPermission(principal,  ResourceType.EM, "*", ResourceAction.ACCESS);
-      }
+            (model.orgSettings() != null && !model.orgSettings()) || !securityEnabled ||
+            !SUtil.isMultiTenant();
 
       Lock settingsLock = cluster.getLock(SETTINGS_LOCK);
       settingsLock.lock();

--- a/core/src/test/java/inetsoft/web/admin/presentation/PresentationSettingsControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PresentationSettingsControllerTest.java
@@ -270,6 +270,52 @@ class PresentationSettingsControllerTest {
       verify(aiSettingsService, never()).resetSettings();
    }
 
+   // [single-tenant, site admin] globalSettings=true, matching what getSettings/applySettings
+   // compute for the identical principal/config (bug #76341) — !isMultiTenant forces global
+   // directly, so no checkPermission call is made
+   @Test
+   void resetSettings_singleTenant_matchesGetAndApplyGlobalScope() throws Exception {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+      when(securityProvider.isVirtual()).thenReturn(false);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(false);
+      stubAllGetters(true);
+
+      controller.resetSettings(
+         PresentationSettingsModel.builder().orgSettings(true).build(), principal);
+
+      verify(fontMappingSettingsService).resetSettings();
+      verify(aiSettingsService).resetSettings();
+      verify(securityProvider, never()).checkPermission(any(), any(), any(), any());
+   }
+
+   // [single-tenant, non-admin caller granted only the narrow presentation-settings
+   // EM_COMPONENT permission] models a caller granted only settings/presentation/org-settings,
+   // who is not a site admin or org admin and so fails the broader EM/*/ACCESS check. Before the
+   // #76341 fix, resetSettings replaced its already-true single-tenant result with this failing
+   // checkPermission call and ended up org-scoped, diverging from getSettings/applySettings for
+   // the identical caller; after the fix !isMultiTenant forces global directly and
+   // checkPermission is never consulted.
+   @Test
+   void resetSettings_singleTenant_nonAdminNarrowPermission_matchesGetAndApplyGlobalScope()
+      throws Exception
+   {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+      when(securityProvider.isVirtual()).thenReturn(false);
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(false);
+      stubAllGetters(true);
+
+      lenient().when(securityProvider.checkPermission(
+            any(), eq(ResourceType.EM), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      controller.resetSettings(
+         PresentationSettingsModel.builder().orgSettings(true).build(), principal);
+
+      verify(fontMappingSettingsService).resetSettings();
+      verify(aiSettingsService).resetSettings();
+      verify(securityProvider, never()).checkPermission(any(), any(), any(), any());
+   }
+
    // -------------------------------------------------------------------------
    // helpers
    // -------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`PresentationSettingsController.resetSettings` computed `globalSettings` with
a formula that omitted the unconditional `|| !SUtil.isMultiTenant()` OR-term
present in both `getSettings` and `applySettings`. Instead, when the
deployment is single-tenant and the first computation is false, it fell back
to a live `provider.checkPermission(principal, EM, "*", ACCESS)` call and
*replaced* (not OR'd) the computed value with that result.

On a single-tenant, security-enabled deployment, a caller granted only the
narrow `settings/presentation/(org-)settings` `EM_COMPONENT` permission
(exactly what this endpoint's own `@Secured` annotation accepts as
sufficient to call it) is neither a site admin nor an org admin, so
`checkPermission(EM, "*", ACCESS)` resolves to `false` — no code path in the
repo ever grants a `Permission` on the literal `EM`/`"*"` resource.
`resetSettings` then computes `globalSettings = false` (org-scoped),
honoring the caller's own `orgSettings: true` request, while
`getSettings`/`applySettings` unconditionally force `globalSettings = true`
(global) for the identical principal/config via the bare
`!SUtil.isMultiTenant()` term. The reset silently writes to org scope while
the rest of the controller reads/writes global scope on that deployment
shape — an orphaned, silently ineffective reset that looks like success.

Git archaeology (`8904da03f`, "fix Bug #70090...") shows `applySettings`
already had the `!isMultiTenant` term when this `checkPermission` fallback
was added to `resetSettings` instead of mirroring it — an inconsistent
follow-up to the same original fix, not a deliberate broader-permission
design for a "more destructive" reset.

## Fix

`resetSettings` now matches `applySettings`'s formula verbatim: add the
unconditional `!SUtil.isMultiTenant()` OR-term, drop the `checkPermission`
fallback branch entirely (it only ever ran under `!SUtil.isMultiTenant()` to
begin with, so nothing multi-tenant-shaped changes).

## Tests

Added to `PresentationSettingsControllerTest`:
- `resetSettings_singleTenant_matchesGetAndApplyGlobalScope`
- `resetSettings_singleTenant_nonAdminNarrowPermission_matchesGetAndApplyGlobalScope`

Both fail against the pre-fix code (confirmed by temporarily reverting the
controller change) and pass after the fix. Full
`PresentationSettingsControllerTest` suite: 10/10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)