### PR TITLE
Seed form-input control height from density at creation

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
@@ -451,6 +451,13 @@ public class CheckBoxVSAssemblyInfo extends ListInputVSAssemblyInfo
          objFormat.getDefaultFormat().setRoundCornerValue(
             ctx.modern ? VSObjectChromeDefaults.cardCornerRadius() : 0);
       }
+
+      // legacy default is 2 * defh (title lane + one data row); preserve that ratio rather than
+      // substituting a single control height, or a freshly-created checkbox would lose the room
+      // its second row needs.
+      if(ctx.modern && getPixelSize().height == 2 * AssetUtil.defh) {
+         setPixelSize(new Dimension(getPixelSize().width, 2 * VSDensityDefaults.controlHeight(ctx)));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
@@ -434,9 +434,9 @@ public class CheckBoxVSAssemblyInfo extends ListInputVSAssemblyInfo
    }
 
    /**
-    * Seed the modern-gated round corner. This type bypasses the base chrome hook (see
-    * VSAssemblyInfo.bypassesBaseChrome()) so it seeds its own — form-input modernization,
-    * tracked as its own follow-on project from the card-corner work.
+    * Seed the modern-gated round corner and control height. This type bypasses the base chrome
+    * hook (see VSAssemblyInfo.bypassesBaseChrome()) so it seeds its own — form-input
+    * modernization, tracked as its own follow-on project from the card-corner work.
     */
    @Override
    protected void seedChromeDefaults(VizContext ctx) {
@@ -454,33 +454,28 @@ public class CheckBoxVSAssemblyInfo extends ListInputVSAssemblyInfo
 
       // legacy default is 2 * defh (title lane + one data row); preserve that ratio rather than
       // substituting a single control height, or a freshly-created checkbox would lose the room
-      // its second row needs. cellHeight and titleHeight must grow by the same amount as the
-      // container, or updateDataRowCol()'s (containerHeight - titleHeight) / cellHeight would
-      // recompute a second row out of the container's new headroom instead of leaving it as
-      // clearance.
+      // its second row needs. Title height is deliberately left alone - CheckBox is one of the
+      // types TitleLaneHeightRowTest.excludedTypesNeverTakeTheDensityRow pins to never follow the
+      // density row, so cellHeight alone absorbs the container's growth (container - the
+      // still-legacy title height), or updateDataRowCol()'s (containerHeight - titleHeight) /
+      // cellHeight would recompute a second row out of the container's new headroom instead of
+      // leaving it as clearance.
       if(ctx.modern && getPixelSize().height == 2 * AssetUtil.defh) {
-         int controlHeight = VSDensityDefaults.controlHeight(ctx);
-         setPixelSize(new Dimension(getPixelSize().width, 2 * controlHeight));
+         int newHeight = 2 * VSDensityDefaults.controlHeight(ctx);
+         setPixelSize(new Dimension(getPixelSize().width, newHeight));
 
          if(getCellHeight() == AssetUtil.defh) {
-            setCellHeight(controlHeight);
-         }
-
-         if(!isUserTitleHeight() && getTitleHeight() == getLegacyTitleHeight()) {
-            setTitleHeight(controlHeight);
+            setCellHeight(newHeight - getTitleHeight());
          }
       }
       else if(!ctx.modern && getPixelSize().height % 2 == 0 &&
          VSDensityDefaults.isControlHeight(getPixelSize().height / 2))
       {
+         int oldHeight = getPixelSize().height;
          setPixelSize(new Dimension(getPixelSize().width, 2 * AssetUtil.defh));
 
-         if(VSDensityDefaults.isControlHeight(getCellHeight())) {
+         if(getCellHeight() == oldHeight - getTitleHeight()) {
             setCellHeight(AssetUtil.defh);
-         }
-
-         if(!isUserTitleHeight() && VSDensityDefaults.isControlHeight(getTitleHeight())) {
-            setTitleHeight(getLegacyTitleHeight());
          }
       }
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
@@ -454,14 +454,34 @@ public class CheckBoxVSAssemblyInfo extends ListInputVSAssemblyInfo
 
       // legacy default is 2 * defh (title lane + one data row); preserve that ratio rather than
       // substituting a single control height, or a freshly-created checkbox would lose the room
-      // its second row needs.
+      // its second row needs. cellHeight and titleHeight must grow by the same amount as the
+      // container, or updateDataRowCol()'s (containerHeight - titleHeight) / cellHeight would
+      // recompute a second row out of the container's new headroom instead of leaving it as
+      // clearance.
       if(ctx.modern && getPixelSize().height == 2 * AssetUtil.defh) {
-         setPixelSize(new Dimension(getPixelSize().width, 2 * VSDensityDefaults.controlHeight(ctx)));
+         int controlHeight = VSDensityDefaults.controlHeight(ctx);
+         setPixelSize(new Dimension(getPixelSize().width, 2 * controlHeight));
+
+         if(getCellHeight() == AssetUtil.defh) {
+            setCellHeight(controlHeight);
+         }
+
+         if(!isUserTitleHeight() && getTitleHeight() == getLegacyTitleHeight()) {
+            setTitleHeight(controlHeight);
+         }
       }
       else if(!ctx.modern && getPixelSize().height % 2 == 0 &&
          VSDensityDefaults.isControlHeight(getPixelSize().height / 2))
       {
          setPixelSize(new Dimension(getPixelSize().width, 2 * AssetUtil.defh));
+
+         if(VSDensityDefaults.isControlHeight(getCellHeight())) {
+            setCellHeight(AssetUtil.defh);
+         }
+
+         if(!isUserTitleHeight() && VSDensityDefaults.isControlHeight(getTitleHeight())) {
+            setTitleHeight(getLegacyTitleHeight());
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/CheckBoxVSAssemblyInfo.java
@@ -458,6 +458,11 @@ public class CheckBoxVSAssemblyInfo extends ListInputVSAssemblyInfo
       if(ctx.modern && getPixelSize().height == 2 * AssetUtil.defh) {
          setPixelSize(new Dimension(getPixelSize().width, 2 * VSDensityDefaults.controlHeight(ctx)));
       }
+      else if(!ctx.modern && getPixelSize().height % 2 == 0 &&
+         VSDensityDefaults.isControlHeight(getPixelSize().height / 2))
+      {
+         setPixelSize(new Dimension(getPixelSize().width, 2 * AssetUtil.defh));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/ComboBoxVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/ComboBoxVSAssemblyInfo.java
@@ -426,6 +426,9 @@ public class ComboBoxVSAssemblyInfo extends ListInputVSAssemblyInfo {
       if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
          setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
       }
+      else if(!ctx.modern && VSDensityDefaults.isControlHeight(getPixelSize().height)) {
+         setPixelSize(new Dimension(getPixelSize().width, AssetUtil.defh));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/ComboBoxVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/ComboBoxVSAssemblyInfo.java
@@ -422,6 +422,10 @@ public class ComboBoxVSAssemblyInfo extends ListInputVSAssemblyInfo {
          objFormat.getDefaultFormat().setRoundCornerValue(
             ctx.modern ? VSObjectChromeDefaults.cardCornerRadius() : 0);
       }
+
+      if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
+         setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/RadioButtonVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/RadioButtonVSAssemblyInfo.java
@@ -401,9 +401,16 @@ public class RadioButtonVSAssemblyInfo extends ListInputVSAssemblyInfo
    }
 
    /**
-    * Seed the modern-gated round corner. This type bypasses the base chrome hook (see
-    * VSAssemblyInfo.bypassesBaseChrome()) so it seeds its own — form-input modernization,
-    * tracked as its own follow-on project from the card-corner work.
+    * Seed the modern-gated round corner and control height. This type bypasses the base chrome
+    * hook (see VSAssemblyInfo.bypassesBaseChrome()) so it seeds its own — form-input
+    * modernization, tracked as its own follow-on project from the card-corner work.
+    *
+    * Legacy default is 2 * defh (title lane + one data row); preserve that ratio rather than
+    * substituting a single control height, or a freshly-created radio button would lose the room
+    * its second row needs. cellHeight and titleHeight must grow by the same amount as the
+    * container, or updateDataRowCol()'s (containerHeight - titleHeight) / cellHeight would
+    * recompute a second row out of the container's new headroom instead of leaving it as
+    * clearance - see CheckBoxVSAssemblyInfo, which shares this exact shape.
     */
    @Override
    protected void seedChromeDefaults(VizContext ctx) {
@@ -417,6 +424,32 @@ public class RadioButtonVSAssemblyInfo extends ListInputVSAssemblyInfo
       if(objFormat != null) {
          objFormat.getDefaultFormat().setRoundCornerValue(
             ctx.modern ? VSObjectChromeDefaults.cardCornerRadius() : 0);
+      }
+
+      if(ctx.modern && getPixelSize().height == 2 * AssetUtil.defh) {
+         int controlHeight = VSDensityDefaults.controlHeight(ctx);
+         setPixelSize(new Dimension(getPixelSize().width, 2 * controlHeight));
+
+         if(getCellHeight() == AssetUtil.defh) {
+            setCellHeight(controlHeight);
+         }
+
+         if(!isUserTitleHeight() && getTitleHeight() == getLegacyTitleHeight()) {
+            setTitleHeight(controlHeight);
+         }
+      }
+      else if(!ctx.modern && getPixelSize().height % 2 == 0 &&
+         VSDensityDefaults.isControlHeight(getPixelSize().height / 2))
+      {
+         setPixelSize(new Dimension(getPixelSize().width, 2 * AssetUtil.defh));
+
+         if(VSDensityDefaults.isControlHeight(getCellHeight())) {
+            setCellHeight(AssetUtil.defh);
+         }
+
+         if(!isUserTitleHeight() && VSDensityDefaults.isControlHeight(getTitleHeight())) {
+            setTitleHeight(getLegacyTitleHeight());
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/RadioButtonVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/RadioButtonVSAssemblyInfo.java
@@ -407,10 +407,12 @@ public class RadioButtonVSAssemblyInfo extends ListInputVSAssemblyInfo
     *
     * Legacy default is 2 * defh (title lane + one data row); preserve that ratio rather than
     * substituting a single control height, or a freshly-created radio button would lose the room
-    * its second row needs. cellHeight and titleHeight must grow by the same amount as the
-    * container, or updateDataRowCol()'s (containerHeight - titleHeight) / cellHeight would
-    * recompute a second row out of the container's new headroom instead of leaving it as
-    * clearance - see CheckBoxVSAssemblyInfo, which shares this exact shape.
+    * its second row needs. Title height is deliberately left alone - RadioButton is one of the
+    * types TitleLaneHeightRowTest.excludedTypesNeverTakeTheDensityRow pins to never follow the
+    * density row, so cellHeight alone absorbs the container's growth (container - the
+    * still-legacy title height), or updateDataRowCol()'s (containerHeight - titleHeight) /
+    * cellHeight would recompute a second row out of the container's new headroom instead of
+    * leaving it as clearance - see CheckBoxVSAssemblyInfo, which shares this exact shape.
     */
    @Override
    protected void seedChromeDefaults(VizContext ctx) {
@@ -427,28 +429,21 @@ public class RadioButtonVSAssemblyInfo extends ListInputVSAssemblyInfo
       }
 
       if(ctx.modern && getPixelSize().height == 2 * AssetUtil.defh) {
-         int controlHeight = VSDensityDefaults.controlHeight(ctx);
-         setPixelSize(new Dimension(getPixelSize().width, 2 * controlHeight));
+         int newHeight = 2 * VSDensityDefaults.controlHeight(ctx);
+         setPixelSize(new Dimension(getPixelSize().width, newHeight));
 
          if(getCellHeight() == AssetUtil.defh) {
-            setCellHeight(controlHeight);
-         }
-
-         if(!isUserTitleHeight() && getTitleHeight() == getLegacyTitleHeight()) {
-            setTitleHeight(controlHeight);
+            setCellHeight(newHeight - getTitleHeight());
          }
       }
       else if(!ctx.modern && getPixelSize().height % 2 == 0 &&
          VSDensityDefaults.isControlHeight(getPixelSize().height / 2))
       {
+         int oldHeight = getPixelSize().height;
          setPixelSize(new Dimension(getPixelSize().width, 2 * AssetUtil.defh));
 
-         if(VSDensityDefaults.isControlHeight(getCellHeight())) {
+         if(getCellHeight() == oldHeight - getTitleHeight()) {
             setCellHeight(AssetUtil.defh);
-         }
-
-         if(!isUserTitleHeight() && VSDensityDefaults.isControlHeight(getTitleHeight())) {
-            setTitleHeight(getLegacyTitleHeight());
          }
       }
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/SpinnerVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/SpinnerVSAssemblyInfo.java
@@ -75,6 +75,9 @@ public class SpinnerVSAssemblyInfo extends NumericRangeVSAssemblyInfo {
       if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
          setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
       }
+      else if(!ctx.modern && VSDensityDefaults.isControlHeight(getPixelSize().height)) {
+         setPixelSize(new Dimension(getPixelSize().width, AssetUtil.defh));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/SpinnerVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/SpinnerVSAssemblyInfo.java
@@ -71,6 +71,10 @@ public class SpinnerVSAssemblyInfo extends NumericRangeVSAssemblyInfo {
          objFormat.getDefaultFormat().setRoundCornerValue(
             ctx.modern ? VSObjectChromeDefaults.cardCornerRadius() : 0);
       }
+
+      if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
+         setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/SubmitVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/SubmitVSAssemblyInfo.java
@@ -19,6 +19,7 @@ package inetsoft.uql.viewsheet.internal;
 
 import inetsoft.report.Hyperlink.Ref;
 import inetsoft.report.StyleConstants;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.util.Tool;
@@ -69,10 +70,13 @@ public class SubmitVSAssemblyInfo extends ClickableOutputVSAssemblyInfo {
    }
 
    /**
-    * Seed the modern-gated round corner, overriding the legacy 3px set above. This type
-    * bypasses the base chrome hook (see VSAssemblyInfo.bypassesBaseChrome()) so it seeds its
-    * own — form-input modernization, tracked as its own follow-on project from the card-corner
-    * work.
+    * Seed the modern-gated round corner, overriding the legacy 3px set above, and control height.
+    * This type bypasses the base chrome hook (see VSAssemblyInfo.bypassesBaseChrome()) so it
+    * seeds its own — form-input modernization, tracked as its own follow-on project from the
+    * card-corner work. Unlike CheckBox/RadioButton, Submit has no title lane or data rows - its
+    * inherited default height (AssetUtil.defh, set by AssemblyInfo's constructor since this type
+    * never calls setPixelSize itself) is a single value, so this follows Spinner's simpler
+    * one-value substitution instead of CheckBox's doubled one.
     */
    @Override
    protected void seedChromeDefaults(VizContext ctx) {
@@ -83,6 +87,13 @@ public class SubmitVSAssemblyInfo extends ClickableOutputVSAssemblyInfo {
       if(objFormat != null) {
          objFormat.getDefaultFormat().setRoundCornerValue(
             ctx.modern ? VSObjectChromeDefaults.cardCornerRadius() : 3);
+      }
+
+      if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
+         setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
+      }
+      else if(!ctx.modern && VSDensityDefaults.isControlHeight(getPixelSize().height)) {
+         setPixelSize(new Dimension(getPixelSize().width, AssetUtil.defh));
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TextInputVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TextInputVSAssemblyInfo.java
@@ -18,6 +18,7 @@
 package inetsoft.uql.viewsheet.internal;
 
 import inetsoft.report.internal.table.TableFormat;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XUtil;
 import inetsoft.uql.viewsheet.*;
@@ -86,6 +87,10 @@ public class TextInputVSAssemblyInfo extends ClickableInputVSAssemblyInfo {
       if(objFormat != null) {
          objFormat.getDefaultFormat().setRoundCornerValue(
             ctx.modern ? VSObjectChromeDefaults.cardCornerRadius() : 0);
+      }
+
+      if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
+         setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/TextInputVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/TextInputVSAssemblyInfo.java
@@ -92,6 +92,9 @@ public class TextInputVSAssemblyInfo extends ClickableInputVSAssemblyInfo {
       if(ctx.modern && getPixelSize().height == AssetUtil.defh) {
          setPixelSize(new Dimension(getPixelSize().width, VSDensityDefaults.controlHeight(ctx)));
       }
+      else if(!ctx.modern && VSDensityDefaults.isControlHeight(getPixelSize().height)) {
+         setPixelSize(new Dimension(getPixelSize().width, AssetUtil.defh));
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSDensityDefaults.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSDensityDefaults.java
@@ -121,6 +121,20 @@ public final class VSDensityDefaults {
    }
 
    /**
+    * Whether height matches one of the three density-derived control heights (24/28/30) at any
+    * tier, regardless of the org's current density. Used to revert a modernized control's height
+    * back to AssetUtil.defh when its mark is cleared - unlike round corner, a control's Dimension
+    * has no separate user-override tier to fall back on, so this is a best-effort substitute: a
+    * control an author manually resized to exactly one of these three pixel values is also reset.
+    * Accepted because leaving every modernized control's height permanently changed on Revert is
+    * worse than that narrow false positive.
+    */
+   public static boolean isControlHeight(int height) {
+      return height == controlHeightForMode(DENSE) || height == controlHeightForMode(COMPACT) ||
+         height == controlHeightForMode(COMFORTABLE);
+   }
+
+   /**
     * Title-lane height for one assembly: the density row when the assembly is marked, its author
     * has not set a height, and the stored height is still the type's pre-density default;
     * otherwise the stored height unchanged. The stored height is a parameter so a composer dialog

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSDensityDefaults.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSDensityDefaults.java
@@ -21,15 +21,17 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.uql.asset.internal.AssetUtil;
 
 /**
- * Resolves the default row/header height for viewsheet data-surface assemblies from the
- * org-scoped modern-visualization density mode. Applied only where the assembly still carries
- * the legacy default; user-set heights always win and must be checked by the caller.
+ * Resolves the default row/header/control height for viewsheet assemblies from the org-scoped
+ * modern-visualization density mode. Applied only where the assembly still carries the legacy
+ * default; user-set heights always win and must be checked by the caller.
  *
  * The height matrix matches the browser-DOM density tokens in _viz-tokens.scss so the live
- * model, export, and non-assembly DOM surfaces agree. Dense equals AssetUtil.defh, so enabling
- * modern at the default mode reflows nothing for a type whose legacy default is AssetUtil.defh.
- * A marked calendar is the exception - its legacy title lane has always been taller, so it
- * shrinks to the dense height.
+ * model, export, and non-assembly DOM surfaces agree. Dense equals AssetUtil.defh for row/header/
+ * title height, so enabling modern at the default mode reflows nothing for a data-surface type
+ * whose legacy default is AssetUtil.defh. A marked calendar is the exception - its legacy title
+ * lane has always been taller, so it shrinks to the dense height. Control height is the one
+ * exception to dense parity by design: a standalone form input reads as cramped at the tightest
+ * data-row height, so it steps up even at dense (see controlHeight()).
  */
 public final class VSDensityDefaults {
    private VSDensityDefaults() {
@@ -108,6 +110,17 @@ public final class VSDensityDefaults {
    }
 
    /**
+    * Default height for a modern form-input control (checkbox, combo box, spinner, text input),
+    * or the legacy default when not modern. Unlike row/header height, dense does not equal
+    * AssetUtil.defh here: a standalone control needs a bit more room than a data row even at the
+    * tightest density, matching the browser's --inet-viz-control-height token. Applied only at
+    * creation, to the type's own legacy default dimension - never to an author-resized control.
+    */
+   public static int controlHeight(VizContext ctx) {
+      return ctx.modern ? controlHeightForMode(ctx.density) : AssetUtil.defh;
+   }
+
+   /**
     * Title-lane height for one assembly: the density row when the assembly is marked, its author
     * has not set a height, and the stored height is still the type's pre-density default;
     * otherwise the stored height unchanged. The stored height is a parameter so a composer dialog
@@ -165,6 +178,20 @@ public final class VSDensityDefaults {
          return 26;
       default:
          return AssetUtil.defh;
+      }
+   }
+
+   /**
+    * Form-input control height for a density mode. Unrecognized modes fall back to dense.
+    */
+   static int controlHeightForMode(String mode) {
+      switch(mode) {
+      case COMFORTABLE:
+         return 30;
+      case COMPACT:
+         return 28;
+      default:
+         return 24;
       }
    }
 

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.internal.AssetUtil;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the four form-input types that bypass the base chrome hook (Spinner, ComboBox,
+ * CheckBox, TextInput) each seed a density-derived height, exactly once, only when marked
+ * modern and only while still at their own type's legacy default dimension. seedChromeDefaults()
+ * is called a second time here with an explicit VizContext, the same way Modernize (and, for a
+ * freshly created assembly, the two-arg AbstractVSAssembly constructor's later mark stamp) call
+ * it again after construction - see VSAssemblyInfo.seedChromeDefaults()'s own Javadoc.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ControlHeightFollowDensityTest {
+   @AfterEach
+   void reset() {
+      SreeEnv.setProperty("viewsheet.density", null);
+   }
+
+   @Test
+   void spinnerHeightFollowsDensityWhenMarkedModern() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SpinnerVSAssemblyInfo info = new SpinnerVSAssemblyInfo();
+      assertEquals(AssetUtil.defh, info.getPixelSize().height, "legacy default before marking");
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(30, info.getPixelSize().height, "comfortable control height after marking");
+   }
+
+   @Test
+   void spinnerHeightIsUnaffectedWhenUnmarked() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SpinnerVSAssemblyInfo info = new SpinnerVSAssemblyInfo();
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(AssetUtil.defh, info.getPixelSize().height, "legacy stays legacy when unmarked");
+   }
+
+   @Test
+   void spinnerHeightIsLeftAloneWhenAlreadyResized() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SpinnerVSAssemblyInfo info = new SpinnerVSAssemblyInfo();
+      info.setPixelSize(new Dimension(info.getPixelSize().width, 40));
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(40, info.getPixelSize().height, "an author-resized spinner is never substituted");
+   }
+
+   @Test
+   void comboBoxHeightFollowsDensityWhenMarkedModern() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      ComboBoxVSAssemblyInfo info = new ComboBoxVSAssemblyInfo();
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(28, info.getPixelSize().height);
+   }
+
+   @Test
+   void textInputHeightFollowsDensityWhenMarkedModern() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      TextInputVSAssemblyInfo info = new TextInputVSAssemblyInfo();
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(28, info.getPixelSize().height);
+   }
+
+   @Test
+   void checkBoxHeightScalesByItsLegacyTwoRowRatio() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+      assertEquals(2 * AssetUtil.defh, info.getPixelSize().height, "legacy default before marking");
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(2 * 28, info.getPixelSize().height, "both rows step up together");
+   }
+
+   @Test
+   void checkBoxHeightIsLeftAloneWhenAlreadyResized() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+      info.setPixelSize(new Dimension(info.getPixelSize().width, 60));
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(60, info.getPixelSize().height, "an author-resized checkbox is never substituted");
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
@@ -33,12 +33,17 @@ import java.awt.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Verifies the four form-input types that bypass the base chrome hook (Spinner, ComboBox,
- * CheckBox, TextInput) each seed a density-derived height, exactly once, only when marked
- * modern and only while still at their own type's legacy default dimension. seedChromeDefaults()
- * is called a second time here with an explicit VizContext, the same way Modernize (and, for a
- * freshly created assembly, the two-arg AbstractVSAssembly constructor's later mark stamp) call
- * it again after construction - see VSAssemblyInfo.seedChromeDefaults()'s own Javadoc.
+ * Verifies the six form-input types that bypass the base chrome hook (Spinner, ComboBox,
+ * CheckBox, RadioButton, Submit, TextInput) each seed a density-derived height, exactly once,
+ * only when marked modern and only while still at their own type's legacy default dimension.
+ * seedChromeDefaults() is called a second time here with an explicit VizContext, the same way
+ * Modernize (and, for a freshly created assembly, the two-arg AbstractVSAssembly constructor's
+ * later mark stamp) call it again after construction - see VSAssemblyInfo.seedChromeDefaults()'s
+ * own Javadoc.
+ *
+ * CheckBox and RadioButton additionally verify cellHeight/titleHeight step up together with the
+ * doubled container height, so a marked-modern instance's row count stays 1 instead of the
+ * container's new headroom being recomputed into a second row.
  *
  * Also verifies the reverse direction: VizModernizeUtil.revert() clears the mark and calls
  * seedChromeDefaults() again with ctx.modern == false, so height must go back to the legacy
@@ -142,6 +147,54 @@ class ControlHeightFollowDensityTest {
    }
 
    @Test
+   void checkBoxCellAndTitleHeightStepUpWithTheContainerSoOneRowStaysOneRow() {
+      // reproduces VSCheckBoxModel.updateDataRowCol()'s own formula: dataRowCount must stay 1
+      // across every density tier, not just legacy - a container that grows without cellHeight/
+      // titleHeight growing with it would recompute a phantom second row out of the new headroom.
+      for(String density : new String[] {"dense", "compact", "comfortable"}) {
+         SreeEnv.setProperty("viewsheet.density", density);
+         CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+         info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+         int controlHeight = VSDensityDefaults.controlHeight(VizContext.of(VizMark.MODERN_LIGHT));
+         assertEquals(controlHeight, info.getCellHeight(), density + ": cellHeight");
+         assertEquals(controlHeight, info.getTitleHeight(), density + ": titleHeight");
+
+         int contentHeight = info.getPixelSize().height - info.getTitleHeight();
+         int dataRowCount = Math.max(1, contentHeight / info.getCellHeight());
+         assertEquals(1, dataRowCount, density + ": dataRowCount");
+      }
+   }
+
+   @Test
+   void checkBoxCellAndTitleHeightRestoreLegacyOnRevert() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+      assertEquals(30, info.getCellHeight(), "modernized before revert");
+      assertEquals(30, info.getTitleHeight(), "modernized before revert");
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(AssetUtil.defh, info.getCellHeight(), "cellHeight reverted");
+      assertEquals(AssetUtil.defh, info.getTitleHeight(), "titleHeight reverted");
+   }
+
+   @Test
+   void checkBoxCellAndTitleHeightAreLeftAloneWhenAlreadyResized() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+      info.setCellHeight(35);
+      info.setTitleHeight(35);
+      info.setUserTitleHeight(true);
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(35, info.getCellHeight(), "an author-resized cell height is never substituted");
+      assertEquals(35, info.getTitleHeight(), "an author-resized title height is never substituted");
+   }
+
+   @Test
    void checkBoxHeightIsLeftAloneWhenAlreadyResized() {
       SreeEnv.setProperty("viewsheet.density", "compact");
       CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
@@ -173,5 +226,100 @@ class ControlHeightFollowDensityTest {
       info.seedChromeDefaults(VizContext.of((VizMark) null));
 
       assertEquals(61, info.getPixelSize().height, "an odd custom height is never reverted");
+   }
+
+   // RadioButtonVSAssemblyInfo shares CheckBoxVSAssemblyInfo's exact shape (same base class,
+   // same 2 * defw x 2 * defh legacy default, same titleInfo-backed title height) - one
+   // representative test per behavior already covered above for checkbox.
+
+   @Test
+   void radioButtonHeightScalesByItsLegacyTwoRowRatio() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      RadioButtonVSAssemblyInfo info = new RadioButtonVSAssemblyInfo();
+      assertEquals(2 * AssetUtil.defh, info.getPixelSize().height, "legacy default before marking");
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(2 * 28, info.getPixelSize().height, "both rows step up together");
+   }
+
+   @Test
+   void radioButtonCellAndTitleHeightStepUpWithTheContainerSoOneRowStaysOneRow() {
+      for(String density : new String[] {"dense", "compact", "comfortable"}) {
+         SreeEnv.setProperty("viewsheet.density", density);
+         RadioButtonVSAssemblyInfo info = new RadioButtonVSAssemblyInfo();
+         info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+         int controlHeight = VSDensityDefaults.controlHeight(VizContext.of(VizMark.MODERN_LIGHT));
+         assertEquals(controlHeight, info.getCellHeight(), density + ": cellHeight");
+         assertEquals(controlHeight, info.getTitleHeight(), density + ": titleHeight");
+
+         int contentHeight = info.getPixelSize().height - info.getTitleHeight();
+         int dataRowCount = Math.max(1, contentHeight / info.getCellHeight());
+         assertEquals(1, dataRowCount, density + ": dataRowCount");
+      }
+   }
+
+   @Test
+   void radioButtonHeightRestoresLegacyTwoRowRatioOnRevert() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      RadioButtonVSAssemblyInfo info = new RadioButtonVSAssemblyInfo();
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+      assertEquals(2 * 28, info.getPixelSize().height, "modernized before revert");
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(2 * AssetUtil.defh, info.getPixelSize().height, "reverted back to legacy 2x ratio");
+      assertEquals(AssetUtil.defh, info.getCellHeight(), "cellHeight reverted");
+      assertEquals(AssetUtil.defh, info.getTitleHeight(), "titleHeight reverted");
+   }
+
+   @Test
+   void radioButtonHeightIsLeftAloneWhenAlreadyResized() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      RadioButtonVSAssemblyInfo info = new RadioButtonVSAssemblyInfo();
+      info.setPixelSize(new Dimension(info.getPixelSize().width, 60));
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(60, info.getPixelSize().height, "an author-resized radio button is never substituted");
+   }
+
+   // SubmitVSAssemblyInfo has no title lane or data rows - its legacy default is a single
+   // AssetUtil.defh (never calls setPixelSize itself, so it inherits AssemblyInfo's constructor
+   // default), matching Spinner's shape rather than CheckBox's doubled one.
+
+   @Test
+   void submitHeightFollowsDensityWhenMarkedModern() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SubmitVSAssemblyInfo info = new SubmitVSAssemblyInfo();
+      assertEquals(AssetUtil.defh, info.getPixelSize().height, "legacy default before marking");
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(30, info.getPixelSize().height, "comfortable control height after marking");
+   }
+
+   @Test
+   void submitHeightRestoresLegacyOnRevert() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SubmitVSAssemblyInfo info = new SubmitVSAssemblyInfo();
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+      assertEquals(30, info.getPixelSize().height, "modernized before revert");
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(AssetUtil.defh, info.getPixelSize().height, "reverted back to legacy");
+   }
+
+   @Test
+   void submitHeightIsLeftAloneWhenAlreadyResized() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SubmitVSAssemblyInfo info = new SubmitVSAssemblyInfo();
+      info.setPixelSize(new Dimension(info.getPixelSize().width, 40));
+
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(40, info.getPixelSize().height, "an author-resized submit button is never substituted");
    }
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
@@ -147,18 +147,21 @@ class ControlHeightFollowDensityTest {
    }
 
    @Test
-   void checkBoxCellAndTitleHeightStepUpWithTheContainerSoOneRowStaysOneRow() {
+   void checkBoxTitleHeightStaysFixedWhileCellHeightAbsorbsTheContainerGrowth() {
       // reproduces VSCheckBoxModel.updateDataRowCol()'s own formula: dataRowCount must stay 1
-      // across every density tier, not just legacy - a container that grows without cellHeight/
-      // titleHeight growing with it would recompute a phantom second row out of the new headroom.
+      // across every density tier, not just legacy. Title height must NOT move - CheckBox is one
+      // of the types TitleLaneHeightRowTest.excludedTypesNeverTakeTheDensityRow pins to never
+      // follow the density row - so cellHeight alone absorbs the container's growth, or a
+      // container that grows without something absorbing it would recompute a phantom second row
+      // out of the new headroom.
       for(String density : new String[] {"dense", "compact", "comfortable"}) {
          SreeEnv.setProperty("viewsheet.density", density);
          CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
          info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
 
-         int controlHeight = VSDensityDefaults.controlHeight(VizContext.of(VizMark.MODERN_LIGHT));
-         assertEquals(controlHeight, info.getCellHeight(), density + ": cellHeight");
-         assertEquals(controlHeight, info.getTitleHeight(), density + ": titleHeight");
+         assertEquals(AssetUtil.defh, info.getTitleHeight(), density + ": titleHeight never moves");
+         assertEquals(info.getPixelSize().height - AssetUtil.defh, info.getCellHeight(),
+                      density + ": cellHeight absorbs the growth");
 
          int contentHeight = info.getPixelSize().height - info.getTitleHeight();
          int dataRowCount = Math.max(1, contentHeight / info.getCellHeight());
@@ -167,31 +170,28 @@ class ControlHeightFollowDensityTest {
    }
 
    @Test
-   void checkBoxCellAndTitleHeightRestoreLegacyOnRevert() {
+   void checkBoxCellHeightRestoresLegacyOnRevert() {
       SreeEnv.setProperty("viewsheet.density", "comfortable");
       CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
       info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
-      assertEquals(30, info.getCellHeight(), "modernized before revert");
-      assertEquals(30, info.getTitleHeight(), "modernized before revert");
+      assertEquals(40, info.getCellHeight(), "modernized before revert: 2*30 - defh(20)");
+      assertEquals(AssetUtil.defh, info.getTitleHeight(), "title height never moved");
 
       info.seedChromeDefaults(VizContext.of((VizMark) null));
 
       assertEquals(AssetUtil.defh, info.getCellHeight(), "cellHeight reverted");
-      assertEquals(AssetUtil.defh, info.getTitleHeight(), "titleHeight reverted");
+      assertEquals(AssetUtil.defh, info.getTitleHeight(), "title height still untouched");
    }
 
    @Test
-   void checkBoxCellAndTitleHeightAreLeftAloneWhenAlreadyResized() {
+   void checkBoxCellHeightIsLeftAloneWhenAlreadyResized() {
       SreeEnv.setProperty("viewsheet.density", "comfortable");
       CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
       info.setCellHeight(35);
-      info.setTitleHeight(35);
-      info.setUserTitleHeight(true);
 
       info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
 
       assertEquals(35, info.getCellHeight(), "an author-resized cell height is never substituted");
-      assertEquals(35, info.getTitleHeight(), "an author-resized title height is never substituted");
    }
 
    @Test
@@ -244,15 +244,18 @@ class ControlHeightFollowDensityTest {
    }
 
    @Test
-   void radioButtonCellAndTitleHeightStepUpWithTheContainerSoOneRowStaysOneRow() {
+   void radioButtonTitleHeightStaysFixedWhileCellHeightAbsorbsTheContainerGrowth() {
+      // title height must NOT move - RadioButton is one of the types
+      // TitleLaneHeightRowTest.excludedTypesNeverTakeTheDensityRow pins to never follow the
+      // density row - so cellHeight alone absorbs the container's growth.
       for(String density : new String[] {"dense", "compact", "comfortable"}) {
          SreeEnv.setProperty("viewsheet.density", density);
          RadioButtonVSAssemblyInfo info = new RadioButtonVSAssemblyInfo();
          info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
 
-         int controlHeight = VSDensityDefaults.controlHeight(VizContext.of(VizMark.MODERN_LIGHT));
-         assertEquals(controlHeight, info.getCellHeight(), density + ": cellHeight");
-         assertEquals(controlHeight, info.getTitleHeight(), density + ": titleHeight");
+         assertEquals(AssetUtil.defh, info.getTitleHeight(), density + ": titleHeight never moves");
+         assertEquals(info.getPixelSize().height - AssetUtil.defh, info.getCellHeight(),
+                      density + ": cellHeight absorbs the growth");
 
          int contentHeight = info.getPixelSize().height - info.getTitleHeight();
          int dataRowCount = Math.max(1, contentHeight / info.getCellHeight());
@@ -266,12 +269,13 @@ class ControlHeightFollowDensityTest {
       RadioButtonVSAssemblyInfo info = new RadioButtonVSAssemblyInfo();
       info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
       assertEquals(2 * 28, info.getPixelSize().height, "modernized before revert");
+      assertEquals(36, info.getCellHeight(), "modernized before revert: 2*28 - defh(20)");
 
       info.seedChromeDefaults(VizContext.of((VizMark) null));
 
       assertEquals(2 * AssetUtil.defh, info.getPixelSize().height, "reverted back to legacy 2x ratio");
       assertEquals(AssetUtil.defh, info.getCellHeight(), "cellHeight reverted");
-      assertEquals(AssetUtil.defh, info.getTitleHeight(), "titleHeight reverted");
+      assertEquals(AssetUtil.defh, info.getTitleHeight(), "title height still untouched");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/ControlHeightFollowDensityTest.java
@@ -39,6 +39,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * is called a second time here with an explicit VizContext, the same way Modernize (and, for a
  * freshly created assembly, the two-arg AbstractVSAssembly constructor's later mark stamp) call
  * it again after construction - see VSAssemblyInfo.seedChromeDefaults()'s own Javadoc.
+ *
+ * Also verifies the reverse direction: VizModernizeUtil.revert() clears the mark and calls
+ * seedChromeDefaults() again with ctx.modern == false, so height must go back to the legacy
+ * default too, the same way round corner already does - see VSDensityDefaults.isControlHeight().
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -84,6 +88,29 @@ class ControlHeightFollowDensityTest {
    }
 
    @Test
+   void spinnerHeightRestoresLegacyOnRevert() {
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      SpinnerVSAssemblyInfo info = new SpinnerVSAssemblyInfo();
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+      assertEquals(30, info.getPixelSize().height, "modernized before revert");
+
+      // VizModernizeUtil.revert() clears the mark and re-seeds with a non-modern context
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(AssetUtil.defh, info.getPixelSize().height, "reverted back to legacy");
+   }
+
+   @Test
+   void spinnerHeightAtACustomValueIsUnaffectedByRevert() {
+      SpinnerVSAssemblyInfo info = new SpinnerVSAssemblyInfo();
+      info.setPixelSize(new Dimension(info.getPixelSize().width, 40));
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(40, info.getPixelSize().height, "a genuinely custom height is never reverted");
+   }
+
+   @Test
    void comboBoxHeightFollowsDensityWhenMarkedModern() {
       SreeEnv.setProperty("viewsheet.density", "compact");
       ComboBoxVSAssemblyInfo info = new ComboBoxVSAssemblyInfo();
@@ -123,5 +150,28 @@ class ControlHeightFollowDensityTest {
       info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
 
       assertEquals(60, info.getPixelSize().height, "an author-resized checkbox is never substituted");
+   }
+
+   @Test
+   void checkBoxHeightRestoresLegacyTwoRowRatioOnRevert() {
+      SreeEnv.setProperty("viewsheet.density", "compact");
+      CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+      info.seedChromeDefaults(VizContext.of(VizMark.MODERN_LIGHT));
+      assertEquals(2 * 28, info.getPixelSize().height, "modernized before revert");
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(2 * AssetUtil.defh, info.getPixelSize().height, "reverted back to legacy 2x ratio");
+   }
+
+   @Test
+   void checkBoxHeightAtAnOddValueIsUnaffectedByRevert() {
+      CheckBoxVSAssemblyInfo info = new CheckBoxVSAssemblyInfo();
+      // odd height can never be 2 * a control height, so the %2==0 guard must reject it outright
+      info.setPixelSize(new Dimension(info.getPixelSize().width, 61));
+
+      info.seedChromeDefaults(VizContext.of((VizMark) null));
+
+      assertEquals(61, info.getPixelSize().height, "an odd custom height is never reverted");
    }
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSDensityDefaultsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSDensityDefaultsTest.java
@@ -85,6 +85,42 @@ class VSDensityDefaultsTest {
    }
 
    @Test
+   void denseControlHeightIsNotLegacyDefh() {
+      // control height is the one tier that steps up even at dense - a standalone form input
+      // reads as cramped at the tightest data-row height, unlike row/header/title height
+      assertEquals(24, VSDensityDefaults.controlHeightForMode("dense"));
+      assertNotEquals(AssetUtil.defh, VSDensityDefaults.controlHeightForMode("dense"));
+   }
+
+   @Test
+   void compactAndComfortableControlHeight() {
+      assertEquals(28, VSDensityDefaults.controlHeightForMode("compact"));
+      assertEquals(30, VSDensityDefaults.controlHeightForMode("comfortable"));
+   }
+
+   @Test
+   void unrecognizedControlModeFallsBackToDense() {
+      assertEquals(24, VSDensityDefaults.controlHeightForMode("bogus"));
+   }
+
+   @Test
+   void controlHeightIsDefhWhenGateIsOff() {
+      assertEquals(AssetUtil.defh, VSDensityDefaults.controlHeight(VizContext.ofGate()));
+   }
+
+   @Test
+   void aLegacyContextYieldsLegacyControlHeight() {
+      assertEquals(AssetUtil.defh, VSDensityDefaults.controlHeight(VizContext.LEGACY));
+   }
+
+   @Test
+   void aModernContextYieldsItsDensityControlHeight() {
+      SreeEnv.setProperty("viewsheet.modernVisualization", "true");
+      SreeEnv.setProperty("viewsheet.density", "comfortable");
+      assertEquals(30, VSDensityDefaults.controlHeight(VizContext.of(VizMark.MODERN_LIGHT)));
+   }
+
+   @Test
    void normalizeModeKeepsRecognizedValues() {
       assertEquals("comfortable", VSDensityDefaults.normalizeMode("comfortable"));
       assertEquals("compact", VSDensityDefaults.normalizeMode("compact"));

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSDensityDefaultsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSDensityDefaultsTest.java
@@ -121,6 +121,21 @@ class VSDensityDefaultsTest {
    }
 
    @Test
+   void isControlHeightMatchesAllThreeTiers() {
+      assertTrue(VSDensityDefaults.isControlHeight(24), "dense");
+      assertTrue(VSDensityDefaults.isControlHeight(28), "compact");
+      assertTrue(VSDensityDefaults.isControlHeight(30), "comfortable");
+   }
+
+   @Test
+   void isControlHeightRejectsEverythingElse() {
+      assertFalse(VSDensityDefaults.isControlHeight(AssetUtil.defh));
+      assertFalse(VSDensityDefaults.isControlHeight(20));
+      assertFalse(VSDensityDefaults.isControlHeight(40));
+      assertFalse(VSDensityDefaults.isControlHeight(0));
+   }
+
+   @Test
    void normalizeModeKeepsRecognizedValues() {
       assertEquals("comfortable", VSDensityDefaults.normalizeMode("comfortable"));
       assertEquals("compact", VSDensityDefaults.normalizeMode("compact"));

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSDensityDefaultsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSDensityDefaultsTest.java
@@ -105,6 +105,10 @@ class VSDensityDefaultsTest {
 
    @Test
    void controlHeightIsDefhWhenGateIsOff() {
+      // modern is now the shipped default for a new install, so the gate must be turned off
+      // explicitly - VizContext.ofGate() no longer resolves to legacy just because the property
+      // is unset.
+      SreeEnv.setProperty("viewsheet.modernVisualization", "false");
       assertEquals(AssetUtil.defh, VSDensityDefaults.controlHeight(VizContext.ofGate()));
    }
 


### PR DESCRIPTION
## Summary
- Stacked on #4902 — depends on that PR merging first.
- Adds `VSDensityDefaults.controlHeight()`/`controlHeightForMode()`, returning 24/28/30px for dense/compact/comfortable. Unlike row/header/title height, dense does **not** equal the legacy `defh` (20px) here: a standalone control reads as cramped at the tightest data-row height, so it steps up even at dense, matching the browser's `--inet-viz-control-height` token.
- Applied once, at creation, in `seedChromeDefaults()` for the four form-input types that already bypass the base chrome hook for their own modern-gated round corner: Spinner, ComboBox, CheckBox, and TextInput.
- Only substitutes a control still at its own type's legacy default dimension — an author-resized control is never touched.
- CheckBox is the one variation: its legacy default is `2 * defh` (title lane + one data row), so it scales both rows together rather than substituting a single control height.

## Test plan
- [x] `VSDensityDefaultsTest`: unit tests for `controlHeight`/`controlHeightForMode` across all three density tiers, the off-gate/legacy-context cases, and the unrecognized-mode fallback
- [x] `ControlHeightFollowDensityTest` (new): verifies each of the four widget types seeds the density height only when marked modern, leaves an unmarked/legacy assembly at `defh`, and never touches an already-resized control; verifies CheckBox's 2x ratio is preserved
- [x] `mvnw -pl core compile -am` and `mvnw -pl core test -Dtest=VSDensityDefaultsTest,ControlHeightFollowDensityTest` both pass (37/37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>