### PR TITLE
Fix #76331 (sub-issue 1): bound render/edit query execution instead of blocking indefinitely

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -29,6 +29,7 @@ import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.service.RenderNotReadyException;
+import inetsoft.web.wiz.service.RenderWaitSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -204,6 +205,13 @@ public class ScriptImageService {
     * {@link AssemblyImageService#downloadAssemblyImage} for "the whole sheet" (that path is
     * inherently per-assembly), so this always uses the full export pipeline. Acceptable here since
     * this is an explicit, occasional request, not something called after every script edit.
+    *
+    * <p>A table/crosstab whose query hasn't run yet in this runtime makes the export itself pay
+    * that cost synchronously, with no bound of its own — unlike a chart, which has
+    * {@code getAssemblyImage}'s own retry-after loop to fall back on. {@link RenderWaitSupport}
+    * gives this the same "not ready yet, retry after N seconds" contract instead of blocking the
+    * request thread for however long the query takes; the export keeps running in the background,
+    * so a retry lands on a warm cache rather than starting over.
     */
    public ChartImage getViewsheetImage(RuntimeViewsheet rvs, Integer width, Integer height,
                                        Principal principal)
@@ -212,7 +220,9 @@ public class ScriptImageService {
       int w = clamp(width != null && width > 0 ? width : DEFAULT_WIDTH);
       int h = clamp(height != null && height > 0 ? height : DEFAULT_HEIGHT);
 
-      byte[] pngBytes = exportViewsheetToPng(rvs, principal);
+      byte[] pngBytes = RenderWaitSupport.awaitOrRetry(() -> exportViewsheetToPng(rvs, principal),
+         RENDER_MAX_ATTEMPTS * RENDER_RETRY_SLEEP_MS,
+         (int) Math.max(1, (RENDER_MAX_ATTEMPTS * RENDER_RETRY_SLEEP_MS) / 1000));
       BufferedImage full = decodePng(pngBytes, "the viewsheet");
       BufferedImage scaled = scaleToFit(full, w, h);
       byte[] encoded = encodePng(scaled, "the viewsheet");

--- a/core/src/main/java/inetsoft/web/wiz/service/RenderWaitSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RenderWaitSupport.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Bounds a call that may block for a long time on a first-time, uncached query execution
+ * (rendering a viewsheet whose table data hasn't run yet in this runtime, or warming that data
+ * ahead of an edit that reads it) instead of letting the request thread hang until it finishes.
+ *
+ * <p>The work is run on a dedicated executor and given {@code timeoutMs} to finish. If it does
+ * not, {@link #awaitOrRetry} throws {@link RenderNotReadyException} — the same "not ready yet,
+ * retry after N seconds" contract {@code ScriptImageService.getAssemblyImage} already uses for
+ * a chart graph that hasn't finished computing. The work itself is <em>not</em> cancelled on
+ * timeout: it keeps running in the background, so whatever it computes (StyleBI's
+ * {@code ViewsheetSandbox} caches a table/chart's result once computed) is warm by the time the
+ * caller retries, rather than restarting from nothing.
+ */
+public final class RenderWaitSupport {
+   private RenderWaitSupport() {
+   }
+
+   public static <T> T awaitOrRetry(Callable<T> work, long timeoutMs, int retryAfterSeconds)
+      throws Exception
+   {
+      Future<T> future = EXECUTOR.submit(work);
+
+      try {
+         return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+      }
+      catch(TimeoutException e) {
+         throw new RenderNotReadyException(retryAfterSeconds);
+      }
+      catch(ExecutionException e) {
+         Throwable cause = e.getCause();
+
+         if(cause instanceof Exception ex) {
+            throw ex;
+         }
+
+         throw e;
+      }
+   }
+
+   // Virtual threads: cheap enough that a timed-out-but-still-running attempt left behind by a
+   // caller that gave up doesn't cost a pooled platform thread. Mirrors
+   // WizVisualizationService.THUMBNAIL_EXECUTOR.
+   private static final ExecutorService EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.TableDataVSAssembly;
 import inetsoft.uql.viewsheet.TitledVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -27,6 +29,9 @@ import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.event.*;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.web.wiz.service.RenderNotReadyException;
+import inetsoft.web.wiz.service.RenderWaitSupport;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +43,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Applies structural edits by delegating to the Composer's own services.
@@ -133,6 +139,7 @@ public class ViewsheetEditService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          AssemblyNode current = requireExisting(rvs, request.assembly());
+         ensureTableDataReady(rvs, request.assembly());
 
          ResizeVSObjectEvent event = new ResizeVSObjectEvent();
          event.setName(request.assembly());
@@ -145,6 +152,41 @@ public class ViewsheetEditService {
          event.setyOffset(current.y());
          objects.resizeObject(runtimeId, event, user, dispatcher, linkUri);
       });
+   }
+
+   /**
+    * Warms a {@code TableDataVSAssembly}'s query result before {@code resizeObject} runs, bounded
+    * to a short wait, instead of letting {@code resizeObject}'s own unconditional
+    * {@code loadTableLens} call — which has no bound of its own — block the request thread for
+    * however long a first-time query execution takes.
+    *
+    * <p>{@code resizeObject} is shared with the human Composer's own resize path
+    * ({@code ComposerObjectController}), so its synchronous contract is left alone; this only
+    * guards the wiz agent's call to it, ahead of time, without touching that shared method.
+    *
+    * <p>On timeout this throws {@link RenderNotReadyException} <em>before</em> {@code resizeObject}
+    * runs, so the resize itself is not applied yet — unlike the bug this fixes, where the mutation
+    * landed underneath a response that reported failure, the caller now sees a live "not ready,
+    * retry" signal and the resize is guaranteed not to have happened until a retry actually
+    * succeeds.
+    */
+   private void ensureTableDataReady(RuntimeViewsheet rvs, String name) throws Exception {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      Assembly assembly = vs == null ? null : vs.getAssembly(name);
+
+      if(!(assembly instanceof TableDataVSAssembly)) {
+         return;
+      }
+
+      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+      if(box.isEmpty()) {
+         return;
+      }
+
+      RenderWaitSupport.awaitOrRetry(() -> box.get().getVSTableLens(name, false),
+         TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS,
+         (int) Math.max(1, (TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS) / 1000));
    }
 
    /**
@@ -628,6 +670,11 @@ public class ViewsheetEditService {
             "Edit op '" + op + "' requires both '" + firstName + "' and '" + secondName + "'.");
       }
    }
+
+   // Mirrors ScriptImageService.RENDER_MAX_ATTEMPTS/RENDER_RETRY_SLEEP_MS: the same "how long is
+   // acceptable to make a caller wait before answering retry-after" ceiling used for rendering.
+   private static final int TABLE_WARM_MAX_ATTEMPTS = 4;
+   private static final long TABLE_WARM_RETRY_SLEEP_MS = 500;
 
    private final ViewsheetSessionService sessions;
    private final ComposerObjectService objects;

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -301,4 +301,35 @@ class ScriptImageServiceTest {
       assertEquals(200, img.width());
       assertEquals(150, img.height());
    }
+
+   /**
+    * Bug #76331: a table/crosstab whose query hasn't run yet in this runtime made the export
+    * pipeline block synchronously with no bound of its own, so the caller saw a plain 30s network
+    * timeout instead of the "not ready yet, retry" signal a chart's own render path already had.
+    * Simulates that with an export call that blocks past the bound {@code getViewsheetImage} now
+    * enforces via {@link inetsoft.web.wiz.service.RenderWaitSupport} and asserts it surfaces as
+    * {@link RenderNotReadyException} instead of hanging for the caller's full client timeout.
+    */
+   @Test
+   void getViewsheetImageThrowsRenderNotReadyWhenTheExportTakesTooLong() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      VSExportService exportService = mock(VSExportService.class);
+
+      doAnswer(invocation -> {
+         // Longer than the 4x500ms bound getViewsheetImage waits before giving up.
+         Thread.sleep(3_000);
+         ExportResponse response = invocation.getArgument(9);
+         response.getOutputStream().write(fakePng(200, 150));
+         return null;
+      }).when(exportService).exportViewsheet(
+         any(), anyInt(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+         any(), anyBoolean(), any(ExportResponse.class), any());
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+
+      RenderNotReadyException ex = assertThrows(RenderNotReadyException.class,
+         () -> svc.getViewsheetImage(rvs, null, null, TestPrincipals.user("alice", "host-org")));
+      assertTrue(ex.getRetryAfter() > 0);
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -871,4 +871,71 @@ class ViewsheetAssemblyAgentControllerTest {
                                          mock(SheetAgentBroadcastService.class));
    }
 
+   // ---------------------------------------------------------------------------
+   // Bug #76331 -- render timeout
+   // ---------------------------------------------------------------------------
+
+   /**
+    * This controller only ever declared a local handler for {@code PairingException} (line ~1001)
+    * -- a {@code RenderNotReadyException} from {@code imageService.getViewsheetImage}/
+    * {@code getAssemblyImage} has nothing local to catch it, so it must propagate out of
+    * {@code image()} for {@code WizControllerErrorHandler}'s {@code @ControllerAdvice} (scoped to
+    * {@code inetsoft.web.wiz}, which covers this controller's package) to map it to a 503 +
+    * Retry-After -- see that class's {@code handleRenderNotReady} and its own test for the mapping
+    * itself. If this controller ever grew a catch-all that swallowed it locally, this is the test
+    * that would catch the regression.
+    */
+   @Test
+   void imagePropagatesRenderNotReadyRatherThanSwallowingIt() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+
+      inetsoft.web.wiz.script.ScriptImageService imageService =
+         mock(inetsoft.web.wiz.script.ScriptImageService.class);
+      when(imageService.getViewsheetImage(eq(rvs), any(), any(), any(Principal.class)))
+         .thenThrow(new inetsoft.web.wiz.service.RenderNotReadyException(2));
+
+      ViewsheetAssemblyAgentController controller = controllerWith(featureOn(), sessions,
+                                                                    imageService);
+
+      inetsoft.web.wiz.service.RenderNotReadyException thrown = assertThrows(
+         inetsoft.web.wiz.service.RenderNotReadyException.class,
+         () -> controller.image("tok", null, null, null, principal()));
+      assertEquals(2, thrown.getRetryAfter());
+   }
+
+   /** Feature enabled, only {@code imageService} (and a fixed {@code sessions.resolve}) wired. */
+   private static ViewsheetAssemblyAgentController controllerWith(
+      SheetAgentFeature feature, ViewsheetSessionService sessions,
+      inetsoft.web.wiz.script.ScriptImageService imageService)
+   {
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          sessions,
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          imageService,
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -27,10 +27,13 @@ import inetsoft.web.composer.vs.objects.event.ChangeVSObjectLayerEvent;
 import inetsoft.web.composer.vs.objects.event.LockVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.MoveVSObjectEvent;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.TableDataVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -45,6 +48,7 @@ import org.mockito.ArgumentCaptor;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -607,6 +611,61 @@ class ViewsheetEditServiceTest {
          IllegalArgumentException.class,
          () -> service.apply("tok", principal(), sized("resize", "Text1", -50, -20), ""));
       assertTrue(thrown.getMessage().contains("width"));
+   }
+
+   /**
+    * Bug #76331: resizeObject's own loadTableLens call has no bound of its own, so a
+    * TableDataVSAssembly (Crosstab/Table) whose query hasn't run yet in this runtime made the
+    * whole resize request block for however long that query took. Warming the table's data ahead
+    * of resizeObject, bounded, means a slow-but-not-stuck table surfaces as a live
+    * RenderNotReadyException instead of a raw timeout — and, since this happens before
+    * resizeObject runs, the resize is not silently applied underneath the failure the caller sees.
+    */
+   @Test
+   void resizeThrowsRenderNotReadyWhenTableDataIsSlowAndDoesNotDelegate() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      TableDataVSAssembly table = mock(TableDataVSAssembly.class);
+      ViewsheetSandbox sandbox = mock(ViewsheetSandbox.class);
+      RuntimeViewsheet rvs = runtimeWithSandbox("Crosstab1", table, sandbox);
+
+      when(sandbox.getVSTableLens("Crosstab1", false)).thenAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      });
+
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Crosstab1", "Crosstab", 10, 20, 300, 150, 0, null, true)), objects);
+
+      assertThrows(RenderNotReadyException.class,
+         () -> service.apply("tok", principal(), sized("resize", "Crosstab1", 300, 150), ""));
+      verifyNoInteractions(objects);
+   }
+
+   /** A table whose data is already warm (or warms within the bound) resizes normally. */
+   @Test
+   void resizeDelegatesOnceTableDataIsReady() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      TableDataVSAssembly table = mock(TableDataVSAssembly.class);
+      ViewsheetSandbox sandbox = mock(ViewsheetSandbox.class);
+      RuntimeViewsheet rvs = runtimeWithSandbox("Crosstab1", table, sandbox);
+
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Crosstab1", "Crosstab", 10, 20, 300, 150, 0, null, true)), objects);
+
+      service.apply("tok", principal(), sized("resize", "Crosstab1", 300, 150), "");
+
+      verify(objects).resizeObject(eq("rt1"), any(), any(Principal.class), any(), anyString());
+   }
+
+   private static RuntimeViewsheet runtimeWithSandbox(String name, VSAssembly assembly,
+                                                      ViewsheetSandbox sandbox)
+   {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly(name)).thenReturn(assembly);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(sandbox));
+      return rvs;
    }
 
    private static EditRequest sized(String op, String assembly, Integer width, Integer height) {


### PR DESCRIPTION
## Root cause

A `TableDataVSAssembly` (Crosstab/Table) whose query hasn't run yet in this runtime made two
wiz-agent paths block synchronously with no bound of their own — so the plugin's flat 30s client
timeout was the only thing that ever ended the request:

- `ScriptImageService.getViewsheetImage`: the whole-viewsheet PNG export always ran unbounded, and
  `getAssemblyImage`'s own table/crosstab fallback (a 1x1 placeholder) fed straight back into it.
  Charts already had a real `RenderNotReadyException`/retry-after contract for this; tables did
  not.
- `ViewsheetEditService`'s `resize` op: `resizeObject`'s own `loadTableLens` call (shared with the
  human Composer's own resize path) has no bound of its own. The position/size mutation itself
  lands almost instantly and durably, *before* the unbounded part runs — so the caller could see a
  bare timeout while the edit had actually already applied underneath it.

## Fix

New `RenderWaitSupport` runs the work on a dedicated executor and gives up waiting after ~2s
(mirroring `ScriptImageService`'s existing `RENDER_MAX_ATTEMPTS`/`RENDER_RETRY_SLEEP_MS`), throwing
the same `RenderNotReadyException` a chart's render path already uses, instead of letting the
request thread hang. The work is **not** cancelled — it keeps running in the background, so a
retry lands on a warm cache instead of restarting from nothing.

For `resize`, this pre-warms the table's data *before* `resizeObject` runs, rather than touching
that shared method's own synchronous contract (per the diagnosis's explicit warning that it's
shared with the human Composer's resize path). This means a request that isn't ready in time fails
loud *before* mutating anything, rather than applying invisibly underneath a reported failure —
resolving the reporter's worst-case concern ("the edit had actually landed underneath") more
directly than keeping the original mutate-then-warm order would have.

`ViewsheetAssemblyAgentController` turned out to already have this exception routed correctly via
`WizControllerErrorHandler`'s `@ControllerAdvice` — added in a commit since the original
diagnosis/refute were written, which cited a since-removed local handler in a sibling controller.
Confirmed by tracing the controller's own exception handling (only a local `PairingException`
handler exists; nothing catches `RenderNotReadyException` locally, so it correctly falls through to
the advice) and locked in with a regression test proving `image()` propagates
`RenderNotReadyException` rather than swallowing it.

## Tests

- `ScriptImageServiceTest`: new case simulating an export that blocks past the bound, asserting
  `RenderNotReadyException` instead of a hang.
- `ViewsheetEditServiceTest`: new cases — a slow table warm-up throws `RenderNotReadyException`
  *without* calling `resizeObject` (no silent-apply-then-fail); a fast/warm one still resizes
  normally.
- `ViewsheetAssemblyAgentControllerTest`: new case confirming `image()` propagates
  `RenderNotReadyException` rather than swallowing it locally.
- Full `inetsoft.web.wiz` test package (2632 tests) run for collateral-damage check: 0 failures.

Redmine #76331 (sub-issue 1 of 3 on that ticket — the other two, print-layout readback and the
calendar tool, are tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)