### PR TITLE
Fix: SQLHelper mysql timezone SQL cache doesn't invalidate via cluster sync

### DIFF
--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -75,6 +75,13 @@ public class PropertiesEngine {
       addPropertyChangeListener(
          QueryCacheSettings.TIMEOUT_PROPERTY,
          evt -> QueryCacheSettings.applyTimeout((String) evt.getNewValue()));
+      // mysql.server.timezone/mysql.local.timezone are baked into SQLHelper's static dfuncs cache
+      // on first load. applySqlHelperProperty() (below) already resets that cache on the node
+      // that writes the property; this listener covers the cluster-sync path, where a peer node
+      // learns of the change via this KeyValueStorage listener instead of its own setProperty
+      // call and would otherwise never invalidate its own copy of the cache.
+      addPropertyChangeListener("mysql.server.timezone", evt -> SQLHelper.resetCache());
+      addPropertyChangeListener("mysql.local.timezone", evt -> SQLHelper.resetCache());
       kvStorage = keyValueStorageManager.getStorage("sreeProperties");
    }
 

--- a/core/src/test/java/inetsoft/uql/jdbc/SQLHelperMysqlTimezoneCacheTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/SQLHelperMysqlTimezoneCacheTest.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc;
+
+import inetsoft.sree.PropertiesEngine;
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.beans.PropertyChangeSupport;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers the cluster-sync gap fixed by PropertiesEngine.initEngine()'s
+ * mysql.server.timezone/mysql.local.timezone listeners: a peer node that learns of a property
+ * change via PropertiesEngine's cluster-sync PropertyChangeEvent path (rather than its own
+ * direct SreeEnv.setProperty call, which is already covered by applySqlHelperProperty) must
+ * still invalidate SQLHelper's cached CONVERT_TZ SQL template.
+ *
+ * <p>Uses a real Spring-managed PropertiesEngine bean (as ScheduleTaskTest/DerbyHelperTest do)
+ * rather than a hand-built mock, because PropertiesEngine.initEngine() is a @PostConstruct
+ * instance method that (re)registers these listeners on every fresh bean instance -- unlike a
+ * static-initializer-based fix, this is not a once-per-JVM registration whose target instance
+ * depends on which test happens to touch the class first.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class SQLHelperMysqlTimezoneCacheTest {
+
+   @Autowired private PropertiesEngine propertiesEngine;
+
+   private static final String[] CACHE_FIELD_NAMES =
+      { "helperTable", "unsupported", "afuncs", "dfuncs" };
+
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private Object[] savedCacheFields;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      // Other test classes in this JVM (e.g. WindowFrameCapabilityTest) read SQLHelper's cache
+      // fields directly without ever calling getHelperClass() themselves, trusting that some
+      // earlier test already warmed the cache. SQLHelper.resetCache() nulls those fields (not
+      // just this test's own view of them), so save and restore the real static field values
+      // around this test instead of leaving them null/reset for whichever test runs next.
+      savedCacheFields = new Object[CACHE_FIELD_NAMES.length];
+
+      for(int i = 0; i < CACHE_FIELD_NAMES.length; i++) {
+         Field field = SQLHelper.class.getDeclaredField(CACHE_FIELD_NAMES[i]);
+         field.setAccessible(true);
+         savedCacheFields[i] = field.get(null);
+      }
+
+      SQLHelper.resetCache();
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() throws Exception {
+      sreeEnvStatic.close();
+
+      for(int i = 0; i < CACHE_FIELD_NAMES.length; i++) {
+         Field field = SQLHelper.class.getDeclaredField(CACHE_FIELD_NAMES[i]);
+         field.setAccessible(true);
+         field.set(null, savedCacheFields[i]);
+      }
+   }
+
+   @Test
+   void peerNodePropertyChangeEvent_invalidatesCache_soNextLoadUsesNewTimezone() throws Exception {
+      // locale_tz is stubbed as blank in both loads, so it always falls back to the JVM default
+      // (America/New_York, set by core/pom.xml's surefire argLine) -- pick server_tz values that
+      // don't collide with that fallback, so the assertions below test the server_tz baked value
+      // specifically, not the constant locale_tz fallback.
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mysql.server.timezone"))
+         .thenReturn("Asia/Tokyo");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mysql.local.timezone")).thenReturn("");
+
+      String initialCmd = loadMysqlYearCommand();
+      assertTrue(initialCmd.contains("Asia/Tokyo"),
+                 "sanity check: initial load must bake in the configured server timezone: " +
+                 initialCmd);
+
+      // Simulate a peer node's cluster-sync PropertyChangeEvent: the writing node already
+      // invalidates its own cache synchronously via PropertiesEngine.applySqlHelperProperty
+      // (called from setProperty -- not exercised here); a peer node instead learns of the
+      // change only via PropertiesEngine's PropertyChangeSupport, fired exactly this way from
+      // the private onChange() method on every KeyValueStorage entryAdded/Updated/Removed
+      // callback. Firing it directly on the real, Spring-managed PropertiesEngine bean exercises
+      // the actual listener registered by initEngine(), without needing to fake a whole
+      // KeyValueStorage/cluster round-trip.
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mysql.server.timezone")).thenReturn("UTC");
+      firePropertyChange("mysql.server.timezone", "Asia/Tokyo", "UTC");
+
+      String cmdAfterSync = loadMysqlYearCommand();
+      assertTrue(cmdAfterSync.contains("UTC") && !cmdAfterSync.contains("Asia/Tokyo"),
+                 "after the peer-node listener fires, the next load must rebuild the cache using " +
+                 "the new timezone instead of returning the stale cached template: " + cmdAfterSync);
+   }
+
+   @Test
+   void peerNodePropertyChangeEvent_forLocalTimezone_alsoInvalidatesCache() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mysql.server.timezone")).thenReturn("UTC");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mysql.local.timezone"))
+         .thenReturn("Asia/Tokyo");
+
+      String initialCmd = loadMysqlYearCommand();
+      assertTrue(initialCmd.contains("Asia/Tokyo"),
+                 "sanity check: initial load must bake in the configured local timezone: " +
+                 initialCmd);
+
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mysql.local.timezone"))
+         .thenReturn("Europe/London");
+      firePropertyChange("mysql.local.timezone", "Asia/Tokyo", "Europe/London");
+
+      String cmdAfterSync = loadMysqlYearCommand();
+      assertTrue(cmdAfterSync.contains("Europe/London") && !cmdAfterSync.contains("Asia/Tokyo"),
+                 "after the peer-node listener fires for mysql.local.timezone, the next load " +
+                 "must rebuild the cache using the new locale timezone: " + cmdAfterSync);
+   }
+
+   /** Fires a PropertyChangeEvent on the real PropertiesEngine bean's PropertyChangeSupport,
+    *  matching exactly what PropertiesEngine's private onChange() does on a cluster-sync
+    *  KeyValueStorage callback -- the only way to trigger initEngine()'s registered listeners
+    *  without standing up a real clustered KeyValueStorage. */
+   private void firePropertyChange(String name, String oldValue, String newValue) throws Exception {
+      Field supportField = PropertiesEngine.class.getDeclaredField("support");
+      supportField.setAccessible(true);
+      PropertyChangeSupport support = (PropertyChangeSupport) supportField.get(propertiesEngine);
+      support.firePropertyChange(name, oldValue, newValue);
+   }
+
+   /**
+    * Triggers SQLHelper's private getHelperClass() load and returns the mysql "year" CONVERT_TZ
+    * command it bakes into dfuncs, so tests can distinguish a fresh load from a stale one.
+    */
+   private static String loadMysqlYearCommand() throws Exception {
+      Method getHelperClass = SQLHelper.class.getDeclaredMethod("getHelperClass", String.class);
+      getHelperClass.setAccessible(true);
+      getHelperClass.invoke(null, "mysql");
+
+      Field dfuncsField = SQLHelper.class.getDeclaredField("dfuncs");
+      dfuncsField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<String, String> dfuncs = (Map<String, String>) dfuncsField.get(null);
+      String cmd = dfuncs.get("mysql:year");
+      assertNotNull(cmd, "mysql:year should be populated by getHelperClass()");
+
+      return cmd;
+   }
+}


### PR DESCRIPTION
## Scope (narrower than the original bug ledger claim)

`SQLHelper.getHelperClass()` bakes `mysql.server.timezone`/`mysql.local.timezone` into a static `CONVERT_TZ` SQL template cache (`dfuncs`) on first load, cached for the JVM's lifetime. **On a single-node install, or on the node that directly writes either property (EM UI, admin-chat), this already works today** — `PropertiesEngine.applyProperty` → `applySqlHelperProperty` → `SQLHelper.resetCache()` is already wired into both real write paths (`PropertiesController.java`, `AdminChangeService.java`).

The real, narrower gap is **cluster-sync only**: a peer node in a multi-node StyleBI cluster that learns of the property change via `KeyValueStorage` replication (not its own direct `setProperty` call) never invalidates its own cache copy. `PropertiesEngine.ChangeTask.run()` calls `instance.init(true)` (so `SreeEnv.getProperty(...)` correctly reflects the new value on that node) but never calls `applyProperty`/`SQLHelper.resetCache()`, and no `addPropertyChangeListener` was registered for either MySQL timezone property. That peer node's generated SQL keeps using the old timezone until it's restarted.

## Fix

Register the two property names in `PropertiesEngine.initEngine()` (`core/src/main/java/inetsoft/sree/PropertiesEngine.java`), matching the 3 pre-existing `addPropertyChangeListener` registrations there exactly:

```java
addPropertyChangeListener("mysql.server.timezone", evt -> SQLHelper.resetCache());
addPropertyChangeListener("mysql.local.timezone", evt -> SQLHelper.resetCache());
```

**Why `initEngine()` over the alternative `SQLHelper`-static-initializer location** (both were flagged as valid precedents — `TableFormat.java` has a static block doing the equivalent for its own cache): I initially implemented it as a static block in `SQLHelper.java`, mirroring `TableFormat`. While writing the regression test, I confirmed empirically that this location is materially harder to test reliably: a static initializer runs at most once per JVM life, permanently bound to whatever `PropertiesEngine` instance was resolvable via `ConfigurationContext` *the first time any code touches `SQLHelper`* — which, in the shared-JVM Surefire test run, is nondeterministic across test classes. I reproduced this directly: running my test alongside `DerbyHelperTest` (which touches `SQLHelper` first) caused the static-initializer version to silently register against a different `PropertiesEngine` than my test could observe, failing the listener-registration assertion. `initEngine()` is a `@PostConstruct` **instance** method, so it (re)registers correctly on every fresh Spring-managed `PropertiesEngine` bean, sidestepping this entirely — every test's own bean gets its own correctly-wired listeners, verified stable across multiple test orderings.

## Caveat (real, not fully closed by this fix — please read before merging)

The peer-node listener registered here fires **synchronously, immediately**, from `onChange()`'s `support.firePropertyChange(...)` call — but this happens *before*, not as part of, the debounced `ChangeTask.run()`/`instance.init(true)` (~500ms later) that actually reloads the in-memory property value. `SQLHelper.resetCache()` takes no value, so if a MySQL query triggers `getHelperClass()` in that narrow window, the cache rebuilds using the still-stale property value and stays wrong until the *next* actual property-change event fires.

This fix converts the bug from **"stale forever until restart"** into **"stale until the next property-change event, with a narrow residual race window"** — a real improvement, not a full closure. `mysql.server.timezone`/`mysql.local.timezone` are rarely-changed administrative settings, so the odds of a query landing in that sub-second window are low, and this is the same category of listener-fires-before-reload behavior `QueryCacheSettings`'s existing listeners already live with in this same class (see the comment above them). Fully closing this would require `SQLHelper.resetCache()` to consume the event's new value directly, which isn't currently plumbed through the private XML-parsing routine — treated as out of scope for this fix.

## Testing

Added `core/src/test/java/inetsoft/uql/jdbc/SQLHelperMysqlTimezoneCacheTest.java`:
- Uses a real Spring-managed `PropertiesEngine` bean (same convention as `ScheduleTaskTest`/`DerbyHelperTest`: `@ExtendWith(SpringExtension.class)`, `BaseTestConfiguration`).
- Fires a `PropertyChangeEvent` directly on the bean's `PropertyChangeSupport` (via reflection to the private `support` field) — the exact call `onChange()` makes on every real `KeyValueStorage` `entryAdded`/`entryUpdated`/`entryRemoved` callback — simulating the cluster-sync path without standing up a real clustered `KeyValueStorage`.
- Asserts `SQLHelper`'s next `getHelperClass()` load rebuilds the `CONVERT_TZ` template with the new timezone instead of the stale cached one, for both `mysql.server.timezone` and `mysql.local.timezone`.
- Saves/restores `SQLHelper`'s static cache fields around each test (via reflection), since other unrelated test classes in the same JVM (`WindowFrameCapabilityTest`, `WindowFunctionCapabilityTest`) read those fields directly without repopulating them and would NPE if left null.

Verified:
- New test passes in isolation and alongside `DerbyHelperTest`, `WindowFrameCapabilityTest`, `WindowFunctionCapabilityTest`, `PropertyChangeSideEffectsTest`, `SreeEnvTest`, in multiple orderings (53/53 passing).
- Reverting the fix reproduces both test failures (confirms the test actually exercises the gap).
- Command: `./mvnw -o -pl core -am test -Dtest=SQLHelperMysqlTimezoneCacheTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)