### PR TITLE
Fix Bug #76344: LicenseKeyModel.valid() always reports true regardless of actual license validity

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/general/model/LicenseKeyModel.java
+++ b/core/src/main/java/inetsoft/web/admin/general/model/LicenseKeyModel.java
@@ -47,7 +47,8 @@ public interface LicenseKeyModel {
    final class Builder extends ImmutableLicenseKeyModel.Builder {
       public Builder from(License license) {
          return key(license.key())
-            .type(license.description());
+            .type(license.description())
+            .valid(license.valid());
       }
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/general/model/LicenseKeyModelTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/model/LicenseKeyModelTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.admin.general.model;
+
+import inetsoft.report.internal.license.License;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Tag("core")
+class LicenseKeyModelTest {
+   // Builder.from() must carry the license's own valid() signal through to the model. Bug #76344:
+   // an expired/duplicate/unparseable license was silently reported as valid: true in the EM
+   // console's License Key page (and the single-key preview endpoint) because the default
+   // valid() method on the interface always returns true and Builder.from() never overrode it.
+   @Test
+   void fromReportsInvalidLicenseAsInvalid() {
+      License license = mock(License.class);
+      when(license.key()).thenReturn("LICENSE-KEY");
+      when(license.description()).thenReturn("Expired");
+      when(license.valid()).thenReturn(false);
+
+      LicenseKeyModel model = LicenseKeyModel.builder().from(license).build();
+
+      assertFalse(model.valid());
+   }
+
+   @Test
+   void fromReportsValidLicenseAsValid() {
+      License license = mock(License.class);
+      when(license.key()).thenReturn("LICENSE-KEY");
+      when(license.description()).thenReturn("1 Year(s)");
+      when(license.valid()).thenReturn(true);
+
+      LicenseKeyModel model = LicenseKeyModel.builder().from(license).build();
+
+      assertTrue(model.valid());
+   }
+}


### PR DESCRIPTION
## Summary
- `LicenseKeyModel.Builder.from(License)` only set `key()`/`type()`, so the interface's `@Value.Default valid() -> true` was returned unconditionally, even for expired/duplicate/unparseable licenses.
- This feeds `LicenseKeySettingsService.getServerLicenseData()` (EM console's License Key page) and `getSingleServerLicenseKey()` (the single-key preview endpoint the add-license dialog uses to gate its own form validity via `edit-license-key-dialog.component.ts`'s `keyModel.valid` check) — so an invalid key could be silently shown/accepted as valid.
- Fix: wire `license.valid()` into `Builder.from()`.

Redmine #76344.

## Test plan
- [x] Added `LicenseKeyModelTest` (`core/src/test/java/inetsoft/web/admin/general/model/LicenseKeyModelTest.java`): a mocked `License` with `valid() -> false` — confirmed it FAILED before the fix (`model.valid()` returned `true`), and PASSES after.
- [x] Ran broader regression: `LicenseKeyModelTest`, `GeneralSettingsPageControllerTest`, `DataSpaceSettingsServiceTest`, `EmailSettingsServiceTest` — 34/34 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)