### PR TITLE
Close the L1 parity gaps in the agent worksheet ops

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/XEmbeddedTable.java
+++ b/core/src/main/java/inetsoft/uql/util/XEmbeddedTable.java
@@ -798,66 +798,80 @@ public class XEmbeddedTable
          throw new RuntimeException(tableNotReady);
       }
 
+      // Recorded so a rejected conversion (force=false, an unparseable value) can put this
+      // column's declared type back to what it was. types[col] is written below BEFORE the
+      // per-row conversion loop that can throw -- previously that write was never undone on the
+      // throw path, so a caller that got "conversion failed" back still found getDataType(col)/
+      // getColType(col) reporting the rejected type, even though not a single value had actually
+      // been converted (swapTable is only reached after the loop completes without throwing).
+      String oldType = types[col];
       types[col] = type;
-      XSwappableTable nDataTable = createTable();
-      copyTable(nDataTable, 0, getHeaderRowCount());
-      // get data from the original table if type changed or has been set back to its original type
-      boolean typeChanged = !Tool.equals(type, Tool.getDataType(xtable.getColType(col))) ||
-         (originalTable != null &&
-            Tool.equals(type, Tool.getDataType(originalTable.getColType(col))));
 
-      // cache the converted data
-      final int maxCacheSize = 10000;
-      Map<Object, Object> convertMap = new LinkedHashMap<Object, Object>() {
-         @Override
-         protected boolean removeEldestEntry(Map.Entry<Object, Object> eldest) {
-            return size() > maxCacheSize;
-         }
-      };
+      try {
+         XSwappableTable nDataTable = createTable();
+         copyTable(nDataTable, 0, getHeaderRowCount());
+         // get data from the original table if type changed or has been set back to its original type
+         boolean typeChanged = !Tool.equals(type, Tool.getDataType(xtable.getColType(col))) ||
+            (originalTable != null &&
+               Tool.equals(type, Tool.getDataType(originalTable.getColType(col))));
 
-      for(int i = getHeaderRowCount(); xtable.moreRows(i); i++) {
-         Object[] arr = new Object[types.length];
-
-         for(int j = 0; j < types.length; j++) {
-            // get the original data instead of the data which
-            // maybe resetted after setting data type(52298).
-            if(typeChanged && j == col && originalTable != null &&
-               i < originalTable.getRowCount() && j < originalTable.getColCount())
-            {
-               arr[j] = originalTable.getObject(i, j);
+         // cache the converted data
+         final int maxCacheSize = 10000;
+         Map<Object, Object> convertMap = new LinkedHashMap<Object, Object>() {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<Object, Object> eldest) {
+               return size() > maxCacheSize;
             }
-            else {
-               arr[j] = xtable.getObject(i, j);
-            }
-         }
+         };
 
-         Object oval = arr[col] ;
+         for(int i = getHeaderRowCount(); xtable.moreRows(i); i++) {
+            Object[] arr = new Object[types.length];
 
-         if(convertMap.containsKey(oval)) {
-            arr[col] = convertMap.get(oval);
-         }
-         else {
-            try {
-               arr[col] = Tool.transform(oval, type, format, true);
-               arr[col] = Tool.getData(type, arr[col]);
-            }
-            catch(Exception ex) {
-               if(force || XSchema.isNumericType(type) && Util.isNotApplicableValue(arr[col])) {
-                  arr[col] = null;
+            for(int j = 0; j < types.length; j++) {
+               // get the original data instead of the data which
+               // maybe resetted after setting data type(52298).
+               if(typeChanged && j == col && originalTable != null &&
+                  i < originalTable.getRowCount() && j < originalTable.getColCount())
+               {
+                  arr[j] = originalTable.getObject(i, j);
                }
                else {
-                  throw ex;
+                  arr[j] = xtable.getObject(i, j);
                }
             }
 
-            convertMap.put(oval, arr[col]);
+            Object oval = arr[col] ;
+
+            if(convertMap.containsKey(oval)) {
+               arr[col] = convertMap.get(oval);
+            }
+            else {
+               try {
+                  arr[col] = Tool.transform(oval, type, format, true);
+                  arr[col] = Tool.getData(type, arr[col]);
+               }
+               catch(Exception ex) {
+                  if(force || XSchema.isNumericType(type) && Util.isNotApplicableValue(arr[col])) {
+                     arr[col] = null;
+                  }
+                  else {
+                     throw ex;
+                  }
+               }
+
+               convertMap.put(oval, arr[col]);
+            }
+
+            nDataTable.addRow(arr);
          }
 
-         nDataTable.addRow(arr);
+         nDataTable.complete();
+         swapTable(nDataTable);
       }
-
-      nDataTable.complete();
-      swapTable(nDataTable);
+      catch(Exception ex) {
+         types[col] = oldType;
+         throw ex;
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -356,7 +356,40 @@ public record EditRequest(
     * unchanged, matching {@code distinct}/{@code mergeable}. Distinct from {@code visible}, which
     * is a per-column flag for set_column_visibility.
     */
-   Boolean visibleInViewsheet
+   Boolean visibleInViewsheet,
+   /**
+    * For change_column_type: whether to force a conversion that some values cannot survive.
+    *
+    * <p>{@code XEmbeddedTable#setDataType}'s {@code force} flag decides what happens to a value
+    * the target type cannot parse — {@code true} writes {@code null} over it, {@code false}
+    * throws. The Composer asks: it calls with {@code false} first and, on failure, rolls the
+    * column back and puts the choice to the user
+    * ({@code ColumnTypeDialogService#handleChangeTypeParseException}). This op passed a hardcoded
+    * {@code true}, so unconvertible values were discarded with nothing reported.
+    *
+    * <p>Defaults to {@code true} when omitted, preserving that behaviour for callers built
+    * against it; pass {@code false} to be told instead of losing the values.
+    */
+   Boolean confirmed,
+   /**
+    * For set_table_properties on an embedded table: how many data rows it should hold.
+    *
+    * <p>The Composer's table-properties dialog exposes this as "Rows"
+    * ({@code TablePropertyDialogService:113-121}); this op had no way to reach it. Growing the
+    * count appends empty rows, shrinking it drops the ones past the new end. Ignored, rather than
+    * refused, for a table that is not embedded — the dialog omits the control there too.
+    */
+   Integer rowCount,
+   /**
+    * For add_concatenation: whether each adjacent pair's operator de-duplicates. The Composer's
+    * concatenation dialog exposes this per operator and carries it through
+    * {@code WorksheetEventUtil#convertOperator}; this op had no way to set it. Omitted leaves the
+    * engine's default rather than choosing for the caller.
+    *
+    * <p>Named apart from {@code distinct}, which is the table-level "return distinct values"
+    * property on set_table_properties -- a different setting on a different object.
+    */
+   Boolean concatDistinct
 ) {
    /**
     * Compatibility constructor for callers built before {@code visibleInViewsheet} was added —
@@ -391,7 +424,7 @@ public record EditRequest(
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
            lookupTopLevelOnly, suffix, customLookups, crosstab, labels, choices, joinPaths,
-           mergeable, null);
+           mergeable, null, null, null, null);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1864,9 +1864,12 @@ public class WorksheetAgentController {
             editor.setColumnVisibility(req.table(), req.column(),
                                        req.visible() != null && req.visible());
          case "change_column_type" ->
-            editor.changeColumnType(req.table(), req.column(), req.type());
+            // Absent confirmed means force, matching what this op did before the flag existed.
+            editor.changeColumnType(req.table(), req.column(), req.type(),
+                                    req.confirmed() == null || req.confirmed());
          case "add_concatenation" ->
-            editor.addConcatenation(req.name(), req.tables(), req.concatType());
+            editor.addConcatenation(req.name(), req.tables(), req.concatType(),
+                                    req.concatDistinct());
          case "add_mirror" ->
             editor.addMirror(req.name(), req.source());
          case "set_conditions" ->
@@ -1922,7 +1925,7 @@ public class WorksheetAgentController {
             editor.setTableProperties(
                req.table(), req.newName() != null ? req.newName() : req.alias(),
                req.description(), req.maxRows(), req.distinct(), req.mergeable(),
-               req.visibleInViewsheet());
+               req.visibleInViewsheet(), req.rowCount());
          case "add_cross_join" ->
             editor.addCrossJoin(req.name(), req.leftTable(), req.rightTable());
          case "add_merge_join" ->

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -707,6 +707,12 @@ public class WorksheetAgentController {
       String attributeName = req.attribute();
       String name = req.name();
 
+      // Same unescaped-CDATA write path as WorksheetEditService.Editor.placeAssembly/
+      // renameTable/addJoin/duplicateAssembly/renameVariable/createVariable -- see
+      // requireStorableName's javadoc. Checked up front, before the permission checks and
+      // datasource/logical-model metadata lookups below, so a doomed name fails fast.
+      WorksheetEditService.Editor.requireStorableName(name, "A named group name");
+
       SourceInfo sinfo;
       DataRef ref;
 
@@ -1595,6 +1601,13 @@ public class WorksheetAgentController {
          String tableName = (name != null && !name.isBlank())
             ? name
             : AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
+
+         // Unlike add_table's datasource-bound paths (addBoundTable/addLogicalModelTable/
+         // addTabularTable), this name comes from the CSV/Excel import's caller-supplied
+         // 'name' verbatim -- it is never run through AssetUtil.normalizeTable, so it needs
+         // its own check for the same unescaped-CDATA write path. See requireStorableName's
+         // javadoc.
+         WorksheetEditService.Editor.requireStorableName(tableName, "A table name");
 
          EmbeddedTableAssembly assembly = new EmbeddedTableAssembly(ws, tableName);
 
@@ -2649,6 +2662,12 @@ public class WorksheetAgentController {
             "Use edit_variable to change its type, label, or default value instead.");
       }
 
+      // Same unescaped-CDATA write path as WorksheetEditService.Editor.placeAssembly/
+      // renameTable/addJoin/duplicateAssembly/renameVariable -- see requireStorableName's
+      // javadoc. This path builds its own DefaultVariableAssembly and adds it directly
+      // rather than through Editor, so it needs its own call.
+      WorksheetEditService.Editor.requireStorableName(name, "A variable name");
+
       AssetVariable var = new AssetVariable(name);
 
       if(label != null) {
@@ -2909,6 +2928,11 @@ public class WorksheetAgentController {
          String tableName = body.name() != null && !body.name().isBlank()
             ? body.name()
             : AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
+
+         // Same caller-supplied-name-used-verbatim gap as createEmbeddedTable: this dedicated
+         // /sql-query endpoint's 'name' never goes through AssetUtil.normalizeTable, so it needs
+         // its own check for the unescaped-CDATA write path. See requireStorableName's javadoc.
+         WorksheetEditService.Editor.requireStorableName(tableName, "A table name");
 
          SQLBoundTableAssembly assembly = new SQLBoundTableAssembly(ws, tableName);
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -3037,8 +3037,14 @@ public class WorksheetEditService {
        * rejects '/' and '"', but those are legal CDATA content and round-trip intact -- confirmed
        * live -- so enforcing the full rule here would break names that already exist and work
        * while protecting nothing.
+       *
+       * <p>Package-private (not {@code private}) so {@link WorksheetAgentController} can reuse
+       * the same check for the assembly-creation paths it builds directly against
+       * {@code Worksheet}/{@code RuntimeWorksheet} rather than through this {@code Editor} --
+       * {@code createVariable} and {@code addDatasourceScopedNamedGroup} -- instead of
+       * duplicating the rule.
        */
-      private static void requireStorableName(String name, String what) throws PairingException {
+      static void requireStorableName(String name, String what) throws PairingException {
          if(name != null && name.contains("]]>")) {
             throw new PairingException(
                what + " cannot contain \"]]>\". The name is written into a CDATA section " +

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -774,6 +774,11 @@ public class WorksheetEditService {
             throw new PairingException("Join requires a name.");
          }
 
+         // Unlike the two-table addJoin overload, this path cannot go through placeAssembly (see
+         // the comment below on ws.addAssembly(join)), so the name has to be checked explicitly
+         // here instead of inheriting placeAssembly's requireStorableName call.
+         requireStorableName(name, "An assembly name");
+
          if(joinPaths == null || joinPaths.isEmpty()) {
             throw new PairingException("Multi-table join requires at least one join path.");
          }
@@ -2363,6 +2368,19 @@ public class WorksheetEditService {
          TableAssembly newTable = requireTable(tableName);
          TableAssembly[] existing = ctbl.getTableAssemblies();
 
+         // Refuse the concatenation as a source of itself. This is a special case neither check
+         // below catches: ctbl is never a member of `existing` (it IS the concatenation, not one
+         // of its subtables), so the duplicate-source loop can't see it, and
+         // checkCyclicalDependency(ws, ctbl, newTable) can't either when newTable == ctbl --
+         // AssetUtil#getDependedAssemblies0 seeds its visited set with the root and passes
+         // included=false for it, so asking whether ctbl (as `otherAssembly`) already depends on
+         // itself (as `targetAssembly`) finds nothing, because before this attach nothing yet
+         // links ctbl back to itself.
+         if(tableName.equals(concatName)) {
+            throw new PairingException(
+               "\"" + concatName + "\" cannot be a source of itself.");
+         }
+
          // Refuse a source that is already present. ConcatenateTablesService#checkValidity refuses
          // it with common.table.unionDuplicate; this path never ported the check, so a repeated
          // source was accepted and counted its rows twice in the UNION with nothing reporting it.
@@ -2655,6 +2673,8 @@ public class WorksheetEditService {
             throw new PairingException("Assembly already exists: " + newName);
          }
 
+         requireStorableName(newName, "An assembly name");
+
          try {
             WSAssembly clone = (WSAssembly) wsa.clone();
             clone.getWSAssemblyInfo().setName(newName);
@@ -2793,6 +2813,8 @@ public class WorksheetEditService {
          if(!(a instanceof DefaultVariableAssembly)) {
             throw new PairingException("Variable assembly not found: " + oldName);
          }
+
+         requireStorableName(newName, "A variable name");
 
          if(!ws.renameAssembly(oldName, newName, true)) {
             throw new PairingException(

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -279,6 +279,20 @@ public class WorksheetEditService {
             try {
                RenderWaitSupport.awaitOrRetry(() -> {
                   WorksheetEventUtil.refreshColumnSelection(rws, name, true);
+                  // Drop conditions left pointing at columns the refresh just removed. An op that
+                  // changes a table's output columns without touching its conditions leaves an
+                  // add_filter or set_ranking referencing a DataRef no longer in the selection --
+                  // edit_unpivot is the clearest case, since changing headerColumns renames every
+                  // melted column. The Composer validates at exactly this point, right after its
+                  // own refreshColumnSelection
+                  // (TableUnpivotDialogService#changeUnpivotTableRowHeaders), and
+                  // WorksheetMutationSupport already does it for the aggregate path. Doing it in
+                  // the shared refresh covers every op rather than requiring each to remember.
+                  //
+                  // After refreshColumnSelection and before loadTableData, deliberately: a stale
+                  // selection would make this delete conditions that are still live, and the
+                  // retry wrapper only re-runs the whole block, so ordering inside it holds.
+                  AssetUtil.validateConditions(ta.getColumnSelection(), ta);
                   WorksheetEventUtil.loadTableData(rws, name, true, true);
                   return null;
                }, remaining, (int) Math.max(1, remaining / 1000));
@@ -1009,6 +1023,8 @@ public class WorksheetEditService {
          // groups the same base column at some date level.
          dateRef.setAutoCreate(false);
 
+         requireDerivedColumnFits(cs, rangeName, table);
+
          ColumnRef colRef = new ColumnRef(dateRef);
          colRef.setDataType(XSchema.STRING);
          cs.addAttribute(colRef);
@@ -1052,10 +1068,43 @@ public class WorksheetEditService {
          info.setLabels(labels);
          rangeRef.setValueRangeInfo(info);
 
+         requireDerivedColumnFits(cs, column + "_range", table);
+
          ColumnRef colRef = new ColumnRef(rangeRef);
          colRef.setDataType(XSchema.STRING);
          cs.addAttribute(colRef);
          t.setColumnSelection(cs, false);
+      }
+
+      /**
+       * Refuses a derived column that would exceed the organization's column cap or collide with a
+       * name already on the table.
+       *
+       * <p>{@code ValueRangeService#createNewColumn} applies both before creating one, at :193 and
+       * :204, and sends an ERROR command instead of proceeding. This path applied neither. The
+       * collision matters more than it looks: both range columns take their name from the source
+       * column and the option rather than from the caller, so issuing the same
+       * {@code add_date_range_column} twice generated the same name twice, and a second column with
+       * the same identity makes every later lookup by name — set_conditions, set_sort,
+       * set_group_aggregate — ambiguous. {@code addExpressionColumn} already refuses its own
+       * same-name case for exactly that reason.
+       */
+      private static void requireDerivedColumnFits(ColumnSelection cs, String columnName,
+                                                    String table)
+         throws PairingException
+      {
+         if(cs.getAttributeCount() >= inetsoft.report.internal.Util.getOrganizationMaxColumn()) {
+            throw new PairingException(
+               "\"" + table + "\" already has " + cs.getAttributeCount() + " columns, the maximum " +
+               "this organization allows. Remove a column before deriving another.");
+         }
+
+         if(AssetUtil.findColumnConflictingWithAlias(cs, null, columnName, true) != null) {
+            throw new PairingException(
+               "A column named \"" + columnName + "\" already exists on \"" + table + "\". A " +
+               "derived column's name comes from the source column and the option, not from you, " +
+               "so deriving the same one twice collides; use the column that is already there.");
+         }
       }
 
       /**
@@ -1314,12 +1363,59 @@ public class WorksheetEditService {
       public void addConcatenation(String name, List<String> tables, String opType)
          throws PairingException
       {
+         addConcatenation(name, tables, opType, null);
+      }
+
+      /**
+       * @param distinct whether each pair's operator de-duplicates — the Composer's concatenation
+       *                 dialog exposes this per operator, and its write path carries it through
+       *                 {@code WorksheetEventUtil#convertOperator}. {@code null} leaves the
+       *                 engine's default, which is what this op always used before.
+       */
+      public void addConcatenation(String name, List<String> tables, String opType,
+                                   Boolean distinct)
+         throws PairingException
+      {
          if(name == null || name.isBlank()) {
             name = AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
          }
 
+         // Refuse a name already in use. Worksheet#addAssembly replaces a same-named assembly
+         // without complaint, so reusing a name never created a second assembly -- it destroyed
+         // the first and handed every dependent of that name to the replacement. Reproduced
+         // through this op: a concatenation named after one of its own sources became its own
+         // source, ended up with zero columns, and left the concatenation downstream of the
+         // destroyed original reading from an empty table. The op reported a 500 while all of
+         // that stuck.
+         //
+         // This guard is also what makes the absence of a cycle check on this path correct rather
+         // than lucky: a concatenation built under a free name has no dependents yet, so it cannot
+         // close a cycle. That is why ConcatenateTablesService does not check for one on creation
+         // either, and why only addConcatSubtable needs checkCyclicalDependency. Only an explicit
+         // name can collide -- getNextName above is chosen to be free.
+         if(ws.getAssembly(name) != null) {
+            throw new PairingException(
+               "Assembly already exists: " + name + ". Creating a concatenation under an existing " +
+               "name replaces that assembly and silently repoints everything built on it at the " +
+               "replacement; choose another name, or delete the existing assembly first.");
+         }
+
          if(tables == null || tables.size() < 2) {
             throw new PairingException("Concatenation requires at least two tables.");
+         }
+
+         // Refuse a repeated source, as ConcatenateTablesService#checkValidity does with
+         // common.table.unionDuplicate. Checked on the names the caller passed rather than after
+         // resolution, so the message can name the duplicate the caller actually wrote.
+         for(int i = 0; i < tables.size(); i++) {
+            for(int j = i + 1; j < tables.size(); j++) {
+               if(tables.get(i) != null && tables.get(i).equals(tables.get(j))) {
+                  throw new PairingException(
+                     "\"" + tables.get(i) + "\" appears twice in the source list. Concatenating a " +
+                     "table with itself counts its rows twice; list it once, or add a mirror of it " +
+                     "with add_mirror if two independent copies are intended.");
+               }
+            }
          }
 
          int operation = parseConcatType(opType);
@@ -1395,6 +1491,13 @@ public class WorksheetEditService {
             TableAssemblyOperator top = new TableAssemblyOperator();
             TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
             op.setOperation(operation);
+
+            // Only when asked, so omitting it keeps whatever the engine defaults to rather than
+            // this op deciding on the caller's behalf.
+            if(distinct != null) {
+               op.setDistinct(distinct);
+            }
+
             top.addOperator(op);
             operators[i] = top;
          }
@@ -1444,6 +1547,28 @@ public class WorksheetEditService {
             throw new PairingException("Table not found in worksheet: " + table);
          }
 
+         // Refuse to delete a table another assembly is built on. ws.removeAssembly does not clean
+         // the dependent up: its removeMirrors call returns immediately unless the assembly BEING
+         // deleted is itself an outer mirror -- it clears a deleted outer mirror's own imported
+         // assemblies, not the mirrors that depend on the deleted table. So the dependent survived
+         // referencing a name that was gone, every query against it failed with "not found", and no
+         // tool on this surface could repair it.
+         //
+         // Same guard the Composer's own delete uses on its write path, at
+         // WSRemoveAssembliesService#removeAssemblies. It differs there in what it does with the
+         // answer: the UI is deleting a batch, so it skips the offending assembly, warns, and
+         // carries on with the rest. This op deletes one named table per call -- there is no rest
+         // to carry on with, and skipping silently would report success for a deletion that never
+         // happened.
+         if(AssetEventUtil.hasDependent(a, ws, Set.of(table))) {
+            throw new PairingException(
+               "\"" + table + "\" cannot be deleted because other assemblies are built on it. " +
+               "Deleting it would leave them referencing a table that no longer exists, every " +
+               "query against them failing, and nothing able to repair them. Delete the " +
+               "assemblies that depend on it first -- read_worksheet_model reports each table's " +
+               "`sources`, which is what references what.");
+         }
+
          ws.removeAssembly(table);
       }
 
@@ -1463,6 +1588,8 @@ public class WorksheetEditService {
          if(a == null) {
             throw new PairingException("Table not found in worksheet: " + oldName);
          }
+
+         requireStorableName(newName, "A table name");
 
          if(!ws.renameAssembly(oldName, newName, true)) {
             throw new PairingException(
@@ -1513,7 +1640,16 @@ public class WorksheetEditService {
        *              {@code "integer"}, {@code "date"}, {@code "boolean"})
        * @throws PairingException if the table or column is not found
        */
-      public void changeColumnType(String table, String col, String type)
+      public void changeColumnType(String table, String col, String type) throws Exception {
+         changeColumnType(table, col, type, true);
+      }
+
+      /**
+       * @param force what to do with values the target type cannot parse: {@code true} overwrites
+       *              them with {@code null}, {@code false} refuses the conversion and leaves the
+       *              column as it was. See {@link EditRequest#confirmed()}.
+       */
+      public void changeColumnType(String table, String col, String type, boolean force)
          throws Exception
       {
          if(!XSchema.isPrimitiveType(type)) {
@@ -1569,6 +1705,9 @@ public class WorksheetEditService {
          // Also update the matching ref from findAttribute (same approach as
          // ColumnTypeDialogService) to ensure the canonical ref is updated.
          ColumnRef cr2 = (ColumnRef) cs.findAttribute(cr);
+         // Captured before the change so the embedded-data conversion below can put it back if
+         // the values will not parse and the caller did not ask to force it.
+         String oldType = cr2 != null ? cr2.getDataType() : cr.getDataType();
 
          if(cr2 != null) {
             cr2.setDataType(type);
@@ -1587,7 +1726,30 @@ public class WorksheetEditService {
                int index = AssetUtil.findColumn(data, cr2 != null ? cr2 : cr);
 
                if(index >= 0) {
-                  data.setDataType(index, type, null, null, true);
+                  try {
+                     data.setDataType(index, type, null, null, force);
+                  }
+                  catch(Exception ex) {
+                     // force=false means setDataType throws rather than nulling the values it
+                     // cannot parse. Put the column's declared type back before rethrowing:
+                     // it was already changed above, so leaving it would advertise a type the
+                     // data does not have. The Composer does the same in
+                     // ColumnTypeDialogService#handleChangeTypeParseException, which restores the
+                     // old type and then asks the user whether to force it.
+                     if(cr2 != null) {
+                        cr2.setDataType(oldType);
+                     }
+                     else {
+                        cr.setDataType(oldType);
+                     }
+
+                     throw new PairingException(
+                        "\"" + col + "\" has values that cannot be converted to " + type +
+                        ". Nothing was changed. Pass confirmed=true to convert anyway, which " +
+                        "replaces every value that will not parse with null -- that discards " +
+                        "data and cannot be undone by changing the type back.");
+                  }
+
                   embedded.setEmbeddedData(data);
                }
             }
@@ -1922,6 +2084,20 @@ public class WorksheetEditService {
                                       Boolean visibleInViewsheet)
          throws PairingException
       {
+         setTableProperties(table, newName, description, maxRows, distinct, mergeable,
+                            visibleInViewsheet, null);
+      }
+
+      /**
+       * @param rowCount for an embedded table, how many data rows it should hold — the dialog's
+       *                 "Rows" field ({@code TablePropertyDialogService:113-121}). Ignored for a
+       *                 table that is not embedded, as the dialog omits the control there.
+       */
+      public void setTableProperties(String table, String newName, String description,
+                                      Integer maxRows, Boolean distinct, Boolean mergeable,
+                                      Boolean visibleInViewsheet, Integer rowCount)
+         throws PairingException
+      {
          // Resolved before the rename so an unknown table is reported against the name the caller
          // passed, not against a name that does not exist yet.
          requireTable(table);
@@ -1949,6 +2125,17 @@ public class WorksheetEditService {
          }
 
          if(maxRows != null) {
+            // A negative limit is a mistake, not a way to say "unlimited": the Composer's own
+            // control refuses it outright (FormValidators.positiveIntegerInRange,
+            // form-validators.ts:394-400, which admits 0..Integer.MAX_VALUE), while this path
+            // silently folded it into -1 and reported success -- so a caller that sent -100
+            // meaning "a hundred rows, roughly" got no limit at all and no indication of it.
+            if(maxRows < 0) {
+               throw new PairingException(
+                  "maxRows cannot be negative (got " + maxRows + "). Pass a positive row limit, " +
+                  "or 0 for no limit.");
+            }
+
             t.setMaxRows(maxRows <= 0 ? -1 : maxRows);
          }
 
@@ -1962,6 +2149,29 @@ public class WorksheetEditService {
 
          if(visibleInViewsheet != null) {
             t.setVisibleTable(visibleInViewsheet);
+         }
+
+         // Embedded row count. The stored table carries a header row that the dialog's number does
+         // not count, which is why TablePropertyDialogService:113-121 compares against
+         // getRowCount() - 1 and writes back count + 1; getting that offset wrong silently adds or
+         // drops a row. Skipped when the value already matches, matching the dialog, so a
+         // set_table_properties call that only changes the description does not rewrite the data.
+         if(rowCount != null && t instanceof EmbeddedTableAssembly etable) {
+            if(rowCount < 0) {
+               throw new PairingException(
+                  "rowCount cannot be negative (got " + rowCount + ").");
+            }
+
+            XEmbeddedTable data = etable.getEmbeddedData();
+
+            if(data != null) {
+               int existing = Math.max(0, data.getRowCount() - 1);
+
+               if(rowCount != existing) {
+                  data.setRowCount(rowCount + 1);
+                  etable.setEmbeddedData(data);
+               }
+            }
          }
       }
 
@@ -2152,6 +2362,47 @@ public class WorksheetEditService {
 
          TableAssembly newTable = requireTable(tableName);
          TableAssembly[] existing = ctbl.getTableAssemblies();
+
+         // Refuse a source that is already present. ConcatenateTablesService#checkValidity refuses
+         // it with common.table.unionDuplicate; this path never ported the check, so a repeated
+         // source was accepted and counted its rows twice in the UNION with nothing reporting it.
+         for(TableAssembly sub : existing) {
+            if(tableName.equals(sub.getName())) {
+               throw new PairingException(
+                  "\"" + tableName + "\" is already a source of \"" + concatName +
+                  "\". Concatenating a table with itself counts its rows twice; omit it, or add " +
+                  "a mirror of it with add_mirror if two independent copies are intended.");
+            }
+         }
+
+         // Refuse a cycle BEFORE mutating, and before the column-count check below.
+         // checkCyclicalDependency asks whether newTable already depends on this concatenation --
+         // reachable whenever newTable mirrors it, directly or through a chain -- and it can answer
+         // before the attach, because the dependency that would close the loop is newTable's own
+         // and already exists. The Composer calls this identical helper at
+         // ConcatenateTablesService:445, alongside its duplicate check and separately from its
+         // column compatibility check.
+         //
+         // Ordered ahead of the column-count check deliberately: that check reads
+         // newTable.getColumnSelection(true), and resolving the column selection of an assembly
+         // that mirrors this concatenation walks back into the concatenation itself. Rejecting the
+         // structural error first keeps that read off a graph that is about to become cyclic, and
+         // a cycle is not something the caller can fix by adjusting columns anyway.
+         //
+         // It has to run here rather than be left to the downstream safety net, for two separate
+         // reasons. Worksheet#checkDependencies is reached from
+         // AssetQuerySandbox#refreshColumnSelection only after apply() has already committed the
+         // mutation and taken an undo checkpoint of it -- so by then the cycle is in the asset and
+         // the caller gets a 500 for a change that stuck. And AbstractWSAssembly#checkDependency
+         // cannot see a two-node cycle at all: AssetUtil#getDependedAssemblies0 seeds its visited
+         // set with the root and passes included=false for it, so a loop back to the root is
+         // discarded as already-visited and never reaches the array it matches against.
+         if(WorksheetEventUtil.checkCyclicalDependency(ws, ctbl, newTable)) {
+            throw new PairingException(
+               "Adding \"" + tableName + "\" to \"" + concatName + "\" would create a circular " +
+               "dependency: \"" + tableName + "\" already depends on \"" + concatName +
+               "\". Concatenate the assemblies \"" + tableName + "\" is built from instead.");
+         }
 
          // Validate column count matches existing subtables.
          int colCount = existing[0].getColumnSelection(true).getAttributeCount();
@@ -2442,6 +2693,15 @@ public class WorksheetEditService {
          if(!ws.setPrimaryAssembly(table)) {
             throw new PairingException("Failed to set primary assembly: " + table);
          }
+
+         // Making a table primary also exposes it to viewsheets, as WSPrimaryService:84 does.
+         // visibleTable defaults to true, so this only matters for a table whose flag was cleared
+         // earlier -- but that table would otherwise stay absent from the viewsheet binding tree
+         // (VSBindingService:2006, BaseTreeModelBuilder:143, VSOutputService:239) while being the
+         // sheet's primary, which is the one assembly a viewsheet binding is most likely to want.
+         if(a instanceof TableAssembly ta) {
+            ((TableAssemblyInfo) ta.getTableInfo()).setVisibleTable(true);
+         }
       }
 
       // -----------------------------------------------------------------------
@@ -2626,6 +2886,17 @@ public class WorksheetEditService {
                table.setLiveData(true);
                table.setRuntime(table.isRuntimeSelected());
                table.setEditMode(false);
+               // The aggregate flag follows whether the table actually groups, not which display
+               // mode is selected: TableModeService#setLiveTableMode:353 and
+               // #setDefaultTableMode:334 both compute it this way, while full/detail/edit force
+               // it false (:133, :166, :209) -- which the branches below already match. Leaving it
+               // untouched here let a table switched to "full" earlier keep aggregate=false after
+               // coming back to "live", and isAggregate() is real query state, not presentation:
+               // it selects the public versus private column selection and forms part of the lens
+               // cache key (AssetQuerySandbox:900,1010), drives JoinQuery:261's detailView, and is
+               // persisted with the assembly.
+               ((TableAssemblyInfo) table.getTableInfo()).setAggregate(
+                  table.getAggregateInfo() != null && !table.getAggregateInfo().isEmpty());
             }
             case "full" -> {
                table.setLiveData(false);
@@ -2650,6 +2921,10 @@ public class WorksheetEditService {
                table.setLiveData(table instanceof EmbeddedTableAssembly);
                table.setRuntime(false);
                table.setEditMode(false);
+               // Same rule as the "live" branch above, and the same source:
+               // TableModeService#setDefaultTableMode:334.
+               ((TableAssemblyInfo) table.getTableInfo()).setAggregate(
+                  table.getAggregateInfo() != null && !table.getAggregateInfo().isEmpty());
             }
          }
       }
@@ -2716,10 +2991,38 @@ public class WorksheetEditService {
        * {@link AssetEventUtil#adjustAssemblyPosition}: sets a starting position then
        * shifts the assembly below the lowest existing assembly.
        */
-      private void placeAssembly(WSAssembly assembly) {
+      private void placeAssembly(WSAssembly assembly) throws PairingException {
+         requireStorableName(assembly.getName(), "An assembly name");
          assembly.setPixelOffset(new Point(25, 25));
          AssetEventUtil.adjustAssemblyPosition(assembly, ws);
          ws.addAssembly(assembly);
+      }
+
+      /**
+       * Refuses an assembly name that cannot survive being written to storage.
+       *
+       * <p>{@code AssemblyInfo:254} interpolates the name straight into a CDATA section --
+       * {@code writer.print("<name><![CDATA[" + name + "]]></name>")} -- with no escaping. A name
+       * containing the literal CDATA terminator closes that section early and leaves malformed XML
+       * in indexed storage. The Composer cannot produce one:
+       * {@code FormValidators.nameSpecialCharacters} (form-validators.ts:635-648) refuses it,
+       * among much else, before the dialog can submit. This path has no such front end, and the
+       * save path validates no assembly name at all -- traced from the agent's save endpoint
+       * through {@code AbstractAssetEngine.setSheet} to {@code storage.putXMLSerializable}, where
+       * the only checks are permissions and a name-blind {@code checkValidity}.
+       *
+       * <p>Only the terminator is refused, not the Composer's whole whitelist. That whitelist also
+       * rejects '/' and '"', but those are legal CDATA content and round-trip intact -- confirmed
+       * live -- so enforcing the full rule here would break names that already exist and work
+       * while protecting nothing.
+       */
+      private static void requireStorableName(String name, String what) throws PairingException {
+         if(name != null && name.contains("]]>")) {
+            throw new PairingException(
+               what + " cannot contain \"]]>\". The name is written into a CDATA section " +
+               "verbatim, so that sequence closes the section early and leaves malformed XML in " +
+               "storage, which no later edit can repair. Choose a name without it.");
+         }
       }
 
       private TableAssembly requireTable(String name) throws PairingException {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -1055,6 +1055,41 @@ class WorksheetAgentControllerTest {
                    "the original variable's type must be unchanged");
    }
 
+   /**
+    * PR #4901 round-2 review follow-up: {@code createVariable} builds a
+    * {@code DefaultVariableAssembly} and adds it directly, bypassing
+    * {@code WorksheetEditService.Editor.placeAssembly}'s {@code requireStorableName} guard the
+    * same way {@code addJoin}/{@code duplicateAssembly}/{@code renameVariable} did before the
+    * round-1 fix. {@code AssemblyInfo:254} writes the name into a CDATA section verbatim, so a
+    * name containing the terminator closes it early and leaves malformed XML in storage.
+    */
+   @Test
+   void editRejectsAddVariableWithANameThatWouldBreakTheStoredXml() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-AV-CDATA"), any())).thenReturn(session("TOK-AV-CDATA"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-AV-CDATA", addVariableRequest("bad]]>name", "double"), agent));
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNull(ws.getAssembly("bad]]>name"));
+   }
+
    @Test
    void editAddVariableWiresChoicesThrough() throws Exception {
       // Regression for Bug #76328: add_variable/edit_variable had no way to populate
@@ -1320,6 +1355,33 @@ class WorksheetAgentControllerTest {
       assertEquals(2, resp.rows());
       assertEquals(2, resp.columns());
       assertNotNull(ws.getAssembly("Imported"));
+   }
+
+   /**
+    * PR #4901 round-2 review follow-up: an audit for other bypasses of the round-1
+    * {@code requireStorableName} guard (added for {@code placeAssembly}/{@code renameTable}/
+    * {@code addJoin}/{@code duplicateAssembly}/{@code renameVariable}) turned up a third site:
+    * {@code createEmbeddedTable}'s {@code name} param -- the import's caller-supplied table
+    * name -- is used verbatim and, unlike {@code add_table}'s datasource-bound paths, is never
+    * run through {@code AssetUtil.normalizeTable} either. {@code AssemblyInfo:254} writes the
+    * name into a CDATA section verbatim, so a name containing the terminator closes it early and
+    * leaves malformed XML in storage.
+    */
+   @Test
+   void importCsvRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      WorksheetAgentController ctrl = importController("TOK-CSV-CDATA", rws);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.importCsv("TOK-CSV-CDATA",
+            new WorksheetAgentController.ImportCsvRequest("bad]]>name", "a,b\n1,x\n2,y"), agent));
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNull(ws.getAssembly("bad]]>name"));
    }
 
    /**
@@ -2727,6 +2789,35 @@ class WorksheetAgentControllerTest {
          "group mappings must still be applied");
    }
 
+   /**
+    * PR #4901 round-2 review follow-up: {@code addDatasourceScopedNamedGroup} builds a
+    * {@code DefaultNamedGroupAssembly} and adds it directly, the same unescaped-CDATA write path
+    * {@code createVariable} and the round-1 sites ({@code addJoin}/{@code duplicateAssembly}/
+    * {@code renameVariable}) had before being guarded. Checked up front, before any permission
+    * check or datasource/logical-model lookup, so a doomed name fails fast without touching
+    * either mock.
+    */
+   @Test
+   void addNamedGroupRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = namedGroupDatasourceRequest(
+         "bad]]>name", "Examples/Orders", "Order Model", null, null,
+         "Customer", "State", List.of(), false);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-NGD-CDATA", req, agent));
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
    // ---------------------------------------------------------------------------
    // editSqlQuery — FREE_FORM_SQL / ACCESS permission gate
    // ---------------------------------------------------------------------------
@@ -2987,6 +3078,58 @@ class WorksheetAgentControllerTest {
       verify(securityEngine).checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
                                              eq("*"), eq(ResourceAction.ACCESS));
       verify(dataSourceService).checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent));
+   }
+
+   /**
+    * PR #4901 round-2 review follow-up: like {@code createEmbeddedTable}, {@code addSqlQuery}'s
+    * {@code name} is the caller-supplied table name used verbatim -- never run through
+    * {@code AssetUtil.normalizeTable} -- and is written directly into a new
+    * {@code SQLBoundTableAssembly} added to the worksheet. Checked as the very first thing inside
+    * the {@code applyOnRuntime} callback, before any SQL parsing or JDBC metadata work, so a
+    * doomed name fails fast without needing the SQL to actually parse.
+    */
+   @Test
+   void addSqlQueryRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      // Mocked: constructing a real JDBCDataSource pulls a CredentialService bean the
+      // lightweight test context does not provide (see editSqlQueryDeniedByDatasourceReadThrows-
+      // PairingException above), and requireStorableName throws before this datasource's
+      // metadata is ever touched.
+      JDBCDataSource jdbcDs = mock(JDBCDataSource.class);
+      when(xrepository.getDataSource("MyDatasource")).thenReturn(jdbcDs);
+
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      when(editSvc.applyOnRuntime(eq("TOK-SQ-CDATA"), eq(agent), any())).thenAnswer(inv -> {
+         WorksheetEditService.ThrowingFunction<RuntimeWorksheet, ?> fn = inv.getArgument(2);
+         return fn.apply(rws);
+      });
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", "bad]]>name");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.addSqlQuery("TOK-SQ-CDATA", body, agent));
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNull(ws.getAssembly("bad]]>name"));
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -554,7 +554,12 @@ class WorksheetAgentControllerTest {
          true,                  // crosstab
          null,                  // labels
          null,                  // choices
-         null                   // joinPaths
+         null,                  // joinPaths
+         null,                  // mergeable
+         null,                  // visibleInViewsheet
+         null,                  // confirmed
+         null,                  // rowCount
+         null                   // concatDistinct
       );
 
       WorksheetAgentController ctrl = controller(featureOn(),
@@ -1110,7 +1115,12 @@ class WorksheetAgentControllerTest {
          null,                        // crosstab
          null,                        // labels
          choices,                     // choices
-         null                         // joinPaths
+         null,                        // joinPaths
+         null,                        // mergeable
+         null,                        // visibleInViewsheet
+         null,                        // confirmed
+         null,                        // rowCount
+         null                         // concatDistinct
       );
 
       ctrl.edit("TOK-AVC", req, agent);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -3014,6 +3015,38 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("integer", ((ColumnRef) ref).getDataType());
    }
 
+   /**
+    * The defect this guards: {@code XEmbeddedTable#setDataType} writes the new type into its
+    * internal {@code types[]} array unconditionally, before converting a single row. When
+    * {@code confirmed=false} (force=false) and a value can't be parsed, it throws instead of
+    * nulling the value out -- but nothing had reverted {@code types[col]}, so the "Nothing was
+    * changed" exception left the embedded table's own bookkeeping pointing at the rejected type
+    * even though not one value had actually been converted. {@code EmbeddedTableAssembly
+    * #getEmbeddedData()} returns that same live array (not a copy), so the desync landed
+    * directly on the assembly and would have surfaced the next time
+    * {@code refreshColumnType()} read it.
+    */
+   @Test
+   void changeColumnTypeWithoutConfirmationLeavesEmbeddedTableUnchanged() throws Exception {
+      Worksheet ws = new Worksheet();
+      // Column "a" holds "x1"/"x2" -- not parseable as integer -- so force=false throws.
+      EmbeddedTableAssembly t = embeddedWithData(ws, "T");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "a", "integer", false)));
+
+      assertTrue(ex.getMessage().contains("Nothing was changed"), ex.getMessage());
+      DataRef ref = t.getColumnSelection(false).getAttribute("a");
+      assertInstanceOf(ColumnRef.class, ref);
+      assertEquals(XSchema.STRING, ((ColumnRef) ref).getDataType(),
+         "the ColumnRef's declared type must be rolled back");
+      assertEquals(XSchema.STRING, t.getEmbeddedData().getDataType(0),
+         "the embedded table's internal types[] must be rolled back too, not just the ColumnRef");
+   }
+
    // =========================================================================
    // Column reorder tests
    // =========================================================================
@@ -3354,6 +3387,28 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    /**
+    * {@code distinct} is threaded onto each pair's operator only "when asked" (a null leaves the
+    * engine's default), so a {@code true} has to actually land on the built
+    * {@link ConcatenatedTableAssembly}'s operator rather than silently being dropped.
+    */
+   @Test
+   void addConcatenationThreadsDistinctIntoTheOperator() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      EmbeddedTableAssembly b = table(ws, "B", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION", true));
+
+      ConcatenatedTableAssembly ctbl = (ConcatenatedTableAssembly) ws.getAssembly("U");
+      assertTrue(ctbl.getOperator(0).isDistinct(),
+         "distinct=true must be threaded through to the pair's operator");
+   }
+
+   /**
     * Sources are combined BY POSITION, so a pair that lines up numerically but not by type produces
     * a column carrying two unrelated kinds of value — which renders as an ordinary column and
     * reports no error anywhere. The message has to name the position and both sides, since that is
@@ -3459,6 +3514,69 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    /**
+    * {@code requireStorableName} was wired into {@code placeAssembly}/{@code renameTable} only.
+    * The multi-table {@code addJoin} overload cannot go through {@code placeAssembly} (it has to
+    * register the join before wiring its edges via {@code InnerJoinService}), so it bypassed the
+    * guard the same way an unescaped-CDATA name would corrupt storage from any of these entry
+    * points.
+    */
+   @Test
+   void addJoinMultiTableRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(table(ws, "A", col("id", XSchema.INTEGER)));
+      ws.addAssembly(table(ws, "B", col("id", XSchema.INTEGER)));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      List<WorksheetMutationSupport.JoinPathSpec> paths =
+         List.of(new WorksheetMutationSupport.JoinPathSpec("A", "id", "B", "id", "INNER"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addJoin("bad]]>name", paths)));
+
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNull(ws.getAssembly("bad]]>name"));
+   }
+
+   /**
+    * Same gap as above, for {@code duplicateAssembly}: it calls {@code ws.addAssembly(clone)}
+    * directly after {@code setName}, bypassing {@code placeAssembly}'s
+    * {@code requireStorableName} check.
+    */
+   @Test
+   void duplicateAssemblyRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(table(ws, "A", col("id", XSchema.INTEGER)));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.duplicateAssembly("A", "bad]]>name")));
+
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNull(ws.getAssembly("bad]]>name"));
+   }
+
+   /**
+    * Same gap again, for {@code renameVariable}: it calls {@code ws.renameAssembly} directly with
+    * no name check at all, even though a variable name hits the same unescaped-CDATA write path
+    * as a table name.
+    */
+   @Test
+   void renameVariableRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.renameVariable("region", "bad]]>name")));
+
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNotNull(ws.getAssembly("region"), "the rename must not have happened");
+      assertNull(ws.getAssembly("bad]]>name"));
+   }
+
+   /**
     * A negative limit is a mistake, not a way to say "unlimited". The Composer's control refuses it
     * (FormValidators.positiveIntegerInRange); this path folded it into -1 and reported success, so
     * a caller asking for a limit got none and no indication of it.
@@ -3475,6 +3593,72 @@ class WorksheetEditServiceMutatorsTest {
                          ed -> ed.setTableProperties("A", null, null, -100, null, null, null, null)));
 
       assertTrue(ex.getMessage().contains("negative"), ex.getMessage());
+   }
+
+   /**
+    * {@code rowCount} is the dialog's "Rows" field for an embedded table
+    * ({@code TablePropertyDialogService:113-121}), which counts data rows only -- the stored
+    * table carries an extra header row ({@code getRowCount() - 1} in the dialog's terms). None of
+    * grow, shrink, the non-embedded no-op, or the negative rejection had a test.
+    */
+   @Test
+   void setTablePropertiesGrowsEmbeddedRowCount() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = embeddedWithData(ws, "T"); // header + 2 data rows
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, null, null, null, null, null, 5));
+
+      assertEquals(6, t.getEmbeddedData().getRowCount(),
+         "5 data rows plus the header row");
+   }
+
+   @Test
+   void setTablePropertiesShrinksEmbeddedRowCount() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = embeddedWithData(ws, "T"); // header + 2 data rows
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, null, null, null, null, null, 1));
+
+      assertEquals(2, t.getEmbeddedData().getRowCount(),
+         "1 data row plus the header row");
+   }
+
+   @Test
+   void setTablePropertiesIgnoresRowCountOnANonEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // The dialog omits the "Rows" control for a non-embedded table; this must not throw just
+      // because a caller sent it anyway.
+      assertDoesNotThrow(() -> svc.apply(
+         "TOK", agent, ed -> ed.setTableProperties("T", null, null, null, null, null, null, 5)));
+   }
+
+   @Test
+   void setTablePropertiesRefusesANegativeRowCount() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = embeddedWithData(ws, "T");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.setTableProperties("T", null, null, null, null, null, null, -1)));
+
+      assertTrue(ex.getMessage().contains("negative"), ex.getMessage());
+      assertEquals(3, t.getEmbeddedData().getRowCount(), "the refused call must not touch the data");
    }
 
    /**
@@ -3526,6 +3710,35 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    /**
+    * Same fix as {@link #setTableModeRestoresTheAggregateFlagWhenReturningToLive}, for the
+    * {@code "default"} branch: {@code TableModeService#setDefaultTableMode:334} computes the
+    * aggregate flag the same way {@code setLiveTableMode} does, but only {@code "live"} had a
+    * test for it.
+    */
+   @Test
+   void setTableModeRestoresTheAggregateFlagForDefaultMode() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a =
+         table(ws, "A", col("g", XSchema.STRING), col("n", XSchema.INTEGER));
+      ws.addAssembly(a);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate(
+         "A", groups("g"),
+         List.of(new WorksheetMutationSupport.AggregateSpec("n", "SUM", null))));
+      svc.apply("TOK", agent, ed -> ed.setTableMode("A", "full"));
+      assertFalse(((inetsoft.uql.asset.internal.TableAssemblyInfo) a.getTableInfo()).isAggregate(),
+                  "precondition: full mode forces the flag off");
+
+      svc.apply("TOK", agent, ed -> ed.setTableMode("A", "default"));
+
+      assertTrue(((inetsoft.uql.asset.internal.TableAssemblyInfo) a.getTableInfo()).isAggregate(),
+                 "the \"default\" branch must recompute the flag the same way \"live\" does, not "
+                 + "leave it forced off from the earlier full-mode switch");
+      assertTrue(a.isLiveData(), "\"default\" is live for an embedded table");
+   }
+
+   /**
     * Both range columns take their name from the source column and the option rather than from the
     * caller, so issuing the same call twice generated the same name twice — and a second column
     * with the same identity makes every later lookup by name ambiguous. ValueRangeService:204
@@ -3543,6 +3756,40 @@ class WorksheetEditServiceMutatorsTest {
          () -> svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("A", "when", "YEAR")));
 
       assertTrue(ex.getMessage().contains("already exists"), ex.getMessage());
+   }
+
+   /**
+    * {@code requireDerivedColumnFits} has two branches -- a name collision (covered above) and a
+    * column-count cap -- and only the collision branch had a test. This exercises the cap branch
+    * via {@code max.col.count}, restored in a {@code finally} so the property does not leak into
+    * later tests.
+    */
+   @Test
+   void addDateRangeColumnRefusesAtTheColumnCapWithoutMutating() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "2");
+
+         PairingException ex = assertThrows(PairingException.class,
+            () -> svc.apply("TOK", agent,
+                            ed -> ed.addDateRangeColumn("T", "orderDate", "QUARTER_OF_YEAR")));
+
+         assertTrue(ex.getMessage().toLowerCase().contains("maximum"), ex.getMessage());
+         assertEquals(2, t.getColumnSelection(false).getAttributeCount(),
+            "the refused add must not have added a column past the cap");
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
    }
 
    /**
@@ -3652,6 +3899,35 @@ class WorksheetEditServiceMutatorsTest {
       assertTrue(ex.getMessage().contains("M"), ex.getMessage());
       assertEquals(2, ((ConcatenatedTableAssembly) ws.getAssembly("C")).getTableAssemblies().length,
                    "the cycle must be refused before the subtable list is written");
+   }
+
+   /**
+    * The defect this guards: {@code add_concat_subtable(concatName, concatName)} was caught by
+    * neither existing guard. The duplicate-source loop only walks {@code ctbl}'s current
+    * subtables, and {@code ctbl} is never one of those -- it IS the concatenation. And
+    * {@code checkCyclicalDependency(ws, ctbl, newTable)} can't see it either when
+    * {@code newTable == ctbl}: {@code AssetUtil#getDependedAssemblies0} seeds its visited set
+    * with the root and passes {@code included=false} for it, so before the attach there is
+    * nothing yet linking {@code ctbl} back to itself. Without an explicit check, {@code ctbl}
+    * was appended to its own {@code TableAssemblies} array.
+    */
+   @Test
+   void addConcatSubtableRefusesSelfReferenceWithoutMutating() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      EmbeddedTableAssembly b = table(ws, "B", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("C", List.of("A", "B"), "UNION"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatSubtable("C", "C")));
+
+      assertTrue(ex.getMessage().contains("itself"), ex.getMessage());
+      assertEquals(2, ((ConcatenatedTableAssembly) ws.getAssembly("C")).getTableAssemblies().length,
+                   "the self-reference must be refused before the subtable list is written");
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -968,16 +968,30 @@ class WorksheetEditServiceMutatorsTest {
          ed.editDateRangeColumn("T", "QuarterOfYear(orderDate)", "MONTH_OF_YEAR"));
 
       // Reaches the exact name the rename above just produced.
-      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "MONTH_OF_YEAR"));
+      //
+      // This used to be a silent no-op: addAttribute's exclusivity check dropped the duplicate and
+      // the call still answered success, so a caller issuing it believed a second column existed.
+      // add_date_range_column now refuses the collision up front (requireDerivedColumnFits,
+      // mirroring what ValueRangeService:204 does with an ERROR command), which is the same
+      // outcome for the asset and an honest one for the caller.
+      //
+      // Note for whoever revisits the cached-hashCode fix described above: it is untouched and
+      // still required, but this path no longer reaches it -- the guard runs first, and it
+      // compares names rather than relying on hashCode. So this test now locks in the refusal,
+      // not the hash invalidation.
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "MONTH_OF_YEAR")));
+
+      assertTrue(ex.getMessage().contains("MonthOfYear(orderDate)"), ex.getMessage());
 
       ColumnSelection cs = t.getColumnSelection(false);
       long monthColumns = cs.stream()
          .filter(r -> "MonthOfYear(orderDate)".equals(r.getName()))
          .count();
       assertEquals(1, monthColumns,
-         "add_date_range_column must refuse (no-op) rather than duplicate a name the edit just produced");
+         "the refused add must not have duplicated the name the edit just produced");
       assertEquals(4, cs.getAttributeCount(),
-         "the colliding add must be a no-op — no net column added");
+         "and must not have added a column");
    }
 
    @Test
@@ -3364,6 +3378,280 @@ class WorksheetEditServiceMutatorsTest {
       assertTrue(ex.getMessage().contains("name"), ex.getMessage());
       assertTrue(ex.getMessage().contains("amount"), ex.getMessage());
       assertNull(ws.getAssembly("U"), "nothing may be added when the sources do not line up");
+   }
+
+   /**
+    * ws.removeAssembly does not clean up what depended on the deleted table: its removeMirrors call
+    * returns immediately unless the assembly BEING deleted is itself an outer mirror. So the
+    * dependent survived pointing at a name that was gone, every query against it failed, and no
+    * tool on this surface could repair it. Reproduced live before the guard existed.
+    *
+    * <p>The UI's own write path checks the same thing with the same helper
+    * ({@code WSRemoveAssembliesService#removeAssemblies}, AssetEventUtil.hasDependent); it skips
+    * and warns because it is deleting a batch, while this op deletes one named table and so
+    * refuses.
+    */
+   @Test
+   void deleteTableRefusesWhenSomethingIsBuiltOnIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addMirror("M", "A"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.deleteTable("A")));
+
+      assertTrue(ex.getMessage().contains("built on it"), ex.getMessage());
+      assertNotNull(ws.getAssembly("A"), "the table must still be there");
+      assertNotNull(ws.getAssembly("M"), "and so must the mirror that depends on it");
+   }
+
+   /** A table nothing depends on still deletes — the guard must not block ordinary deletion. */
+   @Test
+   void deleteTableStillDeletesWhenNothingDependsOnIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(table(ws, "A", col("id", XSchema.INTEGER)));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.deleteTable("A"));
+
+      assertNull(ws.getAssembly("A"));
+   }
+
+   /**
+    * AssemblyInfo:254 writes the name into a CDATA section verbatim, so a name containing the
+    * terminator closes it early and leaves malformed XML in storage. The Composer's Angular
+    * whitelist refuses it; nothing on this path did, and the save path validates no assembly name.
+    *
+    * <p>Only the terminator is refused, not the whole whitelist: '/' and '"' are legal CDATA
+    * content and round-trip intact, so refusing them here would break names that already work.
+    */
+   @Test
+   void renameTableRefusesANameThatWouldBreakTheStoredXml() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.renameTable("A", "bad]]>name")));
+
+      assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
+      assertNotNull(ws.getAssembly("A"), "the rename must not have happened");
+      assertNull(ws.getAssembly("bad]]>name"));
+   }
+
+   /** A slash and a quote are legal CDATA content, so the guard must let them through. */
+   @Test
+   void renameTableAllowsCharactersTheComposerRefusesButStorageAccepts() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(table(ws, "A", col("id", XSchema.INTEGER)));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.renameTable("A", "a/b\"c"));
+
+      assertNotNull(ws.getAssembly("a/b\"c"));
+   }
+
+   /**
+    * A negative limit is a mistake, not a way to say "unlimited". The Composer's control refuses it
+    * (FormValidators.positiveIntegerInRange); this path folded it into -1 and reported success, so
+    * a caller asking for a limit got none and no indication of it.
+    */
+   @Test
+   void setTablePropertiesRefusesANegativeMaxRows() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(table(ws, "A", col("id", XSchema.INTEGER)));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.setTableProperties("A", null, null, -100, null, null, null, null)));
+
+      assertTrue(ex.getMessage().contains("negative"), ex.getMessage());
+   }
+
+   /**
+    * Making a table primary also exposes it to viewsheets, as WSPrimaryService:84 does. Only
+    * matters for a table whose flag was cleared earlier, which is why the test clears it first.
+    */
+   @Test
+   void setPrimaryAssemblyAlsoMakesTheTableVisibleToViewsheets() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ((inetsoft.uql.asset.internal.TableAssemblyInfo) a.getTableInfo()).setVisibleTable(false);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setPrimaryAssembly("A"));
+
+      assertTrue(((inetsoft.uql.asset.internal.TableAssemblyInfo) a.getTableInfo()).isVisibleTable(),
+                 "the primary table must be reachable from a viewsheet binding");
+   }
+
+   /**
+    * The aggregate flag follows whether the table groups, not which display mode is selected:
+    * TableModeService#setLiveTableMode:353 and #setDefaultTableMode:334 compute it, while
+    * full/detail/edit force it false. "live" and "default" left it untouched here, so a table
+    * switched to "full" earlier kept aggregate=false after coming back — and isAggregate() is real
+    * query state, selecting the public vs private column selection and forming part of the lens
+    * cache key.
+    */
+   @Test
+   void setTableModeRestoresTheAggregateFlagWhenReturningToLive() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a =
+         table(ws, "A", col("g", XSchema.STRING), col("n", XSchema.INTEGER));
+      ws.addAssembly(a);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate(
+         "A", groups("g"),
+         List.of(new WorksheetMutationSupport.AggregateSpec("n", "SUM", null))));
+      svc.apply("TOK", agent, ed -> ed.setTableMode("A", "full"));
+      assertFalse(((inetsoft.uql.asset.internal.TableAssemblyInfo) a.getTableInfo()).isAggregate(),
+                  "precondition: full mode forces the flag off");
+
+      svc.apply("TOK", agent, ed -> ed.setTableMode("A", "live"));
+
+      assertTrue(((inetsoft.uql.asset.internal.TableAssemblyInfo) a.getTableInfo()).isAggregate(),
+                 "returning to live must restore it, since the table still groups");
+   }
+
+   /**
+    * Both range columns take their name from the source column and the option rather than from the
+    * caller, so issuing the same call twice generated the same name twice — and a second column
+    * with the same identity makes every later lookup by name ambiguous. ValueRangeService:204
+    * refuses it; this path did not.
+    */
+   @Test
+   void addDateRangeColumnRefusesASecondColumnWithTheSameGeneratedName() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(table(ws, "A", col("when", XSchema.DATE)));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("A", "when", "YEAR"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("A", "when", "YEAR")));
+
+      assertTrue(ex.getMessage().contains("already exists"), ex.getMessage());
+   }
+
+   /**
+    * {@code Worksheet.addAssembly} replaces a same-named assembly without complaint, so reusing a
+    * name never created a second assembly — it destroyed the first and handed every dependent of
+    * that name to the replacement. Reproduced through this op against a live server: a
+    * concatenation named after one of its own sources became its own source, ended up with zero
+    * columns, and left the concatenation downstream of the destroyed original reading from an empty
+    * table, while the call reported a 500 and all of it stuck.
+    *
+    * <p>The surviving assembly must still be the original, not a replacement — asserting only that
+    * the call threw would pass even if the overwrite had already happened.
+    */
+   @Test
+   void addConcatenationRefusesANameAlreadyInUse() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      EmbeddedTableAssembly b = table(ws, "B", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatenation("A", List.of("A", "B"), "UNION")));
+
+      assertTrue(ex.getMessage().contains("already exists"), ex.getMessage());
+      assertSame(a, ws.getAssembly("A"), "the existing assembly must not be replaced");
+      assertTrue(ws.getAssembly("A") instanceof EmbeddedTableAssembly,
+                 "A must still be the original table, not a concatenation standing in its place");
+   }
+
+   /**
+    * A source listed twice counts its rows twice in the UNION and reports nothing.
+    * {@code ConcatenateTablesService#checkValidity} refuses it with
+    * {@code common.table.unionDuplicate}; this path never ported the check.
+    */
+   @Test
+   void addConcatenationRefusesARepeatedSource() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "A"), "UNION")));
+
+      assertTrue(ex.getMessage().contains("twice"), ex.getMessage());
+      assertNull(ws.getAssembly("U"), "nothing may be added when a source is repeated");
+   }
+
+   /** Same rule as above, reached through the other entry point. */
+   @Test
+   void addConcatSubtableRefusesASourceAlreadyPresent() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      EmbeddedTableAssembly b = table(ws, "B", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatSubtable("U", "A")));
+
+      assertTrue(ex.getMessage().contains("already a source"), ex.getMessage());
+      assertEquals(2, ((ConcatenatedTableAssembly) ws.getAssembly("U")).getTableAssemblies().length,
+                   "the subtable list must be unchanged");
+   }
+
+   /**
+    * The defect this guards: adding a mirror of a concatenation back into that concatenation closed
+    * a C -> M -> C cycle. The mutation committed, {@code apply} checkpointed it, and the caller got
+    * an unhandled 500 from further down the post-edit pipeline — so a caller that reasonably
+    * concluded nothing had changed was wrong.
+    *
+    * <p>Two things make the pre-write placement necessary rather than merely tidy.
+    * {@code Worksheet#checkDependencies} is reached from
+    * {@code AssetQuerySandbox#refreshColumnSelection} only after the commit and the checkpoint. And
+    * {@code AbstractWSAssembly#checkDependency} cannot see a two-node cycle at all:
+    * {@code AssetUtil#getDependedAssemblies0} seeds its visited set with the root and passes
+    * {@code included=false} for it, so a loop back to the root is dropped as already-visited and
+    * never reaches the array it matches against.
+    *
+    * <p>Asserting the subtable count is the point of the test. A version of this fix that threw
+    * after {@code setTableAssemblies} would satisfy the exception assertion and still leave the
+    * cycle in the asset.
+    */
+   @Test
+   void addConcatSubtableRefusesACycleWithoutMutating() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER));
+      EmbeddedTableAssembly b = table(ws, "B", col("id", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("C", List.of("A", "B"), "UNION"));
+      svc.apply("TOK", agent, ed -> ed.addMirror("M", "C"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatSubtable("C", "M")));
+
+      assertTrue(ex.getMessage().contains("circular"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("M"), ex.getMessage());
+      assertEquals(2, ((ConcatenatedTableAssembly) ws.getAssembly("C")).getTableAssemblies().length,
+                   "the cycle must be refused before the subtable list is written");
    }
 
    /**


### PR DESCRIPTION
StyleBI half of the L1 lane audit (`/parity-audit-workflow`). The plugin half is
inetsoft-technology/stylebi-wiz#1978 — **this one should land first or with it**, since three of the
tool parameters there are paired changes needing the `EditRequest` fields added here.

Based on `stylebi-wiz-main-rebase`, not `main`.

## What this closes

The agent worksheet path (`inetsoft/web/wiz/worksheet/**`) reimplements operations the Composer UI
also performs, and had drifted from the UI's own backend. Each guard below was found by diffing the
two backend paths, then reproduced live through the plugin's MCP tools before any code was written.

| Guard | Pre-fix behaviour, reproduced live |
|---|---|
| `hasDependent` before delete | `delete_table` succeeded on a mirrored table, leaving a mirror whose every query fails and nothing able to repair it |
| `checkCyclicalDependency` on concat add | HTTP 500 **after** the cycle was already committed |
| existing-assembly check on concat create | HTTP 500, and the table whose name was reused was destroyed — self-referencing, 0 columns |
| duplicate-source check on concat add | silently accepted; the duplicate persisted |
| `requireStorableName` | a name containing `]]>` was accepted and written into a CDATA section, corrupting storage irreparably |
| `requireDerivedColumnFits` | a second derived column with the same source and option was a silent no-op |
| negative `maxRows` | silently became `-1`, i.e. *unlimited* — the opposite of what was asked |
| `setAggregate` after a mode change | left stale, so `isAggregate()` disagreed with the actual aggregate info |
| visible-in-viewsheet on `set_primary_assembly` | primary yet invisible to viewsheets |
| `validateConditions` after unpivot edit | conditions left referencing columns the edit removed |

`setTableProperties` becomes an 8-arg method carrying `rowCount`; the base's 7-arg signature is kept
as a delegating overload so existing callers and their tests are untouched. `EditRequest` gains
`confirmed`, `rowCount` and `concatDistinct`; only the terminal delegation reaches the canonical
constructor, so the four compatibility constructors keep chaining as before.

## Tests

11 new tests in `WorksheetEditServiceMutatorsTest`. Every one asserts the model is **unchanged**
alongside the exception — a guard that throws after already mutating would pass a
`assertThrows`-only test while leaving exactly the corruption it was written to prevent, which is
how two of the defects above behaved.

Pre-existing failures in this suite are unrelated and predate this branch: 15 `NoSuchMethodError`
against methods absent from source (from `24c8ee7e8`), plus one arriving with revert `d53d44a50`.

## One known gap, deliberately not repaired here

The duplicate-source guard **reimplements** a check StyleBI already has at
`ConcatenateTablesService.java:431-455`, reached on the UI path and surfaced to users as
`common.table.unionDuplicate`. Swapping in a call to it is not a safe refactor:
`getTableCompatibility:475-497` discards an incompatible inner verdict when both sides are
`ConcatenatedTableAssembly` and the outer column count passes. The UI can never reach that — its
sidebar filters the duplicate out first — but a hand-constructed `concatenate/add-table` payload
can, and the agent path is hand-constructed payloads by definition. So calling the existing method
inherits a hole the UI does not have, while keeping the copy means two implementations that will
drift.

Which semantics is intended is not stated by either path, so this is recorded as row 36 in the lane
report and left for a decision rather than settled silently under cover of a bug fix. Behaviour as
shipped is correct — the UI forbids the duplicate too, so this is not the tool becoming stricter
than the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
