### PR TITLE
Fix bug corpus #76350 follow-on item E: BindableColumns.require() empty-listing bypass

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
@@ -79,12 +79,6 @@ public final class BindableColumns {
          }
       }
 
-      // No listing at all means the tree could not be read — a different failure, and refusing
-      // every column on the strength of it would turn a read problem into a write problem.
-      if(available.isEmpty()) {
-         return;
-      }
-
       for(FieldRef field : fields) {
          if(field == null || field.column() == null || field.column().isBlank()) {
             continue;

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -725,9 +725,17 @@ public class BindingAgentController {
       try {
          List<BindableTable> tables =
             fieldsService.list(sessions.runtimeId(sessionToken, user), assembly, user);
+
+         // requireSource runs first: when it has something specific to say about the source
+         // itself -- a stated table the listing does not have, an ambiguous inference, or a
+         // conflicting repoint -- that is the more actionable diagnosis, and require()'s column
+         // check would otherwise win the race and report a bare "column not found" that drops
+         // the table name entirely. When requireSource does not throw (source already known, or
+         // resolved), require() still runs right after to do its own, narrower column check.
+         String source = BindableColumns.requireSource(tables, assembly, table, fields);
          BindableColumns.require(tables, assembly, fields);
 
-         return BindableColumns.requireSource(tables, assembly, table, fields);
+         return source;
       }
       catch(IllegalArgumentException e) {
          throw e;

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
@@ -306,13 +306,47 @@ class BindableColumnsTest {
    }
 
    /**
-    * An empty listing means the binding tree could not be read — a different failure. Refusing
-    * every column on the strength of it would turn a read problem into a write problem.
+    * An empty {@code tables} reaching {@code require} does NOT mean "the tree could not be read"
+    * (bug #76350, PCB-002's own reasoning for {@code requireSource}, which applies identically
+    * here — see {@code requireBindableColumns}/{@code resolveSourceTable}'s shared try/catch). A
+    * genuine read failure is already caught one layer up, before this method ever runs — so by the
+    * time it sees an empty list, the listing succeeded and genuinely found nothing bindable. That
+    * case must refuse, not silently accept the bind and crash later on render.
     */
    @Test
-   void staysOutOfTheWayWhenNothingCouldBeListed() {
-      assertDoesNotThrow(() -> BindableColumns.require(List.of(), "Crosstab1", dim("ANYTHING")));
-      assertDoesNotThrow(() -> BindableColumns.require(null, "Crosstab1", dim("ANYTHING")));
+   void refusesWhenNothingCouldBeListed() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.require(List.of(), "Crosstab1", dim("ANYTHING")));
+      assertTrue(thrown.getMessage().contains("ANYTHING"));
+
+      thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.require(null, "Crosstab1", dim("ANYTHING")));
+      assertTrue(thrown.getMessage().contains("ANYTHING"));
+   }
+
+   /**
+    * Worse than an empty listing overall: the assembly's current table is present but its own
+    * column list came back empty, while a different, non-current table in the same listing still
+    * has columns. The old bypass fired on {@code available} being empty regardless of why, so it
+    * waved through a column belonging to that other table — a cross-table silent bind, not just a
+    * "nothing could be listed" false accept.
+    */
+   @Test
+   void refusesAColumnFromAnotherTableWhenTheCurrentTablesOwnListingIsEmpty() {
+      List<BindableTable> currentTableWithNoColumns = List.of(
+         new BindableTable("Query1", true, List.of()),
+         new BindableTable("Products", false,
+                           List.of(new BindableField("PRODUCT_NAME", null, null))));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.require(currentTableWithNoColumns, "Chart1", dim("PRODUCT_NAME")));
+
+      assertTrue(thrown.getMessage().contains("PRODUCT_NAME"));
+      assertTrue(thrown.getMessage().contains("Query1"),
+                 "the message must name the source the assembly is actually bound to");
    }
 
    @Test


### PR DESCRIPTION
## Root cause

`BindableColumns.require()` had the same over-broad empty-listing bypass that PCB-002 (#4893, merged) already fixed on its sibling method `requireSource()`:

```java
if(available.isEmpty()) {
   return;
}
```

Both of `require()`'s two callers (`BindingAgentController.requireBindableColumns` and `.resolveSourceTable`) already wrap the listing read and `require()` itself in a try/catch that converts a genuine read failure into a logged skip one layer up. `resolveSourceTable` calls `require()` and `requireSource()` back-to-back in the *same* try block on the *same* `tables` value — so by the time `require()` sees `tables`, `fieldsService.list()` has already returned successfully. An empty `available` can therefore only mean a successful-but-empty listing, never an unreadable tree.

Worse than `requireSource()`'s pre-fix bug: when an assembly already has a current source but that one table's own column list came back empty (while the overall listing is non-empty), the bypass waved through *any* field name at all — including one belonging to a **different table** in the same listing. This was empirically demonstrated (binding `PRODUCT_NAME`, a real column of `Products`, to a chart whose current source `Query1` has an empty field list — accepted silently pre-fix).

## Fix

Delete the bypass outright (`core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java`). No replacement condition needed:
- `require()` already has a separate, correct "nothing being written" bypass (`fields.isEmpty()`) at the top of the method.
- Blank/absent column names are already skipped per-field inside the validation loop regardless of `available`.

## Tests

- `BindableColumnsTest.staysOutOfTheWayWhenNothingCouldBeListed` renamed to `refusesWhenNothingCouldBeListed` and flipped from `assertDoesNotThrow` to `assertThrows`, mirroring PCB-002's own `requireSource()` test shape.
- Added `refusesAColumnFromAnotherTableWhenTheCurrentTablesOwnListingIsEmpty`, a permanent regression test for the cross-table silent-bind scenario.
- Verified no other existing `require()` test depends on the old bypass (all use non-empty fixtures).

`./mvnw -pl core -o test -Dtest=BindableColumnsTest` — 22/22 passed.

## Provenance

Diagnosed and refuted in `stylebi-wiz` under `docs/teams/2026-08-30-bugs-corpus-followon/item-E/` (`01-diagnosis.md`, `02-refute.md`) — a follow-on item flagged during PCB-002's own fix (#4893). Refuter verdict: survives fully, no corrections needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)