### PR TITLE
Fix bug #76361, stale originalIndex silently edits wrong portal tab

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsService.java
@@ -146,6 +146,7 @@ public class PortalIntegrationViewSettingsService {
       List<PortalTab> portalTabs = manager.getPortalTabs();
       List<PortalTabModel> tabModels = model.tabs();
       int insertIndex = 0;
+      Catalog catalog = Catalog.getCatalog(principal);
 
       for(int i = 0; i < tabModels.size(); i++) {
          PortalTabModel tabModel = tabModels.get(i);
@@ -156,16 +157,14 @@ public class PortalIntegrationViewSettingsService {
 
             if(originalIndex < 0 || originalIndex >= portalTabs.size()) {
                throw new MessageException(
-                  "Tab list has changed since it was loaded; please reload Presentation " +
-                  "settings and try again.");
+                  catalog.getString("em.presentation.portalIntegration.tabsChanged"));
             }
 
             tab = portalTabs.get(originalIndex);
 
             if(!tab.isEditable() && !Objects.equals(tab.getName(), tabModel.name())) {
                throw new MessageException(
-                  "Tab list has changed since it was loaded; please reload Presentation " +
-                  "settings and try again.");
+                  catalog.getString("em.presentation.portalIntegration.tabsChanged"));
             }
 
             if(tab.isEditable()) {

--- a/core/src/main/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsService.java
@@ -21,6 +21,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.sree.portal.PortalTab;
 import inetsoft.sree.portal.PortalThemesManager;
 import inetsoft.util.Catalog;
+import inetsoft.util.MessageException;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.admin.presentation.model.PortalIntegrationSettingsModel;
@@ -151,7 +152,21 @@ public class PortalIntegrationViewSettingsService {
          PortalTab tab;
 
          if(tabModel.originalIndex() != null) {
-            tab = portalTabs.get(tabModel.originalIndex());
+            int originalIndex = tabModel.originalIndex();
+
+            if(originalIndex < 0 || originalIndex >= portalTabs.size()) {
+               throw new MessageException(
+                  "Tab list has changed since it was loaded; please reload Presentation " +
+                  "settings and try again.");
+            }
+
+            tab = portalTabs.get(originalIndex);
+
+            if(!tab.isEditable() && !Objects.equals(tab.getName(), tabModel.name())) {
+               throw new MessageException(
+                  "Tab list has changed since it was loaded; please reload Presentation " +
+                  "settings and try again.");
+            }
 
             if(tab.isEditable()) {
                tab.setName(tabModel.name());

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4464,6 +4464,7 @@ em.presentation.lookAndFeel.css.invalidCssColor=Not a valid color value
 em.presentation.lookAndFeel.css.invalidCssValue=Invalid characters in the value
 em.presentation.openBookmarkTip=Display bookmarks (report headings) immediately upon opening PDF.
 em.presentation.openThumbnailTip=Display page thumbnails immediately upon opening PDF.
+em.presentation.portalIntegration.tabsChanged=Tab list has changed since it was loaded; please reload Presentation settings and try again.
 em.presentation.theme.confirm=The theme has unsaved changes, close anyway?
 em.presentation.theme.duplicateName=A theme with this name already exists.
 em.propertyEditor.title=Property Editor

--- a/core/src/test/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsServiceTest.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.presentation;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.portal.PortalTab;
+import inetsoft.sree.portal.PortalThemesManager;
+import inetsoft.util.MessageException;
+import inetsoft.web.admin.presentation.model.PortalIntegrationSettingsModel;
+import inetsoft.web.admin.presentation.model.PortalTabModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * setModel resolves a submitted tab by a caller-echoed originalIndex into the manager's live,
+ * shared tab list. If another request reordered or shrank that list between when the caller read
+ * the model and when it submitted, the stale index either throws a raw IndexOutOfBoundsException
+ * or silently applies the edit to the wrong tab. These tests pin the fix: an out-of-range or
+ * identity-mismatched index must fail loud with a clean, field-named error instead.
+ *
+ * Tier: [mock] -- PortalThemesManager is mocked directly and field-injected, no Spring context.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PortalIntegrationViewSettingsServiceTest {
+   @Mock private PortalThemesManager manager;
+   @Mock private Principal principal;
+
+   @InjectMocks
+   private PortalIntegrationViewSettingsService service;
+
+   private MockedStatic<SreeEnv> sreeEnv;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnv = Mockito.mockStatic(SreeEnv.class);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnv.close();
+   }
+
+   @Test
+   void setModel_staleIndexOutOfBounds_throwsCleanError() throws Exception {
+      List<PortalTab> currentTabs = Arrays.asList(
+         new PortalTab("Dashboard", "/dashboard", true, false),
+         new PortalTab("Report", "/report", true, false));
+      when(manager.getPortalTabs()).thenReturn(currentTabs);
+
+      PortalTabModel staleTabModel = PortalTabModel.builder()
+         .name("Data")
+         .label("Data")
+         .uri("/data")
+         .visible(true)
+         .editable(false)
+         .originalIndex(2)
+         .build();
+
+      PortalIntegrationSettingsModel model = baseModelBuilder()
+         .addTabs(staleTabModel)
+         .build();
+
+      assertThrows(MessageException.class, () -> service.setModel(model, principal, true));
+      verify(manager, never()).setPortalTabs(any());
+   }
+
+   @Test
+   void setModel_staleIndexPointsAtDifferentBuiltInTab_throwsCleanError() throws Exception {
+      // caller read [Dashboard(0), Report(1)] but another request reordered it to
+      // [Dashboard(0), Schedule(1)] before this submission arrived
+      List<PortalTab> currentTabs = Arrays.asList(
+         new PortalTab("Dashboard", "/dashboard", true, false),
+         new PortalTab("Schedule", "/schedule", true, false));
+      when(manager.getPortalTabs()).thenReturn(currentTabs);
+
+      PortalTabModel staleTabModel = PortalTabModel.builder()
+         .name("Report")
+         .label("Repository")
+         .uri("/report")
+         .visible(false)
+         .editable(false)
+         .originalIndex(1)
+         .build();
+
+      PortalIntegrationSettingsModel model = baseModelBuilder()
+         .addTabs(staleTabModel)
+         .build();
+
+      assertThrows(MessageException.class, () -> service.setModel(model, principal, true));
+      verify(manager, never()).setPortalTabs(any());
+   }
+
+   @Test
+   void setModel_nonRacingBaseline_appliesNormally() throws Exception {
+      PortalTab editableTab = new PortalTab("OldName", "/old-uri", true, true);
+      List<PortalTab> currentTabs = Arrays.asList(
+         new PortalTab("Dashboard", "/dashboard", true, false),
+         editableTab);
+      when(manager.getPortalTabs()).thenReturn(currentTabs);
+
+      PortalTabModel builtInTabModel = PortalTabModel.builder()
+         .name("Dashboard")
+         .label("Dashboard")
+         .uri("/dashboard")
+         .visible(true)
+         .editable(false)
+         .originalIndex(0)
+         .build();
+
+      // legitimate, non-racing rename of an editable/custom tab
+      PortalTabModel renamedTabModel = PortalTabModel.builder()
+         .name("NewName")
+         .label("NewName")
+         .uri("/new-uri")
+         .visible(true)
+         .editable(true)
+         .originalIndex(1)
+         .build();
+
+      PortalIntegrationSettingsModel model = baseModelBuilder()
+         .addTabs(builtInTabModel, renamedTabModel)
+         .build();
+
+      service.setModel(model, principal, true);
+
+      ArgumentCaptor<List<PortalTab>> captor = ArgumentCaptor.forClass(List.class);
+      verify(manager).setPortalTabs(captor.capture());
+      List<PortalTab> saved = captor.getValue();
+      assertEquals(2, saved.size());
+      assertEquals("NewName", saved.get(1).getName());
+      assertEquals("/new-uri", saved.get(1).getURI());
+   }
+
+   private PortalIntegrationSettingsModel.Builder baseModelBuilder() {
+      return PortalIntegrationSettingsModel.builder()
+         .help(true)
+         .preference(true)
+         .logout(true)
+         .search(true)
+         .dashboardAvailable(true)
+         .home(true);
+   }
+}


### PR DESCRIPTION
## Root cause

`PortalIntegrationViewSettingsService.setModel` resolves each submitted `PortalTabModel` by
indexing directly into `PortalThemesManager`'s live, shared tab list using a caller-echoed
`originalIndex`, with no bounds check and no identity check. `PortalThemesManager` is a Spring
singleton whose `getPortalTabs()` returns the live field by reference (no defensive copy), and
`setModel` itself reloads from disk (`loadThemes()`) as its first statement -- so the race fires
across two *sequential* requests, not just literal concurrency: if another admin reorders or
removes a tab between when a client read the model and when it submits, the client's stale
`originalIndex` either

- throws a raw `ArrayIndexOutOfBoundsException` out of an `@Audited` service method (list shrank), or
- silently applies the edit to the wrong tab (list reordered, same length) -- no error, no indication
  anything went wrong.

## Fix

Two-part fix scoped entirely to `setModel`, no model/DTO changes:

1. Unconditional bounds check on `originalIndex` against `portalTabs.size()` -- throws a clear
   `MessageException` instead of letting `ArrayIndexOutOfBoundsException` escape.
2. Identity check (`tab.getName()` match) for **non-editable (built-in) tabs only** -- for those,
   `getModel` always echoes the raw internal name verbatim and `setModel`'s non-editable branch
   never mutates it, so a non-racing round trip is guaranteed to match. Editable/custom tabs are
   **not** identity-checked, since `tabModel.name()`/`tabModel.uri()` legitimately carry the *new*
   value on a legitimate rename -- comparing against the live tab's current name would
   false-positive. The bounds check alone is what's achievable there without a model change
   (residual gap, not fully closed by this fix).

## Other callers

`PresentationSettingsAccess` (admin-chat's Presentation area, #4844) wires this same
`getModel`/`setModel` as one of 16 sub-model adapters -- it goes through the same choke point, so
this fix protects it too. Confirmed `PresentationChangesetApplyService.apply`'s existing
`catch(Exception e)` around the `access.write(...)` call handles the new `MessageException` the
same as any other exception (recorded as `STATUS_FAILED`, no type-specific catch anywhere in that
path) -- no behavior change in kind for that caller.

`PresentationChangePlanService.requireWholeTabList` is a separate, narrower existing mitigation for
a shorter-array-drops-tabs failure mode; it does not overlap with this fix's stale-index scenario.

## Tests

New file `core/src/test/java/inetsoft/web/admin/presentation/PortalIntegrationViewSettingsServiceTest.java`
(none existed). 3 cases: stale out-of-bounds index, stale index pointing at a different built-in
tab after a reorder, and a non-racing baseline including a legitimate editable-tab rename. All
green; verified both racy-index cases fail against pre-fix code (one crashes with
`ArrayIndexOutOfBoundsException`, the other silently succeeds).

Fixes #76361

🤖 Generated with [Claude Code](https://claude.com/claude-code)