### PR TITLE
Fix CMap.getCMapData silently skipping the DataSpace fallback tier

### DIFF
--- a/core/src/main/java/inetsoft/report/pdf/CMap.java
+++ b/core/src/main/java/inetsoft/report/pdf/CMap.java
@@ -114,9 +114,10 @@ public class CMap {
             }
 
             DataSpace space = DataSpace.getDataSpace();
+            StringTokenizer tok2 = new StringTokenizer(path, ";");
 
-            while(tok.hasMoreTokens()) {
-               String dir = tok.nextToken();
+            while(tok2.hasMoreTokens()) {
+               String dir = tok2.nextToken();
                InputStream in = space.getInputStream(dir + cmapdir, name);
 
                if(in != null) {

--- a/core/src/test/java/inetsoft/report/pdf/CMapTest.java
+++ b/core/src/test/java/inetsoft/report/pdf/CMapTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.pdf;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.DataSpace;
+import inetsoft.util.FileSystemService;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * getCMapData reuses one StringTokenizer across a local-filesystem loop and a data-space
+ * fallback loop; once the first loop drains it, the second loop's body never executes,
+ * silently skipping the data-space tier entirely.
+ */
+@Tag("core")
+class CMapTest {
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private MockedStatic<FileSystemService> fileSystemServiceStatic;
+   private MockedStatic<DataSpace> dataSpaceStatic;
+   private FileSystemService fileSystemService;
+   private DataSpace dataSpace;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvStatic = mockStatic(SreeEnv.class);
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("font.cmap.path")).thenReturn("dirA;dirB");
+
+      fileSystemService = mock(FileSystemService.class);
+      fileSystemServiceStatic = mockStatic(FileSystemService.class);
+      fileSystemServiceStatic.when(FileSystemService::getInstance).thenReturn(fileSystemService);
+
+      File missingA = mock(File.class);
+      when(missingA.exists()).thenReturn(false);
+      File missingB = mock(File.class);
+      when(missingB.exists()).thenReturn(false);
+      when(fileSystemService.getFile("dirA", "cmap.name")).thenReturn(missingA);
+      when(fileSystemService.getFile("dirB", "cmap.name")).thenReturn(missingB);
+
+      dataSpace = mock(DataSpace.class);
+      dataSpaceStatic = mockStatic(DataSpace.class);
+      dataSpaceStatic.when(DataSpace::getDataSpace).thenReturn(dataSpace);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+      fileSystemServiceStatic.close();
+      dataSpaceStatic.close();
+   }
+
+   @Test
+   void getCMapData_localMiss_fallsBackToDataSpace() throws Exception {
+      InputStream dataSpaceStream = new ByteArrayInputStream(new byte[0]);
+      when(dataSpace.getInputStream("dirA", "cmap.name")).thenReturn(null);
+      when(dataSpace.getInputStream("dirB", "cmap.name")).thenReturn(dataSpaceStream);
+
+      InputStream result = CMap.getCMapData("cmap.name");
+
+      assertSame(dataSpaceStream, result);
+   }
+
+   @Test
+   void getCMapData_localAndDataSpaceMiss_fallsThroughToClasspathResource() throws Exception {
+      when(dataSpace.getInputStream("dirA", "cmap.name")).thenReturn(null);
+      when(dataSpace.getInputStream("dirB", "cmap.name")).thenReturn(null);
+
+      InputStream result = CMap.getCMapData("cmap.name");
+
+      assertNull(result);
+      verify(dataSpace).getInputStream("dirA", "cmap.name");
+      verify(dataSpace).getInputStream("dirB", "cmap.name");
+   }
+}


### PR DESCRIPTION
## Root cause

`CMap.getCMapData` (`core/src/main/java/inetsoft/report/pdf/CMap.java:94-133`) builds
one `StringTokenizer tok` over the configured cmap-path directories, fully drains it
in a local-filesystem lookup loop, then reuses the *same* `tok` in a second loop
meant to check the data space:

```java
StringTokenizer tok = new StringTokenizer(path, ";");

while(tok.hasMoreTokens()) {   // loop 1: local filesystem
   ...
}

DataSpace space = DataSpace.getDataSpace();

while(tok.hasMoreTokens()) {   // loop 2: data space -- reuses the exhausted tok
   ...
}
```

`java.util.StringTokenizer` is a forward-only cursor with no reset. Once loop 1 runs
to natural completion (no local file found), `tok.hasMoreTokens()` permanently
returns `false`, so loop 2's body never executes -- `DataSpace.getInputStream` is
never called. Every invocation where no configured directory has a local copy of the
requested CMap silently skips the data-space tier entirely and falls straight
through to the bundled classpath resource (`CMap.class.getResourceAsStream(...)`).

Affects both production paths into this method:
- The direct call at `core/src/main/java/inetsoft/report/pdf/PDF4Printer.java:297`
  (CJK font embedding into generated PDF output).
- The indirect path via `core/src/main/java/inetsoft/report/pdf/TTFontInfo.java:572`
  (`cjkmap = new CMap(cjk[1]);`), whose constructor (`CMap.java:39-56`) itself calls
  `getCMapData` at line 42.

## Fix

Build a second, independent `StringTokenizer tok2` over the same `path` string
immediately before the data-space loop, and use it there instead of the exhausted
`tok`. `path`/`cmapdir` are set once and never reassigned, and nothing computed in
loop 1 is needed by loop 2, so the new tokenizer reproduces the identical directory
list and order that the data-space fallback is supposed to check.

## Testing

Added `core/src/test/java/inetsoft/report/pdf/CMapTest.java`:
- `getCMapData_localMiss_fallsBackToDataSpace` -- both configured directories miss on
  the local filesystem; one of them has a data-space hit. Asserts `getCMapData`
  returns that stream. Fails on the old code (data-space loop never runs), passes
  after the fix.
- `getCMapData_localAndDataSpaceMiss_fallsThroughToClasspathResource` -- both tiers
  miss for both directories; asserts the method falls through to the classpath
  resource, and verifies `DataSpace.getInputStream` was actually invoked for both
  configured directories (guarding against the data-space loop being silently
  skipped again in the future).

Ran via a single-module offline reactor build:
```
./mvnw -o -pl core -am test -Dtest=CMapTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
```
`Tests run: 2, Failures: 0, Errors: 0`.

Found via the property-documentation corpus's own defect audit; no Redmine issue
filed for this one.