### PR TITLE
Fix Bug #76362: LookAndFeelService font-upload path unvalidated filename traversal

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/LookAndFeelService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/LookAndFeelService.java
@@ -360,6 +360,8 @@ public class LookAndFeelService {
       }
 
       for(String fontName : fontNames) {
+         fontName = requireSafeFileName(fontName);
+
          if(space.exists(fontPath, fontName + ".ttf")) {
             space.delete(fontPath, fontName + ".ttf");
          }
@@ -389,7 +391,7 @@ public class LookAndFeelService {
    private void saveFontFaceFiles(UserFontModel fontFaceModel, String fontPath, DataSpace space, Principal principal)
       throws Exception
    {
-      final String fileName = fontFaceModel.getFileNamePrefix();
+      final String fileName = requireSafeFileName(fontFaceModel.getFileNamePrefix());
       deleteFontFiles(Collections.singletonList(fileName), fontPath, space);
 
       Base64.Decoder decoder = Base64.getDecoder();
@@ -424,7 +426,7 @@ public class LookAndFeelService {
    private void writeFontCSS(String family, List<FontFaceModel> fontFaces, String dir, DataSpace space)
       throws IOException
    {
-      final String file = family + ".css";
+      final String file = requireSafeFileName(family) + ".css";
 
       try(DataSpace.Transaction tx = space.beginTransaction();
           OutputStream output = tx.newStream(dir, file))
@@ -491,7 +493,7 @@ public class LookAndFeelService {
 
    /**
     * Rejects a caller-supplied file name that contains a path separator, a ".." traversal
-    * segment, or a NUL byte, since none of these are valid in a CSS/logo/favicon file name.
+    * segment, or a NUL byte, since none of these are valid in a CSS/logo/favicon/font file name.
     */
    private static String requireSafeFileName(String name) {
       if(name == null || name.isEmpty() || name.contains("/") || name.contains("\\") ||

--- a/core/src/test/java/inetsoft/web/admin/presentation/LookAndFeelServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/LookAndFeelServiceTest.java
@@ -50,23 +50,45 @@ package inetsoft.web.admin.presentation;
  * [G5] A safe, ordinary file name still succeeds on all three methods.
  * [G6] A name with no dot at all (falls into the default-extension branch) is unaffected by the
  *      fix for setLogo/setFavicon.
+ *
+ * Bug 76360's fix left the font-upload path (updateFonts/saveFontFaceFiles/writeFontCSS/
+ * deleteFontFiles) untouched even though it carries the identical unvalidated-caller-controlled-
+ * filename pattern, keyed off FontFaceModel/UserFontModel.getFileNamePrefix() and the raw
+ * userFont family string, reaching the same DataSpace write/delete/transaction calls. Bug 76362's
+ * fix reuses the same requireSafeFileName() at each of the three call sites.
+ *
+ * [G7] saveFontFaceFiles rejects a traversal-shaped getFileNamePrefix() before any
+ *      writeStyleFile/withOutputStream call.
+ * [G8] saveFontFaceFiles still succeeds and writes the expected "<prefix>.ttf" for a safe name.
+ * [G9] deleteFontFiles rejects a traversal-shaped name before any space.exists/space.delete call.
+ * [G10] deleteFontFiles still succeeds for a safe name.
+ * [G11] writeFontCSS rejects a traversal-shaped family/userFont string before
+ *       beginTransaction()/newStream().
+ * [G12] writeFontCSS still succeeds and writes "<family>.css" for a safe family name.
+ * [G13] A name containing "^" (the FontFaceModel identifier-separator case) is still accepted by
+ *       all three font-path methods -- pins that the fix does not regress the legitimate
+ *       multi-variant-font case.
  */
 
 import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.portal.FontFaceModel;
 import inetsoft.sree.portal.PortalThemesManager;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.util.DataSpace;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.admin.model.FileData;
+import inetsoft.web.admin.presentation.model.UserFontModel;
 import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -239,5 +261,144 @@ class LookAndFeelServiceTest {
       invoke("setFavicon", safe, "portal", true);
 
       verify(space, times(2)).withOutputStream(eq("portal"), eq("favicon.ico"), any());
+   }
+
+   private UserFontModel userFontModel(String name, String identifier) {
+      return UserFontModel.builder()
+         .name(name)
+         .identifier(identifier)
+         .ttf(fileData("font.ttf", "data"))
+         .build();
+   }
+
+   private void invokeDeleteFontFiles(List<String> fontNames, String fontPath) throws Throwable {
+      Method method = LookAndFeelService.class.getDeclaredMethod(
+         "deleteFontFiles", List.class, String.class, DataSpace.class);
+      method.setAccessible(true);
+
+      try {
+         method.invoke(service, fontNames, fontPath, space);
+      }
+      catch(InvocationTargetException ex) {
+         throw ex.getCause();
+      }
+   }
+
+   private void invokeSaveFontFaceFiles(UserFontModel model, String fontPath) throws Throwable {
+      Method method = LookAndFeelService.class.getDeclaredMethod(
+         "saveFontFaceFiles", UserFontModel.class, String.class, DataSpace.class, Principal.class);
+      method.setAccessible(true);
+
+      try {
+         method.invoke(service, model, fontPath, space, principal);
+      }
+      catch(InvocationTargetException ex) {
+         throw ex.getCause();
+      }
+   }
+
+   private void invokeWriteFontCSS(String family, List<FontFaceModel> fontFaces, String dir) throws Throwable {
+      Method method = LookAndFeelService.class.getDeclaredMethod(
+         "writeFontCSS", String.class, List.class, String.class, DataSpace.class);
+      method.setAccessible(true);
+
+      try {
+         method.invoke(service, family, fontFaces, dir, space);
+      }
+      catch(InvocationTargetException ex) {
+         throw ex.getCause();
+      }
+   }
+
+   @Test
+   void saveFontFaceFilesRejectsTraversalName() throws Exception {
+      UserFontModel traversal = userFontModel("../../../etc/evil", FontFaceModel.EMPTY_IDENTIFIER);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> invokeSaveFontFaceFiles(traversal, "portal/font"));
+      assertTrue(ex.getMessage().contains("../../../etc/evil"));
+
+      verify(space, never()).withOutputStream(anyString(), anyString(), any());
+   }
+
+   @Test
+   void saveFontFaceFilesAcceptsSafeName() throws Throwable {
+      UserFontModel safe = userFontModel("myfont", FontFaceModel.EMPTY_IDENTIFIER);
+
+      invokeSaveFontFaceFiles(safe, "portal/font");
+
+      verify(space).withOutputStream(eq("portal/font"), eq("myfont.ttf"), any());
+   }
+
+   @Test
+   void saveFontFaceFilesAcceptsNameWithIdentifierCaret() throws Throwable {
+      UserFontModel safe = userFontModel("myfont", "bold");
+
+      invokeSaveFontFaceFiles(safe, "portal/font");
+
+      verify(space).withOutputStream(eq("portal/font"), eq("myfont^bold.ttf"), any());
+   }
+
+   @Test
+   void deleteFontFilesRejectsTraversalName() {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> invokeDeleteFontFiles(Collections.singletonList("../../../etc/evil"), "portal/font"));
+      assertTrue(ex.getMessage().contains("../../../etc/evil"));
+
+      verify(space, never()).exists(anyString(), anyString());
+      verify(space, never()).delete(anyString(), anyString());
+   }
+
+   @Test
+   void deleteFontFilesAcceptsSafeName() throws Throwable {
+      when(space.exists("portal/font", "myfont.ttf")).thenReturn(true);
+
+      invokeDeleteFontFiles(Collections.singletonList("myfont"), "portal/font");
+
+      verify(space).delete("portal/font", "myfont.ttf");
+   }
+
+   @Test
+   void deleteFontFilesAcceptsNameWithIdentifierCaret() throws Throwable {
+      when(space.exists("portal/font", "myfont^bold.ttf")).thenReturn(true);
+      when(space.exists("portal/font", "myfont.css")).thenReturn(true);
+
+      invokeDeleteFontFiles(Collections.singletonList("myfont^bold"), "portal/font");
+
+      verify(space).delete("portal/font", "myfont^bold.ttf");
+      verify(space).delete("portal/font", "myfont.css");
+   }
+
+   @Test
+   void writeFontCSSRejectsTraversalFamilyName() {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> invokeWriteFontCSS("../../../etc/evil", Collections.emptyList(), "portal/font"));
+      assertTrue(ex.getMessage().contains("../../../etc/evil"));
+
+      verify(space, never()).beginTransaction();
+   }
+
+   @Test
+   void writeFontCSSAcceptsSafeFamilyName() throws Throwable {
+      DataSpace.Transaction tx = mock(DataSpace.Transaction.class, withSettings().lenient());
+      when(space.beginTransaction()).thenReturn(tx);
+      when(tx.newStream(eq("portal/font"), eq("myfont.css"))).thenReturn(new ByteArrayOutputStream());
+
+      invokeWriteFontCSS("myfont", Collections.emptyList(), "portal/font");
+
+      verify(tx).newStream("portal/font", "myfont.css");
+      verify(tx).commit();
+   }
+
+   @Test
+   void writeFontCSSAcceptsNameWithIdentifierCaret() throws Throwable {
+      DataSpace.Transaction tx = mock(DataSpace.Transaction.class, withSettings().lenient());
+      when(space.beginTransaction()).thenReturn(tx);
+      when(tx.newStream(eq("portal/font"), eq("myfont^bold.css")))
+         .thenReturn(new ByteArrayOutputStream());
+
+      invokeWriteFontCSS("myfont^bold", Collections.emptyList(), "portal/font");
+
+      verify(tx).newStream("portal/font", "myfont^bold.css");
    }
 }


### PR DESCRIPTION
## Root cause

`LookAndFeelService`'s font-upload path (`saveFontFaceFiles`/`deleteFontFiles`/`writeFontCSS`)
carries the identical unvalidated-caller-controlled-filename-reaches-`DataSpace`-write/delete
pattern that PR #4846 (bug 76360) fixed for the CSS/logo/favicon path (`setLogo`/`setFavicon`/
`setViewsheet`) -- but #4846 deliberately left the font path untouched, and it was filed
separately as bug 76362 once noticed during that fix's review.

`FontFaceModel`/`UserFontModel.getFileNamePrefix()` and the raw `userFont` family string are
plain Jackson-deserialized, unvalidated strings (no bean-validation annotation anywhere in the
chain from `PresentationSettingsController.applySettings` down) that reach three `DataSpace`
sinks unmodified:

- `deleteFontFiles`: `space.exists`/`space.delete` in a loop across 5 extensions per font name.
- `saveFontFaceFiles`: `getFileNamePrefix()` used to build `.ttf`/`.eot`/`.woff`/`.svg` names
  passed to `writeStyleFile` -> `space.withOutputStream`.
- `writeFontCSS`: `family + ".css"` passed straight to `space.beginTransaction()`/
  `tx.newStream(...)`, bypassing `writeStyleFile` entirely.

`DataSpace.sanitizePathComponent` intentionally does no `..`-segment detection (shared code with
~10 other legitimate multi-segment-path callers), so a traversal-shaped name survives into the
joined path unmodified.

## Fix

Reuse the existing `requireSafeFileName()` helper (added by #4846, private static in this class)
at the point each caller-controlled string is first used, at all three font-path call sites:

- `deleteFontFiles` (loop top, ~line 362): validates `fontName` before any `space.exists`/
  `space.delete` call.
- `saveFontFaceFiles` (~line 392): validates `fontFaceModel.getFileNamePrefix()` before any
  write.
- `writeFontCSS` (~line 427): validates `family` before building the `.css` filename.

No changes to `DataSpace.sanitizePathComponent`, `requireSafeFileName` itself, or the three
already-#4846-fixed call sites (`setLogo`/`setFavicon`/`setViewsheet`) -- same reasoning #4846
established: shared code, call-site-scoped validation is correct and sufficient.

## Tests

Extended `LookAndFeelServiceTest` (added by #4846) with font-path coverage mirroring its
existing CSS/logo/favicon test shape: one traversal-rejected / safe-name-still-succeeds pair per
call site, plus a `^` (the `FontFaceModel` multi-variant identifier separator) acceptance case
per site pinning that the fix doesn't regress the legitimate multi-font-variant case.

```
cd core && ./mvnw -pl core -o test -Dtest=LookAndFeelServiceTest,PresentationSettingsControllerTest -Dgroups=core
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0 -- LookAndFeelServiceTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0 -- PresentationSettingsControllerTest
```

Diagnosis: `docs/teams/2026-08-29-bugs-wiz-plugin-batch/bug-76362/01-diagnosis.md`
Refutation (verdict: survives): `docs/teams/2026-08-29-bugs-wiz-plugin-batch/bug-76362/02-refute.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)