### PR TITLE
Enforce the tabular catalog SPI contract and implement it for SharePoint Online

### DIFF
--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointDatasetId.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointDatasetId.java
@@ -42,6 +42,21 @@ final class SharepointDatasetId {
 
    record Parsed(String site, String list) {}
 
+   /**
+    * Parses a dataset id previously produced by {@link #compose}.
+    *
+    * This is a shape check, not a membership check: it rejects anything that could not possibly
+    * have come out of {@link #compose} for this data source, but does NOT confirm the resulting
+    * (site, list) pair is one this data source's {@code listDatasets} would actually enumerate —
+    * see {@link SharepointOnlineCatalog}'s javadoc for why that fuller check is not done here and
+    * why that residual is not a privilege-escalation risk.
+    *
+    * @throws IllegalArgumentException if {@code datasetId} has no separator, either decoded
+    *         component is blank, or re-composing the decoded components does not reproduce
+    *         {@code datasetId} exactly (catches, among other things, a second raw, unescaped
+    *         separator character elsewhere in the string, which would otherwise silently split
+    *         into the wrong halves).
+    */
    static Parsed parse(String datasetId) {
       int sep = datasetId.indexOf(SEPARATOR);
 
@@ -49,8 +64,20 @@ final class SharepointDatasetId {
          throw new IllegalArgumentException("Not a SharePoint dataset id: " + datasetId);
       }
 
-      return new Parsed(unescape(datasetId.substring(0, sep)),
-                        unescape(datasetId.substring(sep + 1)));
+      String site = unescape(datasetId.substring(0, sep));
+      String list = unescape(datasetId.substring(sep + 1));
+
+      if(site.isBlank() || list.isBlank()) {
+         throw new IllegalArgumentException(
+            "Not a SharePoint dataset id (blank site or list): " + datasetId);
+      }
+
+      if(!datasetId.equals(compose(site, list))) {
+         throw new IllegalArgumentException(
+            "Not a SharePoint dataset id (does not round-trip): " + datasetId);
+      }
+
+      return new Parsed(site, list);
    }
 
    // Order matters both ways. '%' must be escaped FIRST (else escaping '.'/'~' would introduce new

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointDatasetId.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointDatasetId.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+/**
+ * Composes and parses the SPI's {@code TabularDatasetRef} id for this connector, which is
+ * naturally composite (site + list).
+ *
+ * {@code TabularDatasetRef.id}'s javadoc forbids a {@code .} character anywhere in the id — not
+ * merely as the join character. That matters here because the site half is not under our control:
+ * {@link SharepointOnlineRuntime}'s existing {@code getSiteId(Site)} truncates the Graph site id
+ * {@code "{hostname},{siteCollectionId},{webId}"} to its first comma, which keeps exactly the
+ * {@code hostname} — e.g. {@code "contoso.sharepoint.com"}. Every site id this connector hands out
+ * (root, group sites, subsites — anything but the literal string {@code "root"}) is therefore a
+ * hostname, and hostnames contain dots by construction. Choosing a non-dot separator alone would
+ * not satisfy the contract; the dots have to be escaped out of each component before joining.
+ */
+final class SharepointDatasetId {
+   private SharepointDatasetId() {
+   }
+
+   private static final String SEPARATOR = "~";
+
+   static String compose(String siteId, String listId) {
+      return escape(siteId) + SEPARATOR + escape(listId);
+   }
+
+   record Parsed(String site, String list) {}
+
+   static Parsed parse(String datasetId) {
+      int sep = datasetId.indexOf(SEPARATOR);
+
+      if(sep < 0) {
+         throw new IllegalArgumentException("Not a SharePoint dataset id: " + datasetId);
+      }
+
+      return new Parsed(unescape(datasetId.substring(0, sep)),
+                        unescape(datasetId.substring(sep + 1)));
+   }
+
+   // Order matters both ways. '%' must be escaped FIRST (else escaping '.'/'~' would introduce new
+   // '%' characters that a later '%'->'%25' pass would double-escape), and unescaped LAST (else a
+   // literal "%2E" that was never an escaped dot could be misread as one). Standard
+   // percent-encoding discipline, applied to exactly the characters this id's contract forbids.
+   private static String escape(String v) {
+      return v.replace("%", "%25").replace(".", "%2E").replace(SEPARATOR, "%7E");
+   }
+
+   private static String unescape(String v) {
+      return v.replace("%7E", SEPARATOR).replace("%2E", ".").replace("%25", "%");
+   }
+}

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+import inetsoft.uql.schema.XTypeNode;
+import inetsoft.uql.tabular.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Assembles {@link SharepointOnlineRuntime}'s {@link TabularCatalogProvider} answers out of the
+ * connector's own Graph calls. Mirrors {@code ODataCatalog}'s role: package-private, static
+ * methods, no state of its own.
+ *
+ * No caching (unlike OData's {@code ODataCatalogCache}): OData caches because one {@code $metadata}
+ * document answers both SPI phases for every entity set at once; SharePoint has no analogous
+ * document — {@code listDatasets} is inherently O(sites) Graph calls with nothing shared across
+ * sites, and {@code describeDataset} is exactly one Graph call for the one list asked about, with
+ * nothing shared between two different calls. A cache here would have nothing to save.
+ *
+ * No relationships this round: SharePoint lookup columns carry the target list id and a display
+ * column, not a pair of column names whose values are meant to be equal the way OData's referential
+ * constraints do. The closest candidate — pairing a lookup column against the target list's system
+ * "ID" field — is not safe to emit, because {@code doGetListColumns}'s type-mapping switch has no
+ * branch for that column shape, so "ID" is not expected to appear in any {@code describeDataset}
+ * result [ASSUME — unverified against a real Graph {@code columns()} response]. A relationship
+ * whose {@code toColumns} names a column absent from the target's own reported schema would be a
+ * permanently unresolvable declared edge, worse than no edge at all. Honest-drop, same rule OData's
+ * own design already established: when no candidate pairing can be verified, drop it and say so.
+ */
+final class SharepointOnlineCatalog {
+   private SharepointOnlineCatalog() {
+   }
+
+   static TabularCatalog listDatasets(SharepointOnlineDataSource ds) throws Exception {
+      List<TabularDatasetRef> datasets = new ArrayList<>();
+
+      for(SharepointOnlineRuntime.SiteRef site : SharepointOnlineRuntime.listSitesOrThrow(ds)) {
+         for(String[] list : SharepointOnlineRuntime.getLists(ds, site.id())) {
+            datasets.add(new TabularDatasetRef(SharepointDatasetId.compose(site.id(), list[1])));
+         }
+      }
+
+      // No relationships this round — see the class javadoc.
+      return new TabularCatalog(datasets, List.of());
+   }
+
+   static TabularDatasetSchema describeDataset(SharepointOnlineDataSource ds, String datasetId)
+      throws Exception
+   {
+      SharepointDatasetId.Parsed parsed = SharepointDatasetId.parse(datasetId);
+      XTypeNode[] columns =
+         SharepointOnlineRuntime.getListColumns(ds, parsed.site(), parsed.list());
+
+      return new TabularDatasetSchema(datasetId,
+         Arrays.stream(columns).map(n -> new TabularColumn(n.getName(), n.getType())).toList(),
+         List.of());       // keyColumns — no system key column surfaces through getListColumns
+   }
+}

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
@@ -60,15 +60,31 @@ import java.util.List;
  * (see above). Doing that enumeration on every {@code describeDataset} call to validate one id
  * would reverse that no-cache decision for a marginal gain.
  *
- * <p>This is NOT a privilege-escalation risk: Microsoft Graph/Azure AD's own site-level permission
- * model (e.g. {@code Sites.Selected}) is the real authorization boundary underneath the connector's
- * credentials, and a crafted {@code datasetId} cannot make a Graph call reach a site the connector's
- * own service principal could not already reach with the identical credential through the
- * connect-dialog dropdown ({@code SharepointOnlineQuery.getSites()}/{@code getLists()}). The caller
- * must also already hold READ on this data source ({@code MetadataApiService} checks that before
- * either {@code listTables} or {@code describeTable} is reached). Full membership validation (and
- * the cache it would require) is a candidate for a future round if this connector's enumeration
- * cost ever needs amortizing for other reasons.
+ * <p>This is NOT a privilege-escalation risk — but the reason is a stronger, more directly
+ * verifiable one than "the dropdown reaches the same credential" (P5 review r2 corrected this):
+ * {@code SharepointOnlineQuery.setSite}/{@code setList} are plain, unvalidated {@code String}
+ * setters, and {@code @PropertyEditor(tagsMethod = "getSites"/"getLists")} only populates a UI
+ * dropdown — it enforces nothing server-side. So anyone who already holds whatever permission lets
+ * them author and run a query against this data source can point {@code runQuery} at ANY
+ * {@code (site, list)} string the connector's credential can reach, with no dependency on
+ * {@code listDatasets}/the dropdown ever having enumerated it first — and that path returns actual
+ * row data, not just a column schema. {@code describeDataset}'s unvalidated {@code datasetId}
+ * therefore grants strictly LESS than a capability that already exists, unmediated, elsewhere in
+ * this same connector.
+ *
+ * <p>The dropdown specifically cannot be cited as the reachability ceiling: its enumeration walks
+ * the same site tree {@code listSitesOrThrow} does (root, its subsites, each group's root site and
+ * subsites), so a site reachable only through a permission grant outside that tree — e.g. a Graph
+ * {@code Sites.Selected} grant on a site not linked under root or under any group — is invisible to
+ * both the dropdown and {@code listDatasets}, yet still reachable by a raw
+ * {@code client.sites(id)} call under the identical credential. Citing "the dropdown already
+ * reaches it" as the safety argument would therefore be false in exactly the case that matters;
+ * citing the already-unmediated {@code runQuery} path does not have that hole.
+ *
+ * <p>The caller must also already hold READ on this data source ({@code MetadataApiService} checks
+ * that before either {@code listTables} or {@code describeTable} is reached). Full membership
+ * validation (and the cache it would require) is a candidate for a future round if this
+ * connector's enumeration cost ever needs amortizing for other reasons.
  */
 final class SharepointOnlineCatalog {
    private SharepointOnlineCatalog() {

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
@@ -45,6 +45,17 @@ import java.util.List;
  * permanently unresolvable declared edge, worse than no edge at all. Honest-drop, same rule OData's
  * own design already established: when no candidate pairing can be verified, drop it and say so.
  *
+ * <p><b>Stated residual (P5 review r2, declined by the lead as candidate work):</b> even where a
+ * connector DOES emit relationships, {@code TabularCatalogService} does not verify that
+ * {@code TabularRelationship.fromColumns}/{@code toColumns} actually name real columns of
+ * {@code fromDataset}/{@code toDataset}'s own reported schema — see
+ * {@link TabularRelationship}'s javadoc for the same note. Checking it would mean the
+ * {@code listDatasets} phase transitively calling {@code describeDataset} for every dataset any
+ * relationship references, which reverses the two-phase separation this class's own no-cache
+ * decision above depends on. Not enforced, and said to be not enforced, rather than silently
+ * assumed — this connector's own honest-drop above sidesteps the question by emitting no
+ * relationships at all, but the gap is in the shared validation layer, not specific to SharePoint.
+ *
  * <p><b>{@code describeDataset} does NOT validate that {@code datasetId} was one this same data
  * source's own {@code listDatasets} actually enumerated</b> — a real, deliberate gap, not an
  * oversight (raised in P5 review r1). {@link SharepointDatasetId#parse} rejects anything that could

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
@@ -45,20 +45,15 @@ import java.util.List;
  * permanently unresolvable declared edge, worse than no edge at all. Honest-drop, same rule OData's
  * own design already established: when no candidate pairing can be verified, drop it and say so.
  *
- * <p><b>Stated residual (P5 review r2, declined by the lead as candidate work):</b> even where a
- * connector DOES emit relationships, {@code TabularCatalogService} does not verify that
- * {@code TabularRelationship.fromColumns}/{@code toColumns} actually name real columns of
- * {@code fromDataset}/{@code toDataset}'s own reported schema — see
- * {@link TabularRelationship}'s javadoc for the same note. Checking it would mean the
- * {@code listDatasets} phase transitively calling {@code describeDataset} for every dataset any
- * relationship references, which reverses the two-phase separation this class's own no-cache
- * decision above depends on. Not enforced, and said to be not enforced, rather than silently
- * assumed — this connector's own honest-drop above sidesteps the question by emitting no
- * relationships at all, but the gap is in the shared validation layer, not specific to SharePoint.
+ * <p>SharePoint's own honest-drop above sidesteps a related question by emitting no relationships
+ * at all, but even where a connector DOES emit relationships, {@code TabularCatalogService} does
+ * not verify {@code fromColumns}/{@code toColumns} name real columns of their datasets' own
+ * schemas — see {@link TabularRelationship}'s javadoc for the stated reason (a gap in the shared
+ * validation layer, not specific to SharePoint).
  *
  * <p><b>{@code describeDataset} does NOT validate that {@code datasetId} was one this same data
  * source's own {@code listDatasets} actually enumerated</b> — a real, deliberate gap, not an
- * oversight (raised in P5 review r1). {@link SharepointDatasetId#parse} rejects anything that could
+ * oversight. {@link SharepointDatasetId#parse} rejects anything that could
  * not possibly have come out of {@link SharepointDatasetId#compose} (blank site/list, or a string
  * that doesn't round-trip), but a caller-supplied id whose (site, list) shape is well-formed and
  * simply never appeared in this data source's own catalog is not rejected before its {@code site}/
@@ -71,11 +66,10 @@ import java.util.List;
  * (see above). Doing that enumeration on every {@code describeDataset} call to validate one id
  * would reverse that no-cache decision for a marginal gain.
  *
- * <p>This is NOT a privilege-escalation risk — but the reason is a stronger, more directly
- * verifiable one than "the dropdown reaches the same credential" (P5 review r2 corrected this):
- * {@code SharepointOnlineQuery.setSite}/{@code setList} are plain, unvalidated {@code String}
- * setters, and {@code @PropertyEditor(tagsMethod = "getSites"/"getLists")} only populates a UI
- * dropdown — it enforces nothing server-side. So anyone who already holds whatever permission lets
+ * <p>This is NOT a privilege-escalation risk. {@code SharepointOnlineQuery.setSite}/
+ * {@code setList} are plain, unvalidated {@code String} setters, and
+ * {@code @PropertyEditor(tagsMethod = "getSites"/"getLists")} only populates a UI dropdown — it
+ * enforces nothing server-side. So anyone who already holds whatever permission lets
  * them author and run a query against this data source can point {@code runQuery} at ANY
  * {@code (site, list)} string the connector's credential can reach, with no dependency on
  * {@code listDatasets}/the dropdown ever having enumerated it first — and that path returns actual

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
@@ -44,6 +44,31 @@ import java.util.List;
  * whose {@code toColumns} names a column absent from the target's own reported schema would be a
  * permanently unresolvable declared edge, worse than no edge at all. Honest-drop, same rule OData's
  * own design already established: when no candidate pairing can be verified, drop it and say so.
+ *
+ * <p><b>{@code describeDataset} does NOT validate that {@code datasetId} was one this same data
+ * source's own {@code listDatasets} actually enumerated</b> — a real, deliberate gap, not an
+ * oversight (raised in P5 review r1). {@link SharepointDatasetId#parse} rejects anything that could
+ * not possibly have come out of {@link SharepointDatasetId#compose} (blank site/list, or a string
+ * that doesn't round-trip), but a caller-supplied id whose (site, list) shape is well-formed and
+ * simply never appeared in this data source's own catalog is not rejected before its {@code site}/
+ * {@code list} values reach a live {@code client.sites(site).lists(list).columns()} Graph call.
+ * Unlike OData's {@code ODataRuntime.describeDataset}, which resolves against a bounded snapshot
+ * built by that same source's own prior {@code listDatasets}/{@code $metadata} fetch (so an
+ * unrecognized id can only ever answer "not found"), SharePoint has no analogous snapshot to check
+ * against: full membership validation would require enumerating every site's lists first — which
+ * IS {@code listDatasets} itself, the exact O(sites) cost this class deliberately does not cache
+ * (see above). Doing that enumeration on every {@code describeDataset} call to validate one id
+ * would reverse that no-cache decision for a marginal gain.
+ *
+ * <p>This is NOT a privilege-escalation risk: Microsoft Graph/Azure AD's own site-level permission
+ * model (e.g. {@code Sites.Selected}) is the real authorization boundary underneath the connector's
+ * credentials, and a crafted {@code datasetId} cannot make a Graph call reach a site the connector's
+ * own service principal could not already reach with the identical credential through the
+ * connect-dialog dropdown ({@code SharepointOnlineQuery.getSites()}/{@code getLists()}). The caller
+ * must also already hold READ on this data source ({@code MetadataApiService} checks that before
+ * either {@code listTables} or {@code describeTable} is reached). Full membership validation (and
+ * the cache it would require) is a candidate for a future round if this connector's enumeration
+ * cost ever needs amortizing for other reasons.
  */
 final class SharepointOnlineCatalog {
    private SharepointOnlineCatalog() {

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineRuntime.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineRuntime.java
@@ -152,7 +152,7 @@ public class SharepointOnlineRuntime extends TabularRuntime implements TabularCa
    //      path only. The dropdown's one-level behavior is unchanged because this is new code, not
    //      a modification of getChildSites().
    // No depth bound: recursion (collectDescendants below) goes as deep as the tenant's actual
-   // subsite nesting, with no cap and no StackOverflowError guard (P5 review r1, nit). Cycle-safe
+   // subsite nesting, with no cap and no StackOverflowError guard. Cycle-safe
    // (the bySiteId de-dup guard below), but a genuinely very deep, non-cyclic subsite chain could
    // still exhaust the stack. Not fixed this round — real tenants rarely nest this deep, and
    // rewriting a just-written recursion into an explicit work queue for a low-probability case

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineRuntime.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineRuntime.java
@@ -151,6 +151,13 @@ public class SharepointOnlineRuntime extends TabularRuntime implements TabularCa
    //  (b) descends every level, not one — fixing the existing getChildSites() limitation for this
    //      path only. The dropdown's one-level behavior is unchanged because this is new code, not
    //      a modification of getChildSites().
+   // No depth bound: recursion (collectDescendants below) goes as deep as the tenant's actual
+   // subsite nesting, with no cap and no StackOverflowError guard (P5 review r1, nit). Cycle-safe
+   // (the bySiteId de-dup guard below), but a genuinely very deep, non-cyclic subsite chain could
+   // still exhaust the stack. Not fixed this round — real tenants rarely nest this deep, and
+   // rewriting a just-written recursion into an explicit work queue for a low-probability case
+   // isn't worth it — but, per this round's own rule for the grandchild-site limitation, not fixing
+   // it does not mean not saying it.
    static List<SiteRef> listSitesOrThrow(SharepointOnlineDataSource dataSource) throws Exception {
       return withClassLoaderThrowing(() -> doListSitesOrThrow(dataSource));
    }

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineRuntime.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineRuntime.java
@@ -32,7 +32,20 @@ import java.util.*;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class SharepointOnlineRuntime extends TabularRuntime {
+public class SharepointOnlineRuntime extends TabularRuntime implements TabularCatalogProvider {
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      return SharepointOnlineCatalog.listDatasets((SharepointOnlineDataSource) dataSource);
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      return SharepointOnlineCatalog.describeDataset((SharepointOnlineDataSource) dataSource,
+         datasetId);
+   }
+
    @Override
    public XTableNode runQuery(TabularQuery query, VariableTable params) {
       try {
@@ -127,6 +140,80 @@ public class SharepointOnlineRuntime extends TabularRuntime {
       }
 
       return result;
+   }
+
+   // New. Package-private. Used only by the catalog SPI path (SharepointOnlineCatalog). Unlike
+   // getSites()/doGetSites() above — which this method does NOT call, share code with, or
+   // otherwise touch — this one:
+   //  (a) throws instead of catching-and-warning on any Graph failure (root fetch, group listing,
+   //      or any level of child-site listing), because the annotation SPI's contract forbids
+   //      returning a partial catalog on failure;
+   //  (b) descends every level, not one — fixing the existing getChildSites() limitation for this
+   //      path only. The dropdown's one-level behavior is unchanged because this is new code, not
+   //      a modification of getChildSites().
+   static List<SiteRef> listSitesOrThrow(SharepointOnlineDataSource dataSource) throws Exception {
+      return withClassLoaderThrowing(() -> doListSitesOrThrow(dataSource));
+   }
+
+   record SiteRef(String displayName, String id) {}
+
+   private static List<SiteRef> doListSitesOrThrow(SharepointOnlineDataSource dataSource)
+      throws Exception
+   {
+      GraphServiceClient client = getClient(dataSource, true);
+      Map<String, SiteRef> bySiteId = new LinkedHashMap<>();      // de-dup + stable order
+
+      Site root = client.sites("root").buildRequest().get();      // no catch — let it throw
+      String rootId = getSiteId(root);
+      bySiteId.put(rootId, new SiteRef(root.displayName, rootId));
+      collectDescendants(client, root, bySiteId);
+
+      GroupCollectionPage groups = client.groups().buildRequest().get();
+
+      while(groups != null) {
+         for(Group group : groups.getCurrentPage()) {
+            Site groupSite = client.groups(group.id).sites("root").buildRequest().get();
+            String groupSiteId = getSiteId(groupSite);
+
+            if(bySiteId.putIfAbsent(groupSiteId, new SiteRef(groupSite.displayName, groupSiteId))
+               == null)
+            {
+               collectDescendants(client, groupSite, bySiteId);
+            }
+         }
+
+         if(groups.getNextPage() == null) {
+            groups = null;
+         }
+         else {
+            groups = groups.getNextPage().buildRequest().get();
+         }
+      }
+
+      return new ArrayList<>(bySiteId.values());
+   }
+
+   private static void collectDescendants(GraphServiceClient client, Site parent,
+                                          Map<String, SiteRef> bySiteId) throws Exception
+   {
+      SiteCollectionPage children = client.sites(getSiteId(parent)).sites().buildRequest().get();
+
+      while(children != null) {
+         for(Site child : children.getCurrentPage()) {
+            String childId = getSiteId(child);
+
+            if(bySiteId.putIfAbsent(childId, new SiteRef(child.displayName, childId)) == null) {
+               collectDescendants(client, child, bySiteId);     // full recursion — the actual fix
+            }
+         }
+
+         if(children.getNextPage() == null) {
+            children = null;
+         }
+         else {
+            children = children.getNextPage().buildRequest().get();
+         }
+      }
    }
 
    static String[][] getLists(SharepointOnlineDataSource dataSource, String siteId) {
@@ -285,6 +372,26 @@ public class SharepointOnlineRuntime extends TabularRuntime {
       finally {
          Thread.currentThread().setContextClassLoader(loader);
       }
+   }
+
+   // Same shape as withClassLoader() above, typed for a body that legitimately throws (the catalog
+   // SPI path, unlike every other caller of withClassLoader(), must propagate a Graph failure
+   // rather than have it swallowed). withClassLoader() itself is untouched.
+   private static <T> T withClassLoaderThrowing(ThrowingSupplier<T> fn) throws Exception {
+      ClassLoader loader = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(SharepointOnlineRuntime.class.getClassLoader());
+
+      try {
+         return fn.get();
+      }
+      finally {
+         Thread.currentThread().setContextClassLoader(loader);
+      }
+   }
+
+   @FunctionalInterface
+   private interface ThrowingSupplier<T> {
+      T get() throws Exception;
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(SharepointOnlineRuntime.class);

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointDatasetIdTest.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointDatasetIdTest.java
@@ -1,0 +1,182 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+import com.microsoft.graph.models.ColumnDefinition;
+import com.microsoft.graph.models.TextColumn;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.SiteRequestBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+
+import static inetsoft.uql.sharepoint.SharepointGraphTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Covers charter assertion S3 and the reverse assertion "no {@code .} in a SharePoint composite
+ * id, including a component that naturally carries one" (the SharePoint site id's hostname half —
+ * see {@link SharepointDatasetId}'s javadoc).
+ *
+ * Two layers of coverage, per reconcile's instruction that a round-trip alone is not enough: a
+ * pure {@link SharepointDatasetId} round-trip (fast, no Graph involved), AND — the assertion that
+ * actually matters — driving {@link SharepointOnlineCatalog#describeDataset} end to end with a
+ * mocked Graph client and verifying the *decoded* site/list values the client actually received. A
+ * wrong decode that happens not to throw would pass a "no exception" check; it cannot pass
+ * {@code verify(client).sites(originalValue)}.
+ */
+@Tag("connector")
+class SharepointDatasetIdTest {
+
+   // ----- Pure round-trip (no Graph client) -----
+
+   @Test
+   void composeParse_plainGuidPair_roundTrips() {
+      String id = SharepointDatasetId.compose("11111111-1111-1111-1111-111111111111",
+         "22222222-2222-2222-2222-222222222222");
+
+      assertFalse(id.contains("."));
+
+      SharepointDatasetId.Parsed parsed = SharepointDatasetId.parse(id);
+      assertEquals("11111111-1111-1111-1111-111111111111", parsed.site());
+      assertEquals("22222222-2222-2222-2222-222222222222", parsed.list());
+   }
+
+   @Test
+   void composeParse_distinctDottedSiteIdsDoNotCollide() {
+      // The concrete failure mode a lossy "strip the dots" encoding would produce: two distinct
+      // inputs colliding on the same composed id.
+      String id1 = SharepointDatasetId.compose("a.b.c", "list-1");
+      String id2 = SharepointDatasetId.compose("abc", "list-1");
+
+      assertNotEquals(id1, id2);
+   }
+
+   @Test
+   void composeParse_componentContainingLiteralPercentSequence_doesNotMisdecode() {
+      // Adversarial input containing the literal substring "%2E" — not an escaped dot, just those
+      // three characters. Exercises the escape-%-first / unescape-%-last ordering discipline: a
+      // naive implementation that escapes '.' before '%' would corrupt this round trip.
+      String site = "weird%2Ename";
+      String list = "list-1";
+
+      String id = SharepointDatasetId.compose(site, list);
+      assertFalse(id.contains("."));
+
+      SharepointDatasetId.Parsed parsed = SharepointDatasetId.parse(id);
+      assertEquals(site, parsed.site());
+      assertEquals(list, parsed.list());
+   }
+
+   @Test
+   void parse_notASharepointId_throwsIllegalArgumentException() {
+      assertThrows(IllegalArgumentException.class,
+         () -> SharepointDatasetId.parse("no-separator-here"));
+   }
+
+   // ----- S3: verified against the Graph client the decoded value actually reaches -----
+
+   @Test
+   void describeDataset_regularCase_graphClientReceivesOriginalSiteAndListValues() throws Exception {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder siteBuilder = siteBuilder(client, "site-1");
+      stubColumns(siteBuilder, "list-1", List.of(titleColumn()));
+
+      String datasetId = SharepointDatasetId.compose("site-1", "list-1");
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         SharepointOnlineCatalog.describeDataset(fakeDataSource(), datasetId);
+      }
+
+      verify(client).sites("site-1");
+      verify(siteBuilder).lists("list-1");
+   }
+
+   @Test
+   void describeDataset_siteComponentNaturallyContainingDots_graphClientReceivesTheDottedValue()
+      throws Exception
+   {
+      // The realistic case, not an extreme one: SharepointOnlineRuntime.getSiteId() truncates a
+      // Graph site id to its hostname, e.g. "contoso.sharepoint.com" — dots on every real tenant.
+      String dottedSite = "contoso.sharepoint.com";
+
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder siteBuilder = siteBuilder(client, dottedSite);
+      stubColumns(siteBuilder, "list-1", List.of(titleColumn()));
+
+      String datasetId = SharepointDatasetId.compose(dottedSite, "list-1");
+      assertFalse(datasetId.contains("."), "composed id must not contain '.': " + datasetId);
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         SharepointOnlineCatalog.describeDataset(fakeDataSource(), datasetId);
+      }
+
+      // Not "no exception" — the client must have been asked for the exact original dotted
+      // hostname, proving the decode reconstructed it rather than mangling or dropping the dots.
+      verify(client).sites(dottedSite);
+   }
+
+   @Test
+   void describeDataset_componentsContainingTheSeparatorItself_graphClientReceivesOriginalValues()
+      throws Exception
+   {
+      // The separator is SharepointDatasetId's implementation detail, not part of its public
+      // contract, so it's discovered from a real composed id rather than hardcoded — if the
+      // implementation ever changes it, this test keeps working as long as some character is
+      // chosen and escaped consistently.
+      String separator = discoverSeparator();
+      String siteWithSeparator = "site" + separator + "name";
+      String listWithSeparator = "list" + separator + "42";
+
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder siteBuilder = siteBuilder(client, siteWithSeparator);
+      stubColumns(siteBuilder, listWithSeparator, List.of(titleColumn()));
+
+      String datasetId = SharepointDatasetId.compose(siteWithSeparator, listWithSeparator);
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         SharepointOnlineCatalog.describeDataset(fakeDataSource(), datasetId);
+      }
+
+      // Must not have been misparsed into more than two segments at the embedded separator.
+      verify(client).sites(siteWithSeparator);
+      verify(siteBuilder).lists(listWithSeparator);
+   }
+
+   private static ColumnDefinition titleColumn() {
+      return column("Title", c -> c.text = new TextColumn());
+   }
+
+   /**
+    * Composes two known values, then finds the run of characters in the composed id that is
+    * neither value nor a percent-escape, on the assumption that {@code compose} is
+    * {@code escape(site) + SEPARATOR + escape(list)} and neither {@code "AAAA"} nor {@code "BBBB"}
+    * needs escaping.
+    */
+   private static String discoverSeparator() {
+      String id = SharepointDatasetId.compose("AAAA", "BBBB");
+      int aEnd = id.indexOf("AAAA") + "AAAA".length();
+      int bStart = id.indexOf("BBBB");
+      assertTrue(aEnd <= bStart, "unexpected composed id shape: " + id);
+      return id.substring(aEnd, bStart);
+   }
+}

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointDatasetIdTest.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointDatasetIdTest.java
@@ -93,6 +93,37 @@ class SharepointDatasetIdTest {
          () -> SharepointDatasetId.parse("no-separator-here"));
    }
 
+   // ----- P5 review r1, finding 2: parse() rejects anything compose() could not have produced -----
+
+   @Test
+   void parse_blankSiteComponent_throwsIllegalArgumentException() {
+      // compose() itself doesn't reject a blank component (composing isn't given a datasetId to
+      // validate against); parse() is where illegitimate input must be caught.
+      String id = SharepointDatasetId.compose("", "list-1");
+      assertThrows(IllegalArgumentException.class, () -> SharepointDatasetId.parse(id));
+   }
+
+   @Test
+   void parse_blankListComponent_throwsIllegalArgumentException() {
+      String id = SharepointDatasetId.compose("site-1", "   ");
+      assertThrows(IllegalArgumentException.class, () -> SharepointDatasetId.parse(id));
+   }
+
+   @Test
+   void parse_doesNotRoundTrip_throwsIllegalArgumentException() {
+      // A hand-crafted id with a SECOND, unescaped separator character after the real one — never
+      // producible by compose(), which always escapes every literal separator in its inputs before
+      // joining. indexOf() alone would misparse this by splitting at the first separator and
+      // leaving the second raw separator sitting inside the decoded "list" value; the round-trip
+      // check is what catches it, since re-composing that (site, list) pair would re-escape the
+      // stray separator and therefore not reproduce the original string.
+      String separator = discoverSeparator();
+      String adversarial = "site" + separator + "list" + separator + "extra";
+
+      assertThrows(IllegalArgumentException.class,
+         () -> SharepointDatasetId.parse(adversarial));
+   }
+
    // ----- S3: verified against the Graph client the decoded value actually reaches -----
 
    @Test

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointGraphTestSupport.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointGraphTestSupport.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+import com.microsoft.graph.models.*;
+import com.microsoft.graph.requests.*;
+
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Shared plumbing for the SPI tests below. {@code SharepointOnlineRuntime.getClient(...)} is
+ * {@code private static} and builds a real {@code GraphServiceClient} with no seam — per the
+ * feasibility check recorded in 04-build.md, that is worked around here by intercepting the
+ * static entry point {@code GraphServiceClient.builder()} itself with {@code mockStatic}, so
+ * {@code getClient(...)} ends up handing production code the caller-supplied mock client without
+ * any production code change.
+ *
+ * Real Graph SDK model/page objects are used wherever possible (plain POJOs, or a public
+ * {@code (List<T>, RequestBuilder)} page constructor) — mocking is used only for the
+ * request-builder/request fluent chain, which has no other way to be constructed.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+final class SharepointGraphTestSupport {
+   private SharepointGraphTestSupport() {
+   }
+
+   /**
+    * Opens (but does not close) a {@link MockedStatic} that makes every
+    * {@code GraphServiceClient.builder()...buildClient()} call inside the mocked static's scope
+    * return {@code client}. Callers must close the returned handle (try-with-resources) once done.
+    */
+   static MockedStatic<GraphServiceClient> mockClientFactory(GraphServiceClient client) {
+      MockedStatic<GraphServiceClient> mockedStatic = mockStatic(GraphServiceClient.class);
+      GraphServiceClient.Builder builder = mock(GraphServiceClient.Builder.class);
+      when(builder.authenticationProvider(any())).thenReturn(builder);
+      when(builder.buildClient()).thenReturn(client);
+      mockedStatic.when(GraphServiceClient::builder).thenReturn(builder);
+      return mockedStatic;
+   }
+
+   /**
+    * A real {@code new SharepointOnlineDataSource()} calls {@code createCredential}, which needs a
+    * live Spring application context (none exists in this test tree) — mock instead. None of the
+    * SPI path under test inspects the data source beyond passing it to
+    * {@code SharepointAuthenticator}'s constructor, which only stores the reference.
+    */
+   static SharepointOnlineDataSource fakeDataSource() {
+      return mock(SharepointOnlineDataSource.class);
+   }
+
+   // ----- Graph model fixtures (plain POJOs — no mocking needed) -----
+
+   static Site site(String id, String displayName) {
+      Site site = new Site();
+      site.id = id;
+      site.displayName = displayName;
+      return site;
+   }
+
+   static com.microsoft.graph.models.List spList(String id, String displayName) {
+      com.microsoft.graph.models.List list = new com.microsoft.graph.models.List();
+      list.id = id;
+      list.displayName = displayName;
+      return list;
+   }
+
+   static Group group(String id, String displayName) {
+      Group group = new Group();
+      group.id = id;
+      group.displayName = displayName;
+      return group;
+   }
+
+   static ColumnDefinition column(String name, Consumer<ColumnDefinition> fn) {
+      ColumnDefinition c = new ColumnDefinition();
+      c.name = name;
+      c.displayName = name + " (display)";
+      fn.accept(c);
+      return c;
+   }
+
+   // ----- Graph fluent-chain stubbing -----
+
+   static SiteRequestBuilder siteBuilder(GraphServiceClient client, String siteId) {
+      SiteRequestBuilder builder = mock(SiteRequestBuilder.class);
+      when(client.sites(siteId)).thenReturn(builder);
+      return builder;
+   }
+
+   static void stubSiteGet(SiteRequestBuilder builder, Site site) {
+      SiteRequest request = mock(SiteRequest.class);
+      when(builder.buildRequest()).thenReturn(request);
+      when(request.get()).thenReturn(site);
+   }
+
+   static void stubSiteGetThrows(SiteRequestBuilder builder, RuntimeException failure) {
+      SiteRequest request = mock(SiteRequest.class);
+      when(builder.buildRequest()).thenReturn(request);
+      when(request.get()).thenThrow(failure);
+   }
+
+   static void stubChildren(SiteRequestBuilder builder, List<Site> children) {
+      SiteCollectionRequestBuilder childBuilder = mock(SiteCollectionRequestBuilder.class);
+      SiteCollectionRequest childRequest = mock(SiteCollectionRequest.class);
+      when(builder.sites()).thenReturn(childBuilder);
+      when(childBuilder.buildRequest()).thenReturn(childRequest);
+      when(childRequest.get()).thenReturn(new SiteCollectionPage(children, null));
+   }
+
+   static void stubChildrenThrows(SiteRequestBuilder builder, RuntimeException failure) {
+      SiteCollectionRequestBuilder childBuilder = mock(SiteCollectionRequestBuilder.class);
+      SiteCollectionRequest childRequest = mock(SiteCollectionRequest.class);
+      when(builder.sites()).thenReturn(childBuilder);
+      when(childBuilder.buildRequest()).thenReturn(childRequest);
+      when(childRequest.get()).thenThrow(failure);
+   }
+
+   static void stubLists(SiteRequestBuilder builder, List<com.microsoft.graph.models.List> lists) {
+      ListCollectionRequestBuilder listsBuilder = mock(ListCollectionRequestBuilder.class);
+      ListCollectionRequest listsRequest = mock(ListCollectionRequest.class);
+      when(builder.lists()).thenReturn(listsBuilder);
+      when(listsBuilder.buildRequest()).thenReturn(listsRequest);
+      when(listsRequest.get()).thenReturn(new ListCollectionPage(lists, null));
+   }
+
+   static void stubListsThrows(SiteRequestBuilder builder, RuntimeException failure) {
+      ListCollectionRequestBuilder listsBuilder = mock(ListCollectionRequestBuilder.class);
+      ListCollectionRequest listsRequest = mock(ListCollectionRequest.class);
+      when(builder.lists()).thenReturn(listsBuilder);
+      when(listsBuilder.buildRequest()).thenReturn(listsRequest);
+      when(listsRequest.get()).thenThrow(failure);
+   }
+
+   static ListRequestBuilder stubColumns(SiteRequestBuilder builder, String listId,
+                                        List<ColumnDefinition> columns)
+   {
+      ListRequestBuilder listBuilder = mock(ListRequestBuilder.class);
+      ColumnDefinitionCollectionRequestBuilder columnsBuilder =
+         mock(ColumnDefinitionCollectionRequestBuilder.class);
+      ColumnDefinitionCollectionRequest columnsRequest = mock(ColumnDefinitionCollectionRequest.class);
+      when(builder.lists(listId)).thenReturn(listBuilder);
+      when(listBuilder.columns()).thenReturn(columnsBuilder);
+      when(columnsBuilder.buildRequest()).thenReturn(columnsRequest);
+      when(columnsRequest.get()).thenReturn(new ColumnDefinitionCollectionPage(columns, null));
+      return listBuilder;
+   }
+
+   static void stubGroups(GraphServiceClient client, List<Group> groups) {
+      GroupCollectionRequestBuilder groupsBuilder = mock(GroupCollectionRequestBuilder.class);
+      GroupCollectionRequest groupsRequest = mock(GroupCollectionRequest.class);
+      when(client.groups()).thenReturn(groupsBuilder);
+      when(groupsBuilder.buildRequest()).thenReturn(groupsRequest);
+      when(groupsRequest.get()).thenReturn(new GroupCollectionPage(groups, null));
+   }
+
+   static void stubGroupsThrows(GraphServiceClient client, RuntimeException failure) {
+      GroupCollectionRequestBuilder groupsBuilder = mock(GroupCollectionRequestBuilder.class);
+      GroupCollectionRequest groupsRequest = mock(GroupCollectionRequest.class);
+      when(client.groups()).thenReturn(groupsBuilder);
+      when(groupsBuilder.buildRequest()).thenReturn(groupsRequest);
+      when(groupsRequest.get()).thenThrow(failure);
+   }
+
+   static void stubGroupSite(GraphServiceClient client, String groupId, Site site) {
+      GroupRequestBuilder groupBuilder = mock(GroupRequestBuilder.class);
+      SiteRequestBuilder groupSiteBuilder = mock(SiteRequestBuilder.class);
+      SiteRequest groupSiteRequest = mock(SiteRequest.class);
+      when(client.groups(groupId)).thenReturn(groupBuilder);
+      when(groupBuilder.sites("root")).thenReturn(groupSiteBuilder);
+      when(groupSiteBuilder.buildRequest()).thenReturn(groupSiteRequest);
+      when(groupSiteRequest.get()).thenReturn(site);
+   }
+}

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineCatalogPermissionFailureTest.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineCatalogPermissionFailureTest.java
@@ -1,0 +1,143 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.SiteRequestBuilder;
+import inetsoft.uql.tabular.TabularCatalog;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+
+import static inetsoft.uql.sharepoint.SharepointGraphTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Covers charter assertion S4 — "本轮最重要的一条" — and the reverse assertion that
+ * {@code listDatasets} must never return a partial/empty catalog on a permission or transport
+ * failure. This is the assertion the existing {@code doGetSites}/{@code getChildSites} degrade-
+ * and-warn behavior structurally cannot satisfy, which is exactly why
+ * {@link SharepointOnlineRuntime#listSitesOrThrow} is new code that never calls them.
+ *
+ * S4b is the case most likely to give a false pass: root succeeding means the catalog is
+ * already non-empty by the time groups() fails, so a naive implementation could let the root
+ * site's data through as a "successful" (but silently partial) result. Every case here asserts
+ * the specific exception thrown, not merely "something was thrown" — and S4d proves the fix
+ * didn't overcorrect into treating a legitimately empty list as a failure too.
+ */
+@Tag("connector")
+class SharepointOnlineCatalogPermissionFailureTest {
+
+   @Test
+   void listDatasets_rootSiteFetchThrows_propagatesRatherThanReturningEmptyCatalog() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      ClientException failure = new ClientException("403 Forbidden: Sites.Read.All missing", null);
+      stubSiteGetThrows(rootBuilder, failure);
+
+      Exception thrown;
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         thrown = assertThrows(ClientException.class,
+            () -> SharepointOnlineCatalog.listDatasets(fakeDataSource()));
+      }
+
+      assertSame(failure, thrown);
+      verify(client).sites("root");
+   }
+
+   @Test
+   void listDatasets_groupsCallThrowsAfterRootSucceeds_propagatesRatherThanReturningRootOnly() {
+      // S4b: the sharpest case. Root succeeds and contributes data to the catalog before groups()
+      // fails — a "did it throw" check that runs AFTER catalog.datasets() is already non-empty
+      // would not be caught by the top-level empty-catalog check.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Contoso Root"));
+      stubChildren(rootBuilder, List.of());
+      stubLists(rootBuilder, List.of(spList("list-sales", "Sales")));
+
+      ClientException failure = new ClientException("403 Forbidden: Group.Read.All missing", null);
+      stubGroupsThrows(client, failure);
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         ClientException thrown = assertThrows(ClientException.class,
+            () -> SharepointOnlineCatalog.listDatasets(fakeDataSource()));
+         assertSame(failure, thrown);
+      }
+   }
+
+   @Test
+   void listDatasets_aSiteListsCallThrowsMidRecursion_propagatesRatherThanReturningPartialResult() {
+      // S4c: doGetLists already throws (no catch) — this proves the SPI path doesn't add a new
+      // try/catch on top of it that would turn that into a silent skip.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Contoso Root"));
+      stubChildren(rootBuilder, List.of(site("subsite-1", "Team A")));
+      stubLists(rootBuilder, List.of(spList("list-sales", "Sales")));
+
+      SiteRequestBuilder subsiteBuilder = siteBuilder(client, "subsite-1");
+      stubChildren(subsiteBuilder, List.of());
+      ClientException failure = new ClientException("429 Too Many Requests", null);
+      stubListsThrows(subsiteBuilder, failure);
+
+      stubGroups(client, List.of());
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         ClientException thrown = assertThrows(ClientException.class,
+            () -> SharepointOnlineCatalog.listDatasets(fakeDataSource()));
+         assertSame(failure, thrown);
+      }
+   }
+
+   @Test
+   void listDatasets_oneSiteHasZeroLists_isLegalAndDoesNotThrow() throws Exception {
+      // S4d: the "real" empty case — a site that genuinely has no lists must NOT be treated as a
+      // failure. Overcorrecting S4a-c into "any zero-sized Graph result is an error" would make
+      // this legitimate case fail too.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Contoso Root"));
+      stubChildren(rootBuilder, List.of(site("empty-site", "Empty Site")));
+      stubLists(rootBuilder, List.of(spList("list-sales", "Sales")));
+
+      SiteRequestBuilder emptySiteBuilder = siteBuilder(client, "empty-site");
+      stubChildren(emptySiteBuilder, List.of());
+      stubLists(emptySiteBuilder, List.of());   // legitimately zero lists — not an error
+
+      stubGroups(client, List.of());
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         TabularCatalog catalog = SharepointOnlineCatalog.listDatasets(fakeDataSource());
+
+         // Exactly root's one dataset; empty-site contributed zero, but is not the reason for
+         // failure — and root's dataset must still be present.
+         assertEquals(1, catalog.datasets().size());
+         assertEquals("list-sales", SharepointDatasetId.parse(catalog.datasets().get(0).id()).list());
+      }
+   }
+}

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineCatalogTest.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineCatalogTest.java
@@ -1,0 +1,188 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+import com.microsoft.graph.models.*;
+import com.microsoft.graph.requests.*;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.TabularCatalog;
+import inetsoft.uql.tabular.TabularDatasetRef;
+import inetsoft.uql.tabular.TabularDatasetSchema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static inetsoft.uql.sharepoint.SharepointGraphTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Covers charter assertions S1 (listDatasets: full site x list combination, including recursion
+ * into subsites) and S2 (describeDataset: real columns, Graph type mapping). Uses real Graph SDK
+ * model/page objects and Mockito mocks for the request-builder/request fluent chain — see
+ * {@link SharepointGraphTestSupport}.
+ */
+@Tag("connector")
+class SharepointOnlineCatalogTest {
+
+   @Test
+   void listDatasets_returnsSiteByListFullCombination_rootSubsiteAndGroupSite() throws Exception {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Contoso Root"));
+      stubChildren(rootBuilder, List.of(site("subsite-1", "Team A")));
+      stubLists(rootBuilder, List.of(spList("list-sales", "Sales"), spList("list-hr", "HR")));
+
+      SiteRequestBuilder subsiteBuilder = siteBuilder(client, "subsite-1");
+      stubChildren(subsiteBuilder, List.of());
+      stubLists(subsiteBuilder, List.of(spList("list-tasks", "Tasks")));
+
+      stubGroups(client, List.of(group("group-1", "Marketing Group")));
+      stubGroupSite(client, "group-1", site("group-site-1", "Marketing Site"));
+      SiteRequestBuilder groupSiteBuilder = siteBuilder(client, "group-site-1");
+      stubChildren(groupSiteBuilder, List.of());
+      stubLists(groupSiteBuilder, List.of(spList("list-campaigns", "Campaigns"),
+         spList("list-budget", "Budget")));
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         TabularCatalog catalog = SharepointOnlineCatalog.listDatasets(fakeDataSource());
+
+         // 2 (root) + 1 (subsite) + 2 (group site) = 5 — a real sum, not size-per-site * count.
+         assertEquals(5, catalog.datasets().size());
+
+         Set<String> ids = new HashSet<>();
+
+         for(TabularDatasetRef ref : catalog.datasets()) {
+            assertTrue(ids.add(ref.id()), "duplicate dataset id: " + ref.id());
+         }
+
+         assertEquals(5, ids.size());
+
+         // Round-trip every id back to its (site, list) pair and confirm the set of pairs is
+         // exactly what was declared above — content-level, not "non-empty".
+         Set<String> pairs = new HashSet<>();
+
+         for(String id : ids) {
+            SharepointDatasetId.Parsed parsed = SharepointDatasetId.parse(id);
+            pairs.add(parsed.site() + "|" + parsed.list());
+         }
+
+         assertEquals(Set.of("root|list-sales", "root|list-hr", "subsite-1|list-tasks",
+            "group-site-1|list-campaigns", "group-site-1|list-budget"), pairs);
+      }
+   }
+
+   @Test
+   void listDatasets_threeLevelSubsiteRecursion_allLevelsAppear() throws Exception {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Root"));
+      stubChildren(rootBuilder, List.of(site("level-2", "Level 2")));
+      stubLists(rootBuilder, List.of(spList("list-l1", "Level 1 List")));
+
+      SiteRequestBuilder level2Builder = siteBuilder(client, "level-2");
+      stubChildren(level2Builder, List.of(site("level-3", "Level 3")));
+      stubLists(level2Builder, List.of(spList("list-l2", "Level 2 List")));
+
+      SiteRequestBuilder level3Builder = siteBuilder(client, "level-3");
+      stubChildren(level3Builder, List.of());
+      stubLists(level3Builder, List.of(spList("list-l3", "Level 3 List")));
+
+      stubGroups(client, List.of());
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         TabularCatalog catalog = SharepointOnlineCatalog.listDatasets(fakeDataSource());
+
+         // The whole point of this case: getChildSites() only went one level deep; the new
+         // listSitesOrThrow path must reach level 3, not just level 2.
+         assertEquals(3, catalog.datasets().size());
+
+         Set<String> lists = new HashSet<>();
+
+         for(TabularDatasetRef ref : catalog.datasets()) {
+            lists.add(SharepointDatasetId.parse(ref.id()).list());
+         }
+
+         assertEquals(Set.of("list-l1", "list-l2", "list-l3"), lists);
+      }
+   }
+
+   @Test
+   void describeDataset_mapsAllSevenGraphColumnShapesToXSchema() throws Exception {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+
+      ColumnDefinition text = column("Title", c -> c.text = new TextColumn());
+      ColumnDefinition numberLong = column("Quantity", c -> {
+         c.number = new NumberColumn();
+         c.number.decimalPlaces = "none";
+      });
+      ColumnDefinition numberDouble = column("Weight", c -> {
+         c.number = new NumberColumn();
+         c.number.decimalPlaces = "one";
+      });
+      ColumnDefinition bool = column("IsActive", c -> c.msgraphBoolean = new BooleanColumn());
+      ColumnDefinition dateOnly = column("DueDate", c -> {
+         c.dateTime = new DateTimeColumn();
+         c.dateTime.format = "dateOnly";
+      });
+      ColumnDefinition dateTimeInstant = column("Modified", c -> {
+         c.dateTime = new DateTimeColumn();
+         c.dateTime.format = "dateTime";
+      });
+      ColumnDefinition currency = column("Price", c -> c.currency = new CurrencyColumn());
+
+      stubColumns(rootBuilder, "list-1", List.of(text, numberLong, numberDouble, bool, dateOnly,
+         dateTimeInstant, currency));
+
+      String datasetId = SharepointDatasetId.compose("root", "list-1");
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         TabularDatasetSchema schema =
+            SharepointOnlineCatalog.describeDataset(fakeDataSource(), datasetId);
+
+         assertEquals(datasetId, schema.datasetId());
+         assertEquals(7, schema.columns().size());
+         assertEquals("Title", schema.columns().get(0).name());
+         assertEquals(XSchema.STRING, schema.columns().get(0).type());
+         assertEquals("Quantity", schema.columns().get(1).name());
+         assertEquals(XSchema.LONG, schema.columns().get(1).type());
+         assertEquals("Weight", schema.columns().get(2).name());
+         assertEquals(XSchema.DOUBLE, schema.columns().get(2).type());
+         assertEquals("IsActive", schema.columns().get(3).name());
+         assertEquals(XSchema.BOOLEAN, schema.columns().get(3).type());
+         assertEquals("DueDate", schema.columns().get(4).name());
+         assertEquals(XSchema.DATE, schema.columns().get(4).type());
+         assertEquals("Modified", schema.columns().get(5).name());
+         assertEquals(XSchema.TIME_INSTANT, schema.columns().get(5).type());
+         assertEquals("Price", schema.columns().get(6).name());
+         assertEquals(XSchema.DOUBLE, schema.columns().get(6).type());
+
+         // TabularDatasetSchema.keyColumns() is documented "Never null"; SharePoint declares no
+         // key (the system ID column doesn't surface through this mapping — see class javadoc).
+         assertNotNull(schema.keyColumns());
+         assertTrue(schema.keyColumns().isEmpty());
+      }
+   }
+}

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineDropdownUnaffectedTest.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineDropdownUnaffectedTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.sharepoint;
+
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.SiteRequestBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+
+import static inetsoft.uql.sharepoint.SharepointGraphTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Covers charter assertion S5. {@code inetsoft-sharepoint-online} had zero test files before this
+ * round, so "existing tests green" is vacuously true and proves nothing — per reconcile, the
+ * actual proof is two-part: (1) these characterization tests, pinning today's connect-dialog
+ * dropdown behavior as a baseline it did not have before, and (2) confirming by diff that
+ * {@code doGetSites}/{@code getChildSites}/{@code doGetLists}/{@code doGetListColumns} were not
+ * edited — the SPI path added in this round is new code sitting next to them
+ * ({@link SharepointOnlineRuntime#listSitesOrThrow}), not a modification of them. (2) is recorded
+ * in 04-build.md, not repeated here as a test — there is no meaningful way to assert "these bytes
+ * are unchanged" from inside a JUnit test.
+ *
+ * The interesting contrast with {@link SharepointOnlineCatalogPermissionFailureTest}: the SPI path
+ * must throw on a permission failure; the dropdown path, characterized here, must go on silently
+ * degrading exactly as it always has — because that is a real deliberate difference in
+ * requirements (annotation vs. an interactive dialog the user can just retry), not an
+ * inconsistency to "fix" while touching this connector.
+ */
+@Tag("connector")
+class SharepointOnlineDropdownUnaffectedTest {
+
+   @Test
+   void getSites_rootSucceedsGroupsThrows_stillReturnsRootOnlyWithoutThrowing() {
+      // Pins the pre-existing catch-and-LOG.warn behavior in doGetSites's groups try/catch, which
+      // this round deliberately does NOT touch (contrast with the SPI path's S4b, which must
+      // throw in the same scenario).
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Contoso Root"));
+      stubChildren(rootBuilder, List.of());
+
+      stubGroupsThrows(client, new ClientException("403 Forbidden: Group.Read.All missing", null));
+
+      String[][] result;
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         result = SharepointOnlineRuntime.getSites(fakeDataSource());
+      }
+
+      assertEquals(1, result.length);
+      assertEquals("Contoso Root", result[0][0]);
+      assertEquals("root", result[0][1]);
+   }
+
+   @Test
+   void getSites_rootThrows_returnsWhateverGroupsContributedWithoutThrowing() {
+      // The mirror image: root's own try/catch is independent of groups'. Pins today's behavior
+      // that a root failure alone still doesn't surface as an exception to the dropdown.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGetThrows(rootBuilder, new ClientException("403 Forbidden: Sites.Read.All missing", null));
+
+      stubGroups(client, List.of(group("group-1", "Marketing Group")));
+      stubGroupSite(client, "group-1", site("group-site-1", "Marketing Site"));
+      SiteRequestBuilder groupSiteBuilder = siteBuilder(client, "group-site-1");
+      stubChildren(groupSiteBuilder, List.of());
+
+      String[][] result;
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         result = SharepointOnlineRuntime.getSites(fakeDataSource());
+      }
+
+      assertEquals(1, result.length);
+      assertEquals("Marketing Site", result[0][0]);
+   }
+
+   @Test
+   void getSites_grandchildSites_remainUnreachable_nonRecursiveByDesign() {
+      // Pins the OTHER known limitation (charter's known-limitations list, item 1): the dropdown's
+      // getChildSites() is genuinely one level only. This is deliberately NOT fixed for the
+      // dropdown path in this round (only the new SPI path is recursive) — this test documents
+      // that today's dropdown behavior did not silently change underneath it.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubSiteGet(rootBuilder, site("root", "Contoso Root"));
+      stubChildren(rootBuilder, List.of(site("child-1", "Child Site")));
+
+      SiteRequestBuilder childBuilder = siteBuilder(client, "child-1");
+      stubChildren(childBuilder, List.of(site("grandchild-1", "Grandchild Site")));
+
+      stubGroups(client, List.of());
+
+      String[][] result;
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         result = SharepointOnlineRuntime.getSites(fakeDataSource());
+      }
+
+      List<String> names = List.of(result).stream().map(row -> row[0]).toList();
+      assertTrue(names.contains("Contoso Root"));
+      assertTrue(names.contains("Child Site"));
+      assertFalse(names.contains("Grandchild Site"),
+         "dropdown's getChildSites() is one level only — this must stay true for S5");
+   }
+
+   @Test
+   void getLists_normalCase_returnsListsForTheGivenSite() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder siteBuilder = siteBuilder(client, "site-1");
+      stubLists(siteBuilder, List.of(spList("list-1", "Sales"), spList("list-2", "HR")));
+
+      String[][] result;
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         result = SharepointOnlineRuntime.getLists(fakeDataSource(), "site-1");
+      }
+
+      assertEquals(2, result.length);
+      assertEquals("Sales", result[0][0]);
+      assertEquals("HR", result[1][0]);
+   }
+}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
@@ -50,6 +50,12 @@ public interface TabularCatalogProvider {
     * truncate silently.
     *
     * @return never {@code null}; may be empty only when the source genuinely holds no datasets.
+    *         Note that an empty result is NOT a way to signal success at annotating nothing:
+    *         {@code TabularCatalogService.listTables}, the sole production caller, rejects an
+    *         empty catalog with a named "no datasets to annotate" error rather than completing the
+    *         annotation run having done no work — the same reasoning wiz's own
+    *         {@code handelAnnotateDatabase} applies to an empty JDBC table list. Returning empty is
+    *         legal from this interface's point of view; it is answered with an error one layer up.
     * @throws Exception if the catalog could not be read. Throwing is REQUIRED over returning an
     *         empty catalog on failure — an empty result is indistinguishable from success and
     *         produces an annotation run that looks complete and is not.

--- a/core/src/main/java/inetsoft/uql/tabular/TabularColumn.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularColumn.java
@@ -24,9 +24,7 @@ package inetsoft.uql.tabular;
  * @param type any {@link inetsoft.uql.schema.XSchema} type constant — e.g. XSchema.STRING, LONG,
  *             DOUBLE, DATE, TIME_INSTANT, TIME, BOOLEAN. The names listed here are illustrative,
  *             not exhaustive: the actual, closed vocabulary is every {@code public static final
- *             String} constant {@code XSchema} itself declares (P5 review r3 — an earlier trailing
- *             "..." on this list was read as open-ended and cost a full round to resolve; it is
- *             not open-ended). The connector maps its own native type onto this vocabulary; the
- *             native type name does not cross this boundary.
+ *             String} constant {@code XSchema} itself declares. The connector maps its own native
+ *             type onto this vocabulary; the native type name does not cross this boundary.
  */
 public record TabularColumn(String name, String type) {}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularColumn.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularColumn.java
@@ -21,8 +21,12 @@ package inetsoft.uql.tabular;
  * One column of a dataset.
  *
  * @param name the column name as the source reports it. Non-blank.
- * @param type an {@link inetsoft.uql.schema.XSchema} type constant — XSchema.STRING, LONG, DOUBLE,
- *             DATE, TIME_INSTANT, TIME, BOOLEAN, ... The connector maps its own native type onto
- *             this vocabulary; the native type name does not cross this boundary.
+ * @param type any {@link inetsoft.uql.schema.XSchema} type constant — e.g. XSchema.STRING, LONG,
+ *             DOUBLE, DATE, TIME_INSTANT, TIME, BOOLEAN. The names listed here are illustrative,
+ *             not exhaustive: the actual, closed vocabulary is every {@code public static final
+ *             String} constant {@code XSchema} itself declares (P5 review r3 — an earlier trailing
+ *             "..." on this list was read as open-ended and cost a full round to resolve; it is
+ *             not open-ended). The connector maps its own native type onto this vocabulary; the
+ *             native type name does not cross this boundary.
  */
 public record TabularColumn(String name, String type) {}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularRelationship.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularRelationship.java
@@ -22,7 +22,17 @@ import java.util.List;
 /**
  * A relationship the SOURCE ITSELF declares between two of its datasets — not an inferred one.
  *
- * @param name        stable identifier for this edge within the catalog; non-blank.
+ * <p><b>Stated residual (P5 review r2, declined as candidate work; see
+ * {@code SharepointOnlineCatalog}'s javadoc for the fuller reasoning):</b>
+ * {@code TabularCatalogService} checks {@code fromColumns}/{@code toColumns} for non-emptiness and
+ * equal size, but does NOT verify that an entry actually names a real column of
+ * {@code fromDataset}/{@code toDataset}'s own schema — doing so would require the
+ * {@code listDatasets} phase to call {@code describeDataset} for every referenced dataset, which
+ * reverses the SPI's two-phase separation (the reason a connector like SharePoint does not cache
+ * between phases). A connector emitting a relationship is responsible for this invariant itself.
+ *
+ * @param name        stable identifier for this edge within the catalog; non-blank, and unique
+ *                    within the catalog.
  * @param fromDataset a {@link TabularDatasetRef#id()} present in the same {@link TabularCatalog}.
  * @param toDataset   likewise.
  * @param fromColumns column names in {@code fromDataset}; non-empty, and the same size as

--- a/core/src/main/java/inetsoft/uql/tabular/TabularRelationship.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularRelationship.java
@@ -22,14 +22,13 @@ import java.util.List;
 /**
  * A relationship the SOURCE ITSELF declares between two of its datasets — not an inferred one.
  *
- * <p><b>Stated residual (P5 review r2, declined as candidate work; see
- * {@code SharepointOnlineCatalog}'s javadoc for the fuller reasoning):</b>
- * {@code TabularCatalogService} checks {@code fromColumns}/{@code toColumns} for non-emptiness and
- * equal size, but does NOT verify that an entry actually names a real column of
- * {@code fromDataset}/{@code toDataset}'s own schema — doing so would require the
- * {@code listDatasets} phase to call {@code describeDataset} for every referenced dataset, which
- * reverses the SPI's two-phase separation (the reason a connector like SharePoint does not cache
- * between phases). A connector emitting a relationship is responsible for this invariant itself.
+ * <p><b>Stated residual:</b> {@code TabularCatalogService} checks {@code fromColumns}/
+ * {@code toColumns} for non-emptiness and equal size, but does NOT verify that an entry actually
+ * names a real column of {@code fromDataset}/{@code toDataset}'s own schema — doing so would
+ * require the {@code listDatasets} phase to call {@code describeDataset} for every referenced
+ * dataset, which reverses the SPI's two-phase separation (the reason a connector like SharePoint
+ * does not cache between phases). A connector emitting a relationship is responsible for this
+ * invariant itself.
  *
  * @param name        stable identifier for this edge within the catalog; non-blank, and unique
  *                    within the catalog.

--- a/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
@@ -1119,26 +1119,53 @@ public class TabularUtil {
     *         connector plugin is not loaded.
     */
    public static TabularRuntime createRuntime(String dataSource) {
+      XDataSource ds;
+
       try {
-         XDataSource ds = XRepository.getRepository().getDataSource(dataSource);
-
-         if(ds == null) {
-            return null;
-         }
-
-         String runtimeClass = Config.getConfig().getRuntime(ds.getType());
-
-         if(runtimeClass == null) {
-            return null;
-         }
-
-         return (TabularRuntime) Config.getConfig().getClass(ds.getType(), runtimeClass)
-            .getDeclaredConstructor().newInstance();
+         ds = XRepository.getRepository().getDataSource(dataSource);
       }
       catch(Exception e) {
-         LOG.error("Failed to create a tabular runtime for the given data source: {}",
+         LOG.error("Failed to look up the data source to create a tabular runtime for: {}",
                    dataSource, e);
          return null;
+      }
+
+      if(ds == null) {
+         return null;
+      }
+
+      String runtimeClass = Config.getConfig().getRuntime(ds.getType());
+
+      if(runtimeClass == null) {
+         return null;
+      }
+
+      Class<?> clazz;
+
+      try {
+         clazz = Config.getConfig().getClass(ds.getType(), runtimeClass);
+      }
+      catch(Exception e) {
+         // Plugin/class not loadable — treated as "no runtime available", same as before: this is
+         // still "not implemented" from the caller's point of view, not "broken".
+         LOG.error("Failed to load tabular runtime class {} for data source {}",
+                   runtimeClass, dataSource, e);
+         return null;
+      }
+
+      try {
+         return (TabularRuntime) clazz.getDeclaredConstructor().newInstance();
+      }
+      catch(Exception e) {
+         // The class WAS found and loaded; constructing it failed. A materially different, and
+         // much more actionable, condition than "no runtime" — must not collapse into the same
+         // null that TabularCatalogService.resolveProvider turns into
+         // UnsupportedDatasourceException. TabularCatalogService.java:51 is this method's only
+         // production caller, so this is a safe, contained behavior change.
+         LOG.error("Failed to construct tabular runtime {} for data source {}",
+                   runtimeClass, dataSource, e);
+         throw new RuntimeException("Failed to construct the tabular runtime for data source '" +
+            dataSource + "' (" + runtimeClass + "): " + e.getMessage(), e);
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
@@ -1134,7 +1134,18 @@ public class TabularUtil {
          return null;
       }
 
-      String runtimeClass = Config.getConfig().getRuntime(ds.getType());
+      String runtimeClass;
+
+      try {
+         runtimeClass = Config.getConfig().getRuntime(ds.getType());
+      }
+      catch(Exception e) {
+         // Same "not implemented" treatment as the class-loading catch below — this call is close
+         // to a plain map lookup and unlikely to throw, but the method's contract (never throw,
+         // only ever return null) predates this round's split and must not narrow silently.
+         LOG.error("Failed to look up the tabular runtime class for data source {}", dataSource, e);
+         return null;
+      }
 
       if(runtimeClass == null) {
          return null;
@@ -1164,8 +1175,12 @@ public class TabularUtil {
          // production caller, so this is a safe, contained behavior change.
          LOG.error("Failed to construct tabular runtime {} for data source {}",
                    runtimeClass, dataSource, e);
+         // The full RuntimeException (with the FQCN) is logged above for diagnosis; the message
+         // that reaches the caller — and, via DatasourceMetaApiController.handleException, the
+         // HTTP error body — names only the data source, matching the controlled style
+         // UnsupportedDatasourceException already uses in this area, not an internal class name.
          throw new RuntimeException("Failed to construct the tabular runtime for data source '" +
-            dataSource + "' (" + runtimeClass + "): " + e.getMessage(), e);
+            dataSource + "': " + e.getMessage(), e);
       }
    }
 

--- a/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularUtil.java
@@ -1179,8 +1179,12 @@ public class TabularUtil {
          // that reaches the caller — and, via DatasourceMetaApiController.handleException, the
          // HTTP error body — names only the data source, matching the controlled style
          // UnsupportedDatasourceException already uses in this area, not an internal class name.
+         // Deliberately NOT appending e.getMessage(): for a missing public no-arg constructor,
+         // getDeclaredConstructor() throws NoSuchMethodException whose own message IS the runtime
+         // class's FQCN, which would leak it right back in. The cause is already chained into this
+         // RuntimeException and already logged in full above, so nothing is lost for diagnosis.
          throw new RuntimeException("Failed to construct the tabular runtime for data source '" +
-            dataSource + "': " + e.getMessage(), e);
+            dataSource + "'", e);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -171,10 +171,24 @@ public class TabularCatalogService {
          throw new Exception("Data source '" + dsName + "' target '" + target +
             "' returned no columns — cannot annotate.");
       }
+      validateDatasetIdEchoed(dsName, target, schema);
       validateColumnNames(dsName, target, schema.columns());
       validateKeyColumns(dsName, target, schema);
 
       return toDataset(dsName, xrepository.getDataSource(dsName).getType(), schema, objectMapper);
+   }
+
+   private static void validateDatasetIdEchoed(String dsName, String target,
+                                               TabularDatasetSchema schema) throws Exception
+   {
+      if(!target.equals(schema.datasetId())) {
+         // TabularDatasetSchema.datasetId's javadoc: "echoes the id that was asked for, so a
+         // result is self-identifying." toDataset() below uses schema.datasetId(), not target, to
+         // set OsiDataset.name/.source — a connector that answers with a different dataset's
+         // schema would silently corrupt which dataset the annotation ends up labeled as.
+         throw new Exception("Data source '" + dsName + "' was asked to describe target '" +
+            target + "' but returned a schema for '" + schema.datasetId() + "' instead.");
+      }
    }
 
    private static void validateColumnNames(String dsName, String target, List<TabularColumn> columns)

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -93,6 +93,13 @@ public class TabularCatalogService {
          if(ref == null || ref.id() == null || ref.id().isBlank()) {
             throw new Exception("Data source '" + dsName + "' returned a dataset with a blank id.");
          }
+         if(ref.id().contains(".")) {
+            // TabularDatasetRef.id's javadoc: "Must not contain a '.' character" — wiz's own
+            // bareTableName/sourceMatches split a non-FILE source on '.', so a dotted id would
+            // silently collide two different datasets, or resolve to the wrong one, downstream.
+            throw new Exception("Data source '" + dsName + "' returned a dataset id '" + ref.id() +
+               "' containing '.', which TabularDatasetRef.id's contract forbids.");
+         }
       }
    }
 
@@ -106,11 +113,28 @@ public class TabularCatalogService {
          if(rel == null) {
             throw new Exception("Data source '" + dsName + "' returned a null relationship entry.");
          }
+         if(rel.name() == null || rel.name().isBlank()) {
+            throw new Exception("Data source '" + dsName + "' declared a relationship with a " +
+               "blank name.");
+         }
          if(!ids.contains(rel.fromDataset()) || !ids.contains(rel.toDataset())) {
             throw new Exception("Data source '" + dsName + "' declared relationship '" + rel.name() +
                "' referencing an unknown dataset ('" + rel.fromDataset() + "' -> '" +
                rel.toDataset() + "'); every relationship endpoint must be one of the datasets " +
                "returned by listDatasets.");
+         }
+         if(rel.fromColumns() == null || rel.fromColumns().isEmpty() ||
+            rel.toColumns() == null || rel.toColumns().isEmpty())
+         {
+            throw new Exception("Data source '" + dsName + "' declared relationship '" +
+               rel.name() + "' with an empty fromColumns/toColumns list; both must be non-empty " +
+               "and positionally paired.");
+         }
+         if(rel.fromColumns().size() != rel.toColumns().size()) {
+            throw new Exception("Data source '" + dsName + "' declared relationship '" +
+               rel.name() + "' with fromColumns/toColumns of different sizes (" +
+               rel.fromColumns().size() + " vs " + rel.toColumns().size() +
+               "); they must be positionally paired.");
          }
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -199,7 +199,7 @@ public class TabularCatalogService {
             throw new Exception("Data source '" + dsName + "' target '" + target +
                "' returned a column with a blank name.");
          }
-         if(!XSCHEMA_TYPE_CONSTANTS.contains(column.type())) {
+         if(column.type() == null || !XSCHEMA_TYPE_CONSTANTS.contains(column.type())) {
             // TabularColumn.type's javadoc: "any XSchema type constant" — a closed vocabulary of
             // 21, not the handful the javadoc names as examples. This catches input
             // that never used the vocabulary at all ("varchar", a typo, null) — it cannot and does

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -32,7 +32,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Serves {@code GET /datasource/tables} and {@code POST /datasource/table/meta} for tabular data
@@ -72,8 +74,45 @@ public class TabularCatalogService {
       if(catalog == null || catalog.datasets() == null || catalog.datasets().isEmpty()) {
          throw new Exception("Data source '" + dsName + "' reported no datasets to annotate.");
       }
+      if(catalog.relationships() == null) {
+         throw new Exception("Data source '" + dsName + "' returned a catalog with a null " +
+            "relationships list; TabularCatalogProvider implementations must return an empty " +
+            "list, not null, when there are no relationships.");
+      }
+
+      validateDatasetIds(dsName, catalog.datasets());
+      validateRelationshipEndpoints(dsName, catalog);
 
       return toTablesResponse(dsName, catalog);
+   }
+
+   private static void validateDatasetIds(String dsName, List<TabularDatasetRef> datasets)
+      throws Exception
+   {
+      for(TabularDatasetRef ref : datasets) {
+         if(ref == null || ref.id() == null || ref.id().isBlank()) {
+            throw new Exception("Data source '" + dsName + "' returned a dataset with a blank id.");
+         }
+      }
+   }
+
+   private static void validateRelationshipEndpoints(String dsName, TabularCatalog catalog)
+      throws Exception
+   {
+      Set<String> ids = catalog.datasets().stream().map(TabularDatasetRef::id)
+         .collect(Collectors.toSet());
+
+      for(TabularRelationship rel : catalog.relationships()) {
+         if(rel == null) {
+            throw new Exception("Data source '" + dsName + "' returned a null relationship entry.");
+         }
+         if(!ids.contains(rel.fromDataset()) || !ids.contains(rel.toDataset())) {
+            throw new Exception("Data source '" + dsName + "' declared relationship '" + rel.name() +
+               "' referencing an unknown dataset ('" + rel.fromDataset() + "' -> '" +
+               rel.toDataset() + "'); every relationship endpoint must be one of the datasets " +
+               "returned by listDatasets.");
+         }
+      }
    }
 
    /**
@@ -89,8 +128,20 @@ public class TabularCatalogService {
          throw new Exception("Data source '" + dsName + "' target '" + target +
             "' returned no columns — cannot annotate.");
       }
+      validateColumnNames(dsName, target, schema.columns());
 
       return toDataset(dsName, xrepository.getDataSource(dsName).getType(), schema, objectMapper);
+   }
+
+   private static void validateColumnNames(String dsName, String target, List<TabularColumn> columns)
+      throws Exception
+   {
+      for(TabularColumn column : columns) {
+         if(column == null || column.name() == null || column.name().isBlank()) {
+            throw new Exception("Data source '" + dsName + "' target '" + target +
+               "' returned a column with a blank name.");
+         }
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -199,8 +199,33 @@ public class TabularCatalogService {
             throw new Exception("Data source '" + dsName + "' target '" + target +
                "' returned a column with a blank name.");
          }
+         if(!XSCHEMA_TYPE_CONSTANTS.contains(column.type())) {
+            // TabularColumn.type's javadoc: "any XSchema type constant" — a closed vocabulary of
+            // 21, not the handful the javadoc names as examples (P5 review r3). This catches input
+            // that never used the vocabulary at all ("varchar", a typo, null) — it cannot and does
+            // not catch a semantically wrong but valid choice (a date column labeled STRING); no
+            // whitelist can. Deliberately every declared constant, not a curated subset: a
+            // narrower, hand-picked set would risk rejecting a legitimate future connector mapping
+            // to e.g. XSchema.INTEGER or DECIMAL, which is the same "validator breaks a correct
+            // connector" failure this check exists to avoid causing.
+            throw new Exception("Data source '" + dsName + "' target '" + target +
+               "' returned column '" + column.name() + "' with type '" + column.type() +
+               "', which is not an XSchema type constant.");
+         }
       }
    }
+
+   // Every XSchema type constant, derived directly from XSchema's own declarations rather than
+   // XSchema.isPrimitiveType (checked first, per review guidance: it doesn't fit — it excludes
+   // NULL/COLOR/UNKNOWN and separately includes the non-constant legacy alias "bigdecimal" plus
+   // the UI/role constants ENUM/USER_DEFINED/USER/ROLE, so its shape answers a different question
+   // than "is this any declared XSchema constant").
+   private static final Set<String> XSCHEMA_TYPE_CONSTANTS = Set.of(
+      XSchema.NULL, XSchema.STRING, XSchema.BOOLEAN, XSchema.FLOAT, XSchema.DOUBLE,
+      XSchema.DECIMAL, XSchema.CHAR, XSchema.CHARACTER, XSchema.BYTE, XSchema.SHORT,
+      XSchema.INTEGER, XSchema.LONG, XSchema.TIME_INSTANT, XSchema.DATE, XSchema.TIME,
+      XSchema.ENUM, XSchema.USER_DEFINED, XSchema.ROLE, XSchema.USER, XSchema.COLOR,
+      XSchema.UNKNOWN);
 
    private static void validateKeyColumns(String dsName, String target, TabularDatasetSchema schema)
       throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,8 @@ public class TabularCatalogService {
    private static void validateDatasetIds(String dsName, List<TabularDatasetRef> datasets)
       throws Exception
    {
+      Set<String> seen = new HashSet<>();
+
       for(TabularDatasetRef ref : datasets) {
          if(ref == null || ref.id() == null || ref.id().isBlank()) {
             throw new Exception("Data source '" + dsName + "' returned a dataset with a blank id.");
@@ -100,6 +103,13 @@ public class TabularCatalogService {
             throw new Exception("Data source '" + dsName + "' returned a dataset id '" + ref.id() +
                "' containing '.', which TabularDatasetRef.id's contract forbids.");
          }
+         if(!seen.add(ref.id())) {
+            // TabularDatasetRef.id's javadoc: "must be non-blank and unique within one catalog."
+            // A duplicate becomes two DatabaseTableInfo rows with an identical table field, and a
+            // later describeTable(dsName, thatId) has no way to know which one was meant.
+            throw new Exception("Data source '" + dsName + "' returned the dataset id '" +
+               ref.id() + "' more than once; every dataset id must be unique within one catalog.");
+         }
       }
    }
 
@@ -108,6 +118,7 @@ public class TabularCatalogService {
    {
       Set<String> ids = catalog.datasets().stream().map(TabularDatasetRef::id)
          .collect(Collectors.toSet());
+      Set<String> seenNames = new HashSet<>();
 
       for(TabularRelationship rel : catalog.relationships()) {
          if(rel == null) {
@@ -116,6 +127,14 @@ public class TabularCatalogService {
          if(rel.name() == null || rel.name().isBlank()) {
             throw new Exception("Data source '" + dsName + "' declared a relationship with a " +
                "blank name.");
+         }
+         if(!seenNames.add(rel.name())) {
+            // TabularRelationship.name's javadoc: "stable identifier for this edge within the
+            // catalog" — a duplicate is the same "which one did the connector mean" ambiguity
+            // the dataset-id uniqueness check above exists to close.
+            throw new Exception("Data source '" + dsName + "' declared the relationship name '" +
+               rel.name() + "' more than once; every relationship name must be unique within one " +
+               "catalog.");
          }
          if(!ids.contains(rel.fromDataset()) || !ids.contains(rel.toDataset())) {
             throw new Exception("Data source '" + dsName + "' declared relationship '" + rel.name() +
@@ -153,6 +172,7 @@ public class TabularCatalogService {
             "' returned no columns — cannot annotate.");
       }
       validateColumnNames(dsName, target, schema.columns());
+      validateKeyColumns(dsName, target, schema);
 
       return toDataset(dsName, xrepository.getDataSource(dsName).getType(), schema, objectMapper);
    }
@@ -164,6 +184,29 @@ public class TabularCatalogService {
          if(column == null || column.name() == null || column.name().isBlank()) {
             throw new Exception("Data source '" + dsName + "' target '" + target +
                "' returned a column with a blank name.");
+         }
+      }
+   }
+
+   private static void validateKeyColumns(String dsName, String target, TabularDatasetSchema schema)
+      throws Exception
+   {
+      if(schema.keyColumns() == null) {
+         return;
+      }
+
+      Set<String> columnNames = schema.columns().stream().map(TabularColumn::name)
+         .collect(Collectors.toSet());
+
+      for(String keyColumn : schema.keyColumns()) {
+         if(!columnNames.contains(keyColumn)) {
+            // TabularDatasetSchema.keyColumns' javadoc: "names, from columns, that the source
+            // declares as this dataset's key." A dangling name mislabels the reported primary key
+            // rather than causing an ambiguous lookup, but it is still a documented invariant this
+            // validation layer should not silently trust.
+            throw new Exception("Data source '" + dsName + "' target '" + target +
+               "' declared key column '" + keyColumn + "', which is not one of its own reported " +
+               "columns.");
          }
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -201,7 +201,7 @@ public class TabularCatalogService {
          }
          if(!XSCHEMA_TYPE_CONSTANTS.contains(column.type())) {
             // TabularColumn.type's javadoc: "any XSchema type constant" — a closed vocabulary of
-            // 21, not the handful the javadoc names as examples (P5 review r3). This catches input
+            // 21, not the handful the javadoc names as examples. This catches input
             // that never used the vocabulary at all ("varchar", a typo, null) — it cannot and does
             // not catch a semantically wrong but valid choice (a date column labeled STRING); no
             // whitelist can. Deliberately every declared constant, not a curated subset: a
@@ -231,6 +231,13 @@ public class TabularCatalogService {
       throws Exception
    {
       if(schema.keyColumns() == null) {
+         // Stated residual: TabularDatasetSchema.keyColumns is documented "Never null", but a null
+         // here is tolerated rather than rejected. Unlike TabularCatalog.relationships() — also
+         // documented "Never null", and enforced above (C1), because a null there is a real NPE in
+         // toTablesResponse's for-each — a null keyColumns is fully absorbed by toDataset below:
+         // `schema.keyColumns() == null || schema.keyColumns().isEmpty() ? null : ...` produces an
+         // identical OsiDataset.primaryKey either way. Rejecting it would only punish a connector
+         // that passed null instead of List.of() to no observable difference.
          return;
       }
 

--- a/core/src/test/java/inetsoft/uql/tabular/TabularUtilCreateRuntimeTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularUtilCreateRuntimeTest.java
@@ -124,6 +124,38 @@ class TabularUtilCreateRuntimeTest {
       }
    }
 
+   @Test
+   void createRuntime_noPublicNoArgConstructor_messageDoesNotLeakFqcn() throws Exception {
+      // PR #4909 review finding: getDeclaredConstructor() (no args) on a class with no public
+      // no-arg constructor throws NoSuchMethodException, and that exception's OWN message is the
+      // runtime's FQCN. The prior test only covered a constructor whose BODY throws
+      // (InvocationTargetException, whose getMessage() is null), so the no-FQCN assertion there
+      // passed trivially without ever exercising this path.
+      XDataSource ds = mock(XDataSource.class);
+      when(ds.getType()).thenReturn("NoNoArgCtor");
+
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(ds);
+
+      Config config = mock(Config.class);
+      when(config.getRuntime("NoNoArgCtor")).thenReturn(NoNoArgConstructorRuntime.class.getName());
+      when(config.getClass("NoNoArgCtor", NoNoArgConstructorRuntime.class.getName()))
+         .thenReturn((Class) NoNoArgConstructorRuntime.class);
+
+      try(MockedStatic<XRepository> xrepositoryStatic = mockStatic(XRepository.class);
+          MockedStatic<Config> configStatic = mockStatic(Config.class))
+      {
+         xrepositoryStatic.when(XRepository::getRepository).thenReturn(xrepository);
+         configStatic.when(Config::getConfig).thenReturn(config);
+
+         RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> TabularUtil.createRuntime(DS_NAME));
+
+         assertTrue(ex.getMessage().contains(DS_NAME));
+         assertFalse(ex.getMessage().contains(NoNoArgConstructorRuntime.class.getName()));
+      }
+   }
+
    /**
     * A runtime whose constructor throws — simulates a genuinely broken connector, as opposed to
     * one that was never registered/loadable at all.
@@ -131,6 +163,26 @@ class TabularUtilCreateRuntimeTest {
    public static class BrokenConstructorRuntime extends TabularRuntime {
       public BrokenConstructorRuntime() {
          throw new IllegalStateException("boom");
+      }
+
+      @Override
+      public XTableNode runQuery(TabularQuery query, VariableTable params) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+
+      @Override
+      public void testDataSource(TabularDataSource<?> ds, VariableTable params) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+   }
+
+   /**
+    * A runtime with no public no-arg constructor at all — simulates a connector class that loads
+    * fine but was never written to be instantiable this way, as opposed to one whose no-arg
+    * constructor exists but throws.
+    */
+   public static class NoNoArgConstructorRuntime extends TabularRuntime {
+      public NoNoArgConstructorRuntime(int unused) {
       }
 
       @Override

--- a/core/src/test/java/inetsoft/uql/tabular/TabularUtilCreateRuntimeTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularUtilCreateRuntimeTest.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.XTableNode;
+import inetsoft.uql.util.Config;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers charter assertion C4: {@link TabularUtil#createRuntime} must let a broken connector
+ * constructor be told apart from "this connector never implemented the SPI" — before this round,
+ * both collapsed into a {@code null} return, which {@code TabularCatalogService.resolveProvider}
+ * then turned into the same {@link inetsoft.web.wiz.service.UnsupportedDatasourceException} either
+ * way. There is no prior {@code TabularUtilTest} to extend; this is the first test of this method.
+ */
+@Tag("core")
+class TabularUtilCreateRuntimeTest {
+
+   private static final String DS_NAME = "Fake Tabular Source";
+
+   @Test
+   void createRuntime_constructorThrows_propagatesUncheckedRatherThanReturningNull()
+      throws Exception
+   {
+      XDataSource ds = mock(XDataSource.class);
+      when(ds.getType()).thenReturn("Broken");
+
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(ds);
+
+      Config config = mock(Config.class);
+      when(config.getRuntime("Broken")).thenReturn(BrokenConstructorRuntime.class.getName());
+      when(config.getClass("Broken", BrokenConstructorRuntime.class.getName()))
+         .thenReturn((Class) BrokenConstructorRuntime.class);
+
+      try(MockedStatic<XRepository> xrepositoryStatic = mockStatic(XRepository.class);
+          MockedStatic<Config> configStatic = mockStatic(Config.class))
+      {
+         xrepositoryStatic.when(XRepository::getRepository).thenReturn(xrepository);
+         configStatic.when(Config::getConfig).thenReturn(config);
+
+         RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> TabularUtil.createRuntime(DS_NAME));
+
+         // The whole point of C4: this is an unchecked RuntimeException, structurally impossible
+         // to be the checked UnsupportedDatasourceException the "not implemented" path throws —
+         // the two signals cannot collapse into the same catch clause at the caller.
+         assertTrue(ex.getMessage().contains(DS_NAME));
+         assertTrue(ex.getMessage().contains(BrokenConstructorRuntime.class.getName()));
+      }
+   }
+
+   @Test
+   void createRuntime_classNotLoadable_stillReturnsNull() throws Exception {
+      XDataSource ds = mock(XDataSource.class);
+      when(ds.getType()).thenReturn("Missing");
+
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(ds);
+
+      Config config = mock(Config.class);
+      when(config.getRuntime("Missing")).thenReturn("no.such.RuntimeClass");
+      when(config.getClass("Missing", "no.such.RuntimeClass"))
+         .thenThrow(new ClassNotFoundException("no.such.RuntimeClass"));
+
+      try(MockedStatic<XRepository> xrepositoryStatic = mockStatic(XRepository.class);
+          MockedStatic<Config> configStatic = mockStatic(Config.class))
+      {
+         xrepositoryStatic.when(XRepository::getRepository).thenReturn(xrepository);
+         configStatic.when(Config::getConfig).thenReturn(config);
+
+         // The "not implemented / not loadable" path is untouched — still a plain null, not an
+         // exception of any kind.
+         assertNull(TabularUtil.createRuntime(DS_NAME));
+      }
+   }
+
+   /**
+    * A runtime whose constructor throws — simulates a genuinely broken connector, as opposed to
+    * one that was never registered/loadable at all.
+    */
+   public static class BrokenConstructorRuntime extends TabularRuntime {
+      public BrokenConstructorRuntime() {
+         throw new IllegalStateException("boom");
+      }
+
+      @Override
+      public XTableNode runQuery(TabularQuery query, VariableTable params) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+
+      @Override
+      public void testDataSource(TabularDataSource<?> ds, VariableTable params) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularUtilCreateRuntimeTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularUtilCreateRuntimeTest.java
@@ -69,7 +69,33 @@ class TabularUtilCreateRuntimeTest {
          // to be the checked UnsupportedDatasourceException the "not implemented" path throws —
          // the two signals cannot collapse into the same catch clause at the caller.
          assertTrue(ex.getMessage().contains(DS_NAME));
-         assertTrue(ex.getMessage().contains(BrokenConstructorRuntime.class.getName()));
+         // Review r1 nit: the message must NOT leak the runtime's fully-qualified class name —
+         // it propagates verbatim to the HTTP error body via DatasourceMetaApiController.
+         assertFalse(ex.getMessage().contains(BrokenConstructorRuntime.class.getName()));
+      }
+   }
+
+   @Test
+   void createRuntime_configLookupThrows_stillReturnsNull() throws Exception {
+      // Review r1 finding 3: Config.getConfig().getRuntime(...) sits outside the try/catch that
+      // guards class-loading/construction failures. It must still be treated as "not available",
+      // per this method's javadoc contract (never throws — only ever null), not propagate.
+      XDataSource ds = mock(XDataSource.class);
+      when(ds.getType()).thenReturn("Flaky");
+
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(ds);
+
+      Config config = mock(Config.class);
+      when(config.getRuntime("Flaky")).thenThrow(new IllegalStateException("config unavailable"));
+
+      try(MockedStatic<XRepository> xrepositoryStatic = mockStatic(XRepository.class);
+          MockedStatic<Config> configStatic = mockStatic(Config.class))
+      {
+         xrepositoryStatic.when(XRepository::getRepository).thenReturn(xrepository);
+         configStatic.when(Config::getConfig).thenReturn(config);
+
+         assertNull(TabularUtil.createRuntime(DS_NAME));
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -33,10 +33,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Covers charter assertions C1-C3: {@link TabularCatalogService} must not trust a connector's
- * {@link TabularCatalog}/{@link TabularDatasetSchema} at face value — a null relationships list, a
- * relationship pointing at an unknown dataset, or a blank id/column name must each produce a named
- * exception, not an NPE or a silently-broken wire response.
+ * Covers charter assertions C1-C3 and C6: {@link TabularCatalogService} must not trust a
+ * connector's {@link TabularCatalog}/{@link TabularDatasetSchema} at face value — a null
+ * relationships list, a relationship pointing at an unknown dataset, a blank id/column name, a
+ * dotted dataset id, a blank relationship name, or a mismatched/empty column pairing must each
+ * produce a named exception, not an NPE or a silently-broken wire response.
+ *
+ * C6 was added after P5 review r1 (finding 1): the original C1-C3 pass checked only three of the
+ * SPI's documented invariants, leaving the ones on {@code TabularDatasetRef.id} (no {@code .}) and
+ * {@code TabularRelationship} (non-blank name, paired columns) unchecked — including the very
+ * invariant ({@code id} must not contain {@code .}) that motivated {@code SharepointDatasetId}'s
+ * whole escaping scheme in the sibling implementer.
  *
  * Kept out of {@link TabularCatalogServiceTest} deliberately — that file's stated scope is charter
  * assertion B5 (core carries zero OData knowledge), and charter assertion C5 requires it stay
@@ -172,5 +179,90 @@ class TabularCatalogServiceContractValidationTest {
       assertFalse(ex instanceof UnsupportedDatasourceException);
       assertTrue(ex.getMessage().contains(DS_NAME));
       assertTrue(ex.getMessage().toLowerCase().contains("column"));
+   }
+
+   // ----- C6: TabularDatasetRef.id must not contain '.' -----
+
+   @Test
+   void listTables_dottedDatasetId_throwsNamedException() throws Exception {
+      TabularCatalog catalog =
+         new TabularCatalog(List.of(new TabularDatasetRef("contoso.sharepoint.com")), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("contoso.sharepoint.com"),
+         "message must name the offending id: " + ex.getMessage());
+   }
+
+   // ----- C6: TabularRelationship.name must be non-blank -----
+
+   @Test
+   void listTables_blankRelationshipName_throwsNamedException() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")),
+         List.of(new TabularRelationship("   ", "A", "B", List.of("x"), List.of("y"))));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("name"));
+   }
+
+   // ----- C6: TabularRelationship.fromColumns/toColumns must be non-empty and equal-length -----
+
+   @Test
+   void listTables_emptyFromColumns_throwsNamedException() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")),
+         List.of(new TabularRelationship("R_A_B", "A", "B", List.of(), List.of("y"))));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("R_A_B"),
+         "message must name the offending relationship: " + ex.getMessage());
+   }
+
+   @Test
+   void listTables_emptyToColumns_throwsNamedException() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")),
+         List.of(new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of())));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("R_A_B"),
+         "message must name the offending relationship: " + ex.getMessage());
+   }
+
+   @Test
+   void listTables_mismatchedColumnListSizes_throwsNamedException() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")),
+         List.of(new TabularRelationship("R_A_B", "A", "B",
+            List.of("x1", "x2"), List.of("y1"))));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("R_A_B"),
+         "message must name the offending relationship: " + ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -43,7 +43,11 @@ import static org.mockito.Mockito.when;
  * SPI's documented invariants, leaving the ones on {@code TabularDatasetRef.id} (no {@code .}) and
  * {@code TabularRelationship} (non-blank name, paired columns) unchecked — including the very
  * invariant ({@code id} must not contain {@code .}) that motivated {@code SharepointDatasetId}'s
- * whole escaping scheme in the sibling implementer.
+ * whole escaping scheme in the sibling implementer. Extended again after P5 review r2 (finding 1):
+ * C6 itself still missed the uniqueness half of both "non-blank and unique within one catalog"
+ * ({@code TabularDatasetRef.id}) and "stable identifier ... within the catalog"
+ * ({@code TabularRelationship.name}), plus (r2 nit 2) that {@code TabularDatasetSchema.keyColumns}
+ * entries must actually be one of the dataset's own reported {@code columns}.
  *
  * Kept out of {@link TabularCatalogServiceTest} deliberately — that file's stated scope is charter
  * assertion B5 (core carries zero OData knowledge), and charter assertion C5 requires it stay
@@ -264,5 +268,61 @@ class TabularCatalogServiceContractValidationTest {
       assertTrue(ex.getMessage().contains(DS_NAME));
       assertTrue(ex.getMessage().contains("R_A_B"),
          "message must name the offending relationship: " + ex.getMessage());
+   }
+
+   // ----- C6 (r2, finding 1): TabularDatasetRef.id must be unique within one catalog -----
+
+   @Test
+   void listTables_duplicateDatasetId_throwsNamedException() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("A")), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("A"),
+         "message must name the offending duplicate id: " + ex.getMessage());
+   }
+
+   // ----- C6 (r2, finding 1): TabularRelationship.name must be unique within one catalog -----
+
+   @Test
+   void listTables_duplicateRelationshipName_throwsNamedException() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B"),
+            new TabularDatasetRef("C")),
+         List.of(new TabularRelationship("R", "A", "B", List.of("x"), List.of("y")),
+            new TabularRelationship("R", "B", "C", List.of("x"), List.of("y"))));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("R"),
+         "message must name the offending duplicate relationship name: " + ex.getMessage());
+   }
+
+   // ----- C6 (r2, nit 2): TabularDatasetSchema.keyColumns entries must come from columns -----
+
+   @Test
+   void describeTable_keyColumnNotInColumns_throwsNamedException() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("NotAColumn"));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("NotAColumn"),
+         "message must name the offending key column: " + ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers charter assertions C1-C3: {@link TabularCatalogService} must not trust a connector's
+ * {@link TabularCatalog}/{@link TabularDatasetSchema} at face value — a null relationships list, a
+ * relationship pointing at an unknown dataset, or a blank id/column name must each produce a named
+ * exception, not an NPE or a silently-broken wire response.
+ *
+ * Kept out of {@link TabularCatalogServiceTest} deliberately — that file's stated scope is charter
+ * assertion B5 (core carries zero OData knowledge), and charter assertion C5 requires it stay
+ * unedited this round as a regression tripwire, so new coverage goes in this new file instead.
+ */
+@Tag("core")
+class TabularCatalogServiceContractValidationTest {
+
+   private static final String DS_NAME = "Fake Contract-Breaking Source";
+
+   private TabularCatalogService createService(Function<String, TabularRuntime> runtimeResolver)
+      throws Exception
+   {
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(new FakeTabularDataSource());
+      return new TabularCatalogService(xrepository, new ObjectMapper(), runtimeResolver);
+   }
+
+   // ----- C1: null relationships() -----
+
+   @Test
+   void listTables_nullRelationships_throwsNamedExceptionNotNpe() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(List.of(new TabularDatasetRef("X")), null);
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      // The whole point of C1: distinguishing "actually fixed" from "happened not to crash".
+      assertFalse(ex instanceof NullPointerException);
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("relationship"));
+   }
+
+   // ----- C2: relationship endpoint not in datasets() -----
+
+   @Test
+   void listTables_relationshipFromDatasetMissing_throwsNamingTheViolation() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("B")),
+         List.of(new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of("y"))));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("R_A_B") || ex.getMessage().contains("A"),
+         "message must name the offending relationship or its missing endpoint: " +
+         ex.getMessage());
+   }
+
+   @Test
+   void listTables_relationshipToDatasetMissing_throwsNamingTheViolation() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A")),
+         List.of(new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of("y"))));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("R_A_B") || ex.getMessage().contains("B"),
+         "message must name the offending relationship or its missing endpoint: " +
+         ex.getMessage());
+   }
+
+   // ----- C3: blank dataset id / column name (isBlank(), not isEmpty()) -----
+
+   @Test
+   void listTables_emptyStringDatasetId_throwsNamedException() throws Exception {
+      TabularCatalog catalog =
+         new TabularCatalog(List.of(new TabularDatasetRef("")), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("id"));
+   }
+
+   @Test
+   void listTables_blankWhitespaceDatasetId_throwsNamedException() throws Exception {
+      // Deliberately separate from the empty-string case: "   ".isEmpty() is false, so a
+      // validator written with isEmpty() instead of isBlank() would let this one slip through.
+      TabularCatalog catalog =
+         new TabularCatalog(List.of(new TabularDatasetRef("   ")), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("id"));
+   }
+
+   @Test
+   void describeTable_emptyStringColumnName_throwsNamedException() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("", XSchema.STRING)), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("column"));
+   }
+
+   @Test
+   void describeTable_blankWhitespaceColumnName_throwsNamedException() throws Exception {
+      // Same isBlank()-vs-isEmpty() concern as the dataset-id pair above, on the column-name half
+      // of C3.
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("   ", XSchema.STRING)), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("column"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -400,4 +400,27 @@ class TabularCatalogServiceContractValidationTest {
       assertEquals(1, dataset.getFields().size());
       assertEquals("Quantity", dataset.getFields().get(0).getName());
    }
+
+   @Test
+   void describeTable_nullColumnType_throwsNamedExceptionNotNpe() throws Exception {
+      // Set.of(...).contains(null) throws NullPointerException — XSCHEMA_TYPE_CONSTANTS is a
+      // Set.of(...), so without an explicit null check first, a connector returning a column with
+      // a null type gets a raw NPE out of the validator instead of the named exception the rest
+      // of C1-C6 exist to produce. Same false-positive concern as C1: assertThrows(Exception.class,
+      // ...) alone would pass on the unfixed code too, since NullPointerException is an Exception.
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("Name", null)), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof NullPointerException);
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("Name"),
+         "message must name the offending column: " + ex.getMessage());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -47,7 +47,11 @@ import static org.mockito.Mockito.when;
  * C6 itself still missed the uniqueness half of both "non-blank and unique within one catalog"
  * ({@code TabularDatasetRef.id}) and "stable identifier ... within the catalog"
  * ({@code TabularRelationship.name}), plus (r2 nit 2) that {@code TabularDatasetSchema.keyColumns}
- * entries must actually be one of the dataset's own reported {@code columns}.
+ * entries must actually be one of the dataset's own reported {@code columns}. Extended a third
+ * time after P5 review r3 (the lead's scope decision on r2's reported candidates, item 1):
+ * {@code TabularDatasetSchema.datasetId} must echo the {@code describeTable} target it was asked
+ * to describe — {@code toDataset} uses {@code schema.datasetId()}, not the requested target, to
+ * label the resulting {@code OsiDataset}, so an unchecked mismatch would silently mislabel it.
  *
  * Kept out of {@link TabularCatalogServiceTest} deliberately — that file's stated scope is charter
  * assertion B5 (core carries zero OData knowledge), and charter assertion C5 requires it stay
@@ -324,5 +328,29 @@ class TabularCatalogServiceContractValidationTest {
       assertTrue(ex.getMessage().contains(DS_NAME));
       assertTrue(ex.getMessage().contains("NotAColumn"),
          "message must name the offending key column: " + ex.getMessage());
+   }
+
+   // ----- C6 (r3, candidate #1): TabularDatasetSchema.datasetId must echo the requested target -----
+
+   @Test
+   void describeTable_schemaDatasetIdDoesNotMatchTarget_throwsNamedException() throws Exception {
+      // The connector was asked to describe "Products" but answered with a schema self-labeled
+      // as "Categories" — FakeCatalogRuntime's Map key ("Products") is what describeTable is
+      // called with; the schema's own datasetId field is independent and simulates the bug.
+      TabularDatasetSchema schema = new TabularDatasetSchema("Categories",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("Products"),
+         "message must name the requested target: " + ex.getMessage());
+      assertTrue(ex.getMessage().contains("Categories"),
+         "message must name the schema's actual (wrong) datasetId: " + ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.tabular.*;
+import inetsoft.web.wiz.model.osi.OsiDataset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +53,10 @@ import static org.mockito.Mockito.when;
  * {@code TabularDatasetSchema.datasetId} must echo the {@code describeTable} target it was asked
  * to describe — {@code toDataset} uses {@code schema.datasetId()}, not the requested target, to
  * label the resulting {@code OsiDataset}, so an unchecked mismatch would silently mislabel it.
+ * Extended a fourth time, same r3 round, item 3 (unblocked after the lead ruled on the closure of
+ * {@code TabularColumn.type}'s previously open-ended-looking javadoc list): {@code type} must be
+ * one of {@code XSchema}'s declared type constants, not merely the seven the javadoc gives as
+ * examples.
  *
  * Kept out of {@link TabularCatalogServiceTest} deliberately — that file's stated scope is charter
  * assertion B5 (core carries zero OData knowledge), and charter assertion C5 requires it stay
@@ -352,5 +357,47 @@ class TabularCatalogServiceContractValidationTest {
          "message must name the requested target: " + ex.getMessage());
       assertTrue(ex.getMessage().contains("Categories"),
          "message must name the schema's actual (wrong) datasetId: " + ex.getMessage());
+   }
+
+   // ----- C6 (r3, candidate #3): TabularColumn.type must be an XSchema type constant -----
+
+   @Test
+   void describeTable_columnTypeNotAnXSchemaConstant_throwsNamedException() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("Name", "varchar")), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().contains("Name"),
+         "message must name the offending column: " + ex.getMessage());
+      assertTrue(ex.getMessage().contains("varchar"),
+         "message must name the bad type: " + ex.getMessage());
+   }
+
+   @Test
+   void describeTable_columnTypeIsAnXSchemaConstantNotNamedInJavadocExamples_isAccepted()
+      throws Exception
+   {
+      // The regression guard for the inversion review r3 flagged: TabularColumn's javadoc only
+      // names 7 example constants (STRING, LONG, DOUBLE, DATE, TIME_INSTANT, TIME, BOOLEAN), but
+      // the actual vocabulary is all 21 XSchema declares. A whitelist built from just the 7 named
+      // examples would wrongly reject a legitimate connector mapping to XSchema.INTEGER — this
+      // pins that it does not.
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("Quantity", XSchema.INTEGER)), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      OsiDataset dataset = service.describeTable(DS_NAME, "Products");
+
+      assertEquals(1, dataset.getFields().size());
+      assertEquals("Quantity", dataset.getFields().get(0).getName());
    }
 }


### PR DESCRIPTION
## Problem

`TabularCatalogProvider` documents invariants on its record types — never-null collections, non-blank and unique identifiers, `TabularDatasetRef.id` free of `.`, column types drawn from `XSchema` — and `TabularCatalogService` enforced none of them. A connector violating one either crashed core with an NPE deep in response assembly (`relationships() == null` hits a for-each), or produced a silently wrong annotation target: a dotted dataset id is indistinguishable downstream from a database-qualified name, and a duplicated id makes `describeDataset` ambiguous.

The SPI also had only one implementer (OData), so its boundary had never been tested against a connector whose identifiers are shaped differently.

## Fix

**Contract enforcement (C1–C6).** `TabularCatalogService` now validates every documented invariant before mapping to the wire type, each failure raising a named exception that identifies the offending connector, dataset, and field: null collections; blank, duplicate, or dot-containing dataset ids; blank or duplicate relationship names; relationship endpoints not present in the catalog; `fromColumns`/`toColumns` non-empty and equal in length; blank column names; `keyColumns` membership in `columns`; a `describeDataset` result echoing the requested target; and `TabularColumn.type` being an `XSchema` type constant.

The type check whitelists all 21 constants `XSchema` declares rather than the seven its javadoc lists as examples — the javadoc's claim is "an `XSchema` type constant", and a narrower set would reject a legitimate connector mapping to `INTEGER` or `DECIMAL`. `XSchema.isPrimitiveType` is deliberately not reused: it omits `NULL`/`COLOR`/`UNKNOWN` and includes the internal-only `"bigdecimal"`, so it answers a different question.

**SharePoint Online implements the SPI.** `SharepointOnlineRuntime` gains `listDatasets`/`describeDataset` over sites and lists. Because a dataset must be addressable by a single string while a SharePoint list is identified by a (site, list) pair, `SharepointDatasetId` composes the two with three-character percent escaping: Graph's site id is `{hostname},{siteCollectionId},{webId}` and `getSiteId()` truncates it at the first comma, keeping the hostname — so the site component always contains dots, and choosing a non-dot separator is not sufficient. The id is validated by round-trip: any id where `compose(parse(id))` does not reproduce the input is rejected.

The new path does not reuse `doGetSites`, whose two `catch(Exception) { LOG.warn }` blocks swallow permission failures indiscriminately — annotation must surface those rather than silently return a short list. `listSitesOrThrow` propagates instead, and enumerates sub-sites recursively (`doGetSites` stops at one level, so grandchild sites were invisible). No existing catch block is modified; the connector's dropdown behaviour is unchanged, with a regression test asserting it.

## Testing

74 tests across 12 classes; full `core` 8236 pass. `inetsoft-sharepoint-online` gains its first test coverage (21 tests). Graph is exercised through `mockStatic(GraphServiceClient.class)`, leaving `getClient()` unmodified — the same layer at which the OData tests substitute WireMock. `*CollectionPage` results are built with the SDK's public `(List<T>, RequestBuilder)` constructor rather than mocked.

Live Microsoft 365 behaviour is not covered: no tenant is available. `SharepointOnlineCatalog`'s javadoc records the one load-bearing assumption this leaves unverified.