### PR TITLE
Bug #76335, guard getAuthenticationProvider against unknown provider name

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -108,6 +108,11 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
    public AuthenticationProviderModel getAuthenticationProvider(String name) {
       boolean enterprise = LicenseManager.isEnterprise();
       AuthenticationProvider selectedProvider = getProviderByName(name);
+
+      if(selectedProvider == null) {
+         throw new MessageException(Catalog.getCatalog().getString("em.security.providerNotFound"));
+      }
+
       AuthenticationProviderModel.Builder builder = AuthenticationProviderModel.builder()
          .providerName(name)
          .oldName(name)

--- a/core/src/test/java/inetsoft/web/admin/security/AuthenticationProviderServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/AuthenticationProviderServiceTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.security.AuthenticationChain;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.util.MessageException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AuthenticationProviderServiceTest {
+
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SimpMessagingTemplate messageTemplate;
+   @Mock private Cluster cluster;
+   @Mock private AuthenticationChain authenticationChain;
+
+   private AuthenticationProviderService service;
+
+   @BeforeEach
+   void setUp() {
+      service = new AuthenticationProviderService(securityEngine, new ObjectMapper(),
+                                                   messageTemplate, cluster);
+   }
+
+   // getAuthenticationProvider(name) with a name that matches no configured provider must throw
+   // a MessageException, not an NPE (bug #76335).
+   @Test
+   void getAuthenticationProvider_unknownName_throwsMessageExceptionNotNPE() {
+      when(securityEngine.getAuthenticationChain()).thenReturn(Optional.of(authenticationChain));
+      when(authenticationChain.stream()).thenReturn(Stream.empty());
+
+      assertThrows(MessageException.class,
+                   () -> service.getAuthenticationProvider("does-not-exist"));
+   }
+}


### PR DESCRIPTION
## Summary
- `AuthenticationProviderService.getAuthenticationProvider(name)` fed a `null` provider (returned by `getProviderByName` on a miss) into the switch's `case null, default` arm, which called `AuthenticationProviderModel.Builder.customProviderModel(null, mapper)` and threw an unhandled `NullPointerException` (`provider.writeConfiguration(mapper)`) instead of a clean, caller-friendly error.
- Add a null check immediately after resolving `selectedProvider`, throwing `MessageException` with the existing generic `em.security.providerNotFound` catalog key ("Could not find provider") — mirroring the identical guard already present in the sibling `AuthorizationProviderService.getAuthorizationProvider`.
- Root cause and fix independently diagnosed and refuted twice against real source with a reproduced NPE stack trace; see `docs/teams/2026-08-29-bugs-c5-scoping-followups/bug-76335/` in the `stylebi-wiz` repo for the full analysis.

## Test plan
- [x] Added `AuthenticationProviderServiceTest.getAuthenticationProvider_unknownName_throwsMessageExceptionNotNPE`, which mocks an empty authentication chain and asserts `getAuthenticationProvider("does-not-exist")` throws `MessageException` (fails with NPE against the pre-fix code, passes after the fix).
- [x] `./mvnw -o -pl core -am test -Dtest=AuthenticationProviderServiceTest,AuthenticationProviderControllerTest -Dsurefire.failIfNoSpecifiedTests=false` — 7 tests, 0 failures, 0 errors.