### PR TITLE
Fix BaseTableCellModel's inverted hyperlink.indicator underline polarity

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/model/table/BaseTableCellModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/table/BaseTableCellModel.java
@@ -73,7 +73,7 @@ public class BaseTableCellModel implements BaseTableCellModelPrototype,
       this.isImage = isImage ? isImage : null;
       this.rowPadding = rowPadding;
       this.colPadding = colPadding;
-      this.underline = !"false".equals(SreeEnv.getProperty("hyperlink.indicator"));
+      this.underline = "true".equals(SreeEnv.getProperty("hyperlink.indicator"));
    }
 
    private BaseTableCellModel(Object cellData) {
@@ -102,7 +102,7 @@ public class BaseTableCellModel implements BaseTableCellModelPrototype,
       this.options = options;
       this.presenter = presenter;
       this.editable = editable ? editable : null;
-      this.underline = !"false".equals(SreeEnv.getProperty("hyperlink.indicator"));
+      this.underline = "true".equals(SreeEnv.getProperty("hyperlink.indicator"));
    }
 
    public static BaseTableCellModel createSimpleCell(XTable lens, int row, int col) {

--- a/core/src/test/java/inetsoft/web/viewsheet/model/table/BaseTableCellModelTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/model/table/BaseTableCellModelTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.model.table;
+
+import inetsoft.report.TableDataPath;
+import inetsoft.report.composition.VSTableLens;
+import inetsoft.report.lens.DefaultTableLens;
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.composer.model.vs.HyperlinkModel;
+import inetsoft.web.viewsheet.model.VSFormatModel;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * hyperlink.indicator's underline polarity must agree across BaseTableCellModel,
+ * VSTableLens, and GraphUtil for any value, not just the two shipped ones ("true"/"false") --
+ * BaseTableCellModel used to test !"false".equals(...) while the others test "true".equals(...),
+ * which only agree for those two literal strings.
+ */
+@Tag("core")
+class BaseTableCellModelTest {
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @AfterEach
+   void tearDown() {
+      if(sreeEnvStatic != null) {
+         sreeEnvStatic.close();
+      }
+   }
+
+   @Test
+   void underline_true_turnsUnderlineOn() throws Exception {
+      mockHyperlinkIndicator("true");
+
+      assertTrue(newRegularCell().isUnderline());
+      assertTrue(newFormCell().isUnderline());
+   }
+
+   @Test
+   void underline_false_turnsUnderlineOff() throws Exception {
+      mockHyperlinkIndicator("false");
+
+      assertFalse(newRegularCell().isUnderline());
+      assertFalse(newFormCell().isUnderline());
+   }
+
+   @Test
+   void underline_nonStandardValue_turnsUnderlineOff() throws Exception {
+      mockHyperlinkIndicator("1");
+
+      // Fails before the fix: BaseTableCellModel kept underline ON for anything that
+      // wasn't the literal string "false".
+      assertFalse(newRegularCell().isUnderline());
+      assertFalse(newFormCell().isUnderline());
+   }
+
+   @Test
+   void underline_nonStandardValue_matchesVSTableLens() throws Exception {
+      mockHyperlinkIndicator("1");
+
+      assertEquals(vsTableLensUnderline(), newRegularCell().isUnderline(),
+                   "BaseTableCellModel and VSTableLens must agree on underline for a "
+                   + "non-standard hyperlink.indicator value");
+   }
+
+   private void mockHyperlinkIndicator(String value) {
+      sreeEnvStatic = mockStatic(SreeEnv.class);
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("hyperlink.indicator")).thenReturn(value);
+   }
+
+   private static BaseTableCellModel newRegularCell() throws Exception {
+      Constructor<BaseTableCellModel> ctor = BaseTableCellModel.class.getDeclaredConstructor(
+         Object.class, Object.class, int.class, int.class, VSFormatModel.class, String.class,
+         HyperlinkModel[].class, TableDataPath.class, String.class, boolean.class, int.class,
+         int.class);
+      ctor.setAccessible(true);
+      return ctor.newInstance("data", "label", 0, 0, null, null, null, null, null, false, 0, 0);
+   }
+
+   private static BaseTableCellModel newFormCell() throws Exception {
+      Constructor<BaseTableCellModel> ctor = BaseTableCellModel.class.getDeclaredConstructor(
+         Object.class, Object.class, int.class, int.class, VSFormatModel.class,
+         HyperlinkModel[].class, TableDataPath.class, String.class, String[].class, String.class,
+         boolean.class);
+      ctor.setAccessible(true);
+      return ctor.newInstance("data", "label", 0, 0, null, null, null, null, null, null, false);
+   }
+
+   private static boolean vsTableLensUnderline() throws Exception {
+      VSTableLens lens = new VSTableLens(new DefaultTableLens(new Object[][]{{"a"}}));
+      Field field = VSTableLens.class.getDeclaredField("underline");
+      field.setAccessible(true);
+      return field.getBoolean(lens);
+   }
+}


### PR DESCRIPTION
## Root cause

`BaseTableCellModel.java` (both underline-setting constructors, lines 76 and 105)
tested:
```java
this.underline = !"false".equals(SreeEnv.getProperty("hyperlink.indicator"));
```
keeping the hyperlink underline **on** for anything other than the exact string
`"false"`. `VSTableLens.java:64` and `GraphUtil.java:1814` both instead test:
```java
"true".equals(SreeEnv.getProperty("hyperlink.indicator"))
```
turning the underline on only for the exact string `"true"`.

For the two shipped values (`"true"`/`"false"`) all three agree. For any other value
-- a typo, `"1"`, `"yes"`, a truthy-looking value copied from another system's config
convention -- a Viewer table cell shows the hyperlink underline while the
exported/embedded `VSTableLens` rendering and any chart hyperlink (`GraphUtil`) on
the same dashboard suppress it.

This exposure is real, not just theoretical: the EM UI's `hyperlink.indicator` value
field (`property-settings-view.component.html`) is a plain text input with a
non-restrictive Material autocomplete overlay offering `true`/`false` as
suggestions -- not a dropdown/select -- and the server-side
`PropertiesController.editProperty` endpoint only `.trim()`s the value with no
generic boolean-type validation for any property. The property is also settable
directly via env var, Redis-backed config, or a raw REST call, none of which go
through the EM UI at all.

## Why `"true".equals(...)` is the correct polarity to standardize on, not the reverse

- Exact-match `"true".equals(...)` is this codebase's dominant convention for
  boolean-style `SreeEnv` properties by roughly an **11:1** ratio over
  case-insensitive matching (independently confirmed on two separate greps), including
  the shared `SreeEnv.getBooleanPropertyValue()` helper (`return "true".equals(value);`
  when no custom `trueValues` are supplied) used by dozens of other properties.
- `VSTableLens`/`GraphUtil`'s exact-match form has been in place since the
  repository's initial commit; `BaseTableCellModel`'s inverted form was added about 7
  months later. Critically, per `git show` on that commit, `BaseTableCellModel`'s
  underline support was an **independent, from-scratch feature addition** (a new
  field, new getter/setter, and the two inverted-polarity lines, none of which
  existed in the class before) -- not an edit to previously-matching code. So there
  is no legacy `BaseTableCellModel`-specific behavior to preserve; it simply chose
  the opposite polarity from the already-established convention.
- It matches the shipped default (`defaults.properties: hyperlink.indicator=true`)
  with no case-folding needed, and closes the gap completely rather than narrowing it
  (unlike `equalsIgnoreCase`, which would still diverge for values like `"1"` or
  `"yes"`).

## Fix

Changed both of `BaseTableCellModel`'s underline assignments (lines 76, 105) from
`!"false".equals(...)` to `"true".equals(...)`, matching `VSTableLens`/`GraphUtil`
verbatim. No change needed to those two files -- they already use the polarity being
standardized on. No other reader of `hyperlink.indicator` exists in the repository.

## Testing

Added `core/src/test/java/inetsoft/web/viewsheet/model/table/BaseTableCellModelTest.java`
(reflection-based, since the relevant constructors are private):
- `underline_true_turnsUnderlineOn` / `underline_false_turnsUnderlineOff` -- both
  underline-setting constructors, both shipped values.
- `underline_nonStandardValue_turnsUnderlineOff` -- `hyperlink.indicator="1"` must
  turn underline off. This is the assertion that fails on the pre-fix code (it would
  incorrectly stay on).
- `underline_nonStandardValue_matchesVSTableLens` -- cross-class consistency check
  confirming `BaseTableCellModel` and `VSTableLens` agree on the same non-standard
  value.

Ran via a single-module offline reactor build:
```
./mvnw -o -pl core -am test -Dtest=BaseTableCellModelTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
```
`Tests run: 4, Failures: 0, Errors: 0`.

Found via the property-documentation corpus's own defect audit; no Redmine issue
filed for this one.