### PR TITLE
Bug #76342, enforce cluster.pause.enabled server-side for pause/resume

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
+++ b/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
@@ -151,6 +151,22 @@ public class AdminExceptionHandler {
    }
 
    /**
+    * Error handler for access denied when a controller throws the checked
+    * {@link SecurityException} directly (not via {@link inetsoft.web.security.SecuredAspect},
+    * which is handled above through {@link #handleUndeclaredThrowable}).
+    */
+   @ExceptionHandler(SecurityException.class)
+   @ResponseBody
+   @ApiResponses({
+      @ApiResponse(
+         responseCode = "403",
+         description = "Access was denied because the requested action is not enabled or permitted.")
+   })
+   public ResponseEntity<GenericError> handleAccessDenied(SecurityException e) {
+      return accessDenied(e);
+   }
+
+   /**
     * Builds a sanitized 403 response for an authorization denial. The exception is logged at
     * debug level and the client receives a generic, localized message so that no principal,
     * role, group, or organization details are exposed.

--- a/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
+++ b/core/src/main/java/inetsoft/web/admin/AdminExceptionHandler.java
@@ -162,7 +162,7 @@ public class AdminExceptionHandler {
          responseCode = "403",
          description = "Access was denied because the requested action is not enabled or permitted.")
    })
-   public ResponseEntity<GenericError> handleAccessDenied(SecurityException e) {
+   public ResponseEntity<GenericError> handleCheckedAccessDenied(SecurityException e) {
       return accessDenied(e);
    }
 

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin.ai.cluster;
 
+import inetsoft.sree.security.SecurityException;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.*;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
@@ -142,6 +143,7 @@ public class ClusterChangesetApplyService {
 
    private void applyOne(String txId, String task, PlanChange change, ClusterChangeRequest original,
                          String reviewOutcome, Principal user, List<ClusterApplyOutcome> results)
+      throws SecurityException
    {
       String server = change.property();
       String verb = ClusterChangePlanService.requireVerb("apply", original.getVerb());

--- a/core/src/main/java/inetsoft/web/admin/cluster/ClusterController.java
+++ b/core/src/main/java/inetsoft/web/admin/cluster/ClusterController.java
@@ -121,7 +121,7 @@ public class ClusterController {
       )
    )
    @PostMapping("/api/em/monitoring/cluster/pause-server")
-   public void pauseServer(@RequestBody String[] servers) {
+   public void pauseServer(@RequestBody String[] servers) throws SecurityException {
       clusterService.pauseServers(servers);
    }
 
@@ -133,7 +133,7 @@ public class ClusterController {
       )
    )
    @PostMapping("/api/em/monitoring/cluster/resume-server")
-   public void resumeServer(@RequestBody String[] servers) {
+   public void resumeServer(@RequestBody String[] servers) throws SecurityException {
       clusterService.resumeServers(servers);
    }
 

--- a/core/src/main/java/inetsoft/web/admin/cluster/ClusterService.java
+++ b/core/src/main/java/inetsoft/web/admin/cluster/ClusterService.java
@@ -19,6 +19,7 @@ package inetsoft.web.admin.cluster;
 
 import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.web.admin.monitoring.*;
 import inetsoft.web.cluster.ServerClusterClient;
 import inetsoft.web.cluster.ServerClusterStatus;
@@ -93,11 +94,15 @@ public class ClusterService extends MonitorLevelService implements StatusUpdater
    public ClusterEnabledModel getClusterEnabled() {
       return ClusterEnabledModel.builder()
          .enabled(LicenseManager.isEnterprise())
-         .pauseEnabled("true".equals(SreeEnv.getProperty("cluster.pause.enabled", "false")))
+         .pauseEnabled(isPauseEnabled())
          .build();
    }
 
-   public void pauseServers(String[] servers) {
+   public void pauseServers(String[] servers) throws SecurityException {
+      if(!isPauseEnabled()) {
+         throw new SecurityException("Cluster pause is not enabled");
+      }
+
       ServerClusterClient client = new ServerClusterClient();
 
       for(String server : servers) {
@@ -113,7 +118,11 @@ public class ClusterService extends MonitorLevelService implements StatusUpdater
       }
    }
 
-   public void resumeServers(String[] servers) {
+   public void resumeServers(String[] servers) throws SecurityException {
+      if(!isPauseEnabled()) {
+         throw new SecurityException("Cluster pause is not enabled");
+      }
+
       ServerClusterClient client = new ServerClusterClient();
 
       for(String server : servers) {
@@ -127,6 +136,10 @@ public class ClusterService extends MonitorLevelService implements StatusUpdater
             LOG.warn("Failed to resume server");
          }
       }
+   }
+
+   private boolean isPauseEnabled() {
+      return "true".equals(SreeEnv.getProperty("cluster.pause.enabled", "false"));
    }
 
    private final ServerClusterClient client;

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
@@ -90,7 +90,7 @@ class ClusterChangesetApplyServiceTest {
    // success -- read-back drives "verified", uses a FRESH getStatus call, not the pre-apply snapshot
    // -------------------------------------------------------------------------
 
-   @Test void appliesAPauseAndReportsVerifiedFromFreshReadBack() {
+   @Test void appliesAPauseAndReportsVerifiedFromFreshReadBack() throws Exception {
       stubStatus("s1", ServerClusterStatus.Status.OK, false);
       String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
 
@@ -179,7 +179,7 @@ class ClusterChangesetApplyServiceTest {
    // failure does not stop subsequent entries -- item 4's structural divergence
    // -------------------------------------------------------------------------
 
-   @Test void aSingleEntryFailureDoesNotStopProcessingOfSubsequentEntries() {
+   @Test void aSingleEntryFailureDoesNotStopProcessingOfSubsequentEntries() throws Exception {
       stubStatus("s1", ServerClusterStatus.Status.DOWN, false);
       stubStatus("s2", ServerClusterStatus.Status.OK, false);
       String hash = planService.resolve(
@@ -221,7 +221,7 @@ class ClusterChangesetApplyServiceTest {
       }
    }
 
-   @Test void overallStatusIsAppliedWhenEveryEntrySucceeds() {
+   @Test void overallStatusIsAppliedWhenEveryEntrySucceeds() throws Exception {
       stubStatus("s1", ServerClusterStatus.Status.OK, false);
       stubStatus("s2", ServerClusterStatus.Status.OK, false);
       String hash = planService.resolve(
@@ -243,7 +243,7 @@ class ClusterChangesetApplyServiceTest {
    // a throw mid-apply is recorded as failed, never stops remaining entries, never rolled back
    // -------------------------------------------------------------------------
 
-   @Test void aThrowDuringApplyIsRecordedAsFailedAndDoesNotAbortRemainingEntries() {
+   @Test void aThrowDuringApplyIsRecordedAsFailedAndDoesNotAbortRemainingEntries() throws Exception {
       stubStatus("s1", ServerClusterStatus.Status.OK, false);
       stubStatus("s2", ServerClusterStatus.Status.OK, false);
       String hash = planService.resolve(

--- a/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
@@ -119,7 +119,7 @@ class ClusterControllerTest {
 
    // [G4] pauseServer delegates server array to clusterService.pauseServers
    @Test
-   void pauseServer_delegatesToService() {
+   void pauseServer_delegatesToService() throws SecurityException {
       String[] servers = { "node1", "node2" };
 
       controller.pauseServer(servers);
@@ -129,7 +129,7 @@ class ClusterControllerTest {
 
    // [G5] resumeServer delegates server array to clusterService.resumeServers
    @Test
-   void resumeServer_delegatesToService() {
+   void resumeServer_delegatesToService() throws SecurityException {
       String[] servers = { "node1" };
 
       controller.resumeServer(servers);

--- a/core/src/test/java/inetsoft/web/admin/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cluster/ClusterServiceTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.cluster;
+
+/*
+ * Test strategy
+ *
+ * Bug #76342: cluster.pause.enabled gated only a UI button, not the server-side
+ * pauseServers/resumeServers methods, so a direct REST call could pause/resume a cluster
+ * even when the property was unset/"false" (the shipped default).
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] pauseServers throws SecurityException and never calls ServerClusterClient.pauseServer
+ *      when cluster.pause.enabled is "false" (the default).
+ * [G2] pauseServers proceeds and still calls ServerClusterClient.pauseServer when
+ *      cluster.pause.enabled is "true" (no regression to the enabled path).
+ * [G3] resumeServers throws SecurityException and never calls ServerClusterClient.resumeServer
+ *      when cluster.pause.enabled is "false" (the default).
+ * [G4] resumeServers proceeds and still calls ServerClusterClient.resumeServer when
+ *      cluster.pause.enabled is "true" (no regression to the enabled path).
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.cluster.ServerClusterClient;
+import inetsoft.web.cluster.ServerClusterStatus;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ClusterServiceTest {
+
+   private ClusterService service;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @BeforeEach
+   void setUp() {
+      service = new ClusterService(mock(ServerClusterClient.class));
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   // [G1] pause disabled by default → refuse, never call pauseServer
+   @Test
+   void pauseServers_propertyFalse_throwsAndNeverPauses() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("false");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(false);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+             }))
+      {
+         assertThrows(SecurityException.class,
+            () -> service.pauseServers(new String[]{ "node1" }));
+
+         assertTrue(construction.constructed().isEmpty());
+      }
+   }
+
+   // [G2] pause enabled → proceeds, still calls pauseServer (no regression)
+   @Test
+   void pauseServers_propertyTrue_pausesServer() throws SecurityException {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("true");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(false);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+                when(mockClient.pauseServer(anyString())).thenReturn(true);
+             }))
+      {
+         service.pauseServers(new String[]{ "node1" });
+
+         verify(construction.constructed().get(0)).pauseServer("node1");
+      }
+   }
+
+   // [G3] resume disabled by default → refuse, never call resumeServer
+   @Test
+   void resumeServers_propertyFalse_throwsAndNeverResumes() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("false");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(true);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+             }))
+      {
+         assertThrows(SecurityException.class,
+            () -> service.resumeServers(new String[]{ "node1" }));
+
+         assertTrue(construction.constructed().isEmpty());
+      }
+   }
+
+   // [G4] resume enabled → proceeds, still calls resumeServer (no regression)
+   @Test
+   void resumeServers_propertyTrue_resumesServer() throws SecurityException {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("true");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(true);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+                when(mockClient.resumeServer(anyString())).thenReturn(true);
+             }))
+      {
+         service.resumeServers(new String[]{ "node1" });
+
+         verify(construction.constructed().get(0)).resumeServer("node1");
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- `cluster.pause.enabled` was read only by `ClusterService.getClusterEnabled()`, which feeds the EM console's Pause/Resume button visibility — neither `ClusterService.pauseServers`/`resumeServers` nor `ClusterController.pauseServer`/`resumeServer` ever checked it, so a direct REST call to `POST /api/em/monitoring/cluster/pause-server` (or `resume-server`) could pause/resume cluster servers even with the property unset/`"false"` (the shipped default).
- Extracted the existing boolean expression into `ClusterService.isPauseEnabled()`, reused by `getClusterEnabled()` and new guards at the top of `pauseServers`/`resumeServers` that throw `inetsoft.sree.security.SecurityException` when disabled (fail loud, not a silent no-op).
- Added an `@ExceptionHandler(SecurityException.class)` in `AdminExceptionHandler` mapping that checked exception to 403, since it wasn't already covered there (the existing 403 handling only applied to the unchecked `java.lang.SecurityException` from `SecuredAspect`, wrapped in `UndeclaredThrowableException`).

## Test plan
- [x] New `core/src/test/java/inetsoft/web/admin/cluster/ClusterServiceTest.java`: pause/resume both throw and never call the underlying client when the property is false/unset, and both still proceed normally when the property is `"true"` (no regression to the enabled path).
- [x] Updated `ClusterControllerTest` for the new checked `throws SecurityException` on `pauseServer`/`resumeServer`.
- [x] `./mvnw.cmd -pl core test -Dtest=ClusterServiceTest,ClusterControllerTest` — 10/10 passing.