### PR TITLE
Fix import file-size cap precedence: CSV must not honour excel.import.max

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogService.java
@@ -1004,15 +1004,19 @@ public class ImportCSVDialogService {
          csvmax = SreeEnv.getProperty("csv.import.max");
       }
 
-      if(csvmax != null && file.length() > Long.parseLong(csvmax)) {
-         long sizeK = Long.parseLong(csvmax) / 1024;
+      Long maxBytes = parseImportMax(csvmax);
+
+      if(maxBytes != null && file.length() > maxBytes) {
+         long sizeK = maxBytes / 1024;
          long sizeM = sizeK / 1024;
          String sizeStr = sizeM > 0 ? sizeM + "M" : sizeK + "K";
          String msg = Catalog.getCatalog().getString("common.csvmax", sizeStr);
 
          // when using excel max for excel file, hint to the user to use CSV instead
-         if(!csv && csvImportMax != null && excelImportMax != null) {
-            long csvSizeM = Long.parseLong(csvImportMax) / 1024 / 1024;
+         Long csvImportMaxBytes = !csv ? parseImportMax(csvImportMax) : null;
+
+         if(csvImportMaxBytes != null && excelImportMax != null) {
+            long csvSizeM = csvImportMaxBytes / 1024 / 1024;
             msg = Catalog.getCatalog().getString("common.excelmax", sizeM, csvSizeM);
          }
 
@@ -1027,6 +1031,24 @@ public class ImportCSVDialogService {
       }
 
       return false;
+   }
+
+   /**
+    * Parses an excel.import.max/csv.import.max value, treating a malformed value as unbounded
+    * (logged, not thrown) so an admin typo cannot fail every import until fixed.
+    */
+   private static Long parseImportMax(String value) {
+      if(value == null) {
+         return null;
+      }
+
+      try {
+         return Long.parseLong(value);
+      }
+      catch(NumberFormatException e) {
+         LOG.warn("Ignoring non-numeric excel.import.max/csv.import.max value: {}", value);
+         return null;
+      }
    }
 
    private static void populateResultMap(HashMap<String, Object> resultMap,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1134,7 +1134,7 @@ public class WorksheetAgentController {
       // The same guard the multipart route gets: a JSON body's csv string is no less capable of
       // driving an unbounded temp-file write and loader scan than an uploaded file is.
       byte[] bytes = body.csv().getBytes(StandardCharsets.UTF_8);
-      checkImportFileSize(bytes.length, "CSV");
+      checkImportFileSize(bytes.length, "CSV", true);
 
       return importCsvBytes(sessionToken, user, body.name(), body.replaceTable(), bytes, settings);
    }
@@ -1171,7 +1171,7 @@ public class WorksheetAgentController {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "file is required");
       }
 
-      checkImportFileSize(file.getSize(), "CSV");
+      checkImportFileSize(file.getSize(), "CSV", true);
 
       CsvSettings settings = csvSettings(encoding, delimiter, delimiterTab, detectType,
                                          firstRowAsHeader, removeQuotes, unpivot, headerCols);
@@ -1337,7 +1337,7 @@ public class WorksheetAgentController {
                                            "fileType must be either \"XLS\" or \"XLSX\"");
       }
 
-      checkImportFileSize(file.getSize(), "Excel");
+      checkImportFileSize(file.getSize(), "Excel", false);
 
       byte[] bytes = file.getBytes();
 
@@ -1440,9 +1440,16 @@ public class WorksheetAgentController {
          : createEmbeddedTable(sessionToken, user, name, types, data, nrows, ncols);
    }
 
-   private void checkImportFileSize(long size, String what) {
+   private void checkImportFileSize(long size, String what, boolean csv) {
       String excelImportMax = SreeEnv.getProperty("excel.import.max");
-      String max = excelImportMax != null ? excelImportMax : SreeEnv.getProperty("csv.import.max");
+      String csvImportMax = SreeEnv.getProperty("csv.import.max");
+      String max = csv ? csvImportMax : excelImportMax;
+
+      // csv max applied to excel if excel max is not defined -- mirrors
+      // ImportCSVDialogService.isAboveMaxFileSize
+      if(max == null && !csv) {
+         max = csvImportMax;
+      }
 
       if(max == null) {
          return;

--- a/core/src/test/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogServiceTest.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws.dialog;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.execution.AssetDataCache;
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.util.FileSystemService;
+import inetsoft.util.MessageException;
+import inetsoft.web.composer.model.ws.ImportCSVDialogModelValidator;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.service.BinaryTransferService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for isAboveMaxFileSize's per-file-type precedence (CSV -> csv.import.max
+ * only; Excel -> excel.import.max, falling back to csv.import.max when unset) and for both
+ * Long.parseLong call sites now catching a malformed property value instead of throwing.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ImportCSVDialogServiceTest {
+   private ImportCSVDialogService createService() {
+      return new ImportCSVDialogService(mock(ViewsheetService.class), mock(VSLayoutService.class),
+         mock(BinaryTransferService.class), mock(AssetDataCache.class),
+         mock(FileSystemService.class));
+   }
+
+   private boolean invokeIsAboveMaxFileSize(ImportCSVDialogService service, File file,
+                                             boolean csv) throws Exception
+   {
+      Method method = ImportCSVDialogService.class.getDeclaredMethod(
+         "isAboveMaxFileSize", File.class, ImportCSVDialogModelValidator.Builder.class,
+         boolean.class);
+      method.setAccessible(true);
+
+      try {
+         return (boolean) method.invoke(service, file, null, csv);
+      }
+      catch(java.lang.reflect.InvocationTargetException e) {
+         if(e.getCause() instanceof RuntimeException re) {
+            throw re;
+         }
+
+         throw e;
+      }
+   }
+
+   private static File fileOfLength(long length) {
+      File file = mock(File.class);
+      when(file.length()).thenReturn(length);
+      return file;
+   }
+
+   @Test
+   void csvNeverReadsExcelImportMax() throws Exception {
+      ImportCSVDialogService service = createService();
+      File file = fileOfLength(2000);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         // Tiny enough that honouring it would reject this file; csv.import.max is left unset.
+         sreeEnv.when(() -> SreeEnv.getProperty("excel.import.max")).thenReturn("1");
+         sreeEnv.when(() -> SreeEnv.getProperty("csv.import.max")).thenReturn(null);
+
+         assertFalse(invokeIsAboveMaxFileSize(service, file, true),
+                     "CSV must not be capped by excel.import.max");
+      }
+   }
+
+   @Test
+   void excelFallsBackToCsvImportMaxWhenExcelImportMaxUnset() throws Exception {
+      ImportCSVDialogService service = createService();
+      File file = fileOfLength(2000);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("excel.import.max")).thenReturn(null);
+         sreeEnv.when(() -> SreeEnv.getProperty("csv.import.max")).thenReturn("100");
+
+         assertThrows(MessageException.class,
+                      () -> invokeIsAboveMaxFileSize(service, file, false),
+                      "Excel must fall back to csv.import.max when excel.import.max is unset");
+      }
+   }
+
+   @Test
+   void malformedCsvImportMaxIsTreatedAsUnboundedForCsv() throws Exception {
+      ImportCSVDialogService service = createService();
+      File file = fileOfLength(2000);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("excel.import.max")).thenReturn(null);
+         sreeEnv.when(() -> SreeEnv.getProperty("csv.import.max")).thenReturn("not-a-number");
+
+         assertFalse(invokeIsAboveMaxFileSize(service, file, true),
+                     "a malformed csv.import.max must be caught and treated as unbounded, "
+                     + "not thrown");
+      }
+   }
+
+   /**
+    * Regression guard for the second, independent Long.parseLong call in the "hint to use CSV
+    * instead" branch (isAboveMaxFileSize's excelmax-hint text) - a malformed csv.import.max here
+    * must not throw NumberFormatException even though excel.import.max (the value actually being
+    * enforced) is well-formed and the file legitimately exceeds it.
+    */
+   @Test
+   void malformedCsvImportMaxInHintBranchDoesNotThrowNumberFormatException() throws Exception {
+      ImportCSVDialogService service = createService();
+      File file = fileOfLength(2000);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("excel.import.max")).thenReturn("100");
+         sreeEnv.when(() -> SreeEnv.getProperty("csv.import.max")).thenReturn("not-a-number");
+
+         // The file legitimately exceeds excel.import.max, so this must still throw - but as
+         // MessageException (the documented behavior), never as a raw NumberFormatException
+         // escaping from the hint branch's own parse of the malformed csv.import.max.
+         assertThrows(MessageException.class,
+                      () -> invokeIsAboveMaxFileSize(service, file, false));
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -1536,6 +1536,72 @@ class WorksheetAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // Import file-size cap precedence (CSV must not honour excel.import.max)
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void importCsvIgnoresExcelImportMax() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      WorksheetAgentController ctrl = importController("TOK-CSV-NOEXCELMAX", rws);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class, CALLS_REAL_METHODS)) {
+         // Tiny enough that honouring it (the pre-fix, excel-first-then-csv behavior) would
+         // reject this CSV. csv.import.max is left unset.
+         sreeEnv.when(() -> SreeEnv.getProperty("excel.import.max")).thenReturn("1");
+
+         WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv("TOK-CSV-NOEXCELMAX",
+            new WorksheetAgentController.ImportCsvRequest("Imported", "a,b\n1,x\n2,y"), agent);
+
+         assertEquals("Imported", resp.tableName());
+      }
+   }
+
+   @Test
+   void importCsvStillHonorsCsvImportMax() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      WorksheetAgentController ctrl = importController("TOK-CSV-CSVMAX", rws);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class, CALLS_REAL_METHODS)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("csv.import.max")).thenReturn("1");
+
+         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> ctrl.importCsv("TOK-CSV-CSVMAX",
+               new WorksheetAgentController.ImportCsvRequest("Imported", "a,b\n1,x\n2,y"), agent));
+         assertEquals(400, ex.getStatusCode().value());
+      }
+   }
+
+   @Test
+   void importCsvTreatsMalformedCsvImportMaxAsUnbounded() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      WorksheetAgentController ctrl = importController("TOK-CSV-BADMAX", rws);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class, CALLS_REAL_METHODS)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("csv.import.max")).thenReturn("not-a-number");
+
+         WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv("TOK-CSV-BADMAX",
+            new WorksheetAgentController.ImportCsvRequest("Imported", "a,b\n1,x\n2,y"), agent);
+
+         assertEquals("Imported", resp.tableName());
+      }
+   }
+
+   // ---------------------------------------------------------------------------
    // Exception handling
    // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

`WorksheetAgentController.checkImportFileSize` (`core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java:1443-1469`) applies `excelImportMax != null ? excelImportMax : csvImportMax` unconditionally for all three import routes it guards - `importCsv` (JSON body), `importCsvFile` (multipart), and `importExcel` - including the two CSV routes. So a small `excel.import.max` wrongly caps a CSV upload the Composer's own Import dialog would accept.

`ImportCSVDialogService.isAboveMaxFileSize` (`core/src/main/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogService.java:995-1030`) is the original, intentional per-type design: CSV reads `csv.import.max` only; Excel reads `excel.import.max`, falling back to `csv.import.max` only when unset. `excel.import.max` never applies to a CSV file there.

**Git history** confirms which rule is intended, not just which is older: the excel-first fallback was introduced in `2da940a663` when the size-check helper (`checkExcelFileSize` at the time) was Excel-only, with a commit message stating it was written "mirroring `ImportCSVDialogService`" - correctly, since only the Excel branch (`csv=false`) was reachable at that point. It was generalized to the two CSV routes in two later commits - `0fc0808282` (multipart `importCsvFile`) and, three commits and one code-review cycle later, `68c5a513b9` ("Address review comments on PR #4678", adding the JSON-route `importCsv` call) - neither of which touches or discusses the size-check body's precedence logic. A second engineer, in a PR review comment, was still treating the helper as a single undifferentiated "import size limit" to copy for parity between the two CSV routes. That's a drift, not a design decision.

## Fix

Gave `checkImportFileSize` a `boolean csv` parameter and applied `ImportCSVDialogService`'s exact per-type precedence: `importCsv`/`importCsvFile` -> `csv=true` (reads `csv.import.max` only); `importExcel` -> `csv=false` (reads `excel.import.max`, falling back to `csv.import.max` when unset).

Also fixed a real gap: `isAboveMaxFileSize` has a **second, independent** `Long.parseLong(csvImportMax)` call in its "hint to use CSV instead" branch, parsing a different property than the one already checked. Both `Long.parseLong` calls now go through one small helper (`parseImportMax`) that logs and treats a malformed value as unbounded, matching `checkImportFileSize`'s existing policy - standardizing on catch-and-warn rather than `isAboveMaxFileSize`'s previous uncaught throw. This is a real, established idiom in this codebase for config-derived numeric values - `DataSpaceSettingsService`, `PerformanceSettingsService`, and `MonitorLevelService` all catch a malformed property value and fall back to a default rather than letting it propagate. (Two other candidates considered as precedent, `VSDndEvent`/`ChartDndHandler`, parse event/region type codes rather than admin-configured properties - a weaker analogy, not cited here. A third, `DeployService`, actually does the opposite - catches and rethrows as `IllegalArgumentException` - so it's not cited as supporting evidence either.)

**Accepted tradeoff, not additionally guarded against:** the two multipart routes (`importCsvFile`, `importExcel`) keep Spring's own `spring.servlet.multipart.max-file-size`/`max-request-size` (160MB, `server/src/main/resources/application.yaml`) as a backstop regardless of a malformed property, so "treat as unbounded" there really means "capped at 160MB instead of the admin's configured value." The JSON route (`importCsv`) has no equivalent backstop in this repo, so a malformed property there genuinely leaves it unbounded (heap-limited only) - a real asymmetry, but not something this fix adds new handling for; the property is opt-in/off-by-default and admin-only, and a config typo should not outage every import in the meantime.

## Testing

`core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java` - three new tests: `importCsvIgnoresExcelImportMax` (a tiny `excel.import.max` no longer rejects a CSV upload), `importCsvStillHonorsCsvImportMax` (the inverse - `csv.import.max` is still enforced), `importCsvTreatsMalformedCsvImportMaxAsUnbounded`. Run through the CSV route rather than Excel for the malformed-value case - the existing Excel size-check test in this file already documents that `core` has no `ExcelFileSupport` on its test classpath (a pre-existing, structural cross-module gap noted in that file), and the malformed-value path only needs to reach the shared check, which the CSV route already exercises fully within `core`.

New `core/src/test/java/inetsoft/web/composer/ws/dialog/ImportCSVDialogServiceTest.java` (no test file existed for this class before): CSV never reads `excel.import.max`; Excel falls back to `csv.import.max` when `excel.import.max` is unset; a malformed `csv.import.max` is caught and treated as unbounded for a CSV file; and a malformed `csv.import.max` in the "hint" branch does not throw `NumberFormatException` even when `excel.import.max` (the value actually being enforced) is valid and exceeded.

Ran `./mvnw -o -pl core -am test -Dtest=WorksheetAgentControllerTest,ImportCSVDialogServiceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`: `Tests run: 78, Failures: 0, Errors: 0` (74 in `WorksheetAgentControllerTest`, including 71 pre-existing + 3 new; 4 new in `ImportCSVDialogServiceTest`), full `core` module build succeeded.