### PR TITLE
Fix PCB-003: get_viewsheet_image renders StyleBI's failed-query placeholder as real chart data

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/AssemblyImageService.java
@@ -21,6 +21,7 @@ import inetsoft.analytic.composition.VSPortalHelper;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
 import inetsoft.graph.EGraph;
+import inetsoft.graph.data.DataSet;
 import inetsoft.graph.geo.service.WebMapLimitException;
 import inetsoft.graph.internal.DimensionD;
 import inetsoft.report.TableLens;
@@ -29,6 +30,7 @@ import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.composition.graph.VGraphPair;
+import inetsoft.report.composition.graph.VSDataSet;
 import inetsoft.report.filter.ColumnMapFilter;
 import inetsoft.report.gui.viewsheet.*;
 import inetsoft.report.gui.viewsheet.cylinder.VSCylinder;
@@ -60,6 +62,7 @@ import inetsoft.util.profile.ProfileUtils;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.service.WizVsService;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -719,6 +722,17 @@ public class AssemblyImageService {
                      !pair.isPlotted())
                   {
                      return new ImageRenderResult(1);
+                  }
+
+                  // pair.isCompleted()/isPlotted() report a normal successful render even when
+                  // the underlying live query failed and AssetQuery silently substituted
+                  // fabricated design-time sample data (see WizVsService#checkFailedQuery) --
+                  // check for that before rendering it as if it were real, instead of returning
+                  // a plausible-looking image over made-up rows.
+                  DataSet dset = WizVsService.unwrapDataSet(pair.getData());
+
+                  if(dset instanceof VSDataSet vds) {
+                     WizVsService.checkFailedQuery(vds.getTable(), false);
                   }
 
                   if(svg) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2548,7 +2548,7 @@ public class WizVsService {
     *        cause instead, for callers surfacing failures on non-expression tables (e.g. a raw SQL
     *        query table) where the "check the expression columns" advice would mislead.
     */
-   static void checkFailedQuery(XTable lens, boolean wrapExpressionError) {
+   public static void checkFailedQuery(XTable lens, boolean wrapExpressionError) {
       if(lens == null) {
          return;
       }
@@ -2740,7 +2740,7 @@ public class WizVsService {
    }
 
    /** Unwraps dataset wrappers (pair/filter chains) to reach the underlying aggregated data. */
-   private static DataSet unwrapDataSet(DataSet dset) {
+   public static DataSet unwrapDataSet(DataSet dset) {
       while(true) {
          if(dset instanceof VSDataSet) {
             return dset;

--- a/core/src/test/java/inetsoft/web/viewsheet/controller/AssemblyImageServiceFailedQueryTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/controller/AssemblyImageServiceFailedQueryTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.controller;
+
+import inetsoft.graph.data.DataSet;
+import inetsoft.graph.data.PairsDataSet;
+import inetsoft.report.composition.graph.AliasedColumnDataSet;
+import inetsoft.report.composition.graph.VSDataSet;
+import inetsoft.report.internal.XNodeMetaTable;
+import inetsoft.report.lens.DefaultTableLens;
+import inetsoft.web.wiz.service.WizVsService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression for PCB-003: {@code AssemblyImageService}'s chart-rendering branch (see
+ * {@code processGetAssemblyImage1}) unwraps {@code VGraphPair#getData()} the same way
+ * {@code WizVsService#extractChartData} already does and must catch StyleBI's own failed-live-query
+ * fallback data (see {@code WizVsServiceCheckFailedQueryTest}) instead of silently rendering the
+ * fabricated substitute as if it were real. Exercises the two corrections the refuter pass flagged:
+ * (1) the data must be unwrapped ({@link WizVsService#unwrapDataSet}) before the check, since a
+ * dual-axis/pareto chart's {@code VGraphPair#getData()} returns a wrapped {@code DataSetFilter}, not
+ * a bare {@link VSDataSet}; (2) the check must use the non-expression-wrapped message
+ * ({@code wrapExpressionError=false}), since nothing is wrong with an expression here.
+ */
+@Tag("core")
+class AssemblyImageServiceFailedQueryTest {
+   @Test
+   void detectsFailedQueryOnUnwrappedVSDataSet() {
+      VSDataSet vds = new VSDataSet(failedQueryTable("column region_id does not exist"), null);
+
+      DataSet unwrapped = WizVsService.unwrapDataSet(vds);
+      assertTrue(unwrapped instanceof VSDataSet, "a bare VSDataSet should unwrap to itself");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> WizVsService.checkFailedQuery(((VSDataSet) unwrapped).getTable(), false));
+      assertTrue(ex.getMessage().contains("column region_id does not exist"),
+                 "should surface the real cause, was: " + ex.getMessage());
+      assertFalse(ex.getMessage().contains("expression"),
+                  "non-expression callers must not get the misleading expression-column advice, was: " +
+                  ex.getMessage());
+   }
+
+   @Test
+   void detectsFailedQueryThroughDataSetFilterWrapper() {
+      // AliasedColumnDataSet is a generic DataSetFilter wrapper -- exercises the same wrapping shape
+      // ChartVSAQuery produces for a dual-axis/pareto chart binding.
+      VSDataSet vds = new VSDataSet(failedQueryTable("true"), null);
+      AliasedColumnDataSet wrapped = new AliasedColumnDataSet(vds);
+
+      DataSet unwrapped = WizVsService.unwrapDataSet(wrapped);
+      assertTrue(unwrapped instanceof VSDataSet,
+                 "a DataSetFilter-wrapped VSDataSet should unwrap to the underlying VSDataSet");
+
+      assertThrows(IllegalArgumentException.class,
+         () -> WizVsService.checkFailedQuery(((VSDataSet) unwrapped).getTable(), false),
+         "a failed-query table wrapped behind a DataSetFilter must still be caught, not missed");
+   }
+
+   @Test
+   void detectsFailedQueryThroughPairsDataSetWrapper() {
+      // PairsDataSet is the scatter-matrix-specific wrapper the debugger/refuter both called out by
+      // name as a concrete case where a naive instanceof VSDataSet cast (skipping unwrapDataSet)
+      // would silently miss the failed-query table.
+      VSDataSet vds = new VSDataSet(failedQueryTable("true"), null);
+      PairsDataSet wrapped = new PairsDataSet(vds);
+
+      DataSet unwrapped = WizVsService.unwrapDataSet(wrapped);
+      assertTrue(unwrapped instanceof VSDataSet,
+                 "a PairsDataSet-wrapped VSDataSet should unwrap to the underlying VSDataSet");
+
+      assertThrows(IllegalArgumentException.class,
+         () -> WizVsService.checkFailedQuery(((VSDataSet) unwrapped).getTable(), false),
+         "a failed-query table wrapped behind a PairsDataSet must still be caught, not missed");
+   }
+
+   @Test
+   void doesNotThrowForCleanData() {
+      VSDataSet vds = new VSDataSet(new DefaultTableLens(1, 1), null);
+
+      DataSet unwrapped = WizVsService.unwrapDataSet(vds);
+      assertTrue(unwrapped instanceof VSDataSet);
+      assertDoesNotThrow(() -> WizVsService.checkFailedQuery(((VSDataSet) unwrapped).getTable(), false));
+   }
+
+   private static DefaultTableLens failedQueryTable(String cause) {
+      DefaultTableLens lens = new DefaultTableLens(1, 1);
+      lens.setProperty(XNodeMetaTable.FAILED_QUERY_PROPERTY, cause);
+      return lens;
+   }
+}


### PR DESCRIPTION
## Root cause

`get_viewsheet_image`'s chart branch (`AssemblyImageService.processGetAssemblyImage1`) only checked
`VGraphPair.isCompleted()/isPlotted()/isCancelled()` before rendering — never whether the underlying
data was StyleBI's own "live query failed → substitute fabricated design-time sample data" fallback
(`AssetQuery.doGetTableLens`, gated on `AssetQuerySandbox.isLiveMode(mode)`, which is always true for
a Composer-editing viewsheet — exactly what composer-chat's paired sessions run). That substitution
happens entirely inside `box.getData()`, before `VGraphPair` ever sees an exception, so the pair looks
like a completely normal, successfully-plotted render.

Symptom: a chart with 2+ dimensions stacked on one shelf (hierarchy/drill binding) renders a
deterministic placeholder — `XNodeMetaTable.getExampler`'s "XXXXX"/"XXXX" X-string example values and
`ChartMetaTableGenerator`'s canned ~1000-shaped measure values — with a normal-looking success
response (width/height/summary all populated), no error, no flag.

`WizVsService.extractChartData` (`create_viewsheet`'s inline chart-data preview) already detects this
exact condition via `checkFailedQuery`/`failedQueryCause`, built for Redmine #75484 —
`AssemblyImageService`, a much older, non-wiz-specific class, never got the equivalent check.

## Fix

Widen `WizVsService.checkFailedQuery(XTable, boolean)` and `WizVsService.unwrapDataSet(DataSet)` from
package-private/private to `public static` (both already dependency-free static helpers — no other
caller needed a behavior change) and call them in `AssemblyImageService`'s chart branch, right after
the existing `pair.isCompleted()/isPlotted()` check and before rendering:

```java
DataSet dset = WizVsService.unwrapDataSet(pair.getData());

if(dset instanceof VSDataSet vds) {
   WizVsService.checkFailedQuery(vds.getTable(), false);
}
```

`unwrapDataSet` is needed (not just `checkFailedQuery`) because `pair.getData()` returns the same
wrapped `DataSetFilter`/`PairsDataSet` shape `extractChartData` already has to unwrap — a naive
`instanceof VSDataSet` cast on the raw `pair.getData()` would miss the failed-query table whenever
it's wrapped (e.g. a dual-axis/pareto chart binding).

`wrapExpressionError=false` is used deliberately instead of `checkFailedQuery`'s 1-arg default: the
default message tells the caller to "check the worksheet's expression columns," which is correct for
#75484's actual bad-expression bug but would be actively misleading here — nothing is wrong with any
expression in a plain hierarchy binding.

## Explicitly out of scope

The exact reason a 2+-dimension-per-shelf binding trips the underlying live query failure in the
first place is **not** resolved by this PR — confirmed a dead end from source alone by two
independent investigation passes (diagnosis + refute). This fix makes that failure surface loud
instead of silently substituting fake data; finding why it fails needs a live session (promoting the
`LOG.warn` at `AssetQuery.java:840` to include a stack trace, or attaching a debugger).

## Tests

New `AssemblyImageServiceFailedQueryTest` (4 tests) covers the unwrap+check combination for:
- a bare `VSDataSet` carrying `FAILED_QUERY_PROPERTY`
- the same wrapped behind a generic `DataSetFilter` (`AliasedColumnDataSet`)
- the same wrapped behind `PairsDataSet` (the dual-axis/pareto-chart-specific wrapper called out by
  both the diagnosis and refute passes)
- a clean table (no false positive)

Existing `WizVsServiceCheckFailedQueryTest` (3 tests) still passes unchanged.

Ran `inetsoft.web.wiz.**` (2708 tests) and `inetsoft.web.viewsheet.controller.**` (20 tests) as
collateral-regression checks for the widened visibility — both BUILD SUCCESS, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Blast-radius disclosure (added during review)

`AssemblyImageService.processGetAssemblyImage1`'s chart branch is shared by more callers than
`get_viewsheet_image`. Traced every caller reaching the modified branch directly (not by grep alone):

- `ScriptImageService`/`WizVisualizationService`/`GetImageController` — the plugin's own paths,
  covered by the `inetsoft.web.wiz.**` (2708 tests) and `inetsoft.web.viewsheet.controller.**`
  (20 tests) collateral runs above.
- `ExportController.exportViewsheetChart` (`/export/vs-chart/**`, `inetsoft.web.composer.vs.controller`)
  — the human Composer's "export/download chart image" action — also reaches this branch and now
  gets the same hard-throw-on-failed-query behavior. No existing test (`ExportControllerTest`
  doesn't exist) covers this path either before or after this change.
  This is a real, wider behavior change than the wiz-agent scope this fix is framed around: traced
  `ExportController` → `VSLifecycleService.openViewsheet` → `ViewsheetEngine.openViewsheet`, and
  the `OpenViewsheetEvent` this endpoint builds has no `viewer`/parameters/`drillFrom` set, so
  `RuntimeViewsheet.mode` resolves to `VIEWSHEET_DESIGN_MODE` (`entry.getProperty("viewer")` is
  `"false"`) — i.e. `AssetQuerySandbox.isLiveMode` is true for *every* chart-image export via this
  endpoint, not only for a viewsheet a human happens to have open mid-edit in the Composer. In other
  words, exporting a chart with a failed live query will now fail loud instead of silently
  downloading a fabricated placeholder image, for any export request through this endpoint.
  Judged desirable: a human explicitly asking to export/download a chart image is a case where a
  silently-fabricated placeholder was always the wrong outcome, not a tolerable
  still-mid-edit-so-it's-fine case — same class of improvement as `WizVsService.extractChartData`'s
  existing check for `create_viewsheet`'s data preview.
- `ImageHashService` (`inetsoft.util`) does **not** actually reach this branch — it only reuses the
  nested `AssemblyImageService.ImageRenderResult` type as a return value for the unrelated static/
  dynamic "Image" viewsheet-component rendering path (raw bytes it computes itself), with no call
  into `processGetAssemblyImage`/`VGraphPair`/`AssetQuery` anywhere. (An earlier review pass flagged
  it as a possible additional caller based on the class-name match; tracing the actual call graph
  shows it isn't one.)
