### PR TITLE
Fix #76350 PWA-004: read_worksheet_model reads public column selection on aggregated tables

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -347,7 +347,12 @@ public class WorksheetReadService {
    // -------------------------------------------------------------------------
 
    private List<WorksheetModel.ColumnModel> readColumns(TableAssembly t) {
-      ColumnSelection cs = t.getColumnSelection(false);
+      // A grouped/aggregated table's private (pre-aggregation) selection keeps the original
+      // column definitions, while its public selection is regenerated from the AggregateInfo and
+      // reflects the query's actual output (correct alias, correct computed type) — the same
+      // public view list_bindable_fields/preview_worksheet_data already read. Reading the private
+      // selection unconditionally here is what made read_worksheet_model disagree with them.
+      ColumnSelection cs = t.getColumnSelection(t.isAggregate());
 
       if(cs == null) {
          return Collections.emptyList();

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -94,6 +94,70 @@ class WorksheetReadServiceTest {
       assertEquals("QUARTER", group.dateLevel());
    }
 
+   /**
+    * PWA-004: read_worksheet_model must report the same post-aggregation column shape that
+    * list_bindable_fields/preview_worksheet_data already do. A grouped table's public column
+    * selection carries only columns that are a group key or an aggregate output (a raw column
+    * that is neither is dropped, per AbstractTableAssembly's own public-selection regeneration);
+    * the private (pre-aggregation) selection this method used to read unconditionally keeps every
+    * raw column regardless. None of this file's other aggregate fixtures can catch a regression
+    * here: readsColumnsAggregatesConditionsSort sets its AggregateInfo directly
+    * (t.setAggregateInfo), which never flips isAggregate() true, so
+    * t.getColumnSelection(t.isAggregate()) resolves identically to the old unconditional
+    * getColumnSelection(false) there regardless of this fix; readsDateGroupLevelOnGroupedColumn
+    * and readsNForParametrizedFormula do go through applyAggregateInfo (isAggregate() true), but
+    * their 2-column fixtures make every raw column either the group key or the aggregated column,
+    * so private and public selections have the identical shape either way. This fixture adds a
+    * 3rd, untouched raw column ("region") specifically so the two selections differ in shape.
+    */
+   @Test
+   void groupedTableReportsOnlyThePublicAggregateOutputColumns() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val", "region");
+      ws.addAssembly(t);
+
+      WorksheetMutationSupport.applyAggregateInfo(t,
+         List.of(new WorksheetMutationSupport.GroupSpec("cat", null)),
+         List.of(new WorksheetMutationSupport.AggregateSpec("val", "SUM", null)));
+
+      // applyAggregateInfo itself only regenerates the public selection when a secondary
+      // aggregate forces a cs2 rebuild (see its own setColumnSelection(cs2) call) -- a plain
+      // single-group/single-aggregate call, the common case here, does not. In production this
+      // regeneration instead happens via WorksheetEventUtil.refreshColumnSelection, called by
+      // WorksheetAgentController right after set_group_aggregate, which needs a live
+      // AssetQuerySandbox this unit test has no reason to stand up. Forcing the same
+      // setColumnSelection(private, false) regeneration directly is the same idiom this file's own
+      // concatenationReportsWhetherItsSourcesLineUpByType test already uses for the identical
+      // reason (public selection holds clones taken when private was installed).
+      t.setColumnSelection(t.getColumnSelection(false), false);
+
+      WorksheetModel.TableModel tm = tableNamed(read(ws), "T");
+      List<String> names = tm.columns().stream().map(WorksheetModel.ColumnModel::name).toList();
+
+      assertTrue(names.contains("cat"));
+      assertTrue(names.contains("val"));
+      assertFalse(names.contains("region"),
+         "\"region\" is neither a group key nor an aggregate output -- the public selection " +
+            "list_bindable_fields/preview_worksheet_data already read drops it, and " +
+            "read_worksheet_model must agree rather than keep reporting the private, " +
+            "pre-aggregation column list: " + names);
+   }
+
+   /** The fix must be a no-op for a non-grouped table: isAggregate() is false, so
+    *  t.getColumnSelection(t.isAggregate()) resolves to the same private selection
+    *  getColumnSelection(false) always read here -- byte-identical to the pre-fix behaviour. */
+   @Test
+   void nonGroupedTableStillReportsAllItsRawColumns() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val", "region");
+      ws.addAssembly(t);
+
+      WorksheetModel.TableModel tm = tableNamed(read(ws), "T");
+      List<String> names = tm.columns().stream().map(WorksheetModel.ColumnModel::name).toList();
+
+      assertEquals(List.of("cat", "val", "region"), names);
+   }
+
    // Bug #75954: even after set_group_aggregate correctly applied N, read_worksheet_model
    // reported the formula as bare "NthLargest" with N gone — this is the read-back half
    // of that bug.


### PR DESCRIPTION
## Root cause

`WorksheetReadService.readColumns()` (`core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java:349`) hardcoded `t.getColumnSelection(false)` -- the table's PRIVATE (pre-aggregation) column selection -- regardless of whether the table `isAggregate()`. For a grouped/aggregated table, `list_bindable_fields` and `preview_worksheet_data` both correctly read/derive from the PUBLIC (post-aggregation) view, so `read_worksheet_model` disagreed with both about the same table's live column state (PWA-004, part of Redmine #76350's plugin-composer bug-reports corpus).

## Fix

```java
- ColumnSelection cs = t.getColumnSelection(false);
+ ColumnSelection cs = t.getColumnSelection(t.isAggregate());
```

This mirrors the existing `AbstractTableAssembly.getExpressionWidth(boolean)` precedent in the same class hierarchy (`getColumnSelection(embedded || isAggregate())`). No-op for a non-grouped table: `isAggregate()` is `false`, so the call resolves identically to the pre-fix behavior.

## Tests

Added `groupedTableReportsOnlyThePublicAggregateOutputColumns` and `nonGroupedTableStillReportsAllItsRawColumns` to `WorksheetReadServiceTest`, using a 3-raw-column fixture (group by one column, sum another, leave a third -- `region` -- untouched) specifically constructed so the private and public selections differ in shape.

None of the existing 3 aggregate-adjacent fixtures in this file would have caught this regression:
- `readsColumnsAggregatesConditionsSort` sets `AggregateInfo` directly via `t.setAggregateInfo(...)`, which never flips `isAggregate()` true, so the fix's branch resolves identically to the old unconditional call there regardless.
- `readsDateGroupLevelOnGroupedColumn` / `readsNForParametrizedFormula` do go through the production `applyAggregateInfo` path (`isAggregate()` true), but their 2-column fixtures make every raw column either the group key or the aggregated column, so private and public selections have the identical shape either way.

Verified by temporarily reverting the fix: the new grouped-table test fails (`region` incorrectly present) while the non-grouped test still passes, confirming the new fixture actually exercises the changed branch and that the fix is a genuine no-op for non-grouped tables.

`mvn -pl core -am test -Dtest=WorksheetReadServiceTest,WorksheetAgentControllerTest,WorksheetScriptControllerTest -Dsurefire.failIfNoSpecifiedTests=false -o` -- 115/115 pass.

## Out of scope

PWA-004's "type revert" sub-question (why a `change_column_type` fix on an `add_expression_column`-defaulted column can silently revert after a later `set_group_aggregate`) is a separate, still-unconfirmed mechanism per the diagnosis/refute docs -- not touched here. PWA-001 (`set_group_aggregate` poisoning a table as a chart source) is likewise untouched, still undiagnosed pending live-session access.

See `docs/teams/2026-08-29-bugs-plugin-composer-corpus/cluster-B/` in the `stylebi-wiz` repo for the full diagnosis/refute trail.

Generated with Claude Code