### PR TITLE
Fix Bug 76332 (PVA-007): add attach_base_worksheet for a baseless viewsheet

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -30,9 +30,11 @@ import org.springframework.web.server.ResponseStatusException;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.script.ScriptImageService;
 
 import java.security.Principal;
@@ -972,6 +974,104 @@ public class ViewsheetAssemblyAgentController {
       }
 
       broadcast.broadcastSave(rvs, rvs.getID(), user);
+   }
+
+   /**
+    * Request body for the attach-base-worksheet endpoint.
+    *
+    * @param path  path of an existing worksheet asset to attach as this viewsheet's base
+    *              (e.g. {@code "Sample Queries/customers"} or {@code "My Folder/agent_ws_1"}).
+    * @param scope optional scope to resolve {@code path} in — {@code "global"} (default) for the
+    *              shared repository, {@code "user"} for the caller's private folder.
+    */
+   public record AttachBaseWorksheetRequest(String path, String scope) {}
+
+   /**
+    * {@code attach_base_worksheet}. Attaches an existing, named worksheet asset as this paired
+    * viewsheet's base, for a viewsheet that currently has none — closing the gap
+    * {@code open_base_worksheet} deliberately leaves open (it can only ever follow an
+    * already-attached base, never name one). Refuses rather than silently repointing a viewsheet
+    * that already has a base; use the Composer UI's own Viewsheet Properties dialog to swap one.
+    *
+    * <p>This never persists the viewsheet — like every other mutation on this controller, it only
+    * updates the paired session's own in-memory {@link Viewsheet}. Call {@code save_viewsheet}
+    * separately once ready.</p>
+    *
+    * @param sessionToken the token obtained at join time
+    * @param body         the worksheet path to attach
+    * @param user         the authenticated agent principal
+    * @throws PairingException if the session is invalid/expired, the viewsheet already has a
+    *                          base, no {@code path} was supplied, or {@code path} does not name a
+    *                          worksheet the caller can read
+    */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/attach-base-worksheet")
+   public void attachBaseWorksheet(@PathVariable String sessionToken,
+                                   @RequestBody AttachBaseWorksheetRequest body,
+                                   Principal user) throws PairingException
+   {
+      requireEnabled();
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs.getBaseEntry() != null) {
+         throw new PairingException(
+            "This viewsheet already has a base worksheet (\"" + vs.getBaseEntry().toView() +
+            "\"). attach_base_worksheet only attaches a base when there is none — use " +
+            "open_base_worksheet to inspect the current one.");
+      }
+
+      String path = body != null && body.path() != null ? body.path().trim() : null;
+
+      if(path == null || path.isEmpty()) {
+         throw new PairingException("Provide a 'path' naming the worksheet asset to attach " +
+                                    "(e.g. \"Sample Queries/customers\").");
+      }
+
+      if(!(user instanceof XPrincipal xp)) {
+         throw new PairingException("Cannot attach base worksheet: agent principal is not an " +
+                                    "XPrincipal (" + user.getClass().getName() + ")");
+      }
+
+      IdentityID uname = IdentityID.getIdentityIDFromKey(user.getName());
+      int assetScope = body.scope() != null && "user".equalsIgnoreCase(body.scope())
+         ? AssetRepository.USER_SCOPE
+         : AssetRepository.GLOBAL_SCOPE;
+      IdentityID owner = assetScope == AssetRepository.USER_SCOPE ? uname : null;
+      AssetEntry entry = new AssetEntry(assetScope, AssetEntry.Type.WORKSHEET, path,
+                                        owner, uname.orgID);
+
+      AssetRepository rep = rvs.getAssetRepository();
+
+      // permission=true so this actually enforces read access, unlike the superficially similar
+      // getSheet(entry, null, false, ...) probe used elsewhere in this codebase for freshness
+      // checks (e.g. ComposerViewsheetService.checkWorksheetChanged) -- that call deliberately
+      // skips the permission check, which would be wrong here: this is a caller-supplied path
+      // naming an arbitrary asset, and only checking existence would let an agent confirm a
+      // worksheet's presence/absence without being able to read it.
+      Object resolved;
+
+      try {
+         resolved = rep.getSheet(entry, xp, true, AssetContent.ALL, false);
+      }
+      catch(Exception e) {
+         throw new PairingException(
+            "no worksheet named '" + path + "' was found, or you lack permission to read it", e);
+      }
+
+      if(resolved == null) {
+         throw new PairingException(
+            "no worksheet named '" + path + "' was found, or you lack permission to read it");
+      }
+
+      try {
+         vs.setBaseEntry(entry);
+         vs.reloadBaseWorksheet(rep, xp);
+      }
+      catch(Exception e) {
+         throw new PairingException("Failed to attach base worksheet: " + e.getMessage(), e);
+      }
+
+      broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, rvs.getID(), user);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/undo")

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -1068,6 +1068,14 @@ public class ViewsheetAssemblyAgentController {
          vs.reloadBaseWorksheet(rep, xp);
       }
       catch(Exception e) {
+         // reloadBaseWorksheet performs its own independent getSheet call and can fail even
+         // after the probe above succeeded (a permission change, storage error, or corrupt
+         // worksheet XML in the narrow window between the two fetches). Roll back setBaseEntry
+         // so a failed attach leaves the session exactly as it was before this call -- without
+         // this, wentry would stay set while the worksheet (ws) never got populated, reproducing
+         // this bug's own broken state, and the guard above would then refuse every retry with a
+         // misleading "already has a base worksheet" message.
+         vs.setBaseEntry(null);
          throw new PairingException("Failed to attach base worksheet: " + e.getMessage(), e);
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -18,8 +18,10 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
@@ -27,6 +29,7 @@ import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
@@ -804,6 +807,208 @@ class ViewsheetAssemblyAgentControllerTest {
 
       verify(viewsheetService).setViewsheet(any(), eq(savedEntry), any(), eq(true), eq(true));
       verify(rvs).setEntry(savedEntry);
+   }
+
+   // ---------------------------------------------------------------------------
+   // attachBaseWorksheet -- Bug 76332 / PVA-007: no mcp__composer-chat__* tool could attach an
+   // existing worksheet asset as a baseless viewsheet's base. Viewsheet tracks "what worksheet
+   // backs this sheet" in two fields (wentry via setBaseEntry, ws via reloadBaseWorksheet/update);
+   // list_bindable_fields's backing tree-builder (VSEventUtil.refreshBaseWSTree) reads the cached
+   // ws field, not wentry -- so a correct fix must populate both, in that order (reloadBaseWorksheet
+   // reads wentry as an instance field). See docs/teams/2026-08-30-bug-76332/ for the full
+   // deep-debug-workflow archive this fix comes from.
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void attachBaseWorksheetOnABaselessViewsheetSetsEntryThenReloads() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(any(), eq(agent), eq(true), eq(AssetContent.ALL), eq(false)))
+         .thenReturn(mock(inetsoft.uql.asset.Worksheet.class));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+      when(rvs.getID()).thenReturn("rt-vs-3");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(sessions, viewsheetService, broadcast);
+
+      controller.attachBaseWorksheet("tok",
+         new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+            "Sample Queries/customers", null),
+         agent);
+
+      ArgumentCaptor<AssetEntry> entryCaptor = ArgumentCaptor.forClass(AssetEntry.class);
+      // Order matters: reloadBaseWorksheet(...) reads the wentry field setBaseEntry(...) sets, on
+      // the same Viewsheet instance -- verified explicitly, not just that both were called.
+      InOrder order = inOrder(vs);
+      order.verify(vs).setBaseEntry(entryCaptor.capture());
+      order.verify(vs).reloadBaseWorksheet(eq(rep), eq(agent));
+
+      assertEquals(AssetRepository.GLOBAL_SCOPE, entryCaptor.getValue().getScope());
+      assertEquals(AssetEntry.Type.WORKSHEET, entryCaptor.getValue().getType());
+      assertEquals("Sample Queries/customers", entryCaptor.getValue().getPath());
+
+      // Never persisted -- attach only mutates the paired session's in-memory Viewsheet.
+      verifyNoInteractions(viewsheetService);
+      verify(broadcast).broadcastRefresh(eq(rvs), eq(SheetType.VIEWSHEET), eq("rt-vs-3"), eq(agent));
+   }
+
+   /** Permission is actually enforced (getSheet's permission arg is true), not skipped. */
+   @Test
+   void attachBaseWorksheetProbesWithPermissionCheckingEnabled() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(any(), any(), anyBoolean(), any(), anyBoolean()))
+         .thenReturn(mock(inetsoft.uql.asset.Worksheet.class));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      controller.attachBaseWorksheet("tok",
+         new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("Sample Queries/x", null),
+         agent);
+
+      // permission=true, distinct from the superficially similar existence-only probe used
+      // elsewhere in this codebase (e.g. ComposerViewsheetService.checkWorksheetChanged, which
+      // deliberately passes permission=false/user=null for a freshness check, not a security
+      // gate) -- this endpoint resolves a caller-supplied path naming an arbitrary asset, so
+      // skipping the permission check would let a caller confirm a worksheet's existence without
+      // being able to read it.
+      verify(rep).getSheet(any(), eq(agent), eq(true), eq(AssetContent.ALL), eq(false));
+   }
+
+   @Test
+   void attachBaseWorksheetRefusesWhenAlreadyBased() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry existing = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
+         AssetEntry.Type.WORKSHEET, "Existing WS", null);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(existing);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("Other WS", null),
+            agent));
+      assertTrue(ex.getMessage().contains("Existing WS"));
+
+      verifyNoInteractions(rep);
+      verify(vs, never()).setBaseEntry(any());
+   }
+
+   @Test
+   void attachBaseWorksheetRefusesOnANonexistentOrUnreadablePath() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(any(), any(), anyBoolean(), any(), anyBoolean())).thenReturn(null);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("No Such WS", null),
+            agent));
+
+      verify(vs, never()).setBaseEntry(any());
+   }
+
+   /** A denied permission check throws out of getSheet -- must surface the same clean refusal. */
+   @Test
+   void attachBaseWorksheetRefusesWhenPermissionCheckThrows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(any(), any(), anyBoolean(), any(), anyBoolean()))
+         .thenThrow(new SecurityException("no read permission"));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("Secret WS", null),
+            agent));
+
+      verify(vs, never()).setBaseEntry(any());
+   }
+
+   @Test
+   void attachBaseWorksheetRefusesWhenNoPathSupplied() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(null, null), agent));
+      assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("  ", null), agent));
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -898,6 +898,54 @@ class ViewsheetAssemblyAgentControllerTest {
       verify(rep).getSheet(any(), eq(agent), eq(true), eq(AssetContent.ALL), eq(false));
    }
 
+   /**
+    * reloadBaseWorksheet performs its own independent getSheet call and can fail even after the
+    * endpoint's earlier probe succeeded (permission change, storage error, corrupt worksheet XML
+    * in the narrow window between the two fetches). Without a rollback, a failure here would leave
+    * wentry set / ws null -- this bug's own exact broken state -- on a session the already-based
+    * guard would then refuse to ever retry. Regression for docs/teams/2026-08-30-bug-76332's
+    * 06-review-r1.md finding.
+    */
+   @Test
+   void attachBaseWorksheetRollsBackSetBaseEntryWhenReloadBaseWorksheetFails() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      doThrow(new java.io.IOException("worksheet XML corrupt"))
+         .when(vs).reloadBaseWorksheet(any(), any());
+
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(any(), eq(agent), eq(true), eq(AssetContent.ALL), eq(false)))
+         .thenReturn(mock(inetsoft.uql.asset.Worksheet.class));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+               "Sample Queries/customers", null),
+            agent));
+      assertTrue(ex.getMessage().contains("Failed to attach base worksheet"));
+
+      // setBaseEntry is called twice: once with the real entry (before reloadBaseWorksheet
+      // throws), once with null to roll back -- confirms the failure path doesn't leave the
+      // session in the wentry-set/ws-null state this bug is about.
+      ArgumentCaptor<AssetEntry> entryCaptor = ArgumentCaptor.forClass(AssetEntry.class);
+      verify(vs, times(2)).setBaseEntry(entryCaptor.capture());
+      assertEquals("Sample Queries/customers", entryCaptor.getAllValues().get(0).getPath());
+      assertNull(entryCaptor.getAllValues().get(1));
+   }
+
    @Test
    void attachBaseWorksheetRefusesWhenAlreadyBased() throws Exception {
       Principal agent = TestPrincipals.user("alice", "host-org");


### PR DESCRIPTION
No `mcp__composer-chat__*` tool could attach an existing worksheet asset as a baseless viewsheet's base, or create a viewsheet asset at all. This closes the **attach** half (the **create** half is a separate, longer-term project — a `create_viewsheet`-shaped tool, out of scope here).

New endpoint on `ViewsheetAssemblyAgentController`:
`POST /api/wiz/v1/agent/viewsheet/{sessionToken}/attach-base-worksheet`

## Root cause

Full archive: `docs/teams/2026-08-30-bug-76332/` (stylebi-wiz repo) — a `/deep-debug-workflow` run with two independent, adversarial investigators.

`Viewsheet` tracks its base worksheet in two fields — `wentry` (public `setBaseEntry`/`getBaseEntry`) and `ws` (private, populated only by `update()`/`reloadBaseWorksheet()`/`repopulateWorksheet()`, read by `getBaseWorksheet()`). `list_bindable_fields`'s backing tree-builder (`VSEventUtil.refreshBaseWSTree`) reads the cached `ws` field, not `wentry`, and no code path on this tool surface ever called `setBaseEntry` for a baseless viewsheet at all, let alone the `ws`-populating follow-up a correct attach also needs.

## Fix

Resolve the caller-supplied worksheet path to a permission/existence-checked `AssetEntry` (`AssetRepository.getSheet(entry, principal, true, AssetContent.ALL, false)` — `permission=true`, actually enforcing read access, unlike the superficially similar existence-only probe `ComposerViewsheetService.checkWorksheetChanged` uses for an unrelated freshness check), refuse loudly if the viewsheet already has a base (no silent overwrite/repoint), then `vs.setBaseEntry(entry)` followed by `vs.reloadBaseWorksheet(assetRepository, principal)` — in that order, since `reloadBaseWorksheet` reads `wentry` as an instance field.

Deliberately **not** `update()`: both are traced in full in the archive; `update()`'s extra `clearCache()`/embedded-viewsheet-refresh/`layout()` work is a confirmed no-op for a freshly-attached, assembly-free viewsheet, and its catch-and-return-`false` failure mode is a worse fit for an unattended agent caller than `reloadBaseWorksheet()`'s propagate-the-exception behavior.

Does not persist — like every other mutation on this controller, only the paired session's in-memory `Viewsheet` changes; `save_viewsheet` still owns persistence.

## Tests

7 new regression tests: attach on a baseless viewsheet sets entry then reloads (in that order, verified via `InOrder`); refuses when already based; refuses on a nonexistent/unreadable path; refuses when the permission check itself throws; refuses with no path; permission check is actually enabled (`permission=true`), not skipped.

Full `inetsoft.web.wiz.viewsheet` package (564 tests) and the broader `inetsoft.web.wiz` package (2708 tests) re-run clean.

## What this PR may and may not claim

The mechanism is structurally demonstrated and unit-tested against real (unmocked) `Viewsheet`/`VSEventUtil` code (`docs/teams/2026-08-30-bug-76332/03-repro.md`), but **no live composer-chat/StyleBI session was available this run** for full end-to-end confirmation, and `AssetRepository` permission-check parity for an agent-session `Principal` vs. a live Composer session's was not independently verified. **Not claimed fixed-and-live-confirmed** — claimed fixed-and-unit-tested, live confirmation outstanding.

Companion `stylebi-wiz` PR (plugin-side `attach_base_worksheet` tool): see the linked PR in that repo.

Fixes #76332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>