### PR TITLE
Fix Bug #76331 (sub-issue 3): REST endpoint to set a Calendar assembly's selected date(s)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/CalendarDisplayService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/CalendarDisplayService.java
@@ -168,6 +168,91 @@ public class CalendarDisplayService {
    }
 
    /**
+    * Sets a calendar's selected date(s) — the real setter behind the browser's own calendar
+    * widget ({@link VSCalendarService#applyCalendar}), previously unreachable via REST.
+    *
+    * <p>Which shape {@code dates} needs depends on the calendar's mode (read from
+    * {@code CalendarVSAssembly.getConditionList}, not guessed): a single calendar ORs every token
+    * as its own condition — a drag-selected "March 1–15" arrives as 15 day tokens, not a compact
+    * range; a double calendar in range mode reads only the first two entries as literal min/max
+    * endpoints; a double calendar in period-comparison mode needs an even-length array, split in
+    * half between the two periods. {@code getConditionList} already throws a bare
+    * {@code RuntimeException} for a malformed count (period odd-length, range more-than-two) — this
+    * validates the same two cases first, with a named, field-specific message, rather than letting
+    * that exception surface.
+    *
+    * <p>{@code currentDate1}/{@code currentDate2} are the calendar's navigation position (which
+    * month is currently displayed), not part of the selection, so they are echoed back unchanged
+    * rather than taken as a parameter — mirroring {@link #setDisplay}.
+    */
+   public Map<String, Object> setDates(String sessionToken, Principal user, String assemblyName,
+                                       List<String> dates, String linkUri)
+      throws Exception
+   {
+      requireName(assemblyName);
+
+      if(dates == null || dates.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'dates' is required and must not be empty — use clear_calendar to clear a " +
+            "selection.");
+      }
+
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalendarVSAssembly calendar = requireCalendar(rvs, assemblyName);
+         CalendarVSAssemblyInfo info = (CalendarVSAssemblyInfo) calendar.getVSAssemblyInfo();
+
+         boolean dual = info.getViewMode() == CalendarVSAssemblyInfo.DOUBLE_CALENDAR_MODE;
+         boolean period = dual && info.isPeriod();
+
+         validateDateCount(dual, period, dates.size(), assemblyName);
+
+         String[] previous = info.getDates();
+
+         result.put("assembly", assemblyName);
+         result.put("mode", period ? "period" : dual ? "range" : "single");
+         result.put("datesSelected", dates.size());
+         result.put("previousDatesCleared", previous != null && previous.length > 0);
+
+         calendars.applyCalendar(
+            runtimeId, assemblyName,
+            ImmutableCalendarSelectionEvent.builder()
+               .dates(dates.toArray(new String[0]))
+               .currentDate1(nullToEmpty(info.getCurrentDate1()))
+               .currentDate2(info.getCurrentDate2())
+               .build(),
+            user, dispatcher, linkUri);
+      });
+
+      result.put("persistsOnSave", true);
+      return result;
+   }
+
+   /**
+    * Refuses a {@code dates} count that {@code CalendarVSAssembly.getConditionList} would reject
+    * (period mode: odd length; range mode: more than two) with a named, field-specific message
+    * before the call ever reaches the server — turning an existing but unfriendly runtime
+    * {@code RuntimeException} into an actionable one, not closing a silent-failure gap (the runtime
+    * is already loud for these two cases).
+    */
+   static void validateDateCount(boolean dual, boolean period, int count, String assemblyName) {
+      if(dual && period && count % 2 != 0) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a double calendar in period-comparison mode, which needs " +
+            "an even number of dates split evenly between the two periods — got " + count + ".");
+      }
+
+      if(dual && !period && count > 2) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a double calendar in range mode, which reads only the " +
+            "first two dates as the range's start and end — got " + count + ". Pass at most 2 " +
+            "dates, or use an even-length array with rangeComparison on for period-comparison " +
+            "mode.");
+      }
+   }
+
+   /**
     * What a display request means: which endpoints to call, and which invisible side effects to
     * report.
     *

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -489,6 +489,19 @@ public class ViewsheetAssemblyAgentController {
       return calendarService.clear(sessionToken, user, request.assembly(), linkUri);
    }
 
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/calendar/dates")
+   public Map<String, Object> setCalendarDates(@PathVariable String sessionToken,
+                                               @RequestBody CalendarDatesRequest request,
+                                               @RequestParam(required = false, defaultValue = "")
+                                               String linkUri,
+                                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calendarService.setDates(sessionToken, user, request.assembly(), request.dates(),
+                                     linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/input/value")
    public Map<String, Object> setInputValue(@PathVariable String sessionToken,
                                             @RequestBody InputValueRequest request,
@@ -503,6 +516,7 @@ public class ViewsheetAssemblyAgentController {
 
    public record CalendarDisplayRequest(String assembly, Boolean yearView, Boolean doubleCalendar,
                                         Boolean rangeComparison) {}
+   public record CalendarDatesRequest(String assembly, java.util.List<String> dates) {}
    public record InputValueRequest(String assembly, java.util.List<Object> value) {}
 
    public record SubtreeRequest(String assembly, java.util.List<String> path, String mode) {}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/CalendarInputServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/CalendarInputServiceTest.java
@@ -175,6 +175,103 @@ class CalendarInputServiceTest {
       verifyNoInteractions(h.calendars);
    }
 
+   // ── setDates ──────────────────────────────────────────────────────────────
+   //
+   // validateDateCount is the mode-aware count check, tested directly for the same reason plan()
+   // is: CalendarVSAssemblyInfo cannot be constructed or mocked outside a Spring context, so the
+   // full setDates flow can only be exercised up to (not through) requireCalendar.
+
+   @Test
+   void refusesNullDates() {
+      CalendarHarness h = calendarWith(null);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDates("tok", principal(), "Cal1", null, ""));
+
+      assertTrue(e.getMessage().contains("empty"), e.getMessage());
+      verifyNoInteractions(h.calendars);
+   }
+
+   @Test
+   void refusesEmptyDates() {
+      CalendarHarness h = calendarWith(null);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDates("tok", principal(), "Cal1", List.of(), ""));
+
+      assertTrue(e.getMessage().contains("empty"), e.getMessage());
+      verifyNoInteractions(h.calendars);
+   }
+
+   @Test
+   void refusesANonCalendarAssemblyForDates() {
+      CalendarHarness h = calendarWith(mock(ChartVSAssembly.class));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDates("tok", principal(), "Chart1", List.of("d2026-3-1"), ""));
+
+      assertTrue(e.getMessage().contains("not a calendar"), e.getMessage());
+      verifyNoInteractions(h.calendars);
+   }
+
+   @Test
+   void refusesAnUnknownCalendarForDates() {
+      CalendarHarness h = calendarWith(null);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDates("tok", principal(), "Nope", List.of("d2026-3-1"), ""));
+
+      assertTrue(e.getMessage().contains("Nope"), e.getMessage());
+      verifyNoInteractions(h.calendars);
+   }
+
+   /** A single calendar ORs every token, so any count is legal -- no mode check applies. */
+   @Test
+   void validateDateCountAllowsAnyCountOnASingleCalendar() {
+      assertDoesNotThrow(() -> CalendarDisplayService.validateDateCount(false, false, 1, "Cal1"));
+      assertDoesNotThrow(() -> CalendarDisplayService.validateDateCount(false, false, 15, "Cal1"));
+   }
+
+   /** Double-calendar range mode reads only dates[0]/dates[1] -- up to 2 is fine. */
+   @Test
+   void validateDateCountAllowsUpToTwoInRangeMode() {
+      assertDoesNotThrow(() -> CalendarDisplayService.validateDateCount(true, false, 1, "Cal1"));
+      assertDoesNotThrow(() -> CalendarDisplayService.validateDateCount(true, false, 2, "Cal1"));
+   }
+
+   /**
+    * Mirrors {@code CalendarVSAssembly.getConditionList}'s own {@code range && dates.length > 2}
+    * check -- more than 2 would otherwise be silently truncated to the first 2 by the runtime.
+    */
+   @Test
+   void validateDateCountRefusesMoreThanTwoInRangeMode() {
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> CalendarDisplayService.validateDateCount(true, false, 3, "Cal1"));
+
+      assertTrue(e.getMessage().contains("range mode"), e.getMessage());
+      assertTrue(e.getMessage().contains("Cal1"), e.getMessage());
+   }
+
+   /** Double-calendar period-comparison mode splits the array in half -- even counts are fine. */
+   @Test
+   void validateDateCountAllowsEvenCountInPeriodMode() {
+      assertDoesNotThrow(() -> CalendarDisplayService.validateDateCount(true, true, 2, "Cal1"));
+      assertDoesNotThrow(() -> CalendarDisplayService.validateDateCount(true, true, 4, "Cal1"));
+   }
+
+   /**
+    * Mirrors {@code CalendarVSAssembly.getConditionList}'s own {@code period && dates.length % 2 !=
+    * 0} check, which otherwise throws a bare {@code RuntimeException}.
+    */
+   @Test
+   void validateDateCountRefusesOddCountInPeriodMode() {
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> CalendarDisplayService.validateDateCount(true, true, 3, "Cal1"));
+
+      assertTrue(e.getMessage().contains("period-comparison"), e.getMessage());
+      assertTrue(e.getMessage().contains("Cal1"), e.getMessage());
+   }
+
    // ── inputs ────────────────────────────────────────────────────────────────
 
    /** A check box's several values travel as an Object[] in the scalar parameter. */


### PR DESCRIPTION
## Root cause

`VSCalendarService.applyCalendar` — the real setter behind the browser's own calendar widget — was
only wired to a WebSocket `MessageMapping` (`VSCalendarController.applyCalendar`), never to a REST
endpoint. The wiz-agent REST surface (`ViewsheetAssemblyAgentController`) already had
`calendar/display` and `calendar/clear` mappings, but nothing to set a date selection — so no
wiz-plugin tool could ever select a date/date-range on a Calendar assembly (Redmine #76331,
sub-issue 3).

## Fix

- `CalendarDisplayService.setDates` (new) mirrors the existing `setDisplay`/`clear` methods: wraps
  `VSCalendarService.applyCalendar` in `ViewsheetSessionService.mutate`
  (`ViewsheetSessionService.java:143-186`), which is what actually supplies the undo checkpoint and
  Composer-session broadcast for every wiz-agent write — independent of the `@Undoable`/
  `@LoadingMask` annotations the WebSocket path carries, which this REST path doesn't need (already
  covered by `sessions.mutate`, same as `setDisplay`/`clear`).
- Validates `dates.length` against the calendar's current mode (single / double-range /
  double-period) before calling `applyCalendar`, mirroring
  `CalendarVSAssembly.getConditionList`'s own `period && length%2!=0` / `range && length>2` checks
  (`.java:644-647`). That method already throws a bare `RuntimeException` for those two cases — this
  turns that into a named, field-specific `IllegalArgumentException` before the call is even made;
  it is not closing a silent-truncation gap (there isn't one for those two specific counts).
- New mapping: `POST /api/wiz/v1/agent/viewsheet/{sessionToken}/calendar/dates`.

## Tests

`core/src/test/java/inetsoft/web/wiz/viewsheet/CalendarInputServiceTest.java` — added coverage for
`validateDateCount`'s mode-aware policy (single/range/period, valid and invalid counts) and the
empty-dates/wrong-type/unknown-assembly guards on `setDates`. 29/29 pass
(`./mvnw -pl core test -o -Dtest=CalendarInputServiceTest`).
`ViewsheetAssemblyAgentControllerTest` unaffected, 29/29 pass.

Companion PRs (wiz-services route + plugin/composer tool) land in `stylebi-wiz`.

Full investigation: `docs/teams/2026-08-29-bugs-wiz-plugin-batch/bug-76331-calendar-tool/{01-diagnosis,02-refute}.md` in the `stylebi-wiz` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)