### PR TITLE
Fix worksheet condition vocabulary/date_in bugs (bug corpus #76350, Cluster D: PC-003, PC-006)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -590,7 +590,13 @@ public class ViewsheetAssemblyAgentController {
       throws Exception
    {
       requireEnabled();
-      sessions.resolve(sessionToken, user);
+      // vocabulary() is a pure static lookup with no per-sheet-type argument, so this only needs
+      // resolve()'s underlying liveness/ownership/pane-scope check, not its VIEWSHEET-hardcoded
+      // RuntimeViewsheet lookup -- which made this endpoint unreachable from a worksheet-only
+      // session (it would 100% throw "Viewsheet runtime not found or expired", mislabeling a
+      // worksheet session as an invalid viewsheet one). requireSession() is the sheet-type-agnostic
+      // check resolve() itself calls before doing that VIEWSHEET-specific part.
+      sessions.requireSession(sessionToken, user);
       return conditionService.vocabulary();
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1960,11 +1960,18 @@ public final class WorksheetMutationSupport {
          case "LIKE"                     -> XCondition.LIKE;
          case "NULL", "IS_NULL"          -> XCondition.NULL;
          case "NOT_NULL"                 -> XCondition.NULL;    // negated via setNegated
+         // DATE_IN was already a first-class viewsheet-side operator (ConditionVocabulary maps
+         // it to XCondition.DATE_IN and advertises it via list_condition_operators), but this
+         // worksheet-side parser never got the same case -- add_filter/set_conditions rejected an
+         // operator the vocabulary endpoint told the caller was legal. Value semantics (resolving
+         // a named range like "Last month" into a literal) are a separate, still-open piece of
+         // work; this only stops the operator name itself from being rejected.
+         case "DATE_IN"                  -> XCondition.DATE_IN;
          default -> throw new IllegalArgumentException(
             "'" + operation + "' is not a condition operator. Accepted: =, !=, <, <=, >, >=, " +
-            "BETWEEN, ONE_OF, NOT_ONE_OF, STARTING_WITH, CONTAINS, LIKE, NULL, NOT_NULL. Omit the " +
-            "operator entirely to mean equals -- an unrecognised one used to be applied as " +
-            "equals, which quietly returns a different data set.");
+            "BETWEEN, ONE_OF, NOT_ONE_OF, STARTING_WITH, CONTAINS, LIKE, NULL, NOT_NULL, " +
+            "DATE_IN. Omit the operator entirely to mean equals -- an unrecognised one used to " +
+            "be applied as equals, which quietly returns a different data set.");
       };
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -93,6 +93,31 @@ class ViewsheetAssemblyAgentControllerTest {
    }
 
    /**
+    * PC-003 (bug corpus #76350): conditionVocabulary hardcoded {@code sessions.resolve(...)},
+    * which forces a VIEWSHEET-typed {@code RuntimeViewsheet} lookup that a worksheet-only session
+    * token can never satisfy -- every call from a worksheet session failed with "Viewsheet
+    * runtime not found or expired", mislabeling a live worksheet session as an invalid viewsheet
+    * one. {@code vocabulary()} takes no arguments and never uses the resolved object, so
+    * {@code requireSession()} (sheet-type-agnostic) is enough to keep the same liveness/
+    * ownership/pane-scope guarantee without the VIEWSHEET-only lookup.
+    */
+   @Test
+   void conditionVocabularySucceedsForAWorksheetSession() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      AssemblyConditionService conditionService = mock(AssemblyConditionService.class);
+      Map<String, Object> vocabulary = Map.of("operators", List.of("date_in"));
+      when(conditionService.vocabulary()).thenReturn(vocabulary);
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWithConditionService(sessions, conditionService);
+
+      assertSame(vocabulary, controller.conditionVocabulary("tok", principal()));
+
+      verify(sessions).requireSession(eq("tok"), any(Principal.class));
+      verify(sessions, never()).resolve(anyString(), any(Principal.class));
+   }
+
+   /**
     * detach took the session token and nothing else, so any authenticated caller holding or
     * guessing another user's token could terminate their pairing session. Every other endpoint
     * binds the token to the caller through {@code sessions.resolve(token, user)}; this one
@@ -414,6 +439,43 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class),
                                           layoutSessionService,
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
+   }
+
+   /** Feature enabled, {@code sessions} and {@code conditionService} wired -- for the
+    * conditionVocabulary worksheet-session test. */
+   private static ViewsheetAssemblyAgentController controllerWithConditionService(
+      ViewsheetSessionService sessions, AssemblyConditionService conditionService)
+   {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          sessions,
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          conditionService,
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class),
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -3818,7 +3818,7 @@ class WorksheetEditServiceMutatorsTest {
          () -> WorksheetMutationSupport.parseOperation("nonsense")).getMessage();
 
       for(String op : List.of("=", "!=", "<", "<=", ">", ">=", "BETWEEN", "ONE_OF", "NOT_ONE_OF",
-                              "STARTING_WITH", "CONTAINS", "LIKE", "NULL", "NOT_NULL"))
+                              "STARTING_WITH", "CONTAINS", "LIKE", "NULL", "NOT_NULL", "DATE_IN"))
       {
          assertDoesNotThrow(() -> WorksheetMutationSupport.parseOperation(op),
                             op + " must be a recognised operator");
@@ -3838,6 +3838,20 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals(XCondition.EQUAL_TO, WorksheetMutationSupport.parseOperation("   "));
       assertEquals(XCondition.EQUAL_TO, WorksheetMutationSupport.parseOperation(""));
       assertEquals(XCondition.EQUAL_TO, WorksheetMutationSupport.parseOperation(null));
+   }
+
+   /**
+    * PC-006 (bug corpus #76350): list_condition_operators/list_condition_date_ranges advertise
+    * date_in (ConditionVocabulary maps it to XCondition.DATE_IN), but this worksheet-side parser
+    * had no DATE_IN case at all -- add_filter/set_conditions rejected the exact operator name the
+    * vocabulary endpoint told the caller was legal. Only the operator-name half is fixed here;
+    * resolving a named range (e.g. "Last month") into a literal condition value is untraced and
+    * intentionally not attempted by this test.
+    */
+   @Test
+   void dateInIsAcceptedCaseInsensitively() {
+      assertEquals(XCondition.DATE_IN, WorksheetMutationSupport.parseOperation("DATE_IN"));
+      assertEquals(XCondition.DATE_IN, WorksheetMutationSupport.parseOperation("date_in"));
    }
 
    private static Object firstConditionOrNull(TableAssembly t) {


### PR DESCRIPTION
## Summary

Two Java-side fixes from the plugin-composer bug-reports corpus (Redmine #76350, Cluster D — worksheet conditions & ranking).

### PC-003 — `list_condition_operators` mislabels a live worksheet session

`ViewsheetAssemblyAgentController.conditionVocabulary()` called `sessions.resolve(sessionToken, user)`, which hardcodes a `SheetType.VIEWSHEET` `RuntimeViewsheet` lookup — a worksheet-only session token can never satisfy it. Every call from a worksheet session failed with `"Viewsheet runtime not found or expired"`, mislabeling a live worksheet session as an invalid viewsheet one, even though `conditionService.vocabulary()` (what the endpoint actually returns) is a pure, zero-arg static lookup that never uses the resolved object.

**Fix**: swap to `sessions.requireSession(sessionToken, user)` — the sheet-type-agnostic liveness/ownership/pane-scope check `resolve()` itself already calls first, one line before doing the VIEWSHEET-specific part that this endpoint never needed.

Traced `resolve()`'s other side effects (`applySocketSession`, ownership-bypass grant, runtime keep-alive touch via `rs.access(true)`) one by one — all are safe to drop for this specific call, since the resolved `RuntimeViewsheet` is discarded immediately and nothing else here depends on them. `resolve()` does more than verify, but none of it matters for this discard-the-result call.

Other `sessions.resolve(...)` call sites in the same controller (`conditionDateRanges`, `browseValues`, etc.) *do* use the resolved runtime for a real per-sheet lookup and are correctly left untouched — this fix is narrowly scoped to `conditionVocabulary` only.

### PC-006 — `list_condition_operators` advertises `date_in`, `add_filter` rejects it

`WorksheetMutationSupport.parseOperation`'s switch had no `DATE_IN` case, even though the viewsheet-side `ConditionVocabulary` already lists `date_in` and maps it to `XCondition.DATE_IN` — two independently hand-maintained operator vocabularies had drifted apart. `add_filter`/`set_conditions` rejected the exact operator name the vocabulary endpoint told a caller was legal.

**Fix**: adds a `DATE_IN` case to `parseOperation`, mirroring `ConditionVocabulary`'s mapping.

**Scope note**: this only fixes operator-*name* acceptance. Resolving a `DATE_IN` clause's *value* (a named range string like `"Last month"`, not a literal) into an actual condition is a separate, untraced piece of work — not attempted here, flagged as a follow-up.

## Regression tests

- `ViewsheetAssemblyAgentControllerTest.conditionVocabularySucceedsForAWorksheetSession` (new, plus a new `controllerWithConditionService` helper) — verifies `conditionVocabulary` now succeeds via `requireSession` and never calls `resolve`.
- `WorksheetEditServiceMutatorsTest.dateInIsAcceptedCaseInsensitively` — `parseOperation("DATE_IN")`/`("date_in")` both resolve to `XCondition.DATE_IN`.
- `DATE_IN` added to the existing `everyAcceptedOperatorIsOfferedByTheRefusalMessage` coverage list.

Ran `ViewsheetAssemblyAgentControllerTest` + `WorksheetEditServiceMutatorsTest` together: 192 tests, all pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)