### PR TITLE
Fix Bug #76302: set_table_source(force:true) never discards old shelf fields

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -111,6 +111,9 @@ public class TableBindingService {
          if(!force) {
             requireNoBoundFields(model, assemblyName, resolved);
          }
+         else {
+            discardBoundFields(model, resolved);
+         }
 
          // Only type, prefix and source survive the trip back: VSBindingService.updateSourceInfo
          // calls SourceInfo.toSourceAttr, which rebuilds the asset source from exactly those
@@ -184,6 +187,30 @@ public class TableBindingService {
             "). Changing its source would discard them, because those columns belong to the " +
             "old source. Clear the shelves first, or pass force:true to discard them " +
             "deliberately.");
+      }
+   }
+
+   /**
+    * The {@code force:true} counterpart to {@link #requireNoBoundFields}: actually does the
+    * discard that method only refuses to let happen silently. Without this, a repoint left the
+    * old source's field refs sitting on every shelf {@code force} didn't itself touch, and those
+    * stale refs were written straight back onto the live assembly's design headers by the
+    * factory that follows this mutation.
+    */
+   private static void discardBoundFields(BaseTableBindingModel model, String table) {
+      SourceInfo current = model.getSource();
+
+      if(current != null && table.equalsIgnoreCase(current.getSource())) {
+         return;
+      }
+
+      // A calc table has no shelves to discard — see requireNoBoundFields above.
+      if(model instanceof CalcTableBindingModel) {
+         return;
+      }
+
+      for(String shelf : TableBindingMutator.shelvesOf(model)) {
+         TableBindingMutator.setShelf(model, shelf, List.of());
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -217,6 +217,57 @@ class TableBindingServiceTest {
 
       CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
       assertEquals("CUSTOMERS", posted.getSource().getSource());
+      assertTrue(posted.getRows().isEmpty(),
+                 "force:true must discard the old source's fields, not just skip the refusal");
+   }
+
+   /**
+    * The regression for the bug where {@code force:true} skipped the refusal but never actually
+    * discarded anything: setSource left every shelf's old-source field refs in place, and those
+    * stale refs were written straight back onto the live assembly by the factory that follows
+    * this mutation — read back later (e.g. via get_binding) as fields from a source the assembly
+    * no longer has.
+    */
+   @Test
+   void setSourceDiscardsEveryShelfWhenForced() throws Exception {
+      CrosstabBindingModel existing = withTables("CUSTOMERS", "ORDERS1");
+      TableBindingMutator.setShelf(existing, "rows", List.of(dim("STATE")));
+      TableBindingMutator.setShelf(existing, "cols", List.of(dim("RESELLER")));
+      TableBindingMutator.setShelf(existing, "aggregates",
+                                   List.of(new FieldRef("CUSTOMER_ID", "measure", "sum", null,
+                                                        null)));
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setSource("tok", principal(), "Crosstab1", "ORDERS1", true);
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals("ORDERS1", posted.getSource().getSource());
+      assertTrue(posted.getRows().isEmpty(), "old source's rows field must not survive");
+      assertTrue(posted.getCols().isEmpty(), "old source's cols field must not survive");
+      assertTrue(posted.getAggregates().isEmpty(),
+                 "old source's aggregates field must not survive");
+   }
+
+   /**
+    * force:true against the source the assembly already has is a no-op repoint, not a real
+    * source change — nothing to discard, and doing so anyway would destroy a binding the caller
+    * never asked to touch.
+    */
+   @Test
+   void setSourceForcedButUnchangedKeepsFields() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
+      TableBindingMutator.setShelf(existing, "rows", List.of(dim("STATE")));
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setSource("tok", principal(), "Crosstab1", "ORDERS", true);
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals(1, posted.getRows().size(),
+                    "the source didn't actually change, so nothing should be discarded");
    }
 
    /**


### PR DESCRIPTION
## Summary
- `TableBindingService.setSource`'s `force` flag only skipped the `requireNoBoundFields` refusal — it never actually cleared `model.getRows()/getCols()/getAggregates()`, so a forced source repoint on a Crosstab/Table left the old source's field refs in place, and those stale refs got written straight back onto the live assembly's design headers. `get_binding` then read them back verbatim as fields from a source the assembly no longer has. The method's own class-level javadoc already documented the discard as intended behavior; the code below it never implemented it.
- Adds `discardBoundFields`, which reuses the existing `TableBindingMutator.setShelf(model, shelf, List.of())` to clear every shelf when `force` is set and the source is actually changing. Mirrors `requireNoBoundFields`'s own early returns: a no-op repoint against the *same* source is left untouched, and a calc table (no shelves — its binding lives in cells) is skipped.
- Checked the sibling `ChartBindingService.setSource` for the identical pattern — it has the same bug, but chart shelves are structurally different and more numerous (x/y/group/color/shape/size/text/etc. vs. a crosstab's three), so it isn't a trivial one-line mirror of this fix. Left as a follow-up rather than scope-creeping this PR.

## Test plan
- [x] `TableBindingServiceTest` — updated `setSourceProceedsWhenForced` to assert fields are discarded, added `setSourceDiscardsEveryShelfWhenForced` (all three shelves cleared on a real source change) and `setSourceForcedButUnchangedKeepsFields` (no discard when the source doesn't actually change)
- [x] Ran `./mvnw.cmd -pl core -am test -Dtest=TableBindingMutatorTest,TableBindingServiceTest -Dsurefire.failIfNoSpecifiedTests=false` — 66/66 pass (51 `TableBindingMutatorTest` + 15 `TableBindingServiceTest`, run together since the fix reuses `TableBindingMutator.setShelf`)

Fixes Redmine #76302.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>