### PR TITLE
Fix Bug #76325 (item 4): note when a single-assembly render omits the chart's own title

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -22,6 +22,7 @@ import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import inetsoft.util.Tool;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
@@ -196,7 +197,21 @@ public class ScriptImageService {
          }
       }
 
-      return new ChartImage(bytes, result.isPng(), result.getWidth(), result.getHeight(), null);
+      // This tile render is the same title-less path the live browser uses for its own on-screen
+      // assembly tile (title.getInfo() is drawn separately as a sibling DOM element there) — so
+      // unlike a whole-viewsheet render, a titled assembly's own title bar never appears in these
+      // bytes no matter what titleVisible is set to. Note it rather than silently returning a
+      // plausible-but-incomplete image (see class doc's tables/crosstabs fallback for the same
+      // pattern).
+      String note = null;
+
+      if(assembly.getInfo() instanceof TitledVSAssemblyInfo titledInfo && titledInfo.isTitleVisible()) {
+         note = "\"" + assemblyName + "\" has its own title bar, which this single-assembly " +
+            "render does not include — call get_viewsheet_image without a target to see the " +
+            "whole viewsheet, including this assembly's title.";
+      }
+
+      return new ChartImage(bytes, result.isPng(), result.getWidth(), result.getHeight(), note);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -243,8 +243,49 @@ class ScriptImageServiceTest {
       assertTrue(img.note().contains("Table1"));
    }
 
+   /**
+    * Charts default to {@code titleVisible=true} ({@code ChartVSAssemblyInfo}'s own
+    * {@code titleInfo} field init), so this hides the title explicitly — otherwise it would be
+    * indistinguishable from {@link #attachesATitleNoteWhenTheChartsTitleIsVisible}.
+    */
    @Test
-   void successfulRenderHasNoNote() throws Exception {
+   void successfulRenderHasNoNoteWhenTheTitleIsHidden() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      ChartVSAssembly chart = (ChartVSAssembly) rvs.getViewsheet().getAssembly("Chart1");
+      // The runtime setter, not ChartVSAssembly.setTitleVisible (which only sets the design-time
+      // value) — isTitleVisible() reads the runtime value, which nothing here executes/syncs.
+      chart.getChartInfo().setTitleVisible(false);
+      byte[] png = fakePng(800, 600);
+      BinaryTransfer transfer = mock(BinaryTransfer.class);
+      AssemblyImageService.ImageRenderResult result =
+         new AssemblyImageService.ImageRenderResult(true, transfer, 800, 600);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), eq(800.0), eq(600.0), eq(800.0), eq(600.0),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(result);
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      when(binaryTransferService.getData(transfer)).thenReturn(png);
+
+      ScriptImageService svc = new ScriptImageService(
+         imageService, binaryTransferService, mock(VSExportService.class));
+      ScriptImageService.ChartImage img = svc.getAssemblyImage(
+         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNull(img.note());
+   }
+
+   /**
+    * Bug #76325 item 4: a chart's own title bar is drawn by the live browser as a DOM sibling of
+    * the tile image, never inside the tile bytes — the single-assembly render path
+    * ({@code AssemblyImageService.getChartImage}) has no title-drawing code at all, so a caller
+    * asking for just the chart would otherwise get a plausible-but-incomplete image with no
+    * warning that the (visible, correctly-configured) title was left out.
+    */
+   @Test
+   void attachesATitleNoteWhenTheChartsTitleIsVisible() throws Exception {
       RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
       byte[] png = fakePng(800, 600);
       BinaryTransfer transfer = mock(BinaryTransfer.class);
@@ -264,6 +305,26 @@ class ScriptImageServiceTest {
          imageService, binaryTransferService, mock(VSExportService.class));
       ScriptImageService.ChartImage img = svc.getAssemblyImage(
          rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNotNull(img.note());
+      assertTrue(img.note().contains("Chart1"));
+      assertTrue(img.note().contains("get_viewsheet_image"));
+   }
+
+   /**
+    * The whole-viewsheet/export path (no {@code target}) already paints the title via
+    * {@code AbstractVSExporter} — it has nothing to warn about, regardless of title visibility.
+    */
+   @Test
+   void getViewsheetImageNeverAttachesATitleNote() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      VSExportService exportService = mock(VSExportService.class);
+      stubExport(exportService, fakePng(400, 300));
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
 
       assertNull(img.note());
    }


### PR DESCRIPTION
## Root cause

Redmine #76325 item 4: "chart title never renders despite titleVisible:true."

This reclassifies item 4 from a StyleBI product bug to a plugin tool gap (see
`stylebi-wiz` PR for the companion fix). The chart title renders correctly:

- In the live viewer, via the shared `vs-title` Angular component, wired
  identically to every other titled assembly type.
- In whole-viewsheet PNG exports, via `AbstractVSExporter`, which explicitly
  checks `isTitleVisible()` and paints the title.

The only place it's silently missing is `ScriptImageService.getAssemblyImage`'s
tile path for a chart target — the same lightweight render the live browser uses
for its own on-screen assembly tile (`AssemblyImageService.getChartImage`), which
structurally cannot include the title (the browser composites it separately as a
DOM sibling, not baked into the tile image). This produced a plausible-but-wrong
result (a title-less image) with no warning, for a completely reasonable request
("render this chart").

## Fix

`ScriptImageService.getAssemblyImage` now attaches a `note` to the response
(mirroring the existing tables/crosstabs fallback note) when the rendered
assembly implements `TitledVSAssemblyInfo` and `isTitleVisible()` is true,
pointing the caller at a target-omitted `get_viewsheet_image` call to see the
title. Checked which tile-path assembly types (chart, gauge, thermometer,
cylinder, sliding scale, image, shape, group container) actually implement
`TitledVSAssemblyInfo` — only `ChartVSAssemblyInfo` does; the others have no
title concept at all.

Does not touch `AssemblyImageService`/`GetImageController` — those are shared
with the live browser's own tile-rendering path, which deliberately wants a
title-less tile (it draws the title separately in the DOM); changing them would
double-draw the title live.

## Tests

Added to `ScriptImageServiceTest`: a titleVisible=true chart render gets the
note; a titleVisible=false chart render does not; a whole-viewsheet
(`getViewsheetImage`) render never attaches one, since the export path already
includes the title.

```
./mvnw test -pl core -Dtest=ScriptImageServiceTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```