### PR TITLE
fix(viewsheet): resolve stacked-measure highlight collision by colName

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
@@ -94,6 +94,19 @@ public class HighlightDialogService {
 
       if(box.isPresent() && assemblyInfo instanceof TableDataVSAssemblyInfo) {
          lens = box.get().getVSTableLens(objectId, false);
+
+         if(assembly instanceof CrosstabVSAssembly) {
+            VSCrosstabInfo cinfo = ((CrosstabVSAssembly) assembly).getVSCrosstabInfo();
+            int[] resolved = resolveStackedMeasureCell(cinfo.getRuntimeAggregates(),
+               cinfo.isSummarySideBySide(), lens.getHeaderRowCount(), lens.getHeaderColCount(),
+               colName);
+
+            if(resolved != null) {
+               row = resolved[0];
+               col = resolved[1];
+            }
+         }
+
          dataPath = lens.getTableDataPath(row, col);
 
          if(assemblyInfo instanceof TableVSAssemblyInfo) {
@@ -371,6 +384,64 @@ public class HighlightDialogService {
       model.setHighlights(highlightModelList.toArray(new HighlightModel[0]));
       model.setRevision(rvs.getWriteRevision());
       return model;
+   }
+
+   /**
+    * The physical {@code {row, col}} of a crosstab's stacked aggregate measure named by
+    * {@code colName}, or {@code null} when there is nothing to resolve or nothing to disambiguate.
+    *
+    * <p>{@code lens.getTableDataPath(row, col)} is a pure function of {@code (row, col)} alone --
+    * {@code colName} plays no part in it -- so two calls that differ only in which measure they
+    * name, both leaving {@code row}/{@code col} at their caller-omitted default, always land on the
+    * exact same {@code TableDataPath}. Every stacked measure's highlight then collapses onto the
+    * one cell the first measure occupies (bug 76307), the same way {@code colName} already fails to
+    * disambiguate the fields available in {@code getRefsForVSAssembly} -- it is read there too, but
+    * only to filter, never to pick a cell.
+    *
+    * <p>A crosstab's stacked measures sit at one fixed offset apart from the first data cell -- one
+    * row apart when stacked (the default), one column apart when
+    * {@code VSCrosstabInfo#isSummarySideBySide()} -- in the same order as
+    * {@code VSCrosstabInfo#getRuntimeAggregates()}, which is also the order
+    * {@code AbstractCrosstabVSAQuery} assigns each aggregate's column when it builds the rendered
+    * lens. Reusing that order resolves the measure's cell directly, without re-deriving the lens's
+    * own row/col header traversal.
+    *
+    * <p>Mirrors the chart branch below, where {@code colName} is already a standalone address
+    * (a chart has no rows/columns to combine it with) -- here it takes priority over whatever
+    * {@code row}/{@code col} arrived, but only once it actually matches one of this crosstab's
+    * aggregates; a {@code colName} naming something else (or absent, or a crosstab with fewer than
+    * two aggregates, where there is nothing to disambiguate) leaves {@code row}/{@code col}
+    * untouched.
+    */
+   static int[] resolveStackedMeasureCell(DataRef[] runtimeAggregates, boolean summarySideBySide,
+                                          int headerRowCount, int headerColCount, String colName)
+   {
+      if(colName == null || runtimeAggregates == null || runtimeAggregates.length < 2) {
+         return null;
+      }
+
+      int index = -1;
+
+      for(int i = 0; i < runtimeAggregates.length; i++) {
+         if(runtimeAggregates[i] instanceof VSAggregateRef) {
+            VSAggregateRef aggregate = (VSAggregateRef) runtimeAggregates[i];
+
+            if(Tool.equals(aggregate.getName(), colName) ||
+               Tool.equals(aggregate.getFullName(), colName))
+            {
+               index = i;
+               break;
+            }
+         }
+      }
+
+      if(index < 0) {
+         return null;
+      }
+
+      return summarySideBySide
+         ? new int[] { headerRowCount, headerColCount + index }
+         : new int[] { headerRowCount + index, headerColCount };
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/HighlightDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/HighlightDialogServiceTest.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.dialog;
+
+import inetsoft.report.TableDataPath;
+import inetsoft.report.filter.CrossTabFilter;
+import inetsoft.report.filter.SumFormula;
+import inetsoft.report.lens.DefaultTableLens;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug 76307: a crosstab with 2+ stacked aggregate measures had no way to resolve a highlight
+ * call's {@code colName} to that measure's own cell -- {@code lens.getTableDataPath(row, col)} is
+ * a pure function of {@code (row, col)} alone, so two calls naming different measures but both
+ * omitting row/col always collapsed onto the SAME {@code TableDataPath}, and every measure but the
+ * first lost its highlight.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class HighlightDialogServiceTest {
+   private static VSAggregateRef aggregate(String column, AggregateFormula formula) {
+      VSAggregateRef ref = new VSAggregateRef();
+      ref.setDataRef(new AttributeRef(column));
+      ref.setFormula(formula);
+      return ref;
+   }
+
+   // ── resolveStackedMeasureCell: pure unit coverage ──────────────────────────
+
+   @Test
+   void resolvesTheSecondStackedMeasureToOneRowPastTheFirstDataCell() {
+      DataRef[] aggregates = {
+         aggregate("PAID", AggregateFormula.SUM), aggregate("DISCOUNT", AggregateFormula.SUM),
+         aggregate("QTY", AggregateFormula.SUM),
+      };
+
+      int[] cell = HighlightDialogService.resolveStackedMeasureCell(
+         aggregates, false, 2, 1, "DISCOUNT");
+
+      assertArrayEquals(new int[]{ 3, 1 }, cell, "stacked: row advances by the measure's index");
+   }
+
+   @Test
+   void resolvesBySideBySideMeasureToAColumnOffsetInstead() {
+      DataRef[] aggregates = {
+         aggregate("PAID", AggregateFormula.SUM), aggregate("DISCOUNT", AggregateFormula.SUM),
+         aggregate("QTY", AggregateFormula.SUM),
+      };
+
+      int[] cell = HighlightDialogService.resolveStackedMeasureCell(
+         aggregates, true, 2, 1, "QTY");
+
+      assertArrayEquals(new int[]{ 2, 3 }, cell, "side by side: col advances by the measure's index");
+   }
+
+   @Test
+   void matchesByFullNameWhenTheBareColumnNameDoesNotMatch() {
+      VSAggregateRef paid = aggregate("PAID", AggregateFormula.SUM);
+      DataRef[] aggregates = { paid, aggregate("PAID", AggregateFormula.AVG) };
+
+      int[] cell = HighlightDialogService.resolveStackedMeasureCell(
+         aggregates, false, 1, 1, paid.getFullName());
+
+      assertArrayEquals(new int[]{ 1, 1 }, cell);
+   }
+
+   @Test
+   void leavesTheCellUnresolvedWhenColNameIsAbsent() {
+      DataRef[] aggregates = {
+         aggregate("PAID", AggregateFormula.SUM), aggregate("DISCOUNT", AggregateFormula.SUM),
+      };
+
+      assertNull(HighlightDialogService.resolveStackedMeasureCell(aggregates, false, 1, 1, null),
+                 "no colName means nothing to resolve -- the existing fallback is left alone");
+   }
+
+   @Test
+   void leavesTheCellUnresolvedWhenColNameNamesNoRuntimeAggregate() {
+      DataRef[] aggregates = {
+         aggregate("PAID", AggregateFormula.SUM), aggregate("DISCOUNT", AggregateFormula.SUM),
+      };
+
+      assertNull(HighlightDialogService.resolveStackedMeasureCell(
+         aggregates, false, 1, 1, "NOT_A_MEASURE"));
+   }
+
+   @Test
+   void leavesTheCellUnresolvedWithOnlyOneStackedMeasure() {
+      DataRef[] aggregates = { aggregate("PAID", AggregateFormula.SUM) };
+
+      assertNull(HighlightDialogService.resolveStackedMeasureCell(aggregates, false, 1, 1, "PAID"),
+                 "a single measure has nothing to disambiguate -- leave the existing " +
+                 "first-data-cell fallback alone");
+   }
+
+   // ── end-to-end against a real crosstab lens ────────────────────────────────
+
+   /**
+    * The direct regression test for the collapse: two measures, resolved via {@code colName}
+    * through the real {@code CrossTabFilter}/{@code CrossFilterDataDescriptor} row/col-to-path
+    * machinery (not a mock), must land on two DISTINCT {@code TableDataPath}s -- and each must be
+    * the actual cell holding that measure's own summed value, not merely "a" different cell.
+    */
+   @Test
+   void resolvedCellsForTwoStackedMeasuresAreDistinctRealDataCellsNotJustDifferentNumbers() {
+      Object[][] data = {
+         { "YEAR", "PAID", "DISCOUNT", "QTY" },
+         { 2021, 100, 10, 5 },
+         { 2022, 200, 20, 6 },
+      };
+      int[] rowh = { 0 };
+      int[] colh = {};
+      int[] dcol = { 1, 2, 3 };
+      DataRef[] runtimeAggregates = {
+         aggregate("PAID", AggregateFormula.SUM), aggregate("DISCOUNT", AggregateFormula.SUM),
+         aggregate("QTY", AggregateFormula.SUM),
+      };
+
+      CrossTabFilter table = new CrossTabFilter(new DefaultTableLens(data), rowh, colh, dcol,
+         new SumFormula[]{ new SumFormula(), new SumFormula(), new SumFormula() });
+
+      int headerRowCount = table.getHeaderRowCount();
+      int headerColCount = table.getHeaderColCount();
+
+      int[] paidCell = HighlightDialogService.resolveStackedMeasureCell(
+         runtimeAggregates, table.isSummarySideBySide(), headerRowCount, headerColCount, "PAID");
+      int[] discountCell = HighlightDialogService.resolveStackedMeasureCell(
+         runtimeAggregates, table.isSummarySideBySide(), headerRowCount, headerColCount,
+         "DISCOUNT");
+
+      assertNotNull(paidCell);
+      assertNotNull(discountCell);
+      assertFalse(java.util.Arrays.equals(paidCell, discountCell),
+                  "PAID and DISCOUNT must resolve to different physical cells");
+
+      TableDataPath paidPath = table.getDescriptor().getCellDataPath(paidCell[0], paidCell[1]);
+      TableDataPath discountPath =
+         table.getDescriptor().getCellDataPath(discountCell[0], discountCell[1]);
+
+      assertNotNull(paidPath);
+      assertNotNull(discountPath);
+      assertNotEquals(paidPath, discountPath,
+                       "the whole bug: before this fix both measures' calls resolved to the " +
+                       "SAME TableDataPath, so their highlights collapsed into one HighlightGroup");
+
+      // Not just structurally distinct -- each path's cell actually holds that measure's own
+      // value for the first row group (2021), confirming the offset lands on the real measure,
+      // not merely a different one.
+      assertEquals(100.0, ((Number) table.getObject(paidCell[0], paidCell[1])).doubleValue(),
+                   0.0001);
+      assertEquals(10.0, ((Number) table.getObject(discountCell[0], discountCell[1])).doubleValue(),
+                   0.0001);
+   }
+}


### PR DESCRIPTION
Fixes bug #76307: set_highlight/list_highlights/delete_highlight on a
crosstab with 2+ stacked aggregate measures collapsed every measure's
highlight onto the same cell when row/col/colName were omitted or only
colName was given.

Root cause: AssemblyHighlightService.read() falls forward to
HighlightDialogService.getFirstDataCell() — a pure function of the
crosstab's header geometry with no parameter for which measure the caller
meant. That fixed (row, col) always resolved to the same TableDataPath in
TableHighlightAttr.hlmap, and HighlightGroup's first-registered-match-wins
semantics produced the reported "vanishing"/"borrowing" behavior.

Fix: new HighlightDialogService.resolveStackedMeasureCell() matches
colName against the crosstab's runtime aggregates (using the same index
order AbstractCrosstabVSAQuery assigns when building the rendered lens)
and offsets the first data cell by that aggregate's position — one row
apart when stacked, one column apart when side-by-side. When colName
names a real aggregate, it now takes priority over whatever row/col
arrived, matching the policy the chart branch already uses. No-op for
every already-working case (single measure, or colName absent/unmatched).

Tests: HighlightDialogServiceTest (new, 7 tests including one against a
real CrossTabFilter proving two stacked measures resolve to distinct
TableDataPath objects holding each measure's own correct value).
AssemblyHighlightServiceTest/CrossTabFilterTest/CrossCalcFilterTest all
still pass (0 regressions) — AssemblyHighlightServiceTest mocks
HighlightDialogService entirely so it never exercised the changed code.

Companion plugin-side fix (loud refusal on genuinely ambiguous calls):
inetsoft-technology/stylebi-wiz#1943

🤖 Generated with debug-workflow (stylebi-wiz)