### PR TITLE
fix(binding): match logical-model-scoped named groups by resolved source

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -22,12 +22,9 @@ import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
-import inetsoft.uql.asset.Assembly;
-import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
-import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import inetsoft.uql.viewsheet.DataVSAssembly;
@@ -330,35 +327,10 @@ public class CalcTableService {
                                                                 DataVSAssembly assembly,
                                                                 String column)
    {
-      List<DefaultNamedGroupAssembly> matches = new ArrayList<>();
       SourceInfo sinfo = assembly.getSourceInfo();
       Worksheet ws = rvs.getViewsheet() == null ? null : rvs.getViewsheet().getBaseWorksheet();
 
-      if(sinfo == null || sinfo.getSource() == null || ws == null) {
-         return matches;
-      }
-
-      for(Assembly wsAssembly : ws.getAssemblies()) {
-         if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
-            ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
-         {
-            continue;
-         }
-
-         SourceInfo attachedSource = ngAssembly.getAttachedSource();
-         DataRef attr = ngAssembly.getAttachedAttribute();
-
-         if(attachedSource == null || attr == null ||
-            !sinfo.getSource().equals(attachedSource.getSource()) ||
-            !column.equals(attr.getAttribute()))
-         {
-            continue;
-         }
-
-         matches.add(ngAssembly);
-      }
-
-      return matches;
+      return WorksheetNamedGroupMatcher.worksheetNamedGroups(ws, sinfo, column);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -21,9 +21,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.internal.binding.AssetNamedGroupInfo;
 import inetsoft.report.internal.binding.SummaryAttr;
 import inetsoft.uql.XConstants;
-import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetRepository;
-import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
@@ -43,7 +41,6 @@ import inetsoft.web.composer.model.condition.ConditionExpression;
 import inetsoft.web.composer.model.condition.ConditionUtil;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /** Converts between StyleBI's ref models and the agent-facing {@link FieldRef}. */
@@ -182,35 +179,10 @@ public final class FieldRefFactory {
    private static List<DefaultNamedGroupAssembly> worksheetNamedGroups(
       RuntimeViewsheet rvs, SourceInfo source, String column)
    {
-      List<DefaultNamedGroupAssembly> matches = new ArrayList<>();
       Worksheet ws = rvs == null || rvs.getViewsheet() == null
          ? null : rvs.getViewsheet().getBaseWorksheet();
 
-      if(source == null || source.getSource() == null || ws == null) {
-         return matches;
-      }
-
-      for(Assembly wsAssembly : ws.getAssemblies()) {
-         if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
-            ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
-         {
-            continue;
-         }
-
-         SourceInfo attachedSource = ngAssembly.getAttachedSource();
-         DataRef attr = ngAssembly.getAttachedAttribute();
-
-         if(attachedSource == null || attr == null ||
-            !source.getSource().equals(attachedSource.getSource()) ||
-            !column.equals(attr.getAttribute()))
-         {
-            continue;
-         }
-
-         matches.add(ngAssembly);
-      }
-
-      return matches;
+      return WorksheetNamedGroupMatcher.worksheetNamedGroups(ws, source, column);
    }
 
    public static FieldRef from(DataRefModel ref) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/WorksheetNamedGroupMatcher.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/WorksheetNamedGroupMatcher.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.uql.asset.AbstractTableAssembly;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AttachedAssembly;
+import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.DataRef;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Finds the worksheet-local {@code DefaultNamedGroupAssembly}(s) {@code add_named_group}
+ * attached to a given column of a given {@code SourceInfo}.
+ *
+ * <p>Shared by {@link CalcTableService} and {@link FieldRefFactory}, which each need this
+ * lookup for a different caller shape (a bound {@code DataVSAssembly} vs. a bare
+ * {@code SourceInfo}) but must apply identical matching -- previously hand-mirrored as two
+ * separate copies, which is how one of the two creation modes below was fixed in only one
+ * of the two consumers.
+ *
+ * <p>{@code add_named_group} attaches a created group's {@code SourceInfo} one of two ways:
+ * <ul>
+ *   <li>Plain worksheet-table+column mode: {@code attachedSource} is set to that worksheet
+ *       table's own bound {@code SourceInfo} verbatim -- matches {@code sinfo} (the crosstab/
+ *       table's own bound {@code SourceInfo}, always {@code SourceInfo.ASSET} with source =
+ *       the worksheet table's assembly name) directly.</li>
+ *   <li>Datasource-scoped (logical-model or physical-table attribute) mode: {@code
+ *       attachedSource} is set to the datasource/logical-model/physical-table {@code
+ *       SourceInfo} itself (e.g. {@code SourceInfo.MODEL}, source = the logical model name) --
+ *       never equal to {@code sinfo}, which is always the worksheet table's own name. This only
+ *       matches the worksheet table assembly's <em>own</em> {@code SourceInfo} (what a {@code
+ *       BoundTableAssembly} created the same way carries), which {@code sinfo.getSource()}
+ *       names but is not itself equal to.</li>
+ * </ul>
+ */
+final class WorksheetNamedGroupMatcher {
+   private WorksheetNamedGroupMatcher() {
+   }
+
+   static List<DefaultNamedGroupAssembly> worksheetNamedGroups(
+      Worksheet ws, SourceInfo sinfo, String column)
+   {
+      List<DefaultNamedGroupAssembly> matches = new ArrayList<>();
+
+      if(sinfo == null || sinfo.getSource() == null || ws == null) {
+         return matches;
+      }
+
+      Assembly bound = ws.getAssembly(sinfo.getSource());
+      SourceInfo boundSource =
+         bound instanceof AbstractTableAssembly table ? table.getSourceInfo() : null;
+
+      for(Assembly wsAssembly : ws.getAssemblies()) {
+         if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
+            ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
+         {
+            continue;
+         }
+
+         SourceInfo attachedSource = ngAssembly.getAttachedSource();
+         DataRef attr = ngAssembly.getAttachedAttribute();
+
+         if(attachedSource == null || attr == null || !column.equals(attr.getAttribute())) {
+            continue;
+         }
+
+         boolean directMatch = sinfo.getSource().equals(attachedSource.getSource());
+         boolean resolvedMatch = boundSource != null && boundSource.equals(attachedSource);
+
+         if(!directMatch && !resolvedMatch) {
+            continue;
+         }
+
+         matches.add(ngAssembly);
+      }
+
+      return matches;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -38,6 +38,7 @@ import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.NamedGroupInfo;
 import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.AbstractTableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.util.XNamedGroupInfo;
@@ -538,6 +539,45 @@ class CalcTableServiceTest {
       @SuppressWarnings("unchecked")
       List<String> groups = (List<String>) read.get("namedGroups");
       assertTrue(groups.contains("Regions"), "expected worksheet-local group in: " + groups);
+   }
+
+   /**
+    * Bug 76311 / stylebi#4731 (reopened): a group created via {@code add_named_group}'s
+    * datasource-scoped mode (datasource+logicalModel+sourceTable+attribute) attaches
+    * {@code SourceInfo.MODEL}, source = the logical model name (e.g. "Order Model") -- never
+    * equal to the crosstab's own bound {@code SourceInfo} (always {@code SourceInfo.ASSET},
+    * source = the worksheet table's own assembly name). The match must fall back to resolving
+    * the worksheet table assembly's own underlying {@code SourceInfo} and comparing against
+    * that.
+    */
+   @Test
+   void includesWorksheetLocalNamedGroupsForALogicalModelBoundDimension() throws Exception {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Customer1"));
+      Harness h = harnessFor(assembly, 0, 0);
+
+      SourceInfo modelSource = new SourceInfo(SourceInfo.MODEL, "ds", "Order Model");
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("WestStates");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource()).thenReturn(modelSource);
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "State"));
+
+      AbstractTableAssembly boundTable = mock(AbstractTableAssembly.class);
+      when(boundTable.getSourceInfo()).thenReturn(modelSource);
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new Assembly[]{ ngAssembly });
+      when(ws.getAssembly("Customer1")).thenReturn(boundTable);
+      when(h.viewsheet().getBaseWorksheet()).thenReturn(ws);
+
+      Map<String, Object> read =
+         h.service.namedGroups("tok", principal(), "Crosstab1", "State");
+
+      @SuppressWarnings("unchecked")
+      List<String> groups = (List<String>) read.get("namedGroups");
+      assertTrue(groups.contains("WestStates"),
+                 "expected logical-model-bound group in: " + groups);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
@@ -29,6 +29,7 @@ import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.NamedGroupInfo;
 import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.AbstractTableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.AttributeRef;
@@ -258,6 +259,50 @@ class FieldRefFactoryTest {
       assertEquals(1, model.getConditions().size());
       assertEquals("West", model.getConditions().get(0).getName());
       assertEquals(1, model.getConditions().get(0).getList().length);
+   }
+
+   /**
+    * Bug 76311 / stylebi#4731 (reopened): {@code add_named_group}'s datasource-scoped mode
+    * attaches {@code SourceInfo.MODEL}, source = the logical model name -- never equal to the
+    * field's own bound {@code SourceInfo} (always {@code SourceInfo.ASSET}, source = the
+    * worksheet table's own assembly name). Must resolve via the worksheet table's own
+    * underlying source rather than throwing.
+    */
+   @Test
+   void resolveNamedGroupInfoBuildsAnExpertNamedGroupForALogicalModelBoundDimension()
+      throws Exception
+   {
+      SourceInfo modelSource = new SourceInfo(SourceInfo.MODEL, "ds", "Order Model");
+      SourceInfo boundSource = new SourceInfo(SourceInfo.ASSET, null, "Customer1");
+
+      Condition condition = mock(Condition.class);
+      when(condition.getOperation()).thenReturn(Condition.EQUAL_TO);
+      when(condition.getValues()).thenReturn(java.util.List.of("CA"));
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(new AttributeRef(null, "State"), condition, 0));
+      NamedGroupInfo namedGroupInfo = new NamedGroupInfo();
+      namedGroupInfo.setGroupCondition("West", conditionList);
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("WestStates");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource()).thenReturn(modelSource);
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "State"));
+      when(ngAssembly.getNamedGroupInfo()).thenReturn(namedGroupInfo);
+
+      AbstractTableAssembly boundTable = mock(AbstractTableAssembly.class);
+      when(boundTable.getSourceInfo()).thenReturn(modelSource);
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[]{ ngAssembly });
+      when(ws.getAssembly("Customer1")).thenReturn(boundTable);
+
+      NamedGroupInfoModel model = FieldRefFactory.resolveNamedGroupInfo(
+         "WestStates", rvsWithWorksheet(ws), boundSource, "State", refModelService());
+
+      assertEquals(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO, model.getType());
+      assertEquals(1, model.getConditions().size());
+      assertEquals("West", model.getConditions().get(0).getName());
    }
 
    @Test


### PR DESCRIPTION
Fixes bug #76311 (stylebi#4731 reopened): a named group created via
add_named_group on a logical-model-bound dimension (e.g. Order Model →
Customer → State) was silently invisible to list_named_groups and refused
by set_table_fields, even though it was stored correctly.

Root cause: add_named_group's logical-model-scoped mode sets
attachedSource = SourceInfo(MODEL, datasource, logicalModelName), but both
CalcTableService.worksheetNamedGroups() and
FieldRefFactory.worksheetNamedGroups() compared that only against the
crosstab/table's own bound SourceInfo (always SourceInfo.ASSET, the
worksheet table's own assembly name) — never equal for this creation mode.

Fix: both matchers now delegate to a new shared
WorksheetNamedGroupMatcher, which additively falls back to resolving the
worksheet table's own underlying SourceInfo (via
ws.getAssembly(sinfo.getSource())) before giving up, on top of the
existing direct-match path (kept for the already-working plain
worksheet-table+column mode).

Tests: CalcTableServiceTest (40 tests), FieldRefFactoryTest (24 tests),
and the full inetsoft.web.wiz.binding suite (16 classes, TableBindingMutatorTest
included) all pass — 0 failures/errors.

🤖 Generated with debug-workflow (stylebi-wiz)