### PR TITLE
Add +/- stepper buttons to the modern spinner

### DIFF
--- a/web/projects/portal/src/app/vsobjects/model/vs-spinner-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/vs-spinner-model.ts
@@ -18,4 +18,5 @@
 import { VSNumericRangeModel } from "./vs-numeric-range-model";
 
 export interface VSSpinnerModel extends VSNumericRangeModel {
+   editing?: boolean;
 }

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.html
@@ -17,6 +17,7 @@
 -->
 @if (model) {
   @let textVerticalPosition = getTextVerticalPosition();
+  @let showAsLabel = showLabel && !model.vizModern;
   <vs-input-label-wrapper
     [labelModel]="model.labelModel"
     [labelSelected]="model.labelSelected"
@@ -34,9 +35,29 @@
     VSPopComponent [popComponentName]="getAssemblyName()" [popContainerName]="model.container"
     [popZIndex]="model.objectFormat.zIndex"
     (selectLabel)="selectLabel($event)">
-    <div class="vs-spinner" (click)="clearLabelSelection()">
-      @if (!showLabel && model) {
+    <div class="vs-spinner" [class.has-steppers]="model.vizModern"
+      [style.border-radius.px]="model.vizModern ? model.objectFormat.roundCorner : null"
+      (click)="clearLabelSelection()" (dblclick)="enableEditing()">
+      @if (!showAsLabel && model) {
+        @if (model.vizModern) {
+          <button type="button" class="vs-spinner-btn vs-spinner-btn-decrement"
+            [class.disable-actions-fade]="!model.enabled"
+            [disabled]="isDecrementDisabled"
+            [attr.aria-disabled]="isDecrementDisabled"
+            [attr.aria-label]="model.absoluteName + ' _#(Decrease)'"
+            [style.border-top-left-radius.px]="model.objectFormat.roundCorner"
+            [style.border-bottom-left-radius.px]="model.objectFormat.roundCorner"
+            (click)="onDecrementClick()"
+            (mousedown)="$event.preventDefault(); startHold(-1)"
+            (mouseup)="cancelHold()"
+            (mouseleave)="cancelHold()">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M3 8h10" stroke-linecap="round"/>
+            </svg>
+          </button>
+        }
         <input
+          #spinnerInput
           (click)="onClick($event)"
           (blur)="onBlur($event)"
           (keyup.enter)="onBlur($event)"
@@ -45,9 +66,10 @@
           [(ngModel)]="model.value"
           [class.form-control]="model.vizModern"
           [class.disable-actions-fade]="!model.enabled"
+          [class.disable-input]="isInputDisabled()"
           [class.move-handle]="(selected || inSelectedGroupContainer) && !viewer"
-          [style.text-align]="model.objectFormat.hAlign"
-          [style.padding]="textVerticalPosition"
+          [style.text-align]="model.vizModern ? 'center' : model.objectFormat.hAlign"
+          [style.padding]="model.vizModern ? null : textVerticalPosition"
           [safeFont]="model.objectFormat.font"
           [style.background]="model.objectFormat.background"
           [style.color]="model.objectFormat.foreground"
@@ -59,11 +81,27 @@
           [style.border-top]="model.objectFormat.border.top"
           [style.border-left]="model.objectFormat.border.left"
           [style.border-right]="model.objectFormat.border.right"
-          [style.border-radius.px]="model.objectFormat.roundCorner"
-          (mouseleave)="showLabel = true"
-          (mousedown)="$event.stopPropagation()">
+          [style.border-radius.px]="model.vizModern ? 0 : model.objectFormat.roundCorner"
+          (mouseleave)="showLabel = true">
+        @if (model.vizModern) {
+          <button type="button" class="vs-spinner-btn vs-spinner-btn-increment"
+            [class.disable-actions-fade]="!model.enabled"
+            [disabled]="isIncrementDisabled"
+            [attr.aria-disabled]="isIncrementDisabled"
+            [attr.aria-label]="model.absoluteName + ' _#(Increase)'"
+            [style.border-top-right-radius.px]="model.objectFormat.roundCorner"
+            [style.border-bottom-right-radius.px]="model.objectFormat.roundCorner"
+            (click)="onIncrementClick()"
+            (mousedown)="$event.preventDefault(); startHold(1)"
+            (mouseup)="cancelHold()"
+            (mouseleave)="cancelHold()">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M8 3v10M3 8h10" stroke-linecap="round"/>
+            </svg>
+          </button>
+        }
       }
-      @if (showLabel && model) {
+      @if (showAsLabel && model) {
         <div class="text-label"
           [style.background-color]="model.objectFormat.background"
           [style.justify-content]="model.objectFormat.justifyContent"

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.html
@@ -82,7 +82,8 @@
           [style.border-left]="model.objectFormat.border.left"
           [style.border-right]="model.objectFormat.border.right"
           [style.border-radius.px]="model.vizModern ? 0 : model.objectFormat.roundCorner"
-          (mouseleave)="showLabel = true">
+          (mouseleave)="showLabel = true"
+          (mousedown)="onMouseDown($event)">
         @if (model.vizModern) {
           <button type="button" class="vs-spinner-btn vs-spinner-btn-increment"
             [class.disable-actions-fade]="!model.enabled"

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.scss
@@ -19,6 +19,74 @@
 .vs-spinner {
    width: 100%;
    height: 100%;
+
+   &.has-steppers {
+      display: flex;
+      align-items: stretch;
+   }
+}
+
+.vs-spinner.has-steppers input.form-control {
+   flex: 1 1 auto;
+   min-width: 0;
+}
+
+// A focused input's own :focus ring (_bootstrap-override.scss's .form-control:focus) only
+// wraps the input segment — draw one unified ring around the whole -/input/+ group instead,
+// and suppress the input's own so they don't double up.
+.vs-spinner.has-steppers:focus-within {
+   box-shadow: var(--inet-focus-ring);
+   outline: var(--inet-focus-ring-outline);
+}
+
+.vs-spinner.has-steppers:focus-within input.form-control {
+   box-shadow: none;
+}
+
+.vs-spinner.has-steppers:focus-within input.form-control,
+.vs-spinner.has-steppers:focus-within .vs-spinner-btn {
+   border-color: var(--inet-primary-color);
+}
+
+.vs-spinner-btn {
+   appearance: none;
+   flex-shrink: 0;
+   width: 18px;
+   padding: 0;
+   box-sizing: border-box;
+   border: 1px solid var(--inet-input-border-color);
+   background: var(--inet-input-bg-color);
+   color: var(--inet-text-muted-color);
+   cursor: pointer;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+   transition: background-color 100ms ease, color 100ms ease;
+
+   svg {
+      width: 10px;
+      height: 10px;
+      flex-shrink: 0;
+   }
+
+   &:not(:disabled):hover {
+      background: var(--inet-ui-neutral-hover-bg-color);
+      color: var(--inet-text-color);
+   }
+
+   &:disabled {
+      color: var(--inet-text-subtle-color);
+      cursor: not-allowed;
+      opacity: 0.6;
+   }
+}
+
+.vs-spinner-btn-decrement {
+   border-right-width: 0;
+}
+
+.vs-spinner-btn-increment {
+   border-left-width: 0;
 }
 
 input {
@@ -42,6 +110,27 @@ input::-webkit-inner-spin-button {
 .vs-spinner input.form-control {
   min-height: 0;
   height: 100%;
+
+  // custom -/+ buttons replace the native spin arrows for modern spinners; suppress them so
+  // no browser/OS combination can render its own arrows alongside ours. display:none (not just
+  // -webkit-appearance:none) is required: the unscoped min-width/min-height rule above still
+  // reserves layout space for the (invisible) pseudo-element inside the input's internal
+  // shadow-DOM flex box otherwise, pushing the centered text left.
+  appearance: textfield;
+  -moz-appearance: textfield;
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    display: none;
+    -webkit-appearance: none;
+    margin: 0;
+    min-width: 0;
+    min-height: 0;
+  }
+}
+
+.disable-input {
+   pointer-events: none;
 }
 
 .text-label {

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.tl.spec.ts
@@ -817,6 +817,16 @@ describe("VSSpinner — isIncrementDisabled / isDecrementDisabled", () => {
       expect(comp.isDecrementDisabled).toBe(true);
    });
 
+   it("should NOT disable increment when max is unset, regardless of value", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 50, max: null } as any) });
+      expect(comp.isIncrementDisabled).toBe(false);
+   });
+
+   it("should NOT disable decrement when min is unset, regardless of value", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 50, min: null } as any) });
+      expect(comp.isDecrementDisabled).toBe(false);
+   });
+
    it("should NOT disable decrement when enabled and above min", () => {
       const { comp } = createComponent({ model: makeModel({ value: 50, min: 0 }) });
       expect(comp.isDecrementDisabled).toBe(false);

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.tl.spec.ts
@@ -757,6 +757,34 @@ describe("VSSpinner — onIncrementClick / onDecrementClick", () => {
       comp.onDecrementClick();
       expect(comp.model.value).toBe(0);
    });
+
+   it("should focus the input after stepping when the input is not gated (viewer)", () => {
+      const { comp } = createComponent({
+         viewer: true,
+         model: makeModel({ vizModern: true, value: 0, increment: 20, max: 100 } as any)
+      });
+      const focusSpy = vi.fn();
+      (comp as any).spinnerInputRef = { nativeElement: { focus: focusSpy } };
+
+      comp.onIncrementClick();
+
+      expect(focusSpy).toHaveBeenCalled();
+   });
+
+   it("should NOT focus the input after stepping when it is still select-then-edit gated", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: true, value: 0, increment: 20, max: 100 } as any)
+      });
+      comp.selected = false; // not yet selected -> isInputDisabled() is true
+      const focusSpy = vi.fn();
+      (comp as any).spinnerInputRef = { nativeElement: { focus: focusSpy } };
+
+      comp.onIncrementClick();
+
+      expect(comp.model.value).toBe(20); // stepping itself is still unaffected by the gate
+      expect(focusSpy).not.toHaveBeenCalled();
+   });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.tl.spec.ts
@@ -33,17 +33,24 @@
  *                       dispatch vs. pendingChange fallback
  *   Group 8 [Risk 3] — changeValue0 (via debounce): ctrlDown deferral, ovalue no-op guard,
  *                       checkFormData confirmedCallback → sendEvent
+ *   Group 14 [Risk 3] — startHold/cancelHold: 300ms initial delay, 60ms repeat interval,
+ *                        1500ms acceleration to 20ms, disabled-bound early stop
  *   Group 2 [Risk 2] — updateOnChange setter: pendingChange flush guard
  *   Group 7 [Risk 2] — onBlur: refresh && updateOnChange dispatch vs. pendingChange fallback
  *                       (no writeBackDirectly bypass, unlike onClick)
  *   Group 9 [Risk 2] — onKeyUp/onKeyDown: ctrlDown tracking + deferred pendingChange2 flush
  *   Group 11 [Risk 2] — getTextVerticalPosition(): font/vAlign/padding branch matrix
- *   Group 1 [Risk 1] — selected setter: labelSelected clear guard
+ *   Group 15 [Risk 2] — onIncrementClick/onDecrementClick: bounds-respecting step + focus
+ *   Group 16 [Risk 2] — isIncrementDisabled/isDecrementDisabled: enabled/bounds matrix
+ *   Group 17 [Risk 2] — enableEditing(): vizModern gate, viewer guard, focus restore
+ *   Group 18 [Risk 2] — isInputDisabled(): vizModern/viewer/selected/editing gate matrix
+ *   Group 1 [Risk 1] — selected setter: labelSelected clear guard, editing reset
  *   Group 3 [Risk 1] — ngOnInit: validate() + ovalue capture
  *   Group 5 [Risk 1] — ngOnDestroy: subscription cleanup
  *   Group 10 [Risk 1] — navigate(): UP/DOWN increment stepping
  *   Group 12 [Risk 1] — selectLabel(): preview guard
  *   Group 13 [Risk 1] — clearLabelSelection(): model-presence guard
+ *   Group 19 [Risk 1] — onMouseDown(): vizModern-gated stopPropagation
  *
  * Confirmed bugs (it.fails): none
  *
@@ -135,6 +142,12 @@ describe("VSSpinner — selected setter", () => {
       const { comp } = createComponent();
       (comp as any)._model = undefined;
       expect(() => comp.selected = false).not.toThrow();
+   });
+
+   it("should clear model.editing when deselected", () => {
+      const { comp } = createComponent({ model: makeModel({ editing: true } as any) });
+      comp.selected = false;
+      expect(comp.model.editing).toBe(false);
    });
 });
 
@@ -613,5 +626,280 @@ describe("VSSpinner — clearLabelSelection", () => {
       const { comp } = createComponent();
       (comp as any)._model = undefined;
       expect(() => comp.clearLabelSelection()).not.toThrow();
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 14: startHold / cancelHold (hold-to-repeat) [Risk 3]
+// ---------------------------------------------------------------------------
+
+describe("VSSpinner — startHold / cancelHold", () => {
+   beforeEach(() => vi.useFakeTimers());
+   afterEach(() => vi.useRealTimers());
+
+   it("should NOT step before the initial 300ms delay elapses", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20 }) });
+      comp.startHold(1);
+      vi.advanceTimersByTime(299);
+      expect(comp.model.value).toBe(0);
+   });
+
+   it("should step once, emit, and mark an unapplied change after the initial delay", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20 }) });
+      const emitted: string[] = [];
+      comp.spinnerClicked.subscribe(v => emitted.push(v));
+
+      comp.startHold(1);
+      vi.advanceTimersByTime(300);
+
+      expect(comp.model.value).toBe(20);
+      expect(emitted).toEqual([comp.model.absoluteName]);
+      expect((comp as any).unappliedChange).toBe(true);
+   });
+
+   it("should repeat stepping every 60ms after the initial delay", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20, max: 1000 }) });
+      comp.startHold(1);
+      vi.advanceTimersByTime(300); // step 1 -> 20
+      vi.advanceTimersByTime(60); // step 2 -> 40
+      vi.advanceTimersByTime(60); // step 3 -> 60
+      expect(comp.model.value).toBe(60);
+   });
+
+   it("should decrement on repeat when held in the negative direction", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 100, increment: 20, min: -1000 }) });
+      comp.startHold(-1);
+      vi.advanceTimersByTime(300); // step 1 -> 80
+      vi.advanceTimersByTime(60); // step 2 -> 60
+      expect(comp.model.value).toBe(60);
+   });
+
+   it("should accelerate the repeat interval to 20ms after 1500ms of continuous holding", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 1, max: 100000 }) });
+      comp.startHold(1);
+      vi.advanceTimersByTime(300 + 1500);
+      expect((comp as any).holdRepeatInterval).toBe(20);
+   });
+
+   it("should stop repeating once the increment bound is reached", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20, max: 40 }) });
+      comp.startHold(1);
+      vi.advanceTimersByTime(300); // step -> 20
+      vi.advanceTimersByTime(60); // step -> 40 (== max, now disabled)
+      vi.advanceTimersByTime(60); // guard should cancel the hold instead of stepping again
+
+      expect(comp.model.value).toBe(40);
+      expect((comp as any).holdRepeatTimer).toBeNull();
+   });
+
+   it("should stop repeating once the decrement bound is reached", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 40, increment: 20, min: 0 }) });
+      comp.startHold(-1);
+      vi.advanceTimersByTime(300); // step -> 20
+      vi.advanceTimersByTime(60); // step -> 0 (== min, now disabled)
+      vi.advanceTimersByTime(60); // guard should cancel the hold instead of stepping again
+
+      expect(comp.model.value).toBe(0);
+      expect((comp as any).holdRepeatTimer).toBeNull();
+   });
+
+   it("should stop all further stepping once cancelHold is called", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20, max: 1000 }) });
+      comp.startHold(1);
+      vi.advanceTimersByTime(300); // step -> 20
+
+      comp.cancelHold();
+      vi.advanceTimersByTime(500);
+
+      expect(comp.model.value).toBe(20);
+   });
+
+   it("should clear the init timer before it fires when cancelHold is called immediately", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20 }) });
+      comp.startHold(1);
+      comp.cancelHold();
+      vi.advanceTimersByTime(1000);
+      expect(comp.model.value).toBe(0);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 15: onIncrementClick / onDecrementClick [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("VSSpinner — onIncrementClick / onDecrementClick", () => {
+   it("should step up by increment, emit, and mark an unapplied change", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20, max: 100 }) });
+      const emitted: string[] = [];
+      comp.spinnerClicked.subscribe(v => emitted.push(v));
+
+      comp.onIncrementClick();
+
+      expect(comp.model.value).toBe(20);
+      expect(emitted).toEqual([comp.model.absoluteName]);
+      expect((comp as any).unappliedChange).toBe(true);
+   });
+
+   it("should do nothing when isIncrementDisabled is true", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 100, increment: 20, max: 100 }) });
+      comp.onIncrementClick();
+      expect(comp.model.value).toBe(100);
+   });
+
+   it("should step down by increment when not disabled", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 100, increment: 20, min: 0 }) });
+      comp.onDecrementClick();
+      expect(comp.model.value).toBe(80);
+   });
+
+   it("should do nothing when isDecrementDisabled is true", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, increment: 20, min: 0 }) });
+      comp.onDecrementClick();
+      expect(comp.model.value).toBe(0);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 16: isIncrementDisabled / isDecrementDisabled [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("VSSpinner — isIncrementDisabled / isDecrementDisabled", () => {
+   it("should disable increment when the assembly is not enabled", () => {
+      const { comp } = createComponent({ model: makeModel({ enabled: false, value: 0, max: 100 } as any) });
+      expect(comp.isIncrementDisabled).toBe(true);
+   });
+
+   it("should disable increment when value has reached max", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 100, max: 100 }) });
+      expect(comp.isIncrementDisabled).toBe(true);
+   });
+
+   it("should NOT disable increment when enabled and below max", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 50, max: 100 }) });
+      expect(comp.isIncrementDisabled).toBe(false);
+   });
+
+   it("should disable decrement when the assembly is not enabled", () => {
+      const { comp } = createComponent({ model: makeModel({ enabled: false, value: 0, min: 0 } as any) });
+      expect(comp.isDecrementDisabled).toBe(true);
+   });
+
+   it("should disable decrement when value has reached min", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 0, min: 0 }) });
+      expect(comp.isDecrementDisabled).toBe(true);
+   });
+
+   it("should NOT disable decrement when enabled and above min", () => {
+      const { comp } = createComponent({ model: makeModel({ value: 50, min: 0 }) });
+      expect(comp.isDecrementDisabled).toBe(false);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 17: enableEditing() [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("VSSpinner — enableEditing", () => {
+   it("should NOT set model.editing for a legacy (non-modern) spinner", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: false } as any)
+      });
+      comp.enableEditing();
+      expect(comp.model.editing).toBeUndefined();
+   });
+
+   it("should set model.editing=true for a modern spinner in the composer", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: true } as any)
+      });
+      comp.enableEditing();
+      expect(comp.model.editing).toBe(true);
+   });
+
+   it("should set model.editing=false for a modern spinner in the viewer", () => {
+      const { comp } = createComponent({
+         viewer: true,
+         model: makeModel({ vizModern: true } as any)
+      });
+      comp.enableEditing();
+      expect(comp.model.editing).toBe(false);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 18: isInputDisabled() [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("VSSpinner — isInputDisabled", () => {
+   it("should always be false for a legacy (non-modern) spinner", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: false } as any)
+      });
+      comp.selected = false;
+      expect(comp.isInputDisabled()).toBe(false);
+   });
+
+   it("should be false in the viewer, regardless of selection/editing state", () => {
+      const { comp } = createComponent({
+         viewer: true,
+         model: makeModel({ vizModern: true } as any)
+      });
+      expect(comp.isInputDisabled()).toBe(false);
+   });
+
+   it("should be true in the composer when not selected", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: true } as any)
+      });
+      comp.selected = false;
+      expect(comp.isInputDisabled()).toBe(true);
+   });
+
+   it("should be true in the composer when selected but not yet editing", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: true, editing: false } as any)
+      });
+      comp.selected = true;
+      expect(comp.isInputDisabled()).toBe(true);
+   });
+
+   it("should be false in the composer when selected and editing", () => {
+      const { comp } = createComponent({
+         viewer: false,
+         model: makeModel({ vizModern: true, editing: true } as any)
+      });
+      comp.selected = true;
+      expect(comp.isInputDisabled()).toBe(false);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 19: onMouseDown() [Risk 1]
+// ---------------------------------------------------------------------------
+
+describe("VSSpinner — onMouseDown", () => {
+   it("should stop propagation for a legacy (non-modern) spinner", () => {
+      const { comp } = createComponent({ model: makeModel({ vizModern: false } as any) });
+      const event = new MouseEvent("mousedown");
+      const stopSpy = vi.spyOn(event, "stopPropagation");
+
+      comp.onMouseDown(event);
+
+      expect(stopSpy).toHaveBeenCalled();
+   });
+
+   it("should NOT stop propagation for a modern spinner", () => {
+      const { comp } = createComponent({ model: makeModel({ vizModern: true } as any) });
+      const event = new MouseEvent("mousedown");
+      const stopSpy = vi.spyOn(event, "stopPropagation");
+
+      comp.onMouseDown(event);
+
+      expect(stopSpy).not.toHaveBeenCalled();
    });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
@@ -142,6 +142,11 @@ implements OnInit, OnChanges, OnDestroy
    }
 
    enableEditing(): void {
+      if(!this.model.vizModern) {
+         // legacy spinners have no select-then-edit gate, so there is nothing to enable
+         return;
+      }
+
       this.model.editing = !this.viewer;
 
       if(this.model.editing) {
@@ -229,6 +234,14 @@ implements OnInit, OnChanges, OnDestroy
       else {
          this.pendingChange = true;
          this.formInputService.addPendingValue(this.model.absoluteName, this.model.value);
+      }
+   }
+
+   onMouseDown(event: MouseEvent): void {
+      if(!this.model.vizModern) {
+         // legacy spinners have no select-then-edit gate, so the input is always directly
+         // interactive; stop the mousedown from also selecting/dragging the composer object.
+         event.stopPropagation();
       }
    }
 

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
@@ -150,7 +150,7 @@ implements OnInit, OnChanges, OnDestroy
    }
 
    isInputDisabled(): boolean {
-      return !this.viewer && (!this.selected || !this.model?.editing);
+      return this.model.vizModern && !this.viewer && (!this.selected || !this.model?.editing);
    }
 
    get isIncrementDisabled(): boolean {
@@ -233,6 +233,12 @@ implements OnInit, OnChanges, OnDestroy
    }
 
    onClick(event: MouseEvent) {
+      if(!this.model.vizModern) {
+         // legacy spinners have no select-then-edit gate, so the input is always directly
+         // interactive; stop the click from also selecting/dragging the composer object.
+         event.stopPropagation();
+      }
+
       this.validate();
       this.spinnerClicked.emit(this.model.absoluteName);
       this.unappliedChange = true;

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
@@ -224,17 +224,7 @@ implements OnInit, OnChanges, OnDestroy
 
    private stepValue(delta: number): void {
       this.model.value = (isNaN(this.model.value) ? 0 : this.model.value) + delta;
-      this.validate();
-      this.spinnerClicked.emit(this.model.absoluteName);
-      this.unappliedChange = true;
-
-      if(this.model.refresh && this.updateOnChange || this.model.writeBackDirectly) {
-         this.changeValue();
-      }
-      else {
-         this.pendingChange = true;
-         this.formInputService.addPendingValue(this.model.absoluteName, this.model.value);
-      }
+      this.commitChange(this.model.writeBackDirectly);
    }
 
    onMouseDown(event: MouseEvent): void {
@@ -252,25 +242,20 @@ implements OnInit, OnChanges, OnDestroy
          event.stopPropagation();
       }
 
-      this.validate();
-      this.spinnerClicked.emit(this.model.absoluteName);
-      this.unappliedChange = true;
-
-      if(this.model.refresh && this.updateOnChange || this.model.writeBackDirectly) {
-         this.changeValue();
-      }
-      else {
-         this.pendingChange = true;
-         this.formInputService.addPendingValue(this.model.absoluteName, this.model.value);
-      }
+      this.commitChange(this.model.writeBackDirectly);
    }
 
    onBlur(event: MouseEvent) {
+      // unlike onClick/stepValue, onBlur has no writeBackDirectly bypass
+      this.commitChange(false);
+   }
+
+   private commitChange(bypassRefreshGate: boolean): void {
       this.validate();
       this.spinnerClicked.emit(this.model.absoluteName);
       this.unappliedChange = true;
 
-      if(this.model.refresh && this.updateOnChange) {
+      if(this.model.refresh && this.updateOnChange || bypassRefreshGate) {
          this.changeValue();
       }
       else {

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
@@ -159,11 +159,13 @@ implements OnInit, OnChanges, OnDestroy
    }
 
    get isIncrementDisabled(): boolean {
-      return !this.model.enabled || (this.model.value != null && this.model.value >= this.model.max);
+      return !this.model.enabled ||
+         (this.model.max != null && this.model.value != null && this.model.value >= this.model.max);
    }
 
    get isDecrementDisabled(): boolean {
-      return !this.model.enabled || (this.model.value != null && this.model.value <= this.model.min);
+      return !this.model.enabled ||
+         (this.model.min != null && this.model.value != null && this.model.value <= this.model.min);
    }
 
    onIncrementClick(): void {

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
@@ -169,13 +169,22 @@ implements OnInit, OnChanges, OnDestroy
    onIncrementClick(): void {
       if(!this.isIncrementDisabled) {
          this.stepValue(this.model.increment);
-         this.spinnerInputRef?.nativeElement?.focus();
+         this.focusInputIfEditable();
       }
    }
 
    onDecrementClick(): void {
       if(!this.isDecrementDisabled) {
          this.stepValue(-this.model.increment);
+         this.focusInputIfEditable();
+      }
+   }
+
+   private focusInputIfEditable(): void {
+      // stepping is always allowed, but the input itself stays gated behind select-then-edit;
+      // focusing it here would grant real keyboard access around that gate (pointer-events:
+      // none only blocks pointer interaction, not a programmatic .focus()).
+      if(!this.isInputDisabled()) {
          this.spinnerInputRef?.nativeElement?.focus();
       }
    }

--- a/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/spinner/vs-spinner.component.ts
@@ -17,6 +17,7 @@
  */
 import {
    Component,
+   ElementRef,
    EventEmitter,
    Input,
    NgZone,
@@ -25,7 +26,8 @@ import {
    OnInit,
    Output,
    SimpleChanges,
-   HostListener
+   HostListener,
+   ViewChild
 } from "@angular/core";
 import { Observable, Subscription } from "rxjs";
 import { ViewsheetClientService } from "../../../common/viewsheet-client";
@@ -61,6 +63,7 @@ implements OnInit, OnChanges, OnDestroy
       this._selected = selected;
 
       if(!selected && this.model) {
+         this.model.editing = false;
          this.model.labelSelected = false;
       }
    }
@@ -70,10 +73,15 @@ implements OnInit, OnChanges, OnDestroy
    }
    @Input() submitted: Observable<boolean>;
    @Output() spinnerClicked = new EventEmitter();
+   @ViewChild("spinnerInput") spinnerInputRef: ElementRef<HTMLInputElement>;
    private _updateOnChange: boolean = true;
    private pendingChange: boolean = false;
    private ovalue: any = null;
    showLabel: boolean = true;
+   private holdInitTimer: any = null;
+   private holdRepeatTimer: any = null;
+   private holdAccelTimer: any = null;
+   private holdRepeatInterval: number = 60;
 
    @Input()
    set updateOnChange(value: boolean) {
@@ -129,10 +137,102 @@ implements OnInit, OnChanges, OnDestroy
       if(this.submittedForm) {
          this.submittedForm.unsubscribe();
       }
+
+      this.cancelHold();
+   }
+
+   enableEditing(): void {
+      this.model.editing = !this.viewer;
+
+      if(this.model.editing) {
+         this.spinnerInputRef?.nativeElement?.focus();
+      }
+   }
+
+   isInputDisabled(): boolean {
+      return !this.viewer && (!this.selected || !this.model?.editing);
+   }
+
+   get isIncrementDisabled(): boolean {
+      return !this.model.enabled || (this.model.value != null && this.model.value >= this.model.max);
+   }
+
+   get isDecrementDisabled(): boolean {
+      return !this.model.enabled || (this.model.value != null && this.model.value <= this.model.min);
+   }
+
+   onIncrementClick(): void {
+      if(!this.isIncrementDisabled) {
+         this.stepValue(this.model.increment);
+         this.spinnerInputRef?.nativeElement?.focus();
+      }
+   }
+
+   onDecrementClick(): void {
+      if(!this.isDecrementDisabled) {
+         this.stepValue(-this.model.increment);
+         this.spinnerInputRef?.nativeElement?.focus();
+      }
+   }
+
+   startHold(direction: 1 | -1): void {
+      this.cancelHold();
+      this.holdRepeatInterval = 60;
+
+      this.holdInitTimer = setTimeout(() => {
+         this.holdInitTimer = null;
+
+         const doRepeat = () => {
+            if(direction > 0 && this.isIncrementDisabled || direction < 0 && this.isDecrementDisabled) {
+               this.cancelHold();
+               return;
+            }
+
+            this.stepValue(direction * this.model.increment);
+            this.holdRepeatTimer = setTimeout(doRepeat, this.holdRepeatInterval);
+         };
+
+         doRepeat();
+
+         this.holdAccelTimer = setTimeout(() => {
+            this.holdRepeatInterval = 20;
+         }, 1500);
+      }, 300);
+   }
+
+   cancelHold(): void {
+      if(this.holdInitTimer != null) {
+         clearTimeout(this.holdInitTimer);
+         this.holdInitTimer = null;
+      }
+
+      if(this.holdRepeatTimer != null) {
+         clearTimeout(this.holdRepeatTimer);
+         this.holdRepeatTimer = null;
+      }
+
+      if(this.holdAccelTimer != null) {
+         clearTimeout(this.holdAccelTimer);
+         this.holdAccelTimer = null;
+      }
+   }
+
+   private stepValue(delta: number): void {
+      this.model.value = (isNaN(this.model.value) ? 0 : this.model.value) + delta;
+      this.validate();
+      this.spinnerClicked.emit(this.model.absoluteName);
+      this.unappliedChange = true;
+
+      if(this.model.refresh && this.updateOnChange || this.model.writeBackDirectly) {
+         this.changeValue();
+      }
+      else {
+         this.pendingChange = true;
+         this.formInputService.addPendingValue(this.model.absoluteName, this.model.value);
+      }
    }
 
    onClick(event: MouseEvent) {
-      event.stopPropagation();
       this.validate();
       this.spinnerClicked.emit(this.model.absoluteName);
       this.unappliedChange = true;


### PR DESCRIPTION
## Summary
- Adds custom decrement/increment buttons flanking the modern spinner's input, matching `number-stepper`'s visual design (rounded outer corners, shared border seam, hover/disabled states, press-and-hold repeat).
- Fixes composer interaction to match `vs-text-input`'s model: single click selects the object, double-click enters editing. The spinner previously swallowed every click on its own input, which blocked normal single-click selection like other assemblies get.
- Centers the value on both axes: removes the native number-input spin-button's reserved layout space (an invisible pseudo-element was still consuming 8px inside the input's internal shadow-DOM flex box even after `-webkit-appearance: none`, pushing the digit left).
- Draws one unified focus ring around the whole `-`/input/`+` group instead of just the input segment, matching the container's configured corner radius.
- Legacy (non-modern) spinners are untouched — every change is gated behind `model.vizModern`.

## Test plan
- [x] Verified in the composer: single click selects, double-click enters editing, `+`/`-` always clickable regardless of selection state (single click steps once, press-and-hold repeats)
- [x] Verified centering via exact pixel measurement (symmetric padding/border/button widths) and live screenshots
- [x] Verified the focus ring wraps the whole group and follows the configured `roundCorner`
- [x] Confirmed legacy spinners are visually and behaviorally unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>