### PR TITLE
fix(wiz): null-check assembly lookup in VSConditionDialogService.getModel

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogService.java
@@ -87,6 +87,12 @@ public class VSConditionDialogService {
          rvs = viewsheetService.getViewsheet(runtimeId, principal);
          vs = rvs.getViewsheet();
          vsAssembly = vs.getAssembly(assemblyName);
+
+         if(vsAssembly == null) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' is not an assembly in this viewsheet.");
+         }
+
          vsAssemblyInfo = vsAssembly.getVSAssemblyInfo();
       }
       catch(Exception e) {

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSConditionDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSConditionDialogServiceTest.java
@@ -43,6 +43,8 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -108,6 +110,23 @@ class VSConditionDialogServiceTest {
          service.getModel("Viewsheet1", "TextAssembly", null);
 
       assertEquals(7, result.getRevision());
+   }
+
+   /**
+    * {@code Viewsheet.getAssembly} returns null, not an exception, when the name doesn't match —
+    * documented on the method itself. Dereferencing that null unchecked used to NPE here; callers
+    * (browse_condition_values, get_condition, set_condition) deserve a named, actionable error
+    * instead of an unhandled NPE that surfaces as a raw 500.
+    */
+   @Test
+   void getModelThrowsNamedErrorWhenAssemblyNotFound() throws Exception {
+      when(viewsheetEngine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(null);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.getModel("Viewsheet1", "NoSuchAssembly", null));
+      assertTrue(ex.getMessage().contains("NoSuchAssembly"));
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -121,6 +121,29 @@ class ViewsheetAssemblyAgentControllerTest {
    }
 
    /**
+    * A bad {@code assembly} name (item D, corpus follow-on): {@code VSConditionDialogService
+    * .getModel} now throws a named {@code IllegalArgumentException} instead of NPE-ing on the
+    * dereference of {@code Viewsheet.getAssembly}'s documented {@code null} return. This asserts
+    * the controller doesn't swallow or re-wrap that -- it reaches {@code WizControllerErrorHandler}
+    * as the same named-field 400 the "not a field of" precedent already gets, never a bare 500.
+    */
+   @Test
+   void browseConditionValuesPropagatesTheNamedFieldErrorForAnUnknownAssembly() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      AssemblyConditionService conditionService = mock(AssemblyConditionService.class);
+      doThrow(new IllegalArgumentException("'NoSuchAssembly' is not an assembly in this viewsheet."))
+         .when(conditionService).browseValues(anyString(), any(Principal.class), anyString(), anyString());
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWithConditionService(sessions, conditionService);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class, () ->
+         controller.browseConditionValues("tok", "NoSuchAssembly", "ORDER_DATE", principal()));
+
+      assertTrue(thrown.getMessage().contains("NoSuchAssembly"));
+   }
+
+   /**
     * detach took the session token and nothing else, so any authenticated caller holding or
     * guessing another user's token could terminate their pairing session. Every other endpoint
     * binds the token to the caller through {@code sessions.resolve(token, user)}; this one


### PR DESCRIPTION
## Root cause

`VSConditionDialogService.getModel()` (`VSConditionDialogService.java:78-102`) dereferences
`vs.getAssembly(assemblyName)` unchecked. `Viewsheet.getAssembly(String)`'s own javadoc documents
it returns `null` when the name doesn't match any assembly in the connected viewsheet — but
`getModel()` calls `.getVSAssemblyInfo()` on that result immediately, NPE-ing on a miss. The
wrapping `catch(Exception e) { throw e; }` is a no-op rethrow; nothing above it in the call chain
wraps it either.

`WizControllerErrorHandler` (`@ControllerAdvice(basePackages = "inetsoft.web.wiz")`) does have a
generic `Exception` catch-all that turns this into a clean-ish JSON 500 rather than a raw
stack-trace dump — but `NullPointerException` doesn't match any of its 7 named handlers, so it
misses the existing `IllegalArgumentException` → 400 handler that's already used two lines away in
`AssemblyConditionService` for this exact "bad name" shape (`browseValues`'s "is not a field of ..."
message, `set`'s "has no condition dialog" message).

`getModel()` is the single implementation backing all four wiz-agent condition tools
(`get_condition`, `set_condition`, `clear_condition`, `browse_condition_values` — via
`AssemblyConditionService.read/set/browseValues`, all three call it with no try/catch of their own)
**and** the interactive Composer's own `VSConditionDialogController.getModel`, which has no
`@HandleAssetExceptions` coverage either.

**Correction (post-review):** the four wiz-agent tools get the full benefit — they route through
`inetsoft.web.wiz`, covered by `WizControllerErrorHandler`'s `IllegalArgumentException` → 400
handler, so they go from an opaque 500 to a clean, actionable 400 naming the bad assembly.
`VSConditionDialogController` (the interactive Composer UI) is in `inetsoft.web.composer.vs.dialog`,
which `WizControllerErrorHandler` does not cover; the advice that does cover that package
(`ComposerControllerErrorHandler`) has no `IllegalArgumentException` handler and no REST-level
`Exception` catch-all. So for that caller, this change is safe (no regression — same call still
throws before doing any work either way) and improves server-log clarity (a named
`IllegalArgumentException` instead of a bare NPE), but the client-visible response is still a
generic, message-suppressed 500 either way (Spring Boot's `server.error.include-message` defaults to
`never`, no override found in this project). It does not close the gap "for both callers" at the
client-response level — only the wiz-agent tools get the clean 400.

## Fix

Null-check `vsAssembly` right after `vs.getAssembly(assemblyName)` and throw a named
`IllegalArgumentException` ("`'<name>' is not an assembly in this viewsheet.`") instead of falling
through to the NPE. This plugs directly into `WizControllerErrorHandler`'s existing
`IllegalArgumentException` → 400 handler for the wiz-agent tools — no new plumbing — and is a
harmless, log-clarity-only improvement for the interactive Composer UI's own caller.

## Framing — important

This was found while investigating PC-005 (`browse_condition_values` raw 500 on a `timeInstant`
column), and is a real, independently-worthwhile defensive fix on its own merits (a documented
`null`-returning contract, dereferenced unchecked, shared across four tools). **It is not being
claimed as a confirmed fix for PC-005 itself** — whether the original PC-005 repro's `assembly`
argument was actually an unresolvable name (this bug) or a resolvable one hitting some other still-
unfound defect could not be settled from source alone (see
`docs/teams/2026-08-30-bugs-corpus-followon/item-D/01-diagnosis.md` and `02-refute.md` in the
stylebi-wiz repo). That attribution question stays open, tracked separately, pending a live replay
of the original call.

## Tests

- `VSConditionDialogServiceTest.getModelThrowsNamedErrorWhenAssemblyNotFound` — unknown assembly
  throws `IllegalArgumentException` naming it, not NPE.
- `VSConditionDialogServiceTest`'s existing happy-path tests (`outputVSAssemblyGetModelWorks`, etc.)
  confirm the real-assembly path is unaffected.
- `ViewsheetAssemblyAgentControllerTest.browseConditionValuesPropagatesTheNamedFieldErrorForAnUnknownAssembly`
  — confirms the wiz-agent controller path doesn't swallow/re-wrap the new error.

All three affected test files pass:
```
core/target/surefire-reports/...VSConditionDialogServiceTest: Tests run: 7, Failures: 0, Errors: 0
core/target/surefire-reports/...AssemblyConditionServiceTest: Tests run: 12, Failures: 0, Errors: 0
core/target/surefire-reports/...ViewsheetAssemblyAgentControllerTest: Tests run: 35, Failures: 0, Errors: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
