### PR TITLE
Fix bug corpus #76350 Cluster E: PQE-001, PSD-001, PCB-001, PCB-002 (StyleBI side)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQueryCacheNormalizer.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQueryCacheNormalizer.java
@@ -118,7 +118,7 @@ public class AssetQueryCacheNormalizer {
     * Transform the resulting table lens to match the original table
     */
    public TableLens transformTableLens(TableLens tableLens) {
-      if(!isApplicable()) {
+      if(tableLens == null || !isApplicable()) {
          return tableLens;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
@@ -128,8 +128,17 @@ public final class BindableColumns {
       List<BindableTable> listed = tables == null ? List.of() : tables;
       List<FieldRef> named = named(fields);
 
-      // No listing is a read failure, and nothing being written has no source to decide.
-      if(listed.isEmpty() || named.isEmpty()) {
+      // Nothing being written has no source to decide. An empty `listed` used to bail here too,
+      // on the theory that no listing meant the tree could not be read (bug #76350, PCB-002) —
+      // but resolveSourceTable's own surrounding try/catch already turns a genuine read failure
+      // into this same null one layer up, before requireSource ever runs. So an empty `listed`
+      // reaching here always means a *successful* listing that is genuinely empty — e.g. a table
+      // not yet visible to the viewsheet because it was never saved — which requested != null
+      // below already refuses correctly via matchListed's "Available: " message, the same
+      // refusal set_chart_source gives for the identical case. Bailing early swallowed that
+      // refusal and returned null instead, so the write proceeded with no source and no error,
+      // then crashed later on render.
+      if(named.isEmpty()) {
          return null;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -181,6 +181,46 @@ public class BindingAgentController {
                                   request.field(), source, linkUri);
    }
 
+   /** @see TableSortRequest — same shape, applied to a chart's x/y/group dimension shelves. */
+   public record ChartSortRequest(String assembly, String shelf, String column, Integer index,
+                                  String direction, String sortByField,
+                                  List<String> manualOrder) {}
+   /** @see TableRankingRequest */
+   public record ChartRankingRequest(String assembly, String shelf, String column, Integer index,
+                                     String mode, Integer n, String measure, Boolean others) {}
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/sort")
+   public void setChartSort(@PathVariable String sessionToken,
+                            @RequestBody ChartSortRequest request,
+                            @RequestParam(required = false, defaultValue = "") String linkUri,
+                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartService.setSort(sessionToken, user, request.assembly(), request.shelf(),
+                           request.column(), request.index(),
+                           new DimensionSortRanking.Sort(request.direction(),
+                                                         request.sortByField(),
+                                                         request.manualOrder()),
+                           linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/ranking")
+   public void setChartRanking(@PathVariable String sessionToken,
+                               @RequestBody ChartRankingRequest request,
+                               @RequestParam(required = false, defaultValue = "") String linkUri,
+                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartService.setRanking(sessionToken, user, request.assembly(), request.shelf(),
+                              request.column(), request.index(),
+                              new DimensionSortRanking.Ranking(request.mode(), request.n(),
+                                                               request.measure(),
+                                                               request.others()),
+                              linkUri);
+   }
+
    @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/type")
    public ChartTypeState chartType(@PathVariable String sessionToken,
                                    @RequestParam String assembly,

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -71,6 +71,7 @@ public class BindingReadService {
 
       BindingModel model = binding.createModel(assembly);
       Map<String, List<FieldRef>> shelves = new LinkedHashMap<>();
+      Map<String, Object> sorts = new LinkedHashMap<>();
 
       if(model instanceof ChartBindingModel chart) {
          // Under Multi Style each measure renders with its own type, so x and y carry it per field.
@@ -86,6 +87,10 @@ public class BindingReadService {
          shelves.put("x", refs(chart.getXFields(), perField));
          shelves.put("y", refs(chart.getYFields(), perField));
          shelves.put("group", refs(chart.getGroupFields()));
+
+         for(String shelf : ChartBindingMutator.SHELVES) {
+            sorts.putAll(ChartBindingMutator.describeSorts(chart, shelf));
+         }
 
          // The ten single-field shelves. Left out of this read until now, so a
          // set_chart_single_shelf write could not be read back at all: four OHLC shelves bound and
@@ -119,7 +124,7 @@ public class BindingReadService {
                                  assembly.getClass().getSimpleName(),
                                  model == null || model.getSource() == null
                                     ? null : model.getSource().getSource(),
-                                 shelves);
+                                 shelves, sorts);
    }
 
    private static List<FieldRef> refs(List<? extends DataRefModel> models) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.SourceInfo;
+import inetsoft.web.binding.model.BDimensionRefModel;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
@@ -27,7 +28,9 @@ import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Read-modify-write over {@code ChartBindingModel}.
@@ -164,6 +167,110 @@ public final class ChartBindingMutator {
       };
 
       return refs == null ? List.of() : refs;
+   }
+
+   // ── per-dimension sort/ranking (bug #76350, PCB-001) ──────────────────────────────────────
+   //
+   // ChartDimensionRefModel extends BDimensionRefModel — the same base class TableBindingMutator
+   // already drives with DimensionSortRanking for a crosstab's rows/cols. A chart's x/y/group
+   // dimensions carry the identical order/sortByCol/ranking fields; FieldRefFactory.toChartRef
+   // simply never set them, which is the whole reason "sort a chart axis by a measure's value"
+   // had no tool despite the model underneath already supporting it.
+
+   /**
+    * The dimension a call means, on a chart's x/y/group shelf. Mirrors
+    * {@code TableBindingMutator.requireDimension} exactly — chart dimensions are addressed by
+    * column name for the same reason: a stable index would silently point at the wrong column
+    * after any shelf reorder.
+    */
+   private static BDimensionRefModel requireDimension(ChartBindingModel model, String shelf,
+                                                       String column, Integer index)
+   {
+      List<ChartRefModel> refs = readShelf(model, shelf);
+      List<String> present = new ArrayList<>();
+      Map<Integer, BDimensionRefModel> matches = new LinkedHashMap<>();
+
+      for(int i = 0; i < refs.size(); i++) {
+         ChartRefModel ref = refs.get(i);
+
+         if(!(ref instanceof ChartDimensionRefModel dimension)) {
+            continue;
+         }
+
+         String value = dimension.getColumnValue() == null
+            ? dimension.getName() : dimension.getColumnValue();
+         present.add(value);
+
+         if(value != null && value.equalsIgnoreCase(column)) {
+            matches.put(i, dimension);
+         }
+      }
+
+      if(index != null) {
+         BDimensionRefModel chosen = matches.get(index);
+
+         if(chosen == null) {
+            throw new IllegalArgumentException(
+               "index " + index + " is not a position of '" + column + "' on the " + shelf +
+               " shelf. It is bound at: " + matches.keySet() + ".");
+         }
+
+         return chosen;
+      }
+
+      if(matches.size() > 1) {
+         throw new IllegalArgumentException(
+            "'" + column + "' is bound " + matches.size() + " times on the " + shelf +
+            " shelf, so this call is ambiguous. Pass 'index' to say which.");
+      }
+
+      if(matches.size() == 1) {
+         return matches.values().iterator().next();
+      }
+
+      throw new IllegalArgumentException(
+         "'" + column + "' is not a dimension on the " + shelf + " shelf. It holds: " +
+         (present.isEmpty() ? "(nothing)" : String.join(", ", present)) + ".");
+   }
+
+   public static void setSort(ChartBindingModel model, String shelf, String column,
+                              Integer index, DimensionSortRanking.Sort sort)
+   {
+      DimensionSortRanking.applySort(requireDimension(model, shelf, column, index), sort);
+   }
+
+   public static void setRanking(ChartBindingModel model, String shelf, String column,
+                                 Integer index, DimensionSortRanking.Ranking ranking)
+   {
+      DimensionSortRanking.applyRanking(requireDimension(model, shelf, column, index), ranking);
+   }
+
+   /** The sort and ranking on every dimension of a chart shelf. */
+   public static Map<String, Object> describeSorts(ChartBindingModel model, String shelf) {
+      Map<String, Object> out = new LinkedHashMap<>();
+      List<ChartRefModel> refs = readShelf(model, shelf);
+      List<BDimensionRefModel> dimensions = new ArrayList<>();
+
+      for(ChartRefModel ref : refs) {
+         if(ref instanceof ChartDimensionRefModel dimension) {
+            dimensions.add(dimension);
+         }
+      }
+
+      for(int i = 0; i < dimensions.size(); i++) {
+         BDimensionRefModel dimension = dimensions.get(i);
+         String column = dimension.getColumnValue() == null
+            ? dimension.getName() : dimension.getColumnValue();
+         long occurrences = dimensions.stream()
+            .map(d -> d.getColumnValue() == null ? d.getName() : d.getColumnValue())
+            .filter(value -> value != null && value.equalsIgnoreCase(column))
+            .count();
+
+         out.put(occurrences > 1 ? column + " [" + i + "]" : column,
+                 DimensionSortRanking.describe(dimension));
+      }
+
+      return out;
    }
 
    /** Reads one single-field shelf, or null when nothing is bound to it. */

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -250,6 +250,47 @@ public class ChartBindingService {
       });
    }
 
+   /**
+    * Sorts a dimension already on the chart's x/y/group shelf, including by another bound
+    * measure's value (bug #76350, PCB-001) — {@code ChartDimensionRefModel} carries the same
+    * order/sortByCol fields {@code TableBindingService.setSort} already drives on a crosstab's
+    * dimensions, {@code FieldRefFactory.toChartRef} just never set them from a shelf write.
+    */
+   public void setSort(String sessionToken, Principal user, String assemblyName, String shelf,
+                       String column, Integer index, DimensionSortRanking.Sort sort,
+                       String linkUri) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         ChartBindingMutator.setSort(model, shelf, column, index, sort);
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         event.setFieldType(shelf);
+         event.setModel(model);
+         refService.changeChartRef(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   /** @see #setSort */
+   public void setRanking(String sessionToken, Principal user, String assemblyName, String shelf,
+                          String column, Integer index, DimensionSortRanking.Ranking ranking,
+                          String linkUri) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         ChartBindingMutator.setRanking(model, shelf, column, index, ranking);
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         event.setFieldType(shelf);
+         event.setModel(model);
+         refService.changeChartRef(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
    public void setChartType(String sessionToken, Principal user, String assemblyName, int type,
                             Boolean multi, Boolean stackMeasures, Boolean separate, String field,
                             String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/AssemblyBinding.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/AssemblyBinding.java
@@ -34,6 +34,13 @@ import java.util.Map;
  * present only when bound, unlike the three list shelves above which are always present: they are
  * meaningful on every chart, whereas {@code milestone} on a pie chart is not, and listing it would
  * advertise a shelf that chart cannot use.
+ *
+ * <p>{@code sorts} carries per-dimension sort/ranking, keyed by column (or {@code "column [i]"}
+ * when the same column is bound more than once on the same shelf) — currently populated for a
+ * chart's x/y/group shelves only, in the vocabulary {@code DimensionSortRanking.describe}
+ * produces. Empty for a table or crosstab, whose own sort/ranking is reported by the richer
+ * {@code table/binding} read instead.
  */
 public record AssemblyBinding(String assembly, String objectType, String source,
-                              Map<String, List<FieldRef>> shelves) {}
+                              Map<String, List<FieldRef>> shelves,
+                              Map<String, Object> sorts) {}

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -2018,8 +2018,8 @@ public class MetadataApiService {
             DatasourceTablesResponse tablesResponse = getDatabaseTables(dsName, principal);
 
             for(DatabaseTableInfo tableInfo : tablesResponse.getTables()) {
-               boolean tableMatches = tableInfo.getTable().toLowerCase(Locale.ROOT)
-                  .contains(queryLower);
+               boolean tableMatches = tableNameMatches(
+                  tableInfo.getTable().toLowerCase(Locale.ROOT), queryLower);
 
                // If searching by field names, look for column matches
                List<SchemaSearchResponse.ColumnMatch> columnMatches = null;
@@ -2059,6 +2059,49 @@ public class MetadataApiService {
       SchemaSearchResponse response = new SchemaSearchResponse();
       response.setResults(results);
       return response;
+   }
+
+   /**
+    * Whether a (lowercased) table name matches a (lowercased) search query — a plain substring
+    * check, plus a stemmed fallback so a singular/plural mismatch (bug #76350, PSD-001, e.g.
+    * "category" searched against a table named "categories") isn't a silent miss.
+    */
+   static boolean tableNameMatches(String tableNameLower, String queryLower) {
+      return tableNameLower.contains(queryLower) || stem(tableNameLower).contains(stem(queryLower));
+   }
+
+   /**
+    * Reduces a lowercased word to a rough singular stem, so a search term and a
+    * pluralized/singularized table name still match (bug #76350, PSD-001 -
+    * "categories".contains("category") is false, a plain English -y -&gt; -ies plural). Not a
+    * full stemmer - just closes the common regular-English-plural gap, applied in addition to
+    * (not instead of) the existing plain substring check.
+    */
+   static String stem(String word) {
+      if(word.length() > 3 && word.endsWith("ies")) {
+         return word.substring(0, word.length() - 3) + "y";
+      }
+
+      // Only treat a trailing "es" as a plural suffix when it forms after a sibilant sound
+      // (box -> boxes, glass -> glasses, church -> churches) - otherwise "es" is just "e" + "s"
+      // (wine -> wines) and stripping both characters overshoots into the wrong stem, which is
+      // how a naive "always strip -es" rule would collide two unrelated words (e.g. "wines" and
+      // "win") that a sibilant check keeps apart.
+      if(word.length() > 2 && word.endsWith("es")) {
+         String base = word.substring(0, word.length() - 2);
+
+         if(base.endsWith("s") || base.endsWith("x") || base.endsWith("z") ||
+            base.endsWith("ch") || base.endsWith("sh"))
+         {
+            return base;
+         }
+      }
+
+      if(word.length() > 1 && word.endsWith("s") && !word.endsWith("ss")) {
+         return word.substring(0, word.length() - 1);
+      }
+
+      return word;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/composition/execution/AssetQueryCacheNormalizerTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/AssetQueryCacheNormalizerTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.TableAssembly;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Bug #76350 PQE-001: AssetQuery.doGetTableLens() legitimately returns null in RUNTIME_MODE
+ * (e.g. a table bound to a dead/misconfigured JDBC connection), but
+ * transformTableLens() used to call tableLens.getColCount() unconditionally, turning that
+ * into an unhandled NPE instead of the existing "table not found or produced no data"
+ * message one layer up in WorksheetPreviewService.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class AssetQueryCacheNormalizerTest {
+   @Test
+   public void testTransformTableLensReturnsNullForNullInput() {
+      // isApplicable() would otherwise be true: not distinct, not design mode, no
+      // ViewsheetSandbox, not an embedded/rotated/SQL-edit table.
+      TableAssembly table = mock(TableAssembly.class);
+      when(table.getColumnSelection(true)).thenReturn(new ColumnSelection());
+      when(table.getColumnSelection(false)).thenReturn(new ColumnSelection());
+
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+
+      AssetQueryCacheNormalizer normalizer =
+         new AssetQueryCacheNormalizer(table, box, AssetQuerySandbox.RUNTIME_MODE);
+
+      assertNull(normalizer.transformTableLens(null));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
@@ -265,12 +265,38 @@ class BindableColumnsTest {
       assertTrue(thrown.getMessage().contains("set_chart_source"), "name the way through");
    }
 
-   /** No listing means the tree could not be read — a read failure, not a write one. */
+   /**
+    * An empty {@code tables} reaching {@code requireSource} does NOT mean "the tree could not be
+    * read" (bug #76350, PCB-002). A genuine read failure is already caught one layer up, in
+    * {@code BindingAgentController.resolveSourceTable}'s own try/catch, before this method ever
+    * runs — so by the time it sees an empty list, the listing succeeded and genuinely found
+    * nothing bindable (e.g. a table that was never saved). That case must refuse exactly the way
+    * set_chart_source already does, not silently accept the bind and crash later on render.
+    */
    @Test
-   void establishesNothingWhenNothingCouldBeListed() {
-      assertNull(BindableColumns.requireSource(List.of(), "Chart1", null,
-                                              List.of(field("ANYTHING"))));
-      assertNull(BindableColumns.requireSource(null, "Chart1", null, List.of(field("ANYTHING"))));
+   void refusesWhenNothingIsListedAndNoTableIsNamed() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(List.of(), "Chart1", null,
+                                             List.of(field("ANYTHING"))));
+      assertTrue(thrown.getMessage().contains("ANYTHING"));
+
+      thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(null, "Chart1", null, List.of(field("ANYTHING"))));
+      assertTrue(thrown.getMessage().contains("ANYTHING"));
+   }
+
+   /** The same case, with a table named — refuses the same way set_chart_source already does. */
+   @Test
+   void refusesAStatedTableWhenNothingIsListed() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(List.of(), "Chart1", "Sales",
+                                             List.of(field("ANYTHING"))));
+
+      assertTrue(thrown.getMessage().contains("Sales"));
+      assertTrue(thrown.getMessage().contains("Available"));
    }
 
    /** Nothing being written means nothing to decide a source from. */

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.junit.jupiter.api.Tag;
@@ -238,5 +239,97 @@ class BindingAgentControllerTest {
          controllerWith(feature, chartService).chartType("tok", "Chart1", principal());
 
       assertSame(state, read, "the controller is a passthrough; it must not rebuild the state");
+   }
+
+   // ---------------------------------------------------------------------------
+   // Bug #76350, PCB-002: set_chart_shelf silently accepted a bind to a table the viewsheet
+   // cannot see yet (unsaved), reported success, then crashed later on render -- while
+   // set_chart_source correctly refused the identical case. BindableColumns.requireSource's own
+   // unit tests (BindableColumnsTest) cover the fixed logic directly; this drives it end to end
+   // through the controller endpoint an agent actually calls.
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void setChartShelfRefusesATableTheListingDoesNotHaveInsteadOfSilentlyDroppingTheSource()
+      throws Exception
+   {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+
+      // The shape an unsaved table produces: a successful listing that is genuinely empty, not a
+      // read failure -- see BindableColumnsTest for why those two used to be conflated.
+      when(fields.list(eq("rt1"), eq("Chart1"), any(Principal.class))).thenReturn(List.of());
+      ChartBindingService chartService = mock(ChartBindingService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class));
+
+      BindingAgentController.ShelfRequest request = new BindingAgentController.ShelfRequest(
+         "Chart1", "x", List.of(new FieldRef("Region", "dimension", null, null, null)), "Sales");
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.setChartShelf("tok", request, "", principal()));
+
+      assertTrue(thrown.getMessage().contains("Sales"), thrown.getMessage());
+      verifyNoInteractions(chartService);
+   }
+
+   /** Same fix, same underlying resolveSourceTable call -- confirming the blast radius is 3
+    *  tools, not 1: set_chart_single_shelf shares the identical gap set_chart_shelf had. */
+   @Test
+   void setChartSingleShelfRefusesATableTheListingDoesNotHave() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), eq("Chart1"), any(Principal.class))).thenReturn(List.of());
+      ChartBindingService chartService = mock(ChartBindingService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class));
+
+      BindingAgentController.SingleShelfRequest request = new BindingAgentController.SingleShelfRequest(
+         "Chart1", "close", new FieldRef("Price", "measure", "Sum", null, null), "Sales");
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.setChartSingleShelf("tok", request, "", principal()));
+
+      assertTrue(thrown.getMessage().contains("Sales"), thrown.getMessage());
+      verifyNoInteractions(chartService);
+   }
+
+   /** @see #setChartSingleShelfRefusesATableTheListingDoesNotHave -- the third of the 3 tools. */
+   @Test
+   void setAestheticFieldRefusesATableTheListingDoesNotHave() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), eq("Chart1"), any(Principal.class))).thenReturn(List.of());
+      ChartAestheticAgentService aestheticService = mock(ChartAestheticAgentService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), mock(ChartBindingService.class), aestheticService,
+         mock(TableBindingService.class), mock(CalcTableService.class));
+
+      BindingAgentController.AestheticFieldRequest request =
+         new BindingAgentController.AestheticFieldRequest(
+            "Chart1", "color", new FieldRef("Region", "dimension", null, null, null), "Sales");
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.setAestheticField("tok", request, "", principal()));
+
+      assertTrue(thrown.getMessage().contains("Sales"), thrown.getMessage());
+      verifyNoInteractions(aestheticService);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -167,4 +167,67 @@ class ChartBindingMutatorTest {
       assertEquals(13, ChartBindingFields.AESTHETIC.size(),
                    "the 2b/2c split is declared once; changing it changes both sides");
    }
+
+   // ── per-dimension sort/ranking (bug #76350, PCB-001) ──────────────────────
+   //
+   // ChartDimensionRefModel extends BDimensionRefModel, the same class TableBindingMutator
+   // already drives with DimensionSortRanking for a crosstab's rows/cols — these mirror that
+   // suite's shape for a chart's x/y/group shelves.
+
+   @Test
+   void sortsADimensionByABoundMeasuresValue() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "x",
+         List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      ChartBindingMutator.setSort(model, "x", "Region", null,
+         new DimensionSortRanking.Sort("value_desc", "Sales", null));
+
+      Map<String, Object> described = ChartBindingMutator.describeSorts(model, "x");
+      assertEquals("value_desc", ((Map<?, ?>) described.get("Region")).get("direction"));
+      assertEquals("Sales", ((Map<?, ?>) described.get("Region")).get("sortByField"));
+   }
+
+   @Test
+   void ranksADimensionByABoundMeasure() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "x",
+         List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      ChartBindingMutator.setRanking(model, "x", "Region", null,
+         new DimensionSortRanking.Ranking("top", 5, "Sales", true));
+
+      Map<String, Object> described = ChartBindingMutator.describeSorts(model, "x");
+      Map<?, ?> region = (Map<?, ?>) described.get("Region");
+      assertEquals("top", region.get("ranking"));
+      assertEquals("5", region.get("rankingN"));
+      assertEquals("Sales", region.get("rankingMeasure"));
+   }
+
+   @Test
+   void rejectsSortingAColumnNotOnTheShelfNamingWhatIsBound() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "x",
+         List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setSort(model, "x", "Product", null,
+            new DimensionSortRanking.Sort("asc", null, null)));
+      assertTrue(thrown.getMessage().contains("Product"));
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void doesNotConfuseAMeasureOnTheShelfWithADimension() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y",
+         List.of(new FieldRef("Sales", "measure", "Sum", null, null)));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setSort(model, "y", "Sales", null,
+            new DimensionSortRanking.Sort("asc", null, null)));
+      assertTrue(thrown.getMessage().contains("Sales"));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceSchemaSearchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceSchemaSearchTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bug #76350 PSD-001: search_schema("category") missed a table literally named "categories" —
+ * "categories".contains("category") is false (they diverge at the plural -y -&gt; -ies spelling
+ * change), not a datasource-scoping bug. These drive {@code tableNameMatches}/{@code stem}
+ * directly, the way {@link MetadataApiServiceStructureTest} drives other package-private
+ * extraction helpers, rather than standing up a full {@code XRepository}-backed searchSchema()
+ * round trip.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class MetadataApiServiceSchemaSearchTest {
+   @Test
+   void singularQueryMatchesPluralTableName() {
+      assertTrue(MetadataApiService.tableNameMatches("categories", "category"));
+   }
+
+   @Test
+   void pluralQueryStillMatchesPluralTableName() {
+      // The opposite direction was already correct before the fix (plain substring), kept as a
+      // regression guard that the new stemmed fallback doesn't disturb it.
+      assertTrue(MetadataApiService.tableNameMatches("categories", "categories"));
+   }
+
+   @Test
+   void esSuffixRequiresASibilantBaseToAvoidOvercorrecting() {
+      // A prior candidate for this guard used "wines"/"win" as a plain tableNameMatches() check
+      // (a bad choice caught in review: "win" is a literal prefix of "wines", so that pair is
+      // already true via plain substring regardless of stemming and proves nothing about the
+      // stemmer). The genuine risk is in stem()'s own output: a naive rule that always strips a
+      // trailing "es" would reduce "wines" to "win" -- a completely unrelated word (victory,
+      // not the plural of wine) -- and that wrong stem, unlike "wine"/"wines" themselves, is not
+      // just a truncation of the input, so it is not automatically caught by the plain substring
+      // check either time it is reused elsewhere. Requiring the "es" to follow a sibilant sound
+      // (box/glass/church-style plurals) keeps "wines" reducing to the correct "wine", not "win".
+      assertEquals("wine", MetadataApiService.stem("wines"));
+      assertFalse(MetadataApiService.stem("wines").equals(MetadataApiService.stem("win")));
+   }
+
+   @Test
+   void sibilantEsPluralsStillStem() {
+      assertTrue(MetadataApiService.tableNameMatches("boxes", "box"));
+      assertTrue(MetadataApiService.tableNameMatches("glasses", "glass"));
+   }
+
+   @Test
+   void stemHandlesIesEsAndSSuffixes() {
+      assertEquals("category", MetadataApiService.stem("categories"));
+      assertEquals("box", MetadataApiService.stem("boxes"));
+      assertEquals("wine", MetadataApiService.stem("wines"));
+      assertEquals("order", MetadataApiService.stem("orders"));
+      assertEquals("glass", MetadataApiService.stem("glass"));
+   }
+}


### PR DESCRIPTION
## Summary

Fixes the StyleBI-side halves of 4 independent bugs from Cluster E of the plugin-composer bug-reports corpus (Redmine #76350). Companion plugin-side PR: stylebi-wiz (link to follow).

PCS-001 is explicitly excluded — both the debugger and refuter confirmed it does not reproduce against current source (see `docs/teams/2026-08-29-bugs-plugin-composer-corpus/cluster-E/01-diagnosis.md` and `02-refute.md` in the stylebi-wiz repo). It needs a live re-check for a deployment-lag theory, not a code fix.

### PQE-001 — `post` datasource query-execution NPE
`AssetQueryCacheNormalizer.transformTableLens()` called `tableLens.getColCount()` with no null guard. `AssetQuery.doGetTableLens()` legitimately returns `null` in `RUNTIME_MODE` (e.g. a table bound to a dead/misconfigured JDBC connection), which `preview_worksheet_data`'s backend (`WorksheetPreviewService`) hits directly — turning a would-be clean "table not found or produced no data" message into a raw NPE. Fix: null-check at the top of `transformTableLens`.

### PSD-001 — `search_schema` misses `CATEGORIES`
`MetadataApiService.searchSchema()`'s table-name match was a plain substring check — `"categories".contains("category")` is `false` (diverges at the plural spelling change), so a search for `"category"` silently missed a table literally named `CATEGORIES` while it also matched a differently-shaped table in another datasource. Fix: a narrow `stem()` helper (`-ies` → `-y`, plus a sibilant-gated `-es`/`-s` strip) applied alongside the existing substring check, not instead of it.

### PCB-001 — no chart value-sort tool
`ChartDimensionRefModel` (server-side) already extends `BDimensionRefModel` and carries the same `order`/`sortByCol`/ranking fields a crosstab dimension uses via the existing `DimensionSortRanking` helper — `FieldRefFactory.toChartRef` simply never wired a chart shelf write to set them. Adds:
- `ChartBindingMutator.setSort`/`setRanking`/`describeSorts` (reusing `DimensionSortRanking` as-is, mirroring `TableBindingMutator`'s existing shape for a crosstab's rows/cols)
- `ChartBindingService.setSort`/`setRanking`
- `POST chart/sort` and `POST chart/ranking` endpoints on `BindingAgentController`
- `AssemblyBinding` gains a `sorts` field (chart shelves only), so `get_binding` can read back what was set

### PCB-002 — `set_chart_shelf` skips the viewsheet-visibility check `set_chart_source` has
`BindableColumns.requireSource()`'s early return on an empty bindable-tables listing was meant to tolerate a listing *read failure*, but `BindingAgentController.resolveSourceTable`'s own surrounding try/catch already converts a genuine read failure into this same `null` one layer up — so by the time `requireSource` sees an empty listing, it always means a successful-but-empty result (e.g. an unsaved table), never a read failure. Narrowed the bypass to only bail when nothing is being written, so an unsaved-table bind now refuses the same way `set_chart_source` already does — for all three callers of `resolveSourceTable` (`setChartShelf`, `setChartSingleShelf`, `setAestheticField`).

## Tests

- `AssetQueryCacheNormalizerTest` (new)
- `MetadataApiServiceSchemaSearchTest` (new)
- `ChartBindingMutatorTest` (+5: sort/ranking on a chart dimension, ambiguous-column refusal, dimension-vs-measure guard)
- `BindableColumnsTest` (updated 2 existing tests whose old assertions encoded the bug; +1 new)
- `BindingAgentControllerTest` (+3: one per `resolveSourceTable` caller)

All of `inetsoft.web.wiz.binding` (494), `inetsoft.web.wiz.service` (815), and `inetsoft.report.composition.execution` (81) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)