### PR TITLE
Fix Bug #76304: set_print_layout's paperSize accepts non-canonical values silently

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/PaperSize.java
+++ b/core/src/main/java/inetsoft/report/internal/PaperSize.java
@@ -129,6 +129,49 @@ public class PaperSize {
          StyleConstants.PORTRAIT;
    }
 
+   /**
+    * Composer's Page Layout dialog's own sentinel for "use customWidth/customHeight instead"
+    * (viewsheet-print-layout-dialog.component.ts). Not one of the 14 predefined sizes, so it must
+    * pass through {@link #canonicalize(String)} unchanged rather than fail the lookup below.
+    */
+   public static final String CUSTOM_SIZE = "(Custom Size)";
+
+   /**
+    * Resolves a paper size name to its canonical, predefined-list form, accepting the bare short
+    * name (e.g. "Letter") as a caller-friendly alias for the full canonical string (e.g.
+    * "Letter [8.5x11 in]") since the two are otherwise indistinguishable to a caller. An already-
+    * canonical string or {@link #CUSTOM_SIZE} is returned unchanged. Anything else is rejected
+    * rather than stored verbatim, since a non-canonical value stored via {@code setPaperSize}
+    * cannot round-trip through this class's own predefined-list lookups or Composer's Page Layout
+    * dialog, whose paper-size select is bound directly against this list.
+    *
+    * @throws IllegalArgumentException if {@code name} is null or matches neither a canonical name,
+    * a bare short name, nor {@link #CUSTOM_SIZE}.
+    */
+   public static String canonicalize(String name) {
+      if(name == null) {
+         throw new IllegalArgumentException("paperSize is required.");
+      }
+
+      if(map.containsKey(name) || CUSTOM_SIZE.equals(name)) {
+         return name;
+      }
+
+      for(Object[] entry : sizes) {
+         String canonical = (String) entry[0];
+         String shortName = canonical.substring(0, canonical.indexOf(" ["));
+
+         if(shortName.equalsIgnoreCase(name)) {
+            return canonical;
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "paperSize: unrecognized value \"" + name + "\" -- expected one of " +
+         String.join(", ", sizestrs) + ", a bare short name (e.g. \"Letter\"), or \"" +
+         CUSTOM_SIZE + "\".");
+   }
+
    static final Object[][] sizes = {
       {"Letter [8.5x11 in]", new Size(8.5, 11)},
       {"Legal [8.5x14 in]", new Size(8.5, 14)},

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.PaperSize;
 import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
 import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
 import inetsoft.web.composer.model.vs.*;
@@ -269,7 +270,7 @@ public class PrintDeviceLayoutPropertyService {
 
          switch(entry.getKey()) {
             case "paperSize":
-               printLayout.setPaperSize(asString(value));
+               printLayout.setPaperSize(PaperSize.canonicalize(asString(value)));
                break;
             case "marginTop":
                printLayout.setMarginTop(toDouble(value));

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
@@ -235,7 +235,7 @@ class LayoutReadServiceTest {
 
       PrintLayoutSettingsModel printSettings = model.printSettings();
       assertNotNull(printSettings);
-      assertEquals("Letter", printSettings.paperSize());
+      assertEquals("Letter [8.5x11 in]", printSettings.paperSize());
       assertEquals(0.8f, printSettings.scaleFont(), 0.0001f);
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
@@ -83,7 +83,52 @@ class PrintDeviceLayoutPropertyServiceTest {
       VSPrintLayoutDialogModel written = captor.getValue().screensPane().getPrintLayout();
       assertNotNull(written);
       assertEquals(1.0f, written.getScaleFont(), 0.0001f);
-      assertEquals("Letter", written.getPaperSize());
+      assertEquals("Letter [8.5x11 in]", written.getPaperSize());
+   }
+
+   @Test
+   void paperSizeBareShortNamesCanonicalizeCaseInsensitively() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      h.service.setPrintLayout("tok", h.principal, Map.of("paperSize", "a4"), "");
+
+      assertEquals("A4 [210x297 mm]", writtenPrintLayout(h).getPaperSize());
+   }
+
+   @Test
+   void paperSizeAlreadyCanonicalPassesThroughUnchanged() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      h.service.setPrintLayout("tok", h.principal, Map.of("paperSize", "A4 [210x297 mm]"), "");
+
+      assertEquals("A4 [210x297 mm]", writtenPrintLayout(h).getPaperSize());
+   }
+
+   @Test
+   void paperSizeCustomSizeSentinelPassesThroughUnchanged() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      h.service.setPrintLayout("tok", h.principal, Map.of("paperSize", "(Custom Size)"), "");
+
+      assertEquals("(Custom Size)", writtenPrintLayout(h).getPaperSize());
+   }
+
+   @Test
+   void paperSizeUnrecognizedValueThrowsNamingTheFieldAndValueBeforeWritingAnything()
+      throws Exception
+   {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> h.service.setPrintLayout("tok", h.principal, Map.of("paperSize", "Leter"), ""));
+
+      assertTrue(thrown.getMessage().contains("paperSize"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("Leter"), thrown.getMessage());
+      // canonicalize() throws while applyPrintLayoutPatch is still building the in-memory
+      // printLayout, before screensPane.setPrintLayout/dialogService.setViewsheetInfo -- the
+      // failed call never persists anything.
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `PrintDeviceLayoutPropertyService.applyPrintLayoutPatch`'s `"paperSize"` case stored the incoming value verbatim with no lookup against `PaperSize`'s 14-entry canonical name table. A bare short name like `"Letter"` (the plugin tool's own documented example) persisted as-is instead of `"Letter [8.5x11 in]"`.
- Composer's Page Layout dialog binds its Paper Size `<select>` directly against the canonical option values (plain `[value]`-bound native select, no `ngValue`/`compareWith`), so a non-canonical stored value renders as a blank selection.
- Added `PaperSize.canonicalize(String)`: passes through an already-canonical name or the `"(Custom Size)"` sentinel unchanged, resolves a bare short name case-insensitively to its canonical form, and throws `IllegalArgumentException` naming the field and value for anything else.
- `applyPrintLayoutPatch`'s `"paperSize"` case now calls `PaperSize.canonicalize(asString(value))` instead of storing the raw string.

## Test plan
- [x] `./mvnw.cmd -pl core -am test -Dtest=PrintDeviceLayoutPropertyServiceTest -Dsurefire.failIfNoSpecifiedTests=false` → `Tests run: 19, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`
- Updated the existing test that pinned the buggy bare-string behavior, and added 4 new tests: bare-short-name case-insensitive canonicalization, already-canonical passthrough, `"(Custom Size)"` sentinel passthrough, and unrecognized-value throws (asserting no partial write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)