### PR TITLE
Bug #76383, set the configuration home before storage init touches the config singleton

### DIFF
--- a/core/src/main/java/inetsoft/setup/StorageInitializer.java
+++ b/core/src/main/java/inetsoft/setup/StorageInitializer.java
@@ -20,6 +20,7 @@ package inetsoft.setup;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.*;
 import inetsoft.storage.LoadKeyValueTask;
+import inetsoft.util.ConfigurationContext;
 import inetsoft.util.HashedPassword;
 import inetsoft.util.PasswordEncryption;
 import inetsoft.util.config.InetsoftConfig;
@@ -87,6 +88,15 @@ public class StorageInitializer implements Callable<Integer> {
 
    @Override
    public Integer call() throws Exception {
+      // Publish the configuration directory as the home before anything can initialize the
+      // InetsoftConfig singleton. Cluster.getInstance(), called while installing plugins, does
+      // just that. If the home is not set first, the singleton config is cached with the default
+      // home (the working directory) and everything later written through it -- including the
+      // assets imported by the local client -- lands outside of the configuration directory.
+      String home = configDirectory.getAbsolutePath();
+      System.setProperty("sree.home", home);
+      ConfigurationContext.getContext().setHome(home);
+
       boolean initialized = isInitialized();
 
       if(initialized) {


### PR DESCRIPTION
## Summary

The Docker `init` container (`storage` service, `command: ["init"]`) reported a successful asset import for every zip in `/var/lib/inetsoft/setup/assets` and exited 0 with `Storage initialized successfully`, but none of the imported assets were present in the persisted storage afterwards. Exporting from the running server returned HTTP 500 `No assets match selection`, or a zip containing only `JarFileInfo.xml` plus the three built-in schedule tasks.

## Root Cause

`StorageInitializer.installPlugins(File)` calls `Cluster.getInstance()` to broadcast the plugin reload. That is the first thing in the process to touch the `InetsoftConfig` **singleton**:

`InetsoftConfig.Reference.get()` → `InetsoftConfig.getConfigFile()` → `ConfigurationContext.getContext().getHome()`

At that point nothing has called `setHome(...)`, so the home is the default `"."` — the process working directory. `InetsoftConfig.createDefault(home)` then pins the mapdb key-value directory to `<cwd>/kv` and the filesystem blob directory to `<cwd>/blob`, and the singleton caches that.

`ClientFactory.createLocalClient()` sets `sree.home` and `ConfigurationContext.setHome(configDir)` afterwards, but the singleton is already built, so it is too late. The asset import goes through the singleton `KeyValueEngine`/`BlobStorage` and writes everything into `<cwd>/kv` and `<cwd>/blob` — the init container's ephemeral filesystem, discarded when the container is removed.

Meanwhile `PropertiesService`/`StorageService` build their own non-singleton `InetsoftConfig` from the `-c` argument (`AbstractStorageService`), which is why their writes (`dataSpace`, `plugins`, `sreeProperties`) *do* land in the configuration directory — making the result look like a partially initialized storage rather than a misdirected one.

Nothing throws, so `importAssets` returns normally and the false success is reported.

The trigger is the plugin install, which is why this reproduces on every containerized run (the image always ships `/usr/local/inetsoft/plugins`) and is completely independent of what is being imported.

This does not occur on `main`: the Epic 70095 rework moved the cluster notification out of `installPlugins()` to after the asset import, and where `main` does touch the cluster (`reloadClusterPlugins()`) it sets `sree.home` + `ConfigurationContext.setHome(home)` + `InetsoftConfig.bootstrap()` first.

## Fix

Publish the configuration directory as the home at the very top of `StorageInitializer.call()`, before anything can build the singleton config:

```java
String home = configDirectory.getAbsolutePath();
System.setProperty("sree.home", home);
ConfigurationContext.getContext().setHome(home);
```

This is the same pattern `ClientFactory.createLocalClient()` already uses, and the same one `main`'s `reloadClusterPlugins()` uses. The later, redundant call from `createLocalClient()` is idempotent — `ConfigurationContext.setHome()` fires a `PropertyChangeSupport` event that is a no-op for an unchanged value, and there are no listeners registered on the `"home"` property.

## Test Plan

Ran the real `inetsoft.setup.StorageInitializer` against scratch configuration directories with a genuine asset-export zip, checking the resulting `<config>/kv/host-org__indexedStorage` entry count and blob contents:

| Run | plugins dir | assets in `<config>` | leaked to CWD |
| --- | --- | --- | --- |
| unpatched, no plugins dir | no | 34 entries (bug not triggered — `Cluster.getInstance()` never reached) | none |
| unpatched, with plugins dir | yes | **0 asset entries** — only `dataSpace`, `plugins`, `sreeProperties` | `<cwd>/kv` + `<cwd>/blob` with all 34 assets and 13 MB of blobs |
| patched, with plugins dir | yes | **34 entries**, 21 MB of blobs, `storage.initialized` set | none |
| patched, re-run on initialized dir | yes | `Storage already initialized`, exit 0 | none |

The unpatched-with-plugins run reproduces the reported log shape exactly: `Joining cluster` before the import, `Imported assets from ...`, `Ignite node stopped OK`, a second Ignite lifecycle, `Storage initialized successfully`, exit 0 — with the assets silently written elsewhere.

Regression checks:

- `./mvnw install -pl core -am -DskipTests` — success.
- `./mvnw test -pl core` — 1788 tests run, 0 failures, 0 errors, 44 skipped.
- End-to-end verification in the reporter's Docker Compose environment: assets now import correctly.

Fixes Redmine #76383.