### PR TITLE
Fix Bug #76322: PropertyAliases omits data-binding vocabulary for 8 assembly types

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -407,6 +407,36 @@ public final class PropertyAliases {
       aliases.put("locked", size + ".locked");
    }
 
+   /**
+    * Gauge, text and image all hold a top-level {@code dataOutputPaneModel} — the query/column
+    * this output assembly's value binds to. {@code aggregate} is genuinely consumed for all
+    * three (not gauge-only — {@code TextPropertyDialogService} and {@code
+    * ImagePropertyDialogService} set it from and read it into {@code AggregateFormula} the same
+    * way {@code GaugePropertyDialogService} does), so it is safe to alias for all three rather
+    * than risking the shadow/projectForwardEnabled "exposes but does nothing" trap.
+    */
+   private static void dataOutput(Map<String, String> aliases) {
+      aliases.put("table", "dataOutputPaneModel.table");
+      aliases.put("column", "dataOutputPaneModel.column");
+      aliases.put("aggregate", "dataOutputPaneModel.aggregate");
+   }
+
+   /**
+    * Slider, spinner and text input all hold a top-level {@code dataInputPaneModel} — the
+    * row/column cell this input assembly's value writes back to. Combobox ALSO has this exact
+    * field, but is deliberately NOT routed through this helper: combobox's dropdown-population
+    * binding lives at {@code comboboxGeneralPaneModel.listValuesPaneModel...
+    * selectionListEditorModel.table}/{@code .column} (see {@link #listInput}), a completely
+    * different StyleBI concept that happens to share the field name {@code table} with
+    * {@code dataInputPaneModel.table}. Aliasing combobox's {@code dataInputPaneModel} under
+    * "table" here would silently collide with that alias and rebind the wrong setting.
+    */
+   private static void dataInput(Map<String, String> aliases) {
+      aliases.put("table", "dataInputPaneModel.table");
+      aliases.put("columnValue", "dataInputPaneModel.columnValue");
+      aliases.put("rowValue", "dataInputPaneModel.rowValue");
+   }
+
    private static Map<String, String> gauge() {
       Map<String, String> aliases = new LinkedHashMap<>();
       outputGeneral(aliases, "gaugeGeneralPaneModel");
@@ -416,6 +446,7 @@ public final class PropertyAliases {
       aliases.put("majorIncrement", "gaugeGeneralPaneModel.numberRangePaneModel.majorIncrement");
       aliases.put("minorIncrement", "gaugeGeneralPaneModel.numberRangePaneModel.minorIncrement");
       aliases.put("showValue", "gaugeAdvancedPaneModel.showValue");
+      dataOutput(aliases);
       return aliases;
    }
 
@@ -425,6 +456,7 @@ public final class PropertyAliases {
       sizePosition(aliases, "textGeneralPaneModel");
       aliases.put("alpha", "textGeneralPaneModel.alpha");
       aliases.put("popComponent", "textGeneralPaneModel.popComponent");
+      dataOutput(aliases);
       return aliases;
    }
 
@@ -437,6 +469,7 @@ public final class PropertyAliases {
       Map<String, String> aliases = new LinkedHashMap<>();
       outputGeneral(aliases, "imageGeneralPaneModel");
       sizePosition(aliases, "imageGeneralPaneModel");
+      dataOutput(aliases);
       return aliases;
    }
 
@@ -535,7 +568,13 @@ public final class PropertyAliases {
 
    // ── Phase 3 batch a ───────────────────────────────────────────────────────
 
-   /** Check box, combo box and radio button share a list-values general pane. */
+   /**
+    * Check box, combo box and radio button share a list-values general pane. This is the
+    * dropdown/list's own choices query — {@code selectionListEditorModel.table}/{@code .column}
+    * — distinct from combobox's separate top-level {@code dataInputPaneModel} (row/column
+    * write-back target), which is deliberately not aliased here or via {@link #dataInput}; see
+    * that method's doc for why the two must not collide under the same alias name.
+    */
    private static Map<String, String> listInput(String prefix, boolean hasTitle) {
       Map<String, String> aliases = new LinkedHashMap<>();
       dataGeneral(aliases, prefix);
@@ -544,6 +583,11 @@ public final class PropertyAliases {
       if(hasTitle) {
          title(aliases, prefix);
       }
+
+      String editor = prefix + ".listValuesPaneModel.comboBoxEditorModel." +
+         "selectionListDialogModel.selectionListEditorModel";
+      aliases.put("table", editor + ".table");
+      aliases.put("column", editor + ".column");
 
       return aliases;
    }
@@ -554,6 +598,7 @@ public final class PropertyAliases {
       sizePosition(aliases, "sliderGeneralPaneModel");
       numericRange(aliases, "sliderGeneralPaneModel");
       aliases.put("snap", "sliderAdvancedPaneModel.snap");
+      dataInput(aliases);
       return aliases;
    }
 
@@ -562,6 +607,7 @@ public final class PropertyAliases {
       dataGeneral(aliases, "spinnerGeneralPaneModel");
       sizePosition(aliases, "spinnerGeneralPaneModel");
       numericRange(aliases, "spinnerGeneralPaneModel");
+      dataInput(aliases);
       return aliases;
    }
 
@@ -569,6 +615,7 @@ public final class PropertyAliases {
       Map<String, String> aliases = new LinkedHashMap<>();
       dataGeneral(aliases, "textInputGeneralPaneModel");
       sizePosition(aliases, "textInputGeneralPaneModel");
+      dataInput(aliases);
       return aliases;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -438,4 +438,77 @@ class PropertyAliasesTest {
                                                    "chartLinePaneModel.gridLineVisible"),
                    "refused on 'chart', but nothing to refuse on a viewsheet");
    }
+
+   // ── data-binding vocabulary (bug 76322) ────────────────────────────────────
+   //
+   // Text, gauge, image, slider, spinner, checkbox, combobox and radiobutton each bind via a
+   // distinct nested path that was previously never aliased -- only reachable through
+   // get_assembly_properties(raw: true), buried in a nested dialog model. These assert the
+   // vocabulary is now discoverable via list_assembly_properties for every affected type.
+
+   @Test
+   void exposesDataOutputBindingForGaugeTextAndImage() {
+      for(String type : java.util.List.of("gauge", "text", "image")) {
+         for(String alias : java.util.List.of("table", "column", "aggregate")) {
+            assertTrue(PropertyAliases.forType(type).aliases().containsKey(alias),
+                       type + " should expose '" + alias + "'");
+         }
+
+         assertEquals("dataOutputPaneModel.table", PropertyAliases.resolve(type, "table"));
+         assertEquals("dataOutputPaneModel.column", PropertyAliases.resolve(type, "column"));
+         assertEquals("dataOutputPaneModel.aggregate", PropertyAliases.resolve(type, "aggregate"));
+      }
+   }
+
+   @Test
+   void exposesDataInputBindingForSliderSpinnerAndTextInput() {
+      for(String type : java.util.List.of("slider", "spinner", "textinput")) {
+         for(String alias : java.util.List.of("table", "columnValue", "rowValue")) {
+            assertTrue(PropertyAliases.forType(type).aliases().containsKey(alias),
+                       type + " should expose '" + alias + "'");
+         }
+
+         assertEquals("dataInputPaneModel.table", PropertyAliases.resolve(type, "table"));
+         assertEquals("dataInputPaneModel.columnValue", PropertyAliases.resolve(type, "columnValue"));
+         assertEquals("dataInputPaneModel.rowValue", PropertyAliases.resolve(type, "rowValue"));
+      }
+   }
+
+   @Test
+   void exposesListValuesBindingForCheckboxComboboxAndRadioButton() {
+      for(String type : java.util.List.of("checkbox", "combobox", "radiobutton")) {
+         assertTrue(PropertyAliases.forType(type).aliases().containsKey("table"),
+                    type + " should expose 'table'");
+         assertTrue(PropertyAliases.forType(type).aliases().containsKey("column"),
+                    type + " should expose 'column'");
+      }
+
+      assertEquals("checkboxGeneralPaneModel.listValuesPaneModel.comboBoxEditorModel." +
+                   "selectionListDialogModel.selectionListEditorModel.table",
+                   PropertyAliases.resolve("checkbox", "table"));
+      assertEquals("comboboxGeneralPaneModel.listValuesPaneModel.comboBoxEditorModel." +
+                   "selectionListDialogModel.selectionListEditorModel.column",
+                   PropertyAliases.resolve("combobox", "column"));
+      assertEquals("radioButtonGeneralPaneModel.listValuesPaneModel.comboBoxEditorModel." +
+                   "selectionListDialogModel.selectionListEditorModel.table",
+                   PropertyAliases.resolve("radiobutton", "table"));
+   }
+
+   /**
+    * Combobox alone has two distinct fields literally named {@code table}:
+    * {@code selectionListEditorModel.table} (the dropdown's own choices query -- what "table"
+    * means for every other list-input type too) and a completely separate top-level
+    * {@code dataInputPaneModel.table} (the row/column write-back target). The "table" alias must
+    * resolve to the former; aliasing the latter under the same name would silently rebind the
+    * wrong StyleBI concept.
+    */
+   @Test
+   void comboboxTableAliasIsTheListValuesQueryNotTheWriteBackTarget() {
+      String resolved = PropertyAliases.resolve("combobox", "table");
+
+      assertTrue(resolved.contains("selectionListEditorModel.table"),
+                 "combobox's 'table' alias should point at the list-values query");
+      assertFalse(resolved.equals("dataInputPaneModel.table"),
+                  "combobox's 'table' alias must not point at the row/column write-back target");
+   }
 }


### PR DESCRIPTION
## Summary
- Text, gauge, image, slider, spinner, checkbox, combobox and radiobutton each bind via a distinct nested path (`dataOutputPaneModel`, `dataInputPaneModel`, or `listValuesPaneModel...selectionListEditorModel`) that `PropertyAliases` never declared, so `list_assembly_properties` never surfaced it — only `get_assembly_properties(raw: true)` could reach it, buried inside the full dialog model.
- Adds the missing aliases via two new shared helpers (`dataOutput`/`dataInput`) plus new `listInput()` entries covering checkbox/combobox/radiobutton, and extends `textInput()` for the same gap in that closely related (9th) type.
- Combobox's separate `dataInputPaneModel` (row/column write-back target) is deliberately left unaliased under `"table"` to avoid colliding with its distinct `listValuesPaneModel...selectionListEditorModel.table` (dropdown query source) — both fields share the name `table` on different StyleBI concepts (see doc-comments on `dataInput()`/`listInput()`).

## Test plan
- [x] `mvn -pl core -am test -Dtest=PropertyAliasesTest -Dsurefire.failIfNoSpecifiedTests=false -o` — 36/36 tests pass (build SUCCESS), including 4 new tests covering the newly-exposed vocabulary and the combobox table-alias collision guard.
