### PR TITLE
fix(wiz): bound worksheet-domain refresh calls with RenderWaitSupport

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -62,6 +62,7 @@ import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.service.RenderWaitSupport;
 import inetsoft.web.wiz.service.TabularEndpointBindingSupport;
 import inetsoft.web.wiz.script.PaneScopeService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
@@ -2331,8 +2332,21 @@ public class WorksheetAgentController {
             }
 
             box.resetTableLens(req.table());
-            WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
-            WorksheetEventUtil.loadTableData(rws, req.table(), true, true);
+
+            // Bug #76350 follow-on (item A): refreshColumnSelection (not loadTableData) is the
+            // call that actually executes a crosstab/grouped table's query, and had no bound —
+            // an explicit refresh_data on a table whose query hadn't run yet in this runtime
+            // (e.g. a cross-join-grouped crosstab) blocked this request for however long that
+            // query took. Bounding both together mirrors ViewsheetEditService.ensureTableDataReady:
+            // this is an explicit, caller-requested op, so a timeout throws RenderNotReadyException
+            // (mapped to 503/RENDER_NOT_READY by WizControllerErrorHandler) rather than being
+            // swallowed — the caller gets a live "not ready, retry" signal instead of a raw hang.
+            RenderWaitSupport.awaitOrRetry(() -> {
+               WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
+               WorksheetEventUtil.loadTableData(rws, req.table(), true, true);
+               return null;
+            }, TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS,
+               (int) Math.max(1, (TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS) / 1000));
          }
          else {
             // Refresh all table assemblies.
@@ -3019,4 +3033,10 @@ public class WorksheetAgentController {
    private final DataSourceService dataSourceService;
    private final SecurityEngine securityEngine;
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetAgentController.class);
+
+   // Mirrors ViewsheetEditService.TABLE_WARM_MAX_ATTEMPTS/TABLE_WARM_RETRY_SLEEP_MS: the same
+   // "how long is acceptable to make a caller wait before answering retry-after" ceiling used
+   // for refreshData's explicit single-table warm-up (see RenderWaitSupport.awaitOrRetry above).
+   private static final int TABLE_WARM_MAX_ATTEMPTS = 4;
+   private static final long TABLE_WARM_RETRY_SLEEP_MS = 500;
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -2174,7 +2174,16 @@ public class WorksheetAgentController {
          info.getQuery().setSQLDefinition(sql);
          sqlTable.setSQLEdited(true);
          sqlTable.setColumnSelection(columns);
-         WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
+
+         // Bug #76350 follow-on (item A), review round 1: refreshColumnSelection executes the
+         // table's query for any crosstab-shaped table (set_group_aggregate works on any
+         // TableAssembly by name, including a SQL-bound one) -- unbounded here had the same hang
+         // shape as refreshData's own single-table branch (3a) above.
+         RenderWaitSupport.awaitOrRetry(() -> {
+            WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
+            return null;
+         }, TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS,
+            (int) Math.max(1, (TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS) / 1000));
          return null;
       });
    }
@@ -2436,8 +2445,17 @@ public class WorksheetAgentController {
          column.setAlias(alias);
          columns.addAttribute(csIndex, column);
          assembly.setColumnSelection(columns);
-         WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
-         WorksheetEventUtil.loadTableData(rws, req.table(), true, true);
+
+         // Bug #76350 follow-on (item A), review round 1: same unbounded shape as refreshData's
+         // single-table branch (3a) above -- an embedded table can be made crosstab-shaped by a
+         // prior set_group_aggregate(crosstab=true), which makes refreshColumnSelection execute
+         // a real query here.
+         RenderWaitSupport.awaitOrRetry(() -> {
+            WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
+            WorksheetEventUtil.loadTableData(rws, req.table(), true, true);
+            return null;
+         }, TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS,
+            (int) Math.max(1, (TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS) / 1000));
          AssetEventUtil.refreshTableLastModified(ws, req.table(), true);
          return null;
       });
@@ -2529,8 +2547,16 @@ public class WorksheetAgentController {
 
          table.reorderTableAssemblies(reordered);
 
-         WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
-         WorksheetEventUtil.loadTableData(rws, req.table(), true, true);
+         // Bug #76350 follow-on (item A), review round 1: same unbounded shape as refreshData's
+         // single-table branch (3a) above -- a concatenated table can be made crosstab-shaped by
+         // a prior set_group_aggregate(crosstab=true), which makes refreshColumnSelection
+         // execute a real query here.
+         RenderWaitSupport.awaitOrRetry(() -> {
+            WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
+            WorksheetEventUtil.loadTableData(rws, req.table(), true, true);
+            return null;
+         }, TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS,
+            (int) Math.max(1, (TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS) / 1000));
          return null;
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -42,6 +42,7 @@ import inetsoft.web.composer.ws.WorksheetControllerService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.service.RenderWaitSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -229,6 +230,31 @@ public class WorksheetEditService {
     * Refresh column selections and reload table data for all assemblies in the worksheet.
     * Mirrors the UI's post-edit steps (InsertDataService calls refreshColumnSelection +
     * loadTableData after column mutations).
+    *
+    * <p>{@code refreshColumnSelection} — not {@code loadTableData} — is the call that actually
+    * executes a crosstab/grouped table's query ({@code AssetQuerySandbox.refreshColumnSelection}'s
+    * {@code query.getTableLens(vars)}); {@code loadTableData} is structural validation and cache
+    * invalidation only. Both are bounded together in one {@link RenderWaitSupport#awaitOrRetry}
+    * call per table so a table whose query hasn't executed yet in this runtime cannot block this
+    * best-effort warm-up past its share of the budget below.</p>
+    *
+    * <p>Bug #76350 follow-on (item A): before this, neither call had any bound, so a single slow
+    * table anywhere in the worksheet — not necessarily the one just edited — made an unrelated,
+    * already-committed write op (add_expression_column, set_group_aggregate, etc.) hang until
+    * that table's query finished, reported to the caller as a false 30s timeout on a call that had
+    * actually already succeeded.</p>
+    *
+    * <p>All tables share one wall-clock budget ({@link #REFRESH_ASSEMBLIES_BUDGET_MS}) rather than
+    * each getting its own independent wait, so the aggregate cost of this warm-up is capped at a
+    * flat ~2s regardless of how many tables the worksheet has. Trade-off, accepted deliberately: a
+    * persistently slow table that sorts early in {@code ws.getAssemblies()}'s iteration order can
+    * consume the whole budget and starve every table after it, on every write op, indefinitely —
+    * worse for those specific tables than the old fully-unbounded design, which eventually warmed
+    * every table given enough time. This is acceptable because this loop is best-effort
+    * cache-warming, not a correctness precondition (unlike {@code ViewsheetEditService}'s
+    * {@code ensureTableDataReady}, which guards a mutation that hasn't happened yet): a table
+    * skipped here is not warmed by this request, but still executes — and gets cached — on the
+    * next real read that needs it.</p>
     */
    private void refreshAssemblies(RuntimeWorksheet rws) {
       Worksheet ws = rws.getWorksheet();
@@ -237,21 +263,45 @@ public class WorksheetEditService {
          return;
       }
 
+      long deadline = System.currentTimeMillis() + REFRESH_ASSEMBLIES_BUDGET_MS;
+
       for(Assembly a : ws.getAssemblies()) {
          if(a instanceof TableAssembly ta) {
             String name = ta.getName();
+            long remaining = deadline - System.currentTimeMillis();
+
+            if(remaining <= 0) {
+               LOG.warn("Skipping refresh for assembly {} - refreshAssemblies budget exhausted",
+                        name);
+               continue;
+            }
 
             try {
-               WorksheetEventUtil.refreshColumnSelection(rws, name, true);
-               WorksheetEventUtil.loadTableData(rws, name, true, true);
+               RenderWaitSupport.awaitOrRetry(() -> {
+                  WorksheetEventUtil.refreshColumnSelection(rws, name, true);
+                  WorksheetEventUtil.loadTableData(rws, name, true, true);
+                  return null;
+               }, remaining, (int) Math.max(1, remaining / 1000));
                WorksheetEventUtil.fixAssemblyInfo(rws, ta);
             }
             catch(Exception ex) {
+               // RenderNotReadyException (a timed-out table) is deliberately swallowed here,
+               // same as any other per-table failure: the mutation this method runs after has
+               // already succeeded and been checkpointed, so this is a best-effort warm-up, not
+               // a precondition the caller needs to know failed.
                LOG.warn("Failed to refresh assembly: {}", name, ex);
             }
          }
       }
    }
+
+   // Mirrors ViewsheetEditService.TABLE_WARM_MAX_ATTEMPTS/TABLE_WARM_RETRY_SLEEP_MS: the same
+   // "how long is acceptable to make a caller wait before answering retry-after" ceiling, applied
+   // here as one shared budget across the whole refreshAssemblies loop rather than per-table.
+   private static final int TABLE_WARM_MAX_ATTEMPTS = 4;
+   private static final long TABLE_WARM_RETRY_SLEEP_MS = 500;
+   private static final long REFRESH_ASSEMBLIES_BUDGET_MS =
+      TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS;
 
    private void applySocketSession(RuntimeWorksheet rws, JoinSession session) {
       if(session.socketSessionId() != null && rws.getSocketSessionId() == null) {

--- a/core/src/test/java/inetsoft/web/wiz/service/RenderWaitSupportTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/RenderWaitSupportTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.util.ThreadContext;
+import inetsoft.web.wiz.pairing.TestPrincipals;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@WizAgentTestSupport
+class RenderWaitSupportTest {
+
+   @Test
+   void returnsTheWorkResultWhenItFinishesInTime() throws Exception {
+      String result = RenderWaitSupport.awaitOrRetry(() -> "ready", 2_000, 2);
+      assertEquals("ready", result);
+   }
+
+   @Test
+   void throwsRenderNotReadyAfterTheTimeout() {
+      assertThrows(RenderNotReadyException.class, () -> RenderWaitSupport.awaitOrRetry(() -> {
+         Thread.sleep(3_000);
+         return null;
+      }, 500, 1));
+   }
+
+   /**
+    * Bug #76350 follow-on (item A) refute round: {@code RenderWaitSupport} runs its work on a
+    * plain JDK virtual thread ({@code Executors.newVirtualThreadPerTaskExecutor()}), not a
+    * {@link inetsoft.util.GroupedThread}. {@code ThreadContext.getContextPrincipal()} checks
+    * {@code GroupedThread} first and only falls back to a plain, non-inheritable
+    * {@code ThreadLocal<Principal>} otherwise — a value set on the calling thread before
+    * {@code awaitOrRetry} is invoked is NOT visible inside the wrapped {@code Callable}, even
+    * though the callable runs synchronously (from the caller's point of view) within the same
+    * method call.
+    *
+    * <p>This is not new to item A's fix — {@code ViewsheetEditService.ensureTableDataReady}
+    * (bug #76331) already crosses this exact same executor boundary in production, and its own
+    * test suite ({@code ViewsheetEditServiceTest}, {@code ScriptImageServiceTest},
+    * {@code ViewsheetAssemblyAgentControllerTest}) does not exercise a join-backed table, so it
+    * never actually observes this gap either way (confirmed by reading those tests directly: all
+    * three simulate "slow" by stubbing a mocked sandbox/service method with
+    * {@code Thread.sleep}, never by running a real {@code JoinQuery}). This test pins the
+    * mechanism itself down directly — with real {@code ThreadContext}, no mocks — so item A's own
+    * fix (which calls this same {@code awaitOrRetry} entry point, not a new one) is confirmed not
+    * to introduce a NEW instance of the problem, even though it does not fix the pre-existing one
+    * either; that is a larger, cross-cutting gap in {@code RenderWaitSupport} itself, out of
+    * scope for this item.</p>
+    */
+   @Test
+   void principalSetOnTheCallingThreadIsNotVisibleInsideTheWrappedCallable() throws Exception {
+      Principal principal = TestPrincipals.user("alice", "host-org");
+      ThreadContext.setPrincipal(principal);
+
+      try {
+         AtomicReference<Principal> seenInsideCallable = new AtomicReference<>();
+
+         RenderWaitSupport.awaitOrRetry(() -> {
+            seenInsideCallable.set(ThreadContext.getContextPrincipal());
+            return null;
+         }, 2_000, 2);
+
+         assertNotEquals(principal, seenInsideCallable.get(),
+            "documents a real, pre-existing gap (not introduced by item A): a plain " +
+            "ThreadLocal principal set on the calling thread does not propagate onto " +
+            "RenderWaitSupport's virtual-thread executor. If this assertion ever starts " +
+            "failing, RenderWaitSupport has started propagating context correctly -- update " +
+            "this test's expectation, and reconsider whether the pre-existing gap noted in " +
+            "bug #76331's fix and this item's write-up still applies.");
+      }
+      finally {
+         ThreadContext.setPrincipal(null);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -44,6 +44,7 @@ import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.web.wiz.model.DatabaseTableMeta;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.uql.tabular.RestParameter;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularUtil;
@@ -210,6 +211,19 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
+         null, null,
+         null, null, null, null, null, null, null
+      );
+   }
+
+   /** Builds a {@code reorder_concat_subtables} EditRequest that routes to reorderConcatSubtables(). */
+   private static EditRequest reorderConcatSubtablesRequest(String table, List<String> subtables) {
+      return new EditRequest(
+         "reorder_concat_subtables", table, null, null, null, null, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, subtables,
          null, null,
          null, null, null, null, null, null, null
       );
@@ -670,6 +684,103 @@ class WorksheetAgentControllerTest {
       ctrl.edit("TOK-RD2", refreshDataRequest("Crosstab1"), agent);
 
       verify(box, atLeastOnce()).refreshColumnSelection(eq("Crosstab1"), anyBoolean());
+   }
+
+   /**
+    * Bug #76350 follow-on (item A), review round 1: {@code insertColumn} calls the same unwrapped
+    * {@code refreshColumnSelection}/{@code loadTableData} pair 3a already bounds for
+    * {@code refresh_data} -- a prior {@code set_group_aggregate(crosstab=true)} on this same
+    * embedded table makes it pay the same expensive query-execution path.
+    */
+   @Test
+   void insertColumnThrowsRenderNotReadyWhenColumnSelectionIsSlow() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      // Row 0 is the header row insertColumn's setEmbeddedData/getEmbeddedData work off of --
+      // TestWorksheets.tableWithColumns only sets a ColumnSelection, no actual XEmbeddedTable
+      // rows, so insertColumn's real column-insertion logic needs a table built this way instead
+      // (mirrors WorksheetEditServiceMutatorsTest#embeddedWithData).
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, "T");
+      t.setEmbeddedData(new XEmbeddedTable(
+         new String[] { XSchema.STRING, XSchema.DOUBLE },
+         new Object[][] { { "cust", "amount" }, { "x1", 1.0 } }));
+      TestWorksheets.withGroupSumAndSort(t, "cust", "amount");
+      ws.addAssembly(t);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      doAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      }).when(box).refreshColumnSelection(eq("T"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-ICS"), any())).thenReturn(session("TOK-ICS"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      assertThrows(RenderNotReadyException.class,
+         () -> ctrl.edit("TOK-ICS", insertColumnRequest("T"), agent));
+   }
+
+   /**
+    * Bug #76350 follow-on (item A), review round 1: {@code reorderConcatSubtables} calls the same
+    * unwrapped pair -- a prior {@code set_group_aggregate(crosstab=true)} on this same
+    * concatenated table makes it pay the same expensive query-execution path.
+    */
+   @Test
+   void reorderConcatSubtablesThrowsRenderNotReadyWhenColumnSelectionIsSlow() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "k", "v");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "k", "v");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setOperation(TableAssemblyOperator.UNION);
+      top.addOperator(op);
+
+      ConcatenatedTableAssembly concat = new ConcatenatedTableAssembly(
+         ws, "Concat1", new TableAssembly[]{ a, b }, new TableAssemblyOperator[]{ top });
+      TestWorksheets.withGroupSumAndSort(concat, "k", "v");
+      ws.addAssembly(concat);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      doAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      }).when(box).refreshColumnSelection(eq("Concat1"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-RC"), any())).thenReturn(session("TOK-RC"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      assertThrows(RenderNotReadyException.class,
+         () -> ctrl.edit("TOK-RC", reorderConcatSubtablesRequest("Concat1", List.of("B", "A")), agent));
    }
 
    @Test
@@ -2709,6 +2820,68 @@ class WorksheetAgentControllerTest {
                  "error should name the denied datasource READ, got: " + ex.getMessage());
 
       verify(dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(agent));
+   }
+
+   /**
+    * Bug #76350 follow-on (item A), review round 1: {@code editSqlQuery} calls
+    * {@code refreshColumnSelection} unwrapped after committing the new SQL/column selection --
+    * the same unbounded-hang shape as {@code refreshData}'s single-table branch (3a), reachable
+    * on any SQL-bound table since {@code set_group_aggregate} can make one crosstab-shaped.
+    * {@code queryManagerService.getColumnSelection} is stubbed directly (bypassing real JDBC
+    * metadata resolution) and the SQL string has no {@code FROM} clause, so
+    * {@code JDBCUtil.fixUniformSQLInfo}'s in-memory shortcut ({@code sql.getTableCount() <= 0})
+    * fires without a live datasource or a {@code Config} Spring bean -- letting the test reach
+    * the wrap without a live JDBC connection, matching this class's existing "stop before real
+    * query execution" convention for SQL-query tests (e.g.
+    * {@code addSqlQueryGrantedPassesBothPermissionGates}, which also uses a table-less
+    * {@code "SELECT 1"}).
+    */
+   @Test
+   void editSqlQueryThrowsRenderNotReadyWhenColumnSelectionIsSlow() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly sqlt = new SQLBoundTableAssembly(ws, "SqlTable1");
+      ((SQLBoundTableAssemblyInfo) sqlt.getInfo()).setQuery(new JDBCQuery());
+      ws.addAssembly(sqlt);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      doAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      }).when(box).refreshColumnSelection(eq("SqlTable1"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-ES4"), any())).thenReturn(session("TOK-ES4"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      ColumnSelection newColumns = new ColumnSelection();
+      newColumns.addAttribute(new ColumnRef(new AttributeRef(null, "a")));
+      newColumns.addAttribute(new ColumnRef(new AttributeRef(null, "b")));
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenReturn(newColumns);
+
+      WorksheetAgentController ctrl = securityController(editSvc, mock(DataSourceService.class),
+         securityEngine, mock(MetadataApiService.class), mock(XRepository.class),
+         queryManagerService);
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT 1");
+
+      assertThrows(RenderNotReadyException.class,
+         () -> ctrl.edit("TOK-ES4", req, agent));
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -55,6 +55,7 @@ import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.service.FakeNamedConnectorQuery;
 import inetsoft.web.wiz.service.MetadataApiService;
+import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.junit.jupiter.api.Tag;
@@ -205,6 +206,19 @@ class WorksheetAgentControllerTest {
    private static EditRequest insertColumnRequest(String table) {
       return new EditRequest(
          "insert_column", table, null, null, null, null, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
+         null, null,
+         null, null, null, null, null, null, null
+      );
+   }
+
+   /** Builds a {@code refresh_data} EditRequest that routes to refreshData(). */
+   private static EditRequest refreshDataRequest(String table) {
+      return new EditRequest(
+         "refresh_data", table, null, null, null, null, null, null, null, null,
          null, null, null, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
@@ -580,6 +594,82 @@ class WorksheetAgentControllerTest {
          "the refusal must name the column kind that does work here: " + ex.getMessage());
       assertEquals(2, t.getColumnSelection(false).getAttributeCount(),
          "nothing may be added to the selection when the data cannot follow");
+   }
+
+   /**
+    * Bug #76350 follow-on (item A): {@code refresh_data} on an explicit table called
+    * {@code refreshColumnSelection} (the call that actually executes a crosstab/grouped table's
+    * query, via {@code AssetQuerySandbox}'s internal {@code query.getTableLens}) with no bound at
+    * all -- a table whose query hadn't run yet in this runtime (e.g. PWA-005's cross-join-grouped
+    * crosstab) blocked this request for however long that query took. Mirrors
+    * {@code ViewsheetEditServiceTest#resizeThrowsRenderNotReadyWhenTableDataIsSlowAndDoesNotDelegate}.
+    */
+   @Test
+   void refreshDataThrowsRenderNotReadyWhenColumnSelectionIsSlow() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      TableAssembly crosstab = TestWorksheets.withGroupSumAndSort(
+         TestWorksheets.nonEmbeddedTableWithColumns(ws, "Crosstab1", "cust", "amount"),
+         "cust", "amount");
+      ws.addAssembly(crosstab);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      doAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      }).when(box).refreshColumnSelection(eq("Crosstab1"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-RD"), any())).thenReturn(session("TOK-RD"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      assertThrows(RenderNotReadyException.class,
+         () -> ctrl.edit("TOK-RD", refreshDataRequest("Crosstab1"), agent));
+   }
+
+   /** A table whose data is already warm (or warms within the bound) refreshes normally. */
+   @Test
+   void refreshDataSucceedsWhenColumnSelectionIsFast() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      TableAssembly crosstab = TestWorksheets.withGroupSumAndSort(
+         TestWorksheets.nonEmbeddedTableWithColumns(ws, "Crosstab1", "cust", "amount"),
+         "cust", "amount");
+      ws.addAssembly(crosstab);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-RD2"), any())).thenReturn(session("TOK-RD2"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-RD2", refreshDataRequest("Crosstab1"), agent);
+
+      verify(box, atLeastOnce()).refreshColumnSelection(eq("Crosstab1"), anyBoolean());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.ColumnSelection;
@@ -73,6 +74,106 @@ class WorksheetEditServiceTest {
 
       assertNull(t.getColumnSelection(false).getAttribute("a"));
       verify(broadcast).broadcastRefresh(eq(rws), eq(SheetType.WORKSHEET), eq("Worksheet/foo-7"), eq(agent));
+   }
+
+   /**
+    * Bug #76350 follow-on (item A): {@code refreshAssemblies} — called unconditionally at the end
+    * of every mutation-applying method, looping over every {@link TableAssembly} in the
+    * worksheet, not just the one edited — called {@code refreshColumnSelection} (the call that
+    * actually executes a crosstab/grouped table's query) with no bound. A slow-to-execute table
+    * anywhere in the worksheet made an unrelated, already-succeeded edit hang and look like a
+    * false 30s timeout (PSM-003/PQE-001). Bounding it in {@code RenderWaitSupport.awaitOrRetry}
+    * and letting the existing {@code catch(Exception ex)} swallow a timeout like any other
+    * per-table failure means the edit itself still returns promptly, successfully.
+    */
+   @Test
+   void applySwallowsATimedOutTableInsteadOfPropagatingTheFailure() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ws.addAssembly(t);
+
+      // An unrelated table elsewhere in the same worksheet whose query hasn't run yet in this
+      // runtime -- refreshAssemblies loops over every TableAssembly, not just "T".
+      TableAssembly slow = TestWorksheets.withGroupSumAndSort(
+         TestWorksheets.nonEmbeddedTableWithColumns(ws, "Slow1", "cust", "amount"),
+         "cust", "amount");
+      ws.addAssembly(slow);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      doAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      }).when(box).refreshColumnSelection(eq("Slow1"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      // Must not throw -- the mutation on "T" already succeeded; "Slow1" timing out during the
+      // best-effort post-edit warm-up must not be reported back as the whole edit failing.
+      svc.apply("TOK", agent, ed -> ed.removeColumn("T", "a"));
+
+      assertNull(t.getColumnSelection(false).getAttribute("a"),
+                 "the mutation itself must still succeed even though Slow1's warm-up timed out");
+   }
+
+   /**
+    * The shared wall-clock budget across the whole {@code refreshAssemblies} loop (added so the
+    * loop's aggregate cost is capped regardless of table count, instead of N x 2s) means a table
+    * that is genuinely slow -- not stuck, just slow -- consumes the entire budget if it sorts
+    * early in {@code ws.getAssemblies()}'s iteration order, and every table after it is skipped
+    * for that pass rather than getting its own independent wait. This is a deliberate, accepted
+    * trade-off (documented on {@code WorksheetEditService.refreshAssemblies} itself) — this test
+    * pins down the behavior so it does not silently change.
+    */
+   @Test
+   void refreshAssembliesSharedBudgetSkipsTablesAfterTheFirstSlowOne() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly slow1 = TestWorksheets.withGroupSumAndSort(
+         TestWorksheets.nonEmbeddedTableWithColumns(ws, "Slow1", "cust", "amount"),
+         "cust", "amount");
+      ws.addAssembly(slow1);
+      TableAssembly slow2 = TestWorksheets.withGroupSumAndSort(
+         TestWorksheets.nonEmbeddedTableWithColumns(ws, "Slow2", "cust", "amount"),
+         "cust", "amount");
+      ws.addAssembly(slow2);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      // Slow1 alone blocks past the whole shared budget, so it consumes it entirely.
+      doAnswer(invocation -> {
+         Thread.sleep(3_000);
+         return null;
+      }).when(box).refreshColumnSelection(eq("Slow1"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      svc.apply("TOK", agent, ed -> {});
+
+      verify(box, never()).refreshColumnSelection(eq("Slow2"), anyBoolean());
    }
 
    @Test


### PR DESCRIPTION
## Root cause

Bug #76350 follow-on batch, item A. `WorksheetAgentController.refreshData` and
`WorksheetEditService.refreshAssemblies` both called
`WorksheetEventUtil.refreshColumnSelection` + `loadTableData` with no bound at all —
unlike `ViewsheetEditService`/`ScriptImageService`, which got `RenderWaitSupport` in
bug #76331 (PR #4886). `refreshColumnSelection` (not `loadTableData`) is the call that
actually executes a crosstab/grouped table's query
(`AssetQuerySandbox.refreshColumnSelection`'s internal `query.getTableLens`);
`loadTableData` is structural validation and cache invalidation only.

## Fix

- **`refreshData`'s explicit single-table branch (3a)**: wraps both calls in one
  `RenderWaitSupport.awaitOrRetry` `Callable` and throws `RenderNotReadyException` on
  timeout, mirroring `ViewsheetEditService.ensureTableDataReady` — an explicit,
  caller-requested op, so "not ready, retry" is the right signal. Fixes PWA-005's
  `refresh_data` half.
- **`WorksheetEditService.refreshAssemblies` (3b)**: called unconditionally at the end
  of `apply`/`applyOnRuntime`/`applyOnRuntimeNoCheckpoint`, looping over every
  `TableAssembly` in the worksheet. A slow table anywhere — not necessarily the one
  just edited — made an unrelated, already-succeeded write op (`add_expression_column`,
  `set_group_aggregate`, `add_table`, `delete_table`, etc.) hang and report a false
  timeout. Now wraps the same pair per table in `RenderWaitSupport`, letting the
  existing `catch(Exception ex)` swallow a timeout like any other per-table failure
  (best-effort cache-warm, not a precondition). All tables share one ~2s wall-clock
  budget rather than each getting an independent wait, so the aggregate cost is capped
  regardless of table count. Fixes PSM-003 and PQE-001's write-timeout half.

**Trade-off, documented on `refreshAssemblies` itself**: the shared budget means a
persistently slow table sorting early in `ws.getAssemblies()`'s iteration order can
starve every table after it, on every write op, indefinitely — worse for those
specific tables than the old fully-unbounded design, which eventually warmed
everything. Accepted because this is best-effort cache-warming, not correctness: a
skipped table still executes (and gets cached) on the next real read.

## Fix-round 1 (review round 1 response): 3 more unwrapped call sites

Review round 1 traced three more call sites with the identical unbounded-`refreshColumnSelection`
shape as `refreshData`'s original single-table branch, untouched by the initial version of this
PR: **`editSqlQuery`**, **`insertColumn`**, **`reorderConcatSubtables`**. Confirmed the exposure
independently: `WorksheetEditService.Editor.setGroupAggregate` resolves its target via
`requireTable(table)` — any `TableAssembly` by name, no type restriction — so
`set_group_aggregate(table=T, crosstab=true)` followed by any of these three ops on that same
now-crosstab table `T` is an ordinary two-op composition that reaches the same unbounded hang.
Fixed with the same `RenderWaitSupport.awaitOrRetry` wrap (throwing `RenderNotReadyException`,
same shape as 3a — these are explicit, caller-requested single-table ops, not `refreshAssemblies`'s
best-effort-after-mutation shape), plus one regression test per site. See
`docs/teams/2026-08-30-bugs-corpus-followon/item-A/03-fix.md`'s "Fix-round 1" section for detail.

**Correction to the numbers/claims below** (review round 1 caught these): the real worst case for
`refresh_data`/`edit_sql_query`/`insert_column`/`reorder_concat_subtables` — ops whose mutation
lambda contains its own explicit wrap _and_ are then followed by `refreshAssemblies`'s own ~2s
budget — is up to **~4s**, not "~2s" as originally stated (still comfortably inside the existing
30s client default). Ops that only go through 3b remain at ~2s. The ThreadLocal-propagation gap
below is recommended as a follow-up, not yet filed as a ticket (no Redmine access in this
fixer/review pairing) — an earlier version of this text implied a ticket already existed; it does
not.

No plugin-side (`stylebi-wiz`) change needed — `wizClient.ts`'s `timeoutHint` is already
worksheet-domain-aware from bug #76331's own fix.

No new exception-handler wiring needed either — `WizControllerErrorHandler`'s
`@ControllerAdvice` is package-scoped over `inetsoft.web.wiz` already.

## ThreadLocal-propagation finding (carried forward per the refute round)

Added `RenderWaitSupportTest`, confirming directly (real `ThreadContext`, no mocks)
that a `Principal` set on the calling thread does **not** propagate onto
`RenderWaitSupport`'s virtual-thread executor — a real, pre-existing gap
(`ThreadContext.PRINCIPAL` is a plain, non-inheritable `ThreadLocal`;
`GroupedThreadFactory`-backed pools elsewhere in the codebase, e.g. `JoinQuery`,
already work around this) that predates this fix and also affects the
already-shipped bug #76331 fix, whose own tests (`ScriptImageServiceTest`,
`ViewsheetEditServiceTest`, `ViewsheetAssemblyAgentControllerTest`) do **not**
exercise a join-backed table either — confirmed by reading all three directly. Not
fixed here (cross-cutting, larger than this item), and recommended as a follow-up
rather than filed as a ticket (see correction above).

## Tests

- `WorksheetAgentControllerTest`: `refreshDataThrowsRenderNotReadyWhenColumnSelectionIsSlow`,
  `refreshDataSucceedsWhenColumnSelectionIsFast`, and (fix-round 1)
  `editSqlQueryThrowsRenderNotReadyWhenColumnSelectionIsSlow`,
  `insertColumnThrowsRenderNotReadyWhenColumnSelectionIsSlow`,
  `reorderConcatSubtablesThrowsRenderNotReadyWhenColumnSelectionIsSlow`
- `WorksheetEditServiceTest`: `applySwallowsATimedOutTableInsteadOfPropagatingTheFailure`,
  `refreshAssembliesSharedBudgetSkipsTablesAfterTheFirstSlowOne` (explicitly exercises the
  starvation trade-off with 2 slow tables)
- `RenderWaitSupportTest` (new): basic behavior + the ThreadContext-propagation finding above

10 new/changed test methods total. All pass:
`./mvnw -pl core test -o -Dtest=WorksheetAgentControllerTest,WorksheetEditServiceTest,RenderWaitSupportTest,ScriptImageServiceTest,ViewsheetEditServiceTest,ViewsheetAssemblyAgentControllerTest,WizControllerErrorHandlerTest`
(219 tests, 0 failures — **correction**: an earlier version of this body said "464 tests"/"100
new test methods," both wrong; re-ran the command to get the real number). Also re-ran the full
`inetsoft.web.wiz.worksheet` package (362 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)