### PR TITLE
Add axis line/label color to /viewsheet/format (Wiz bug #76314 RI-004)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartFormatRequest.java
@@ -75,6 +75,17 @@ public class ChartFormatRequest {
    public Boolean getYAxisLogarithmic() { return yAxisLogarithmic; }
    public void setYAxisLogarithmic(Boolean yAxisLogarithmic) { this.yAxisLogarithmic = yAxisLogarithmic; }
 
+   /** Hex #RRGGBB for the X-axis's own line and label color; null = no change. Distinct from the chart's
+    *  DATA/series color (set via /viewsheet/colors) — this colors the axis itself. */
+   @JsonProperty("xAxisColor")
+   public String getXAxisColor() { return xAxisColor; }
+   public void setXAxisColor(String xAxisColor) { this.xAxisColor = xAxisColor; }
+
+   /** Hex #RRGGBB for the Y-axis's own line and label color; null = no change. */
+   @JsonProperty("yAxisColor")
+   public String getYAxisColor() { return yAxisColor; }
+   public void setYAxisColor(String yAxisColor) { this.yAxisColor = yAxisColor; }
+
    /** none | top | right | bottom | left | in_place (case-insensitive); null leaves the legend unchanged. */
    public String getLegendPosition() { return legendPosition; }
    public void setLegendPosition(String legendPosition) { this.legendPosition = legendPosition; }
@@ -138,6 +149,8 @@ public class ChartFormatRequest {
    private Double yAxisMax;
    private Double yAxisIncrement;
    private Boolean yAxisLogarithmic;
+   private String xAxisColor;
+   private String yAxisColor;
    private String legendPosition;
    private Boolean markerVisible;
    private String markerShape;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -3033,6 +3033,31 @@ public class WizAutoBindingService {
                "This chart has no Y axis, so the axis scale settings were not applied."));
          }
 
+         // Axis color — the axis's OWN line and label color, distinct from the chart's DATA/series
+         // color (set_chart_colors). X and Y are independent binding lists, so each is resolved and
+         // reported separately, mirroring the Y-axis-scale block above.
+         if(request.getXAxisColor() != null) {
+            Color color = parseColor(request.getXAxisColor());
+            int appliedXAxes = vsChartInfo != null
+               ? applyAxisColor(vsChartInfo.getXFields(), color) : 0;
+
+            if(appliedXAxes == 0) {
+               warnings.add(new ApplyWarning("xAxisColor",
+                  "This chart has no X axis, so the axis color was not applied."));
+            }
+         }
+
+         if(request.getYAxisColor() != null) {
+            Color color = parseColor(request.getYAxisColor());
+            int appliedYAxes = vsChartInfo != null
+               ? applyAxisColor(vsChartInfo.getYFields(), color) : 0;
+
+            if(appliedYAxes == 0) {
+               warnings.add(new ApplyWarning("yAxisColor",
+                  "This chart has no Y axis, so the axis color was not applied."));
+            }
+         }
+
          // Legend placement
          if(request.getLegendPosition() != null && desc != null && desc.getLegendsDescriptor() != null) {
             int layout = legendLayout(request.getLegendPosition());
@@ -3920,6 +3945,32 @@ public class WizAutoBindingService {
          case "heat" -> new HeatColorFrame();
          default -> null;
       };
+   }
+
+   /**
+    * Sets {@code color} as both the line color and the label text color on every ref's
+    * {@link AxisDescriptor}, skipping a ref with none. Returns how many axes it actually touched, so
+    * the caller can warn when a chart has no axis on that side (mirrors the Y-axis-scale block's own
+    * appliedAxes counting, for the same reason: a chart with no matching axis still returns 200 and
+    * nothing else marks that as a no-op).
+    */
+   private static int applyAxisColor(ChartRef[] refs, Color color) {
+      int applied = 0;
+
+      if(refs != null) {
+         for(ChartRef ref : refs) {
+            if(ref == null || ref.getAxisDescriptor() == null) {
+               continue;
+            }
+
+            AxisDescriptor axis = ref.getAxisDescriptor();
+            axis.setLineColor(color);
+            axis.getAxisLabelTextFormat().setColor(color);
+            applied++;
+         }
+      }
+
+      return applied;
    }
 
    /** Parses a #RRGGBB hex string into a Color; throws on a malformed value. */

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -30,6 +30,7 @@ import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.uql.viewsheet.graph.AxisDescriptor;
 import inetsoft.uql.viewsheet.graph.ChartDescriptor;
 import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.CompositeTextFormat;
 import inetsoft.uql.viewsheet.graph.LegendsDescriptor;
 import inetsoft.uql.viewsheet.graph.PlotDescriptor;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
@@ -38,7 +39,10 @@ import inetsoft.web.wiz.model.CreateViewsheetResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.awt.Color;
 import java.security.Principal;
 import java.util.Optional;
 
@@ -310,6 +314,80 @@ class WizAutoBindingServiceSetChartFormatTest {
 
       verify(axis).setMaximum(1000.0);
       assertNull(result.getWarnings());
+   }
+
+   // ── Axis color (RI-004: regression guard against the axis color painting the series instead) ──
+
+   @Test
+   void xAxisColorIsAppliedToTheLineAndLabelsOfEveryXAxis() throws Exception {
+      AxisDescriptor axis = mock(AxisDescriptor.class);
+      CompositeTextFormat labelFormat = mock(CompositeTextFormat.class);
+      when(axis.getAxisLabelTextFormat()).thenReturn(labelFormat);
+      ChartRef xref = mock(ChartRef.class);
+      when(xref.getAxisDescriptor()).thenReturn(axis);
+      VSChartInfo chartInfo = mock(VSChartInfo.class);
+      when(chartInfo.getXFields()).thenReturn(new ChartRef[]{ xref });
+      when(info.getVSChartInfo()).thenReturn(chartInfo);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setXAxisColor("#FF0000");
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      verify(axis).setLineColor(new Color(0xFF0000));
+      verify(labelFormat).setColor(new Color(0xFF0000));
+      assertNull(result.getWarnings());
+   }
+
+   @Test
+   void xAxisColorRequestOnAChartWithNoXAxisIsReportedWhileTheRestStillApplies() throws Exception {
+      VSChartInfo chartInfo = mock(VSChartInfo.class);
+      when(chartInfo.getXFields()).thenReturn(new ChartRef[0]);
+      when(info.getVSChartInfo()).thenReturn(chartInfo);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setXAxisColor("#FF0000");
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      verify(info).setTitleValue("Contacts per Account");
+      assertEquals(1, result.getWarnings().size());
+      assertEquals("xAxisColor", result.getWarnings().get(0).getOption());
+   }
+
+   @Test
+   void yAxisColorIsAppliedToTheLineAndLabelsOfEveryYAxisIndependentlyOfXAxisColor() throws Exception {
+      AxisDescriptor yAxis = mock(AxisDescriptor.class);
+      CompositeTextFormat yLabelFormat = mock(CompositeTextFormat.class);
+      when(yAxis.getAxisLabelTextFormat()).thenReturn(yLabelFormat);
+      ChartRef yref = mock(ChartRef.class);
+      when(yref.getAxisDescriptor()).thenReturn(yAxis);
+      VSChartInfo chartInfo = mock(VSChartInfo.class);
+      when(chartInfo.getYFields()).thenReturn(new ChartRef[]{ yref });
+      when(chartInfo.getXFields()).thenReturn(new ChartRef[0]);
+      when(info.getVSChartInfo()).thenReturn(chartInfo);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setYAxisColor("#0000FF");
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      verify(yAxis).setLineColor(new Color(0x0000FF));
+      verify(yLabelFormat).setColor(new Color(0x0000FF));
+      assertNull(result.getWarnings());
+   }
+
+   @Test
+   void aMalformedAxisColorHexIsRejectedAs400() throws Exception {
+      ChartFormatRequest request = new ChartFormatRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setXAxisColor("not-a-color");
+
+      ResponseStatusException thrown = assertThrows(ResponseStatusException.class,
+         () -> service.setChartFormat(request, null));
+
+      assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `ChartFormatRequest` gains `xAxisColor`/`yAxisColor` (hex `#RRGGBB`), applied via `WizAutoBindingService.setChartFormat` to every X/Y `ChartRef`'s `AxisDescriptor` — sets both the axis line color (`AxisDescriptor.setLineColor`) and the axis label text color (`AxisDescriptor.getAxisLabelTextFormat().setColor`).
- Mirrors the existing Y-axis-scale block's shape exactly: loops the axis's `ChartRef[]`, skips a ref with no `AxisDescriptor`, counts how many it actually touched, and warns (doesn't throw) when the chart has no matching axis.
- Backs a wiz-services fix (companion PR in `stylebi-wiz`) for Redmine #76314 RI-004: a chat request like "set the X axis color to red" was silently painting the chart's DATA series instead of the axis, because no axis-color parameter existed anywhere in the wiz endpoint surface (`ChartColorsRequest`/`ChartFormatRequest` both lacked one).

## Test plan
- [x] `./mvnw -o -pl community/core test -Dtest='WizAutoBindingServiceSetChartFormatTest' -DfailIfNoSpecifiedTests=false` — 21/21 pass (5 new: axis color applied to line+labels for X and Y, warning when the chart has no matching axis, malformed hex rejected as 400).
- [x] `./mvnw -o -pl community/core test -Dtest='inetsoft.web.wiz.**' -DfailIfNoSpecifiedTests=false` — 2632 tests, 1 pre-existing unrelated failure (`ScriptApiServiceTest.looksUpPrototypeMethodFromGeneratedCorpus`, nothing to do with charts/format), 1 pre-existing skip.
- [x] `./mvnw -o -q -pl community/core -am compile -DskipTests` — clean compile.