### PR TITLE
fix(wiz): add force flag to open_base_worksheet for orphaned session recovery (PSM-006)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -72,6 +72,24 @@ public class SheetOpenService {
     *                                  problem and, where there is one, the next tool to call.
     */
    public JoinSession openBaseWorksheet(String sessionToken, Principal user) throws Exception {
+      return openBaseWorksheet(sessionToken, user, false);
+   }
+
+   /**
+    * Open the base worksheet of the viewsheet paired to {@code sessionToken}, for {@code user}.
+    *
+    * @param force when {@code true} and a worksheet session is already held for this identity,
+    *              close it and proceed instead of refusing -- the recovery path for a session
+    *              orphaned by a client that lost the local pointer needed to name it for
+    *              {@code detach_sheet} (e.g. a prior {@code connect_sheet(force:true)} that
+    *              predates that client releasing what it replaces server-side).
+    *
+    * @throws IllegalArgumentException on every refusal, with a message naming the specific
+    *                                  problem and, where there is one, the next tool to call.
+    */
+   public JoinSession openBaseWorksheet(String sessionToken, Principal user, boolean force)
+      throws Exception
+   {
       JoinSession vsSession =
          viewsheetSessions.requireSessionAllowingPaneScope(sessionToken, user);
 
@@ -121,9 +139,18 @@ public class SheetOpenService {
       JoinSession held = sheetSessions.findOpen(vsSession.ownerIdentity(), SheetType.WORKSHEET);
 
       if(held != null) {
-         throw new IllegalArgumentException(
-            "A worksheet session is already open (runtimeId=" + held.runtimeId() + "). Call " +
-            "detach_sheet to close it before opening another base worksheet.");
+         if(!force) {
+            throw new IllegalArgumentException(
+               "A worksheet session is already open (runtimeId=" + held.runtimeId() + "). Call " +
+               "detach_sheet to close it, or -- if detach_sheet reports nothing connected because " +
+               "this held session is not in this client's local state -- call open_base_worksheet " +
+               "again with force:true to close it and open this one instead.");
+         }
+
+         // Best-effort: the caller is discarding this session either way, so a session the server
+         // has already forgotten (or that close() otherwise cannot fully act on) must not block
+         // the open that follows.
+         sheetSessions.close(held.sessionToken());
       }
 
       if(vsSession.socketSessionId() == null) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -132,6 +132,11 @@ public class ViewsheetAssemblyAgentController {
                               session.sheetType().name().toLowerCase(), session.editorContext());
    }
 
+   /** {@code force} closes a worksheet session already held for this identity instead of
+    *  refusing; absent (including a body-less request from a client predating this field) means
+    *  false, matching every other {@code force} request record on this controller. */
+   public record OpenBaseWorksheetRequest(Boolean force) {}
+
    /**
     * Opens the base worksheet of the viewsheet paired to {@code sessionToken} and pairs a new
     * session for it. {@link SheetOpenService} performs every guard and the browser broadcast;
@@ -139,11 +144,14 @@ public class ViewsheetAssemblyAgentController {
     * returns, with {@code sheetType} read off the session rather than assumed by the caller.
     */
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/open-base-worksheet")
-   public JoinResponse openBaseWorksheet(@PathVariable String sessionToken, Principal user)
+   public JoinResponse openBaseWorksheet(@PathVariable String sessionToken,
+                                          @RequestBody(required = false) OpenBaseWorksheetRequest body,
+                                          Principal user)
       throws Exception
    {
       requireEnabled();
-      JoinSession session = openService.openBaseWorksheet(sessionToken, user);
+      boolean force = body != null && Boolean.TRUE.equals(body.force());
+      JoinSession session = openService.openBaseWorksheet(sessionToken, user, force);
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext());
    }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -177,6 +177,31 @@ class SheetSessionServiceTest {
       assertEquals(session.sessionToken(), found.sessionToken());
    }
 
+   /**
+    * Pins the invariant PSM-006's fix (open_base_worksheet's {@code force} flag closing exactly
+    * the one session {@code findOpen} returned) relies on: {@code open()} never consults
+    * {@code findOpen} itself, so two pane-scoped sessions of the same (ownerIdentity, sheetType)
+    * -- e.g. a whole-sheet toolbar pairing plus a script-pane pairing on the same viewsheet -- may
+    * legitimately coexist. A fix that made {@code open()} evict whatever {@code findOpen} returns
+    * before minting a new session would silently kill a live, unrelated pane session the first
+    * time a second one is paired; this test would then fail because only one of the two tokens
+    * would still resolve.
+    */
+   @Test
+   void openTwiceForTheSameOwnerAndTypeLeavesBothSessionsLiveAndIndependentlyReachable() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession first = svc.open("rt-7a", "erin~;~org", SheetType.VIEWSHEET, "sock-1", "erin", null);
+      JoinSession second = svc.open(
+         "rt-7b", "erin~;~org", SheetType.VIEWSHEET, "sock-1", "erin",
+         new EditorContext("assemblyMain", "Chart1", null, null));
+
+      assertNotEquals(first.sessionToken(), second.sessionToken());
+      assertNotNull(svc.resolve(first.sessionToken(), "erin~;~org"),
+                    "the first session must still resolve after the second was opened");
+      assertNotNull(svc.resolve(second.sessionToken(), "erin~;~org"),
+                    "the second session must resolve independently of the first");
+   }
+
    @Test
    void expiresAPaneSessionWhenItsSocketGoesAway() {
       SheetSessionService svc = serviceAt(FIXED_NOW);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -141,6 +141,51 @@ class SheetOpenServiceTest {
    }
 
    /**
+    * PSM-006: without an explicit {@code force} argument, the 2-arg overload must refuse exactly
+    * as before -- the safety check this whole feature relies on (a held session may belong to a
+    * different, concurrently-running agent) must not be silently weakened by adding the flag.
+    */
+   @Test
+   void threeArgOverloadWithForceFalseRefusesJustLikeTheTwoArgOverload() {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, "ws-existing");
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.openBaseWorksheet("tok-vs", principal(), false));
+
+      assertTrue(thrown.getMessage().contains("ws-existing"), thrown.getMessage());
+      verify(sheetSessions, never()).close(anyString());
+   }
+
+   /**
+    * PSM-006's recovery path: a session orphaned by a client that lost the local pointer needed to
+    * name it for {@code detach_sheet} can still be recovered by closing it server-side and
+    * proceeding, instead of leaving the caller stuck until the TTL expires it.
+    */
+   @Test
+   void forceClosesTheHeldSessionAndOpensTheNewOneInstead() throws Exception {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, "ws-existing");
+
+      JoinSession opened = service.openBaseWorksheet("tok-vs", principal(), true);
+
+      verify(sheetSessions).close("tok-ws-held");
+      assertEquals(SheetType.WORKSHEET, opened.sheetType());
+      assertEquals("ws-runtime-1", opened.runtimeId());
+   }
+
+   /**
+    * {@code force:true} with nothing actually held must behave exactly like the ordinary happy
+    * path -- no session to close, so {@code close} must never be called.
+    */
+   @Test
+   void forceWithNothingHeldStillOpensNormallyWithoutClosingAnything() throws Exception {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null);
+
+      service.openBaseWorksheet("tok-vs", principal(), true);
+
+      verify(sheetSessions, never()).close(anyString());
+   }
+
+   /**
     * A session with no recorded socket cannot reach a browser, so the worksheet would open
     * nowhere. Refusing beats opening a runtime the user never sees and cannot close.
     */
@@ -237,6 +282,60 @@ class SheetOpenServiceTest {
       service.openBaseWorksheet("tok-vs", principal());
 
       verify(worksheetService).openWorksheet(any(AssetEntry.class), same(BROWSER_PRINCIPAL));
+   }
+
+   /**
+    * PSM-006, against a REAL {@link SheetSessionService} rather than a mock -- proves the held
+    * session is actually closed (unreachable via a fresh {@code findOpen}), not merely that
+    * {@code close} was called with some argument a mock accepted regardless.
+    */
+   @Test
+   void forceActuallyClosesTheHeldSessionAgainstARealSheetSessionService() throws Exception {
+      SheetSessionService realSessions = new SheetSessionService();
+      JoinSession held = realSessions.open(
+         "ws-existing", OWNER, SheetType.WORKSHEET, "sock-1", SOCKET_USER, null);
+      assertNotNull(realSessions.findOpen(OWNER, SheetType.WORKSHEET), "sanity: session is held");
+
+      AssetEntry base = worksheetEntry();
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(base);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getUser()).thenReturn(BROWSER_PRINCIPAL);
+
+      JoinSession vsSession = new JoinSession(
+         "tok-vs", "vs-runtime-1", OWNER, SheetType.VIEWSHEET, 0L,
+         SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+         "sock-1", SOCKET_USER, null);
+      ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
+      when(viewsheetSessions.requireSessionAllowingPaneScope(anyString(), any(Principal.class)))
+         .thenReturn(vsSession);
+      when(viewsheetSessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+
+      WorksheetService realWorksheetService = mock(WorksheetService.class);
+      when(realWorksheetService.openWorksheet(any(AssetEntry.class), any(Principal.class)))
+         .thenReturn("ws-runtime-new");
+
+      SecurityProvider securityProvider = mock(SecurityProvider.class);
+      when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.WORKSHEET),
+                                             eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      SheetOpenService service = new SheetOpenService(
+         viewsheetSessions, realSessions, realWorksheetService, securityProvider,
+         mock(SheetAgentBroadcastService.class));
+
+      JoinSession opened = service.openBaseWorksheet("tok-vs", principal(), true);
+
+      assertEquals("ws-runtime-new", opened.runtimeId());
+      assertNull(realSessions.resolve(held.sessionToken(), OWNER),
+                "the held session must be actually closed, not just ignored");
+      // A fresh session for the new runtime is expected to be held now (openBaseWorksheet's own
+      // happy path mints one) -- the assertion is that it is the NEW one, not the stale one force
+      // was supposed to clear.
+      JoinSession stillFound = realSessions.findOpen(OWNER, SheetType.WORKSHEET);
+      assertNotNull(stillFound);
+      assertEquals("ws-runtime-new", stillFound.runtimeId());
    }
 
    // ── harness ───────────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -318,20 +318,57 @@ class ViewsheetAssemblyAgentControllerTest {
    @Test
    void openBaseWorksheetReturnsTheJoinShapeWithSheetTypeReported() throws Exception {
       SheetOpenService openService = mock(SheetOpenService.class);
-      when(openService.openBaseWorksheet(eq("tok-vs"), any()))
+      when(openService.openBaseWorksheet(eq("tok-vs"), any(), eq(false)))
          .thenReturn(new JoinSession("tok-ws", "ws-runtime-1", "alice", SheetType.WORKSHEET,
                                      0L, 1000L, JoinSession.ConnectionMode.PAIRED, "sock-1",
                                      "alice", null));
 
       ViewsheetAssemblyAgentController controller = controllerWith(openService);
 
-      var response = controller.openBaseWorksheet("tok-vs", principal());
+      var response = controller.openBaseWorksheet("tok-vs", null, principal());
 
       assertEquals("tok-ws", response.sessionToken());
       assertEquals("ws-runtime-1", response.runtimeId());
       // Reported by the server, never inferred: a plugin that guesses the runtime type files the
       // session under the wrong key and overwrites a live one while reporting success.
       assertEquals("worksheet", response.sheetType());
+   }
+
+   /**
+    * PSM-006: a body-less request (a client predating this field, or the plugin's own default)
+    * must default {@code force} to false, not throw on a null body.
+    */
+   @Test
+   void openBaseWorksheetDefaultsForceToFalseWhenTheRequestBodyIsAbsent() throws Exception {
+      SheetOpenService openService = mock(SheetOpenService.class);
+      when(openService.openBaseWorksheet(eq("tok-vs"), any(), eq(false)))
+         .thenReturn(new JoinSession("tok-ws", "ws-runtime-1", "alice", SheetType.WORKSHEET,
+                                     0L, 1000L, JoinSession.ConnectionMode.PAIRED, "sock-1",
+                                     "alice", null));
+
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      controller.openBaseWorksheet("tok-vs", null, principal());
+
+      verify(openService).openBaseWorksheet(eq("tok-vs"), any(Principal.class), eq(false));
+   }
+
+   /** PSM-006: {@code force:true} in the request body must reach the service as {@code true}. */
+   @Test
+   void openBaseWorksheetPassesForceTrueThrough() throws Exception {
+      SheetOpenService openService = mock(SheetOpenService.class);
+      when(openService.openBaseWorksheet(eq("tok-vs"), any(), eq(true)))
+         .thenReturn(new JoinSession("tok-ws", "ws-runtime-1", "alice", SheetType.WORKSHEET,
+                                     0L, 1000L, JoinSession.ConnectionMode.PAIRED, "sock-1",
+                                     "alice", null));
+
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      controller.openBaseWorksheet(
+         "tok-vs", new ViewsheetAssemblyAgentController.OpenBaseWorksheetRequest(true),
+         principal());
+
+      verify(openService).openBaseWorksheet(eq("tok-vs"), any(Principal.class), eq(true));
    }
 
    /**
@@ -345,14 +382,14 @@ class ViewsheetAssemblyAgentControllerTest {
    void openBaseWorksheetReturnsTheSessionsEditorContext() throws Exception {
       SheetOpenService openService = mock(SheetOpenService.class);
       EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
-      when(openService.openBaseWorksheet(eq("tok-vs"), any()))
+      when(openService.openBaseWorksheet(eq("tok-vs"), any(), eq(false)))
          .thenReturn(new JoinSession("tok-ws", "ws-runtime-1", "alice", SheetType.WORKSHEET,
                                      0L, 1000L, JoinSession.ConnectionMode.PAIRED, "sock-1",
                                      "alice", ctx));
 
       ViewsheetAssemblyAgentController controller = controllerWith(openService);
 
-      var response = controller.openBaseWorksheet("tok-vs", principal());
+      var response = controller.openBaseWorksheet("tok-vs", null, principal());
 
       assertEquals(ctx, response.editorContext());
    }


### PR DESCRIPTION
## Summary

- `open_base_worksheet` refuses with `"A worksheet session is already open (runtimeId=...)"` whenever the server's `SheetSessionService` still holds a worksheet session for this identity — even when the plugin's own local state (`status`/`detach_sheet`) has no record of it at all, e.g. a session orphaned by an earlier `connect_sheet(force:true)` reconnect on the client that didn't release it server-side. Today there is no recovery path short of a different owner identity or waiting out the session TTL.
- Adds an opt-in `force` flag to `SheetOpenService.openBaseWorksheet` (new 3-arg overload; the existing 2-arg overload still defaults `force` to `false`, so every existing caller is unaffected). When a held session is found and `force` is `true`, it is closed via `sheetSessions.close(held.sessionToken())` and the open proceeds instead of refusing. Omitting `force` (or passing `false`) preserves the exact existing refusal — the underlying safety check (a held session may belong to a different, concurrently-running agent) is unchanged.
- `ViewsheetAssemblyAgentController`'s `open-base-worksheet` endpoint now accepts an optional request body (`OpenBaseWorksheetRequest(Boolean force)`), defaulting to `false` when the body is absent or `null`, for compatibility with a plugin build predating this field (the existing empty-object POST body still works).

Companion client-side PR (stylebi-wiz): adds the `force` argument to the `open_base_worksheet` MCP tool and passes it through as this endpoint's request body.

Reference: PSM-006 in stylebi-wiz's `docs/bug-reports/plugin-composer-session-management.md`; diagnosis at `docs/teams/2026-08-31-test-composer-plugin/case-PSM-006-session-state-mismatch/01-diagnosis.md` in that repo.

## Test plan

- [x] `./mvnw -pl core test -Dtest="SheetOpenServiceTest,SheetSessionServiceTest,ViewsheetAssemblyAgentControllerTest"` — 90/90 pass, including:
  - a new `SheetSessionServiceTest` regression pinning the "multiple pane-scoped sessions of the same (ownerIdentity, sheetType) may legitimately coexist" invariant this fix must not break.
  - new `SheetOpenServiceTest` cases: the 3-arg overload with `force:false` refuses exactly like the 2-arg overload (and never calls `close`); `force:true` closes the held session and opens the new one; `force:true` with nothing held is a no-op on `close`; and one test driven against a **real** `SheetSessionService` (not a mock) proving the held session is actually closed, not merely ignored.
  - updated/new `ViewsheetAssemblyAgentControllerTest` cases for the request-body wiring (absent body defaults to `false`, `force:true` passes through).
- [x] `./mvnw -pl core test -Dtest='inetsoft.web.wiz.**'` — 2759/2759 pass, no regressions in the wider wiz package.
- [ ] Live end-to-end re-verification against a running StyleBI is intentionally deferred to the lead session that holds a live connection, per this task's instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)