### PR TITLE
Fix #76331: get_layout reports no page-index or table-mode fields

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutReadService.java
@@ -125,11 +125,17 @@ public class LayoutReadService {
       LayoutInfo info = masterVs.getLayoutInfo();
       AbstractLayout layout = vsLayoutService.getViewsheetLayout(info, layoutName);
       boolean print = vsLayoutService.isPrintLayout(layoutName);
+      // Same page size for every object in this layout -- computed once here, not per-object,
+      // since it depends only on the layout's own PrintInfo. null for a device layout, or a
+      // print layout whose PrintInfo has never been configured (VSLayoutService.getPrintPageSize's
+      // own convention).
+      Dimension printPageSize = print ? VSLayoutService.getPrintPageSize((PrintLayout) layout)
+         : null;
 
       List<LayoutObjectModel> objects = vsLayoutService
          .getVSAssemblyLayouts(layout, VSLayoutService.CONTENT)
          .stream()
-         .map(assemblyLayout -> toObjectModel(masterVs, assemblyLayout))
+         .map(assemblyLayout -> toObjectModel(masterVs, assemblyLayout, printPageSize))
          .collect(Collectors.toList());
 
       Boolean mobileOnly = print ? null : ((ViewsheetLayout) layout).isMobileOnly();
@@ -176,7 +182,9 @@ public class LayoutReadService {
          printLayout.getCustomWidth(), printLayout.getCustomHeight(), printLayout.getUnits());
    }
 
-   private LayoutObjectModel toObjectModel(Viewsheet masterVs, VSAssemblyLayout assemblyLayout) {
+   private LayoutObjectModel toObjectModel(Viewsheet masterVs, VSAssemblyLayout assemblyLayout,
+                                           Dimension printPageSize)
+   {
       VSAssembly assembly = masterVs.getAssembly(assemblyLayout.getName());
       Point layoutPos = assemblyLayout.getPosition();
       Dimension layoutSize = assemblyLayout.getSize();
@@ -184,6 +192,8 @@ public class LayoutReadService {
       // reading from the layout-space one above -- see the class doc.
       Point vsPos = assembly == null ? null : assembly.getPixelOffset();
       Dimension vsSize = assembly == null ? null : assembly.getPixelSize();
+      Integer pageIndex = printPageSize == null ? null
+         : vsLayoutService.getPageNumber(assemblyLayout, printPageSize);
 
       return new LayoutObjectModel(
          assemblyLayout.getName(),
@@ -192,7 +202,9 @@ public class LayoutReadService {
          vsPos == null ? 0 : vsPos.y,
          vsSize == null ? 0 : vsSize.width,
          vsSize == null ? 0 : vsSize.height,
-         vsLayoutService.supportTableLayout(assembly));
+         vsLayoutService.supportTableLayout(assembly),
+         assemblyLayout.getTableLayout(),
+         pageIndex);
    }
 
    private Map<String, Object> summarize(String name, String type, Boolean mobileOnly,

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutObjectModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutObjectModel.java
@@ -30,9 +30,21 @@ package inetsoft.web.wiz.viewsheet.model;
  *   PageBreak object that exists only inside this layout and has no assembly on the viewsheet at
  *   all).</li>
  * </ul>
+ *
+ * <p>{@code tableLayout} is this object's own {@code VSAssemblyLayout.getTableLayout()} value
+ * (the same int {@code set_layout_table_options} writes) — reported for every object regardless
+ * of {@code supportsTableLayout}, since the field always has a value even where this tool refuses
+ * to *write* it.
+ *
+ * <p>{@code pageIndex} is the page this object lands on within a <b>print</b> layout, derived
+ * from its layout position and the print layout's page size — {@code null} for a device-layout
+ * object (a device layout has no pages) and also {@code null} for a print layout whose
+ * {@code PrintInfo} has never been configured (mirroring {@link LayoutModel#printSettings()}'s
+ * own null-vs-zeroed convention, rather than a sentinel int that could be mistaken for a real
+ * page).
  */
 public record LayoutObjectModel(String name, int layoutX, int layoutY, int layoutWidth,
                                 int layoutHeight, int viewsheetX, int viewsheetY,
                                 int viewsheetWidth, int viewsheetHeight,
-                                boolean supportsTableLayout) {
+                                boolean supportsTableLayout, int tableLayout, Integer pageIndex) {
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.graph.internal.DimensionD;
+import inetsoft.report.ReportSheet;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.TableVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
@@ -145,6 +146,11 @@ class LayoutReadServiceTest {
       assertEquals(10, text.viewsheetX());
       assertEquals(20, text.viewsheetY());
       assertFalse(text.supportsTableLayout(), "a Text object does not support table layout");
+      assertEquals(ReportSheet.TABLE_FIT_PAGE, text.tableLayout(),
+                   "installPrintLayout never sets Text1's tableLayout -- the class's own default");
+      // installPrintLayout's real Letter/0.5in PrintInfo gives a 720-unit page height -- both
+      // y=200 and y=400 land on page 1 at that height (ceil(200/720) == ceil(400/720) == 1).
+      assertEquals(1, text.pageIndex());
 
       LayoutObjectModel table = model.objects().stream()
          .filter(o -> "Table1".equals(o.name())).findFirst().orElseThrow();
@@ -154,6 +160,51 @@ class LayoutReadServiceTest {
       assertEquals(60, table.viewsheetY());
       assertTrue(table.supportsTableLayout(),
                  "a TableDataVSAssembly-backed object supports table layout");
+      assertEquals(ReportSheet.TABLE_EQUAL_WIDTH, table.tableLayout(),
+                   "installPrintLayout explicitly sets Table1's tableLayout to a non-default value");
+      assertEquals(1, table.pageIndex());
+   }
+
+   @Test
+   void getReportsDifferentPageIndicesForObjectsOnDifferentPages() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayoutSpanningTwoPages();
+
+      LayoutModel model = fx.service.get("tok1", AGENT, PRINT_LAYOUT);
+
+      LayoutObjectModel text = model.objects().stream()
+         .filter(o -> "Text1".equals(o.name())).findFirst().orElseThrow();
+      assertEquals(1, text.pageIndex(), "y=200 is within the first 720-unit page");
+
+      LayoutObjectModel table = model.objects().stream()
+         .filter(o -> "Table1".equals(o.name())).findFirst().orElseThrow();
+      assertEquals(2, table.pageIndex(), "y=800 is past the first page's 720-unit height");
+   }
+
+   @Test
+   void getReportsNullPageIndexWhenThePrintLayoutHasNeverHadPrintInfoConfigured()
+      throws Exception
+   {
+      Fixture fx = new Fixture();
+      fx.installPrintLayoutWithoutPrintInfo();
+
+      LayoutModel model = fx.service.get("tok1", AGENT, PRINT_LAYOUT);
+
+      LayoutObjectModel text = model.objects().stream()
+         .filter(o -> "Text1".equals(o.name())).findFirst().orElseThrow();
+      assertNull(text.pageIndex(),
+                 "no PrintInfo means page size can't be computed -- null, not a sentinel int");
+   }
+
+   @Test
+   void getReportsNullPageIndexForEveryObjectInADeviceLayout() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installDeviceLayoutWithObject("Phone", "Text1");
+
+      LayoutModel model = fx.service.get("tok1", AGENT, "Phone");
+
+      assertEquals(1, model.objects().size());
+      assertNull(model.objects().get(0).pageIndex(), "a device layout has no pages");
    }
 
    @Test
@@ -323,7 +374,63 @@ class LayoutReadServiceTest {
                                             0.5f, 0.5f, 0.5f, 0.5f, "inches"));
          List<VSAssemblyLayout> objects = new ArrayList<>();
          objects.add(new VSAssemblyLayout("Text1", new Point(100, 200), new Dimension(30, 40)));
-         objects.add(new VSAssemblyLayout("Table1", new Point(300, 400), new Dimension(50, 60)));
+         VSAssemblyLayout tableLayout =
+            new VSAssemblyLayout("Table1", new Point(300, 400), new Dimension(50, 60));
+         // Explicit, non-default value -- TABLE_FIT_PAGE (1) is VSAssemblyLayout's own default,
+         // so leaving this unset would let the read-back assertion pass even if the service read
+         // nothing at all.
+         tableLayout.setTableLayout(ReportSheet.TABLE_EQUAL_WIDTH);
+         objects.add(tableLayout);
+         layout.setVSAssemblyLayouts(objects);
+
+         masterVs.getLayoutInfo().setPrintLayout(layout);
+      }
+
+      /**
+       * A print layout using the same real Letter/0.5in PrintInfo as {@link #installPrintLayout},
+       * but with {@code Table1} moved past the first page boundary -- {@code Text1} stays at
+       * {@code y=200} (page 1), {@code Table1} moves to {@code y=800} (page 2, since the fixed
+       * 720-unit page height means {@code ceil(800/720) == 2}) -- so {@code pageIndex} actually
+       * differs between the two objects, unlike {@link #installPrintLayout}'s own {@code
+       * y=200}/{@code y=400} (both page 1 at this page height).
+       */
+      void installPrintLayoutSpanningTwoPages() {
+         TextVSAssembly text = new TextVSAssembly(masterVs, "Text1");
+         text.setPixelOffset(new Point(10, 20));
+         text.setPixelSize(new Dimension(15, 10));
+         masterVs.addAssembly(text);
+
+         TableVSAssembly table = new TableVSAssembly(masterVs, "Table1");
+         table.setPixelOffset(new Point(50, 60));
+         table.setPixelSize(new Dimension(80, 40));
+         masterVs.addAssembly(table);
+
+         PrintLayout layout = new PrintLayout();
+         layout.setPrintInfo(new PrintInfo("Letter", new DimensionD(8.5, 11),
+                                            0.5f, 0.5f, 0.5f, 0.5f, "inches"));
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout("Text1", new Point(100, 200), new Dimension(30, 40)));
+         objects.add(new VSAssemblyLayout("Table1", new Point(300, 800), new Dimension(50, 60)));
+         layout.setVSAssemblyLayouts(objects);
+
+         masterVs.getLayoutInfo().setPrintLayout(layout);
+      }
+
+      /**
+       * A print layout that has never had its {@code PrintInfo} configured -- {@code pageIndex}
+       * must read back {@code null} for every object here, the same "unconfigured, not zeroed"
+       * convention {@code printSettings} already follows.
+       */
+      void installPrintLayoutWithoutPrintInfo() {
+         TextVSAssembly text = new TextVSAssembly(masterVs, "Text1");
+         text.setPixelOffset(new Point(10, 20));
+         text.setPixelSize(new Dimension(15, 10));
+         masterVs.addAssembly(text);
+
+         PrintLayout layout = new PrintLayout();
+         // No setPrintInfo call -- this is the "never configured" case.
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout("Text1", new Point(100, 200), new Dimension(30, 40)));
          layout.setVSAssemblyLayouts(objects);
 
          masterVs.getLayoutInfo().setPrintLayout(layout);
@@ -337,6 +444,30 @@ class LayoutReadServiceTest {
          layout.setMobileOnly(mobileOnly);
          layout.setDeviceIds(deviceIds);
          layout.setVSAssemblyLayouts(new ArrayList<>());
+         List<ViewsheetLayout> layouts = new ArrayList<>(info.getViewsheetLayouts());
+         layouts.add(layout);
+         info.setViewsheetLayouts(layouts);
+      }
+
+      /**
+       * A device (viewsheet) layout named {@code name} with one placed object -- for asserting
+       * {@code pageIndex} is {@code null} on a device layout's own objects (a device layout has
+       * no pages), which {@link #installDeviceLayout}'s empty object list can't exercise.
+       */
+      void installDeviceLayoutWithObject(String name, String objectName) {
+         TextVSAssembly text = new TextVSAssembly(masterVs, objectName);
+         text.setPixelOffset(new Point(10, 20));
+         text.setPixelSize(new Dimension(15, 10));
+         masterVs.addAssembly(text);
+
+         LayoutInfo info = masterVs.getLayoutInfo();
+         ViewsheetLayout layout = new ViewsheetLayout();
+         layout.setName(name);
+         layout.setMobileOnly(false);
+         layout.setDeviceIds(new String[0]);
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout(objectName, new Point(50, 60), new Dimension(30, 40)));
+         layout.setVSAssemblyLayouts(objects);
          List<ViewsheetLayout> layouts = new ArrayList<>(info.getViewsheetLayouts());
          layouts.add(layout);
          info.setViewsheetLayouts(layouts);


### PR DESCRIPTION
## Root cause

`LayoutReadService.toObjectModel` built each `LayoutObjectModel` from position/size and
`supportTableLayout()` only. It never called `VSAssemblyLayout.getTableLayout()` (the field
`set_layout_table_options` already writes on the master), and never computed which page an
object lands on within a print layout, even though `VSLayoutService.getPrintPageSize`/
`getPageNumber` already exist and are used internally for exactly this purpose (page-break
bookkeeping). A caller of `set_layout_table_options`/`edit_layout_objects` (via `plugin/composer`)
got `{ok:true}` back but `get_layout` had no field to confirm either write actually took visible
effect.

## Fix

- `LayoutObjectModel`: add `tableLayout` (`int`) and `pageIndex` (nullable `Integer`).
- `LayoutReadService`: compute the print layout's page size once per `get()` call
  (`VSLayoutService.getPrintPageSize`), thread it into `toObjectModel`, and populate
  `tableLayout`/`pageIndex` per object. `pageIndex` is `null` for a device-layout object (no
  pages) and also `null` when the print layout has never had a `PrintInfo` configured, mirroring
  the existing `printSettings` null-vs-zeroed convention already established in this class.
- `LayoutReadServiceTest`: extended the existing coordinate-space test with `tableLayout`/
  `pageIndex` assertions (giving `Table1` an explicit, non-default `tableLayout` in the fixture so
  the assertion can't pass on the class's own default alone), plus three new fixtures/tests:
  a print layout whose two objects land on different pages, a print layout with no `PrintInfo`
  configured (`pageIndex` must read back `null`, not a sentinel), and a device layout with a
  placed object (`pageIndex` must also read back `null` there).

Note: this bug's diagnosis flagged `getPageNumber`'s existing convention as worth double-checking
before reuse — page `0` only at `y == 0`, page `1` for anything in `(0, pageHeight]` (i.e.
`ceil(y/pageHeight)`, not a "natural" 0/1-based page-containing-this-range function). That's a
pre-existing, already-relied-upon convention elsewhere in `VSLayoutService`; this PR reuses it
as-is rather than reinterpreting it, and the new tests assert the literal values it returns.

## Tests

`./mvnw -pl core -am test -Dtest=LayoutReadServiceTest -Dsurefire.failIfNoSpecifiedTests=false -o`
→ Tests run: 10, Failures: 0, Errors: 0.

## Companion PR

`stylebi-wiz` (doc-only — `get_layout`'s response is an untyped passthrough, no server hop, so no
code change was needed there beyond documenting the two new fields and locking in their
passthrough with a regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)