### PR TITLE
Fix Bug #76325 (item 2): set_viewsheet_properties throws false 500 from null-units print layout

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
@@ -376,6 +376,31 @@ public class ViewsheetPropertyDialogService {
 
       VSPrintLayoutDialogModel vsPrintLayoutDialog = screensPane.getPrintLayout();
       LayoutInfo layoutInfo = viewsheet.getLayoutInfo();
+
+      // Guarantee usable units before either side of the print-layout math below is read.
+      // VSLayoutService.getPLayoutSize's switch(unit) throws NPE unconditionally on a null
+      // unit, and the persisted PrintInfo (read a few lines below via oldPageSize) and the
+      // incoming dialog model (read via radio/newPageSize) are two independent objects -- a
+      // caller that never patches the print layout at all (e.g. set_viewsheet_properties) can
+      // still hit this NPE purely from a layout persisted with null units before this guard
+      // existed. Centralized here, at the one method every print-layout-touching caller shares,
+      // rather than left to each caller to repeat.
+      if(layoutInfo.getPrintLayout() != null) {
+         PrintInfo persistedInfo = layoutInfo.getPrintLayout().getPrintInfo();
+
+         if(persistedInfo != null &&
+            (persistedInfo.getUnit() == null || persistedInfo.getUnit().isBlank()))
+         {
+            persistedInfo.setUnit("inches");
+         }
+      }
+
+      if(vsPrintLayoutDialog != null &&
+         (vsPrintLayoutDialog.getUnits() == null || vsPrintLayoutDialog.getUnits().isBlank()))
+      {
+         vsPrintLayoutDialog.setUnits("inches");
+      }
+
       Dimension oldPageSize = null;
 
       if(vsPrintLayoutDialog != null) {

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.composer.vs.dialog;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.graph.internal.DimensionD;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.test.*;
@@ -110,6 +111,59 @@ public class ViewsheetPropertyDialogServiceTest {
       assertEquals("VSLayout001", viewsheetLayout.getID());
       assertEquals("Foo001", viewsheetLayout.getName());
       assertNotNull(viewsheetLayout.getVSAssemblyLayout("Bar001"));
+   }
+
+   /**
+    * Bug #76325 item 2: set_viewsheet_properties (SheetPropertyService.set) never patches the
+    * print layout at all, but setViewsheetInfo unconditionally recomputes the print layout's
+    * page size whenever one exists. A viewsheet whose print layout was persisted with a null
+    * unit -- left over from before requireUsableUnits existed, or from any path that never runs
+    * it -- must not take down an unrelated write. The persisted PrintInfo (read here via
+    * oldPageSize) and the incoming dialog model are two independent objects: guarding only the
+    * incoming model (as PrintDeviceLayoutPropertyService's own call-site guard does) would still
+    * let this NPE through for a caller, like SheetPropertyService, that has no access to the
+    * persisted LayoutInfo to repair it itself.
+    */
+   @Test
+   public void aPersistedNullUnitsPrintLayoutIsRepairedRatherThanCrashingAnUnrelatedWrite()
+      throws Exception
+   {
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(viewsheetSandbox));
+      ViewsheetInfo viewsheetInfo = new ViewsheetInfo();
+      when(viewsheet.getViewsheetInfo()).thenReturn(viewsheetInfo);
+
+      PrintInfo persistedInfo =
+         new PrintInfo("Letter", new DimensionD(8.5, 11), 1f, 1f, 1f, 1f, null);
+      PrintLayout persistedLayout = new PrintLayout();
+      persistedLayout.setPrintInfo(persistedInfo);
+      LayoutInfo layoutInfo = new LayoutInfo();
+      layoutInfo.setPrintLayout(persistedLayout);
+      when(viewsheet.getLayoutInfo()).thenReturn(layoutInfo);
+
+      ViewsheetPropertyDialogModel model = ViewsheetPropertyDialogModel.builder().build();
+      ScreensPaneModel screensPaneModel = model.screensPane();
+      VSPrintLayoutDialogModel vsPrintLayoutDialog = new VSPrintLayoutDialogModel();
+      vsPrintLayoutDialog.setPaperSize("Letter");
+      vsPrintLayoutDialog.setScaleFont(1.0f);
+      screensPaneModel.setPrintLayout(vsPrintLayoutDialog);
+      screensPaneModel.setDevices(new ArrayList<>());
+      FiltersPaneModel filtersPaneModel = model.filtersPane();
+      filtersPaneModel.setSharedFilters(new ArrayList<>());
+      filtersPaneModel.setFilters(new ArrayList<>());
+      model.vsOptionsPane().getViewsheetParametersDialogModel().setDisabledParameters(new String[0]);
+      model.vsOptionsPane().setDesc("new description");
+
+      if(model.localizationPane() != null) {
+         model.localizationPane().setLocalized(new ArrayList<>());
+      }
+
+      // Must not throw -- this is the reported false 500.
+      service.setViewsheetInfo("Viewsheet1", model, null, commandDispatcher, null, null);
+
+      assertEquals("new description", viewsheetInfo.getDescription());
+      assertEquals("inches", persistedInfo.getUnit());
    }
 
    /**


### PR DESCRIPTION
Fixes bug #76325's Claim B (item 2): set_viewsheet_properties threw an
"unexpected server error" on every call against a viewsheet whose print
layout was persisted with null/blank units, even though the patch never
touches the print layout — most writes still landed anyway (the NPE fires
after the caller's own patch fields are applied, and
ViewsheetSessionService.mutate checkpoints in a finally block regardless).

Root cause: SheetPropertyService.set() routes through the shared
ViewsheetPropertyDialogService.setViewsheetInfo chokepoint, which
unconditionally recomputes the print layout's page size whenever one
exists. Reading the *persisted* PrintInfo for oldPageSize hits
VSLayoutService.getPLayoutSize's switch(unit), which throws NPE
unconditionally on a null String.

Correction beyond the original diagnosis/refutation: the existing
requireUsableUnits guard (added 2026-08-28 for set_print_layout/
manage_device_layout) only repairs the *incoming* dialog-side model, a
separate object graph from the *persisted* PrintInfo the crash actually
reads — so neither of the diagnosis's two proposed approaches would have
fixed this. The fix instead adds two guards directly in
setViewsheetInfo (SheetPropertyService never has access to the persisted
objects at all): heal the persisted PrintInfo's unit in place, and heal
the incoming dialog model's unit too (for the newPageSize computation
further down).

As a side effect, this also closes a residual gap in the existing
(2026-08-28) fix: its own tests mock ViewsheetPropertyDialogService
entirely, so they never exercised the persisted-object read path this
fix now guards for those callers too.

Tests: new ViewsheetPropertyDialogServiceTest
(aPersistedNullUnitsPrintLayoutIsRepairedRatherThanCrashingAnUnrelatedWrite)
confirmed to reproduce the exact reported NPE stack when reverted, and to
pass with the fix applied. ViewsheetPropertyDialogServiceTest (4),
PrintDeviceLayoutPropertyServiceTest (15), SheetPropertyServiceTest (7) —
26 tests total, 0 failures.

🤖 Generated with debug-workflow (stylebi-wiz)