### PR TITLE
Fix bug #76343, pauseServers/resumeServers discard per-server pause/resume result

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/cluster/ClusterController.java
+++ b/core/src/main/java/inetsoft/web/admin/cluster/ClusterController.java
@@ -121,8 +121,8 @@ public class ClusterController {
       )
    )
    @PostMapping("/api/em/monitoring/cluster/pause-server")
-   public void pauseServer(@RequestBody String[] servers) throws SecurityException {
-      clusterService.pauseServers(servers);
+   public Map<String, Boolean> pauseServer(@RequestBody String[] servers) throws SecurityException {
+      return clusterService.pauseServers(servers);
    }
 
    @Secured(
@@ -133,8 +133,8 @@ public class ClusterController {
       )
    )
    @PostMapping("/api/em/monitoring/cluster/resume-server")
-   public void resumeServer(@RequestBody String[] servers) throws SecurityException {
-      clusterService.resumeServers(servers);
+   public Map<String, Boolean> resumeServer(@RequestBody String[] servers) throws SecurityException {
+      return clusterService.resumeServers(servers);
    }
 
    private final ClusterService clusterService;

--- a/core/src/main/java/inetsoft/web/admin/cluster/ClusterService.java
+++ b/core/src/main/java/inetsoft/web/admin/cluster/ClusterService.java
@@ -98,44 +98,54 @@ public class ClusterService extends MonitorLevelService implements StatusUpdater
          .build();
    }
 
-   public void pauseServers(String[] servers) throws SecurityException {
+   public Map<String, Boolean> pauseServers(String[] servers) throws SecurityException {
       if(!isPauseEnabled()) {
          throw new SecurityException("Cluster pause is not enabled");
       }
 
       ServerClusterClient client = new ServerClusterClient();
+      Map<String, Boolean> results = new LinkedHashMap<>();
 
       for(String server : servers) {
          if(client.getStatus(server).isPaused()) {
+            results.put(server, true);
             continue;
          }
 
          boolean success = client.pauseServer(server);
+         results.put(server, success);
 
          if(!success) {
-            LOG.warn("Failed to pause server");
+            LOG.warn("Failed to pause server {}", server);
          }
       }
+
+      return results;
    }
 
-   public void resumeServers(String[] servers) throws SecurityException {
+   public Map<String, Boolean> resumeServers(String[] servers) throws SecurityException {
       if(!isPauseEnabled()) {
          throw new SecurityException("Cluster pause is not enabled");
       }
 
       ServerClusterClient client = new ServerClusterClient();
+      Map<String, Boolean> results = new LinkedHashMap<>();
 
       for(String server : servers) {
          if(!client.getStatus(server).isPaused()) {
+            results.put(server, true);
             continue;
          }
 
          boolean success = client.resumeServer(server);
+         results.put(server, success);
 
          if(!success) {
-            LOG.warn("Failed to resume server");
+            LOG.warn("Failed to resume server {}", server);
          }
       }
+
+      return results;
    }
 
    private boolean isPauseEnabled() {

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4166,6 +4166,7 @@ em.changePassword.requiredOld=Please enter the old password
 em.changePassword.success=The password was changed successfully.
 em.cluster.key.required=Need a valid key.
 em.cluster.pause.last=No cluster node is available.
+em.cluster.pauseResume.failed=Failed to pause/resume the following server(s)
 em.clusterMonitoring.title=Cluster Monitoring
 em.common.clearAll=Are you sure you want to delete all the items?
 em.common.config.integer=Please enter an integer.

--- a/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cluster/ClusterControllerTest.java
@@ -37,8 +37,8 @@ package inetsoft.web.admin.cluster;
  * [G1] getClusterNodes when server.type != "server_cluster" → returns null (not cluster mode).
  * [G2] getClusterStatus delegates to clusterService and returns the result.
  * [G3] getClusterEnabled delegates to clusterService and returns the result.
- * [G4] pauseServer delegates servers array to clusterService.pauseServers().
- * [G5] resumeServer delegates servers array to clusterService.resumeServers().
+ * [G4] pauseServer delegates servers array to clusterService.pauseServers() and returns its result.
+ * [G5] resumeServer delegates servers array to clusterService.resumeServers() and returns its result.
  * [G6] subscribeClusterStatus STOMP handler throws SecurityException when permission denied.
  */
 
@@ -54,6 +54,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -117,23 +118,29 @@ class ClusterControllerTest {
       assertSame(expected, result);
    }
 
-   // [G4] pauseServer delegates server array to clusterService.pauseServers
+   // [G4] pauseServer delegates server array to clusterService.pauseServers and returns its result
    @Test
    void pauseServer_delegatesToService() throws SecurityException {
       String[] servers = { "node1", "node2" };
+      Map<String, Boolean> expected = Map.of("node1", true, "node2", false);
+      when(clusterService.pauseServers(servers)).thenReturn(expected);
 
-      controller.pauseServer(servers);
+      Map<String, Boolean> result = controller.pauseServer(servers);
 
+      assertSame(expected, result);
       verify(clusterService).pauseServers(servers);
    }
 
-   // [G5] resumeServer delegates server array to clusterService.resumeServers
+   // [G5] resumeServer delegates server array to clusterService.resumeServers and returns its result
    @Test
    void resumeServer_delegatesToService() throws SecurityException {
       String[] servers = { "node1" };
+      Map<String, Boolean> expected = Map.of("node1", true);
+      when(clusterService.resumeServers(servers)).thenReturn(expected);
 
-      controller.resumeServer(servers);
+      Map<String, Boolean> result = controller.resumeServer(servers);
 
+      assertSame(expected, result);
       verify(clusterService).resumeServers(servers);
    }
 

--- a/core/src/test/java/inetsoft/web/admin/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/cluster/ClusterServiceTest.java
@@ -34,6 +34,18 @@ package inetsoft.web.admin.cluster;
  *      when cluster.pause.enabled is "false" (the default).
  * [G4] resumeServers proceeds and still calls ServerClusterClient.resumeServer when
  *      cluster.pause.enabled is "true" (no regression to the enabled path).
+ *
+ * Bug #76343: pauseServers/resumeServers were void, discarding each server's per-call
+ * success/failure, so a caller could never tell whether a pause/resume actually took effect.
+ *
+ * [G5] pauseServers returns a map with false for a server whose pauseServer(...) call fails
+ *      and true for one that succeeds.
+ * [G6] pauseServers reports true (not omitted) for a server already paused, without calling
+ *      pauseServer for it.
+ * [G7] resumeServers returns a map with false for a server whose resumeServer(...) call fails
+ *      and true for one that succeeds.
+ * [G8] resumeServers reports true (not omitted) for a server already resumed, without calling
+ *      resumeServer for it.
  */
 
 import inetsoft.sree.SreeEnv;
@@ -43,6 +55,8 @@ import inetsoft.web.cluster.ServerClusterStatus;
 import org.junit.jupiter.api.*;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -142,6 +156,88 @@ class ClusterServiceTest {
          service.resumeServers(new String[]{ "node1" });
 
          verify(construction.constructed().get(0)).resumeServer("node1");
+      }
+   }
+
+   // [G5] pauseServers reports false for a server the client fails to pause, true for one it pauses
+   @Test
+   void pauseServers_returnsFalseForFailedServerAndTrueForSucceeded() throws SecurityException {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("true");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(false);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+                when(mockClient.pauseServer("node1")).thenReturn(true);
+                when(mockClient.pauseServer("node2")).thenReturn(false);
+             }))
+      {
+         Map<String, Boolean> result = service.pauseServers(new String[]{ "node1", "node2" });
+
+         assertEquals(Map.of("node1", true, "node2", false), result);
+      }
+   }
+
+   // [G6] pauseServers reports true (not omitted) for an already-paused server, without calling pauseServer
+   @Test
+   void pauseServers_reportsTrueForAlreadyPausedServerWithoutCallingClient() throws SecurityException {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("true");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(true);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+             }))
+      {
+         Map<String, Boolean> result = service.pauseServers(new String[]{ "node1" });
+
+         assertEquals(Map.of("node1", true), result);
+         verify(construction.constructed().get(0), never()).pauseServer(anyString());
+      }
+   }
+
+   // [G7] resumeServers reports false for a server the client fails to resume, true for one it resumes
+   @Test
+   void resumeServers_returnsFalseForFailedServerAndTrueForSucceeded() throws SecurityException {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("true");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(true);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+                when(mockClient.resumeServer("node1")).thenReturn(true);
+                when(mockClient.resumeServer("node2")).thenReturn(false);
+             }))
+      {
+         Map<String, Boolean> result = service.resumeServers(new String[]{ "node1", "node2" });
+
+         assertEquals(Map.of("node1", true, "node2", false), result);
+      }
+   }
+
+   // [G8] resumeServers reports true (not omitted) for an already-resumed server, without calling resumeServer
+   @Test
+   void resumeServers_reportsTrueForAlreadyResumedServerWithoutCallingClient() throws SecurityException {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("cluster.pause.enabled", "false"))
+         .thenReturn("true");
+
+      try(MockedConstruction<ServerClusterClient> construction =
+             mockConstruction(ServerClusterClient.class, (mockClient, context) -> {
+                ServerClusterStatus status = mock(ServerClusterStatus.class);
+                when(status.isPaused()).thenReturn(false);
+                when(mockClient.getStatus(anyString())).thenReturn(status);
+             }))
+      {
+         Map<String, Boolean> result = service.resumeServers(new String[]{ "node1" });
+
+         assertEquals(Map.of("node1", true), result);
+         verify(construction.constructed().get(0), never()).resumeServer(anyString());
       }
    }
 }

--- a/web/projects/em/src/app/monitoring/cluster/cluster-monitoring-page/cluster-monitoring-page.component.ts
+++ b/web/projects/em/src/app/monitoring/cluster/cluster-monitoring-page/cluster-monitoring-page.component.ts
@@ -136,13 +136,26 @@ export class ClusterMonitoringPageComponent implements OnInit, OnDestroy {
             }
 
             this.http.post("../api/em/monitoring/cluster/pause-server",
-               this.selectedNodes.map((node) => node.server)).subscribe();
+               this.selectedNodes.map((node) => node.server)).subscribe(
+                  (results: Record<string, boolean>) => this.notifyFailedServers(results));
       });
    }
 
    resumeServers() {
       this.http.post("../api/em/monitoring/cluster/resume-server",
-         this.selectedNodes.map((node) => node.server)).subscribe();
+         this.selectedNodes.map((node) => node.server)).subscribe(
+            (results: Record<string, boolean>) => this.notifyFailedServers(results));
+   }
+
+   private notifyFailedServers(results: Record<string, boolean>) {
+      const failedServers = Object.keys(results || {}).filter((server) => !results[server]);
+
+      if(failedServers.length > 0) {
+         this.snackBar.open(
+            "_#(js:em.cluster.pauseResume.failed): " + failedServers.join(", "), null, {
+               duration: Tool.SNACKBAR_DURATION,
+            });
+      }
    }
 
    ngOnInit() {


### PR DESCRIPTION
## Root cause

`ClusterService.pauseServers`/`resumeServers` were `void`, discarding
`ServerClusterClient.pauseServer`/`resumeServer`'s per-server success boolean (only a bare
`LOG.warn`, no aggregation, no return value). `ClusterController.pauseServer`/`resumeServer`
were also `void` REST endpoints delegating straight through, so `POST
/api/em/monitoring/cluster/pause-server` (or `resume-server`) always returned HTTP 200 with an
empty body regardless of whether 0 or all N requested servers actually paused/resumed.

Rebased onto post-#76342 mainline (#4872, `isPauseEnabled()` guard) before making this change;
this fix only changes what happens after that guard passes.

## Fix

- `ClusterService.pauseServers`/`resumeServers` now return `Map<String, Boolean>` (server name
  to success), reporting `true` for a server already in the desired paused/resumed state (not
  omitted) so the caller can do exact input/output reconciliation. `LOG.warn` now names the
  server on failure.
- `ClusterController.pauseServer`/`resumeServer` now return that map instead of `void`. HTTP
  200 stays the status for "request was processed, here is the per-server outcome" -- a mixed
  true/false map is a legitimate outcome, not an exception-worthy one (that's #76342's
  `SecurityException`, for a fundamentally disallowed request).
- EM cluster monitoring page (`cluster-monitoring-page.component.ts`): the previously
  fire-and-forget `pauseServers()`/`resumeServers()` now read the response and surface any
  failed server(s) via the existing snackbar pattern.
- Added `em.cluster.pauseResume.failed` to the base `srinter.properties` bundle.

## Out of scope (left untouched)

`ClusterChangesetApplyService.applyOne`/`readBackWithRetry` -- the admin-chat wrapper (#4823)
already works around this exact gap with its own read-back-with-retry mechanism, referenced by
name in its class javadoc. That mechanism has an independent justification (its own read-back
races a ~50ms debounced status-map write, which this fix's synchronous return value doesn't
address) and may still be the more reliable choice even after this fix lands. Whether to
simplify it to consume this fix's return value is a separate design call, not resolved here.

## Test plan

- [x] `ClusterServiceTest` (8 tests: 4 pre-existing from #76342 + 4 new `[G5]`-`[G8]` covering
      the new `Map<String, Boolean>` return, including the already-satisfied `true` case)
- [x] `ClusterControllerTest` (6 tests: existing `[G4]`/`[G5]` extended to assert pass-through
      of the returned map, matching the `[G2]`/`[G3]` pattern)
- [x] `ClusterChangesetApplyServiceTest` (10 tests, unchanged -- confirmed its `doAnswer`/
      `doThrow` mocks compile and pass unmodified against the new non-void return type)
- [ ] Frontend change reviewed by hand against existing patterns in the file; not run through
      Karma/tsc (no `node_modules` in this worktree) -- flagging for reviewer

```
Tests run: 8, Failures: 0 -- ClusterServiceTest
Tests run: 6, Failures: 0 -- ClusterControllerTest
Tests run: 10, Failures: 0 -- ClusterChangesetApplyServiceTest
```

Full root-cause/diagnosis/refute/fix writeup:
`stylebi-wiz` repo, `docs/teams/2026-08-29-bugs-c5-scoping-followups/bug-76343/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)