### PR TITLE
Fix Bug #76325 (item 3): format a chart's own title without bleeding onto axis titles

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -60,8 +60,9 @@ public class ChartRegionPropertyService {
                "when a measure uses the secondary axis",
             "legend", "the legend's 0-based index",
             "title", "which axis title — x, x2, y, y2, and only ones this chart has. NOT the " +
-               "chart's own title: that lives on the assembly, as set_assembly_properties " +
-               "'title' and 'titleVisible'"),
+               "chart's own title: its text/visibility are set_assembly_properties 'title' and " +
+               "'titleVisible', and its font/color are set_format {assemblies: [chart], target: " +
+               "'title'}"),
          "note", "An axis may also need 'field' when a chart has more than one axis of a type.");
    }
 
@@ -202,9 +203,10 @@ public class ChartRegionPropertyService {
       if("title".equals(region) && "chart".equals(ChartRegionResolver.canonical(target))) {
          throw new IllegalArgumentException(
             "The chart title is not a chart region — only the axis titles (x, x2, y, y2) are. " +
-            "It lives on the assembly: set its text with set_assembly_properties 'title', and " +
-            "show or hide it with 'titleVisible' or with " +
-            "set_chart_element_visibility {element: 'title', target: 'chart'}.");
+            "It lives on the assembly: set its text with set_assembly_properties 'title', show " +
+            "or hide it with 'titleVisible' or with set_chart_element_visibility {element: " +
+            "'title', target: 'chart'}, and set its font/color with set_format {assemblies: " +
+            "[chart], target: 'title'}.");
       }
 
       ChartRegionResolver.Axes axes = sessions.read(
@@ -290,7 +292,8 @@ public class ChartRegionPropertyService {
                case "axis" -> "the axis type, such as y or x.";
                case "legend" -> "the legend's 0-based index.";
                default -> "which axis title: x, x2, y, y2. The chart's own title is not a " +
-                  "region — it is set_assembly_properties 'title'.";
+                  "region — its text is set_assembly_properties 'title', its font/color is " +
+                  "set_format {assemblies: [chart], target: 'title'}.";
             });
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.report.StyleConstants;
+import inetsoft.report.TableDataPath;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -31,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -52,11 +55,20 @@ public class ViewsheetFormatService {
     * @param assemblies the assemblies to format; at least one
     * @param format     the format to apply; may be null only when {@code reset} is true
     * @param reset      clear formatting back to the default rather than applying {@code format}
+    * @param target     {@code "object"} (default, when null/blank) formats the whole assembly;
+    *                   {@code "title"} formats only that assembly's own title-bar text, distinct
+    *                   from a chart's axis titles or any other sub-region
     */
    public record FormatRequest(List<String> assemblies,
                                VSObjectFormatInfoModel format,
-                               boolean reset)
+                               boolean reset,
+                               String target)
    {
+      /** Kept for existing callers that predate {@code target} — defaults it to whole-object. */
+      public FormatRequest(List<String> assemblies, VSObjectFormatInfoModel format, boolean reset) {
+         this(assemblies, format, reset, null);
+      }
+
       /**
        * Reads {@code format} as a plain object, supplying the polymorphic type id ourselves.
        *
@@ -75,9 +87,10 @@ public class ViewsheetFormatService {
       @JsonCreator
       public static FormatRequest fromJson(@JsonProperty("assemblies") List<String> assemblies,
                                            @JsonProperty("format") JsonNode format,
-                                           @JsonProperty("reset") boolean reset)
+                                           @JsonProperty("reset") boolean reset,
+                                           @JsonProperty("target") String target)
       {
-         return new FormatRequest(assemblies, toModel(format), reset);
+         return new FormatRequest(assemblies, toModel(format), reset, target);
       }
 
       private static VSObjectFormatInfoModel toModel(JsonNode format) {
@@ -299,6 +312,8 @@ public class ViewsheetFormatService {
             "set_format requires 'format' unless 'reset' is true.");
       }
 
+      String target = requireTarget(request.target());
+
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          FormatVSObjectEvent event = new FormatVSObjectEvent();
          event.setObjects(request.assemblies().toArray(new String[0]));
@@ -310,8 +325,41 @@ public class ViewsheetFormatService {
          // branches that read getColumnNames()/getIndexes()/getRegions() all live inside that
          // loop, so they never execute for these requests.
          event.setCharts(new String[0]);
+
+         // TITLEPATH is FormatPainterService's own per-assembly TableDataPath[] mechanism
+         // (event.getData(), indexed 1:1 with event.getObjects()) — the same generic slot every
+         // titled assembly (table, gauge, crosstab, chart, ...) already stores its own title-bar
+         // format in, entirely separate from a chart's axis/legend descriptors. Leaving data null
+         // (the default) falls through to a whole-OBJECT write, same as before this parameter
+         // existed.
+         if("title".equals(target)) {
+            ArrayList<TableDataPath[]> data = new ArrayList<>();
+
+            for(int i = 0; i < request.assemblies().size(); i++) {
+               data.add(new TableDataPath[]{ VSAssemblyInfo.TITLEPATH });
+            }
+
+            event.setData(data);
+         }
+
          painter.setFormat(runtimeId, event, user, dispatcher, linkUri);
       });
+   }
+
+   /** Bug 76325 item 3: distinguishes a chart's own title from its whole-object format. */
+   private static String requireTarget(String target) {
+      String name = target == null || target.isBlank() ? "object" : target.trim().toLowerCase();
+
+      if(!"object".equals(name) && !"title".equals(name)) {
+         throw new IllegalArgumentException(
+            "set_format 'target' must be 'object' or 'title', got '" + target + "'. 'object' " +
+            "(the default) formats the whole assembly, including — for a chart — the default " +
+            "text style that unstyled axis titles and tick labels fall back to. 'title' formats " +
+            "only that assembly's own title-bar text; for a chart's x/y axis titles, use " +
+            "set_chart_region_properties with region 'title' instead.");
+      }
+
+      return name;
    }
 
    private final ViewsheetSessionService sessions;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.viewsheet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.report.StyleConstants;
+import inetsoft.report.TableDataPath;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -348,6 +351,83 @@ class ViewsheetFormatServiceTest {
       verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
                                 anyString());
       assertTrue(captor.getValue().isReset());
+   }
+
+   /**
+    * Bug 76325 item 3: no existing tool could format a chart's own title without also bleeding
+    * onto its axis titles and tick labels, because the only write path was the whole-OBJECT
+    * format. {@code target: "title"} routes the write through {@code event.getData()} instead —
+    * the same per-assembly {@code TableDataPath[]} mechanism a table already uses for its own
+    * title/header/cell formats — landing on {@code VSAssemblyInfo.TITLEPATH} specifically rather
+    * than {@code TableDataPath.OBJECT}.
+    */
+   @Test
+   void targetTitleRoutesThroughTheTitlePathInsteadOfTheWholeObject() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+      format.setColor("#000080");
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(
+            List.of("Chart1"), format, false, "title"), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      ArrayList<TableDataPath[]> data = captor.getValue().getData();
+      assertNotNull(data, "target:title must populate event.getData()");
+      assertEquals(1, data.size());
+      assertArrayEquals(new TableDataPath[]{ VSAssemblyInfo.TITLEPATH }, data.get(0));
+   }
+
+   /** Default behaviour (no target, or target:"object") must be unchanged — a whole-object write. */
+   @Test
+   void defaultTargetLeavesDataNullForAWholeObjectWrite() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(List.of("Chart1"), format, false), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      assertNull(captor.getValue().getData(), "no target must not touch event.getData()");
+   }
+
+   @Test
+   void targetTitleAlignsOneTitlePathPerAssembly() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(
+            List.of("Chart1", "Table1"), format, false, "title"), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      ArrayList<TableDataPath[]> data = captor.getValue().getData();
+      assertEquals(2, data.size(), "one TableDataPath[] per assembly, same order as objects[]");
+      assertArrayEquals(new TableDataPath[]{ VSAssemblyInfo.TITLEPATH }, data.get(1));
+   }
+
+   @Test
+   void refusesATargetThatIsNeitherObjectNorTitle() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> serviceWith(mock(FormatPainterService.class)).setFormat(
+            "tok", principal(),
+            new ViewsheetFormatService.FormatRequest(
+               List.of("Chart1"), new VSObjectFormatInfoModel(), false, "axis"), ""));
+      assertTrue(thrown.getMessage().contains("target"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("axis"), thrown.getMessage());
    }
 
    private static ViewsheetFormatService serviceWith(FormatPainterService painter) {


### PR DESCRIPTION
## Summary
- Redmine #76325 item 3: `set_format` could only apply a font/color format to a chart assembly as a whole, which cascades onto every unstyled axis title and tick label (via `FormatInfo`'s object→default-format cascade) with no way to target the chart's own title bar independently.
- Adds `ViewsheetFormatService.FormatRequest.target` (`"object"` default | `"title"`): when `"title"`, the write is routed through `FormatVSObjectEvent.getData()` onto `VSAssemblyInfo.TITLEPATH` rather than the whole-`OBJECT` path — the same generic per-assembly `TableDataPath` mechanism every titled assembly (table/gauge/crosstab/chart) already uses for its own title format, and already read independently by `VSChartModel`'s own `titleFormat` field (confirmed separate from `ChartDescriptor`'s axis/legend descriptors, so it cannot bleed onto axis titles/tick labels).
- No change to `ChartRegionPropertyService`'s deliberate `region:"title", target:"chart"` guard (added after a past NPE) — its error/vocabulary messages now point callers at `set_format {target: "title"}` for font/color, alongside the existing `set_assembly_properties` pointer for text/visibility.

## Test plan
- [x] `./mvnw -pl core -Dtest=ViewsheetFormatServiceTest,ChartRegionPropertyServiceTest test` — 23 + 19 tests pass, including 5 new regression tests (title-path routing, default-target unchanged, multi-assembly alignment, invalid-target rejection).
- [x] `./mvnw -pl core -Dtest=ViewsheetAssemblyAgentControllerTest,FormatPainterServiceTest test` — 30 + 3 tests pass (no regressions in the controller or the shared format-painter service).

Ref: Redmine #76325