### PR TITLE
feat(admin-chat): add community-tier backup_storage tool backend

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/file/AdminFileBackupController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/file/AdminFileBackupController.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.file;
+
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * REST controller for the {@code backup_storage} admin-chat tool (Track C.5 03-reconcile.md
+ * Correction 1). Placed in {@code community/core}, not {@code enterprise/}: it wraps
+ * {@link inetsoft.web.admin.general.DataSpaceSettingsService#doBackup}, a community-tier
+ * dependency, so this area is not enterprise-gated - it works on a community-only deployment too,
+ * matching {@code AdminClusterController}/{@code AdminProviderController}'s own placement, not
+ * the enterprise-tier areas (Data Sources/Viewsheets/Licensing).
+ *
+ * <p>{@code @Secured} names {@code settings/content/data-space}, the same resource
+ * {@code DataSpaceFileSettingsController} uses. Unlike Cluster's {@code monitoring/cluster}, this
+ * resource sets {@code hiddenForMultiTenancy: true}, so {@code @Secured}'s
+ * {@code isComponentAccessible} half is a real, non-inert {@code isSiteAdmin} check on a
+ * multi-tenant deployment - but every tool still adds its own independent
+ * {@link #requireSiteAdmin} gate, the same belt-and-suspenders posture every prior area uses.
+ */
+@RestController
+public class AdminFileBackupController {
+   @Autowired
+   public AdminFileBackupController(AdminFileBackupService backupService) {
+      this.backupService = backupService;
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT,
+      resource = "settings/content/data-space",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/file/backup")
+   public Map<String, String> backup(@RequestBody Map<String, String> body, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return Map.of("backupPath", backupService.backup(body.get("task")));
+   }
+
+   /**
+    * Same rationale and shape as {@code AdminAiController#requireSiteAdmin} - see there.
+    */
+   private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
+      }
+   }
+
+   @ExceptionHandler(IllegalArgumentException.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleIllegalArgument(IllegalArgumentException ex) {
+      return Map.of("status", "failed", "error", String.valueOf(ex.getMessage()));
+   }
+
+   private final AdminFileBackupService backupService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/file/AdminFileBackupService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/file/AdminFileBackupService.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.file;
+
+import inetsoft.web.admin.general.BackupResult;
+import inetsoft.web.admin.general.DataSpaceSettingsService;
+import inetsoft.web.admin.general.model.BackupDataModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+/*
+ * A sibling of {@link inetsoft.web.admin.ai.AdminBackupService}, not a modification to it:
+ * that service exists to protect a single pending admin-chat transaction (tagged
+ * {@code aiSnapshot(true)}, landing in the small, separately-retained {@code ai-snapshots/}
+ * folder). This service is a general-purpose, human-requested "give me a full backup right now"
+ * export - functionally identical in intent to clicking the EM "Backup Now" button, just
+ * triggered through chat - so it deliberately tags {@code aiSnapshot(false)}, landing the export
+ * in the same counted/pruned {@code backup/} folder (bounded by {@code asset.backup.count}) the
+ * EM button itself uses, rather than competing with genuine Tier-2 transaction snapshots for the
+ * much smaller {@code ai.snapshot.count} retention window.
+ */
+@Service
+public class AdminFileBackupService {
+   @Autowired
+   public AdminFileBackupService(DataSpaceSettingsService dataSpaceSettingsService) {
+      this.dataSpaceSettingsService = dataSpaceSettingsService;
+   }
+
+   /**
+    * Exports the live storage to external storage via {@link DataSpaceSettingsService#doBackup},
+    * tagged with the given task description.
+    *
+    * @param task a short, human-readable description of why the backup was requested. Also used,
+    *             literally, as a dataspace-name path segment, so it is validated as a single safe
+    *             path segment.
+    *
+    * @return the external-storage path of the backup that was written.
+    *
+    * @throws IllegalArgumentException if {@code task} is null/blank or is not a safe, single path
+    *         segment (see {@link #requireSafePathSegment}).
+    * @throws IOException if the backup did not produce a usable artifact.
+    */
+   public String backup(String task) throws Exception {
+      requireSafePathSegment(task, "task", "task description");
+
+      BackupDataModel model = BackupDataModel.builder()
+         .dataspace("wiz-manual-" + task)
+         .aiSnapshot(false)
+         .build();
+      BackupResult result = dataSpaceSettingsService.doBackup(model);
+
+      if(result.path() == null) {
+         throw new IOException(
+            "Failed to back up storage for '" + task + "': " + result.status());
+      }
+
+      return result.path();
+   }
+
+   /**
+    * Rejects any null/blank value, or any value containing a path separator ({@code /} or
+    * {@code \}) or {@code ..}, so that a caller-supplied {@code task} can never be used to
+    * construct an unsafe dataspace/path segment. Fails loud with a field-named message rather
+    * than silently truncating or sanitizing the input.
+    */
+   private static void requireSafePathSegment(String value, String fieldName, String description) {
+      if(value == null || value.isBlank() ||
+         value.contains("/") || value.contains("\\") || value.contains(".."))
+      {
+         throw new IllegalArgumentException(fieldName + ": invalid " + description);
+      }
+   }
+
+   private final DataSpaceSettingsService dataSpaceSettingsService;
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/file/AdminFileBackupControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/file/AdminFileBackupControllerTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.file;
+
+import inetsoft.sree.security.OrganizationManager;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminFileBackupControllerTest {
+   @Mock private AdminFileBackupService backupService;
+   @Mock private OrganizationManager orgManager;
+   @Mock private Principal principal;
+   private AdminFileBackupController controller;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+
+   @BeforeEach
+   void setup() {
+      controller = new AdminFileBackupController(backupService);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+      // default to a site-admin caller so the delegation tests exercise delegation; individual
+      // tests override this to false to cover the FORBIDDEN gate
+      lenient().when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
+      // Every endpoint also requires a bearer-authenticated request (AdminAiCallerGuard); bind a
+      // request carrying one so these tests exercise the site-admin gate rather than that guard.
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer test-jwt");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      RequestContextHolder.resetRequestAttributes();
+   }
+
+   @Test void backupThrowsForbiddenWithoutBearerToken() {
+      RequestContextHolder.setRequestAttributes(
+         new ServletRequestAttributes(new MockHttpServletRequest()));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.backup(Map.of("task", "nightly-export"), principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(backupService);
+   }
+
+   @Test void backupThrowsForbiddenForNonSiteAdmin() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.backup(Map.of("task", "nightly-export"), principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(backupService);
+   }
+
+   @Test void backupDelegatesToService() throws Exception {
+      when(backupService.backup("nightly-export")).thenReturn("backup/wiz-manual-nightly-export-123.zip");
+
+      Map<String, String> actual =
+         controller.backup(Map.of("task", "nightly-export"), principal);
+
+      assertEquals("backup/wiz-manual-nightly-export-123.zip", actual.get("backupPath"));
+      verify(backupService).backup("nightly-export");
+   }
+
+   @Test void backupPropagatesExceptionOnFailure() throws Exception {
+      doThrow(new IOException("backup failed")).when(backupService).backup("nightly-export");
+
+      IOException ex = assertThrows(IOException.class,
+         () -> controller.backup(Map.of("task", "nightly-export"), principal));
+
+      assertEquals("backup failed", ex.getMessage());
+   }
+
+   @Test void handleIllegalArgumentReturnsFailedStatusWithMessage() {
+      Map<String, String> actual =
+         controller.handleIllegalArgument(new IllegalArgumentException("task: invalid task description"));
+
+      assertEquals("failed", actual.get("status"));
+      assertEquals("task: invalid task description", actual.get("error"));
+   }
+
+   @Test void handleIllegalArgumentIsAnnotatedBadRequest() throws NoSuchMethodException {
+      ResponseStatus annotation = AdminFileBackupController.class
+         .getMethod("handleIllegalArgument", IllegalArgumentException.class)
+         .getAnnotation(ResponseStatus.class);
+
+      assertNotNull(annotation, "handleIllegalArgument must be annotated @ResponseStatus");
+      assertEquals(HttpStatus.BAD_REQUEST, annotation.value());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/file/AdminFileBackupServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/file/AdminFileBackupServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.file;
+
+import inetsoft.web.admin.general.BackupResult;
+import inetsoft.web.admin.general.DataSpaceSettingsService;
+import inetsoft.web.admin.general.model.BackupDataModel;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminFileBackupServiceTest {
+   @Mock private DataSpaceSettingsService dataSpaceSettingsService;
+
+   private AdminFileBackupService service;
+
+   @BeforeEach
+   void setup() {
+      service = new AdminFileBackupService(dataSpaceSettingsService);
+   }
+
+   @Test
+   void backupReturnsThePathDoBackupReportedAndTagsTheModel() throws Exception {
+      ArgumentCaptor<BackupDataModel> captor = ArgumentCaptor.forClass(BackupDataModel.class);
+      when(dataSpaceSettingsService.doBackup(any()))
+         .thenReturn(new BackupResult("Success", "backup/wiz-manual-nightly-export-123.zip"));
+
+      String path = service.backup("nightly-export");
+
+      assertEquals("backup/wiz-manual-nightly-export-123.zip", path);
+      verify(dataSpaceSettingsService).doBackup(captor.capture());
+      BackupDataModel model = captor.getValue();
+      assertFalse(model.aiSnapshot(),
+                  "aiSnapshot must be false so this lands in the counted/pruned backup folder, "
+                  + "not the ai-snapshots folder");
+      assertEquals("wiz-manual-nightly-export", model.dataspace());
+   }
+
+   @Test
+   void backupThrowsWithTaskAndStatusWhenDoBackupReportsNoPath() {
+      when(dataSpaceSettingsService.doBackup(any()))
+         .thenReturn(new BackupResult("Failed to back up storage: disk full", null));
+
+      IOException ex = assertThrows(IOException.class, () -> service.backup("nightly-export"));
+
+      assertTrue(ex.getMessage().contains("nightly-export"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("Failed to back up storage: disk full"), ex.getMessage());
+      verify(dataSpaceSettingsService).doBackup(any());
+   }
+
+   @Test
+   void backupRejectsTaskWithPathTraversal() {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                                                   () -> service.backup("../../etc/passwd"));
+      assertTrue(ex.getMessage().contains("task"), ex.getMessage());
+      verifyNoInteractions(dataSpaceSettingsService);
+   }
+
+   @Test
+   void backupRejectsTaskWithSlash() {
+      assertThrows(IllegalArgumentException.class, () -> service.backup("nightly/export"));
+      verifyNoInteractions(dataSpaceSettingsService);
+   }
+
+   @Test
+   void backupRejectsTaskWithBackslash() {
+      assertThrows(IllegalArgumentException.class, () -> service.backup("nightly\\export"));
+      verifyNoInteractions(dataSpaceSettingsService);
+   }
+
+   @Test
+   void backupRejectsNullOrBlankTask() {
+      assertThrows(IllegalArgumentException.class, () -> service.backup(null));
+      assertThrows(IllegalArgumentException.class, () -> service.backup("   "));
+      verifyNoInteractions(dataSpaceSettingsService);
+   }
+}


### PR DESCRIPTION
## Summary

Adds the community-tier Java backend for the admin-chat `backup_storage` MCP tool — a new
`POST /api/wiz/v1/admin/file/backup` endpoint that triggers a manual, on-demand StyleBI data-space
backup via the existing `DataSpaceSettingsService.doBackup`, tagged `wiz-manual-<task>` and with
`aiSnapshot: false` (distinguishing it from the AI-snapshot path `AdminBackupService` already uses).

This is one of three sides of Track C.5's repository-maintenance + storage-backup area — design and
review chain in `docs/teams/2026-08-28-track-c5-repo-maintenance-backup/` (`00`–`08`). The area adds
5 tools total: 4 enterprise-gated repository-maintenance tools (`rebuild_dependencies`,
`repair_repository_folders`, PR against `stylebi-enterprise` separately, no submodule involvement)
and this one, `backup_storage`, which is **not** enterprise-gated — it works on a community-only
deployment too, since it wraps a community-tier dependency directly (matching the placement of
Cluster/Providers/Presentation before it, unlike the two enterprise-gated maintenance tools).

## What's new

- `community/core/src/main/java/inetsoft/web/admin/ai/file/AdminFileBackupService.java` — validates
  `task` (no `/`, `\`, `..`, blank/null — same shape `AdminBackupService.backup` already uses),
  calls `doBackup` with `dataspace("wiz-manual-" + task)`, `aiSnapshot(false)`.
- `community/core/src/main/java/inetsoft/web/admin/ai/file/AdminFileBackupController.java` —
  `POST /api/wiz/v1/admin/file/backup`, gated by `AdminAiCallerGuard.requireBearerAuthenticatedRequest()`
  + `OrganizationManager.isSiteAdmin(user)` (the standard admin-chat site-admin gate, first statement
  of the handler), `@Secured("settings/content/data-space")`.
- Regression tests for both classes (`AdminFileBackupServiceTest`, `AdminFileBackupControllerTest`),
  `@Tag("core")`: path-traversal rejection (`verifyNoInteractions` on every unsafe `task` shape),
  `aiSnapshot`/`dataspace` field assertions on the actual model passed to the mocked service, null-path
  → clean `IOException`, site-admin gate rejection.

## Test plan

- [x] `AdminFileBackupServiceTest` + `AdminFileBackupControllerTest`: 12/12 passing (Maven/Surefire,
      `community/core`), confirmed in `docs/teams/2026-08-28-track-c5-repo-maintenance-backup/05-build-community.md`.
- [x] Independent adversarial review (`08-review-r1.md`) re-derived the path-traversal defense from
      the actual sink (`DataSpaceSettingsService.getBackFile`) and the site-admin gate directly from
      source — no findings.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)