### PR TITLE
Fix Bug #76306: translate date-comparison period-level word to XConstants code

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.uql.XConstants;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import inetsoft.web.wiz.binding.VisualFrameAliases;
@@ -234,7 +235,7 @@ public class DateComparisonService {
       }
 
       if(comparison.level() != null) {
-         setDynamic(standard.getDateLevel(), comparison.level());
+         setDynamic(standard.getDateLevel(), normalizeLevel(comparison.level()));
       }
 
       // Setting the end date clears the today anchor, because leaving it set is what discarded
@@ -252,6 +253,32 @@ public class DateComparisonService {
       if(comparison.interval() != null && interval != null) {
          setDynamic(interval.getLevel(), comparison.interval());
       }
+   }
+
+   private static final Map<String, Integer> LEVEL_WORDS = Map.of(
+      "year", XConstants.YEAR_DATE_GROUP,
+      "quarter", XConstants.QUARTER_DATE_GROUP,
+      "month", XConstants.MONTH_DATE_GROUP,
+      "week", XConstants.WEEK_DATE_GROUP,
+      "day", XConstants.DAY_DATE_GROUP
+   );
+
+   /**
+    * Translates the agent vocabulary's period-level word to the numeric
+    * {@code XConstants.*_DATE_GROUP} code every Angular consumer of {@code standardPeriodLevel}
+    * expects. Writing the raw word through untranslated is what emptied
+    * {@code date-comparison-interval-pane.component.ts}'s granularities list and crashed the
+    * Date Comparison editor.
+    */
+   private static String normalizeLevel(String level) {
+      Integer code = LEVEL_WORDS.get(level.trim().toLowerCase());
+
+      if(code == null) {
+         throw new IllegalArgumentException(
+            "'level' must be one of: year, quarter, month, week, day. Got '" + level + "'.");
+      }
+
+      return code.toString();
    }
 
    private static void setDynamic(DynamicValueModel target, String value) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -18,11 +18,15 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.security.Principal;
 import java.util.Map;
@@ -188,7 +192,55 @@ class DateComparisonServiceTest {
       StandardPeriodPaneModel standard =
          model.getPeriodPaneModel().getStandardPeriodPaneModel();
       assertEquals("4", standard.getPreCount().getValue());
-      assertEquals("year", standard.getDateLevel().getValue());
+      assertEquals(String.valueOf(XConstants.YEAR_DATE_GROUP), standard.getDateLevel().getValue());
+   }
+
+   /**
+    * {@code standardPeriodLevel.value} is read as a numeric group code by every Angular
+    * consumer (both {@code date-comparison-standard-periods.component.ts} and, critically,
+    * {@code date-comparison-interval-pane.component.ts}'s {@code granularitiesAllIntervalVisible}).
+    * Writing the raw agent-vocabulary word through untranslated left it stuck at "year", which
+    * matched no case in that switch and emptied the granularities list, crashing the Date
+    * Comparison editor with a {@code TypeError} on {@code granularities[0].value} — bug #76306.
+    */
+   @ParameterizedTest
+   @CsvSource({
+      "year, 5",
+      "quarter, 4",
+      "month, 3",
+      "week, 2",
+      "day, 1",
+      "Year, 5",
+      "QUARTER, 4"
+   })
+   void translatesThePeriodLevelWordToTheNumericGroupCode(String word, String code)
+      throws Exception
+   {
+      DateComparisonPaneModel model = model();
+      DateComparisonService.Comparison comparison =
+         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
+                                              null);
+
+      harness(model).service.set("tok", principal(), "Chart1", comparison, "");
+
+      StandardPeriodPaneModel standard =
+         model.getPeriodPaneModel().getStandardPeriodPaneModel();
+      assertEquals(code, standard.getDateLevel().getValue());
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {"annual", "Y", "", "years"})
+   void refusesAnUnrecognizedPeriodLevel(String word) {
+      DateComparisonPaneModel model = model();
+      DateComparisonService.Comparison comparison =
+         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
+                                              null);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(model).service.set("tok", principal(), "Chart1", comparison, ""));
+
+      assertTrue(thrown.getMessage().contains("level"), thrown.getMessage());
    }
 
    @Test


### PR DESCRIPTION
Fixes bug #76306 (High priority, browser-crashing): set_date_comparison's
level field (e.g. "year") was written verbatim into
StandardPeriodPaneModel.dateLevel.value, but every Angular consumer (both
date-comparison-standard-periods.component.ts and, critically,
date-comparison-interval-pane.component.ts's granularitiesAllIntervalVisible)
expects the numeric XConstants.*_DATE_GROUP code (5/4/3/2/1), never the raw
word. The untranslated "year" matched no case in that switch, emptying the
granularities array; visibleGranularity then unconditionally indexed
granularities[0].value on the empty array, throwing the reported TypeError
and freezing the whole Composer page (grayed out, unresponsive, requiring a
hard refresh).

normalizeLevel() now translates the five agent-vocabulary words
(year/quarter/month/week/day), case-insensitively, to their XConstants
code before the value is stored — and throws a clear
IllegalArgumentException naming the field for anything else.

Tests: DateComparisonServiceTest, 30/30 pass, including a parametrized test
for all 5 words + case-insensitivity, and a rejection test for an
unrecognized level.

🤖 Generated with debug-workflow (stylebi-wiz)