### PR TITLE
Carry a connector's binding parameters through the tabular catalog SPI, and add Cassandra

### DIFF
--- a/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraCatalog.java
+++ b/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraCatalog.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.cassandra;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.*;
+import inetsoft.uql.tabular.*;
+import inetsoft.util.CoreTool;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Assembles {@link CassandraRuntime}'s {@link TabularCatalogProvider} answers from the session's
+ * own schema metadata. Mirrors {@code ODataCatalog}'s/{@code SharepointOnlineCatalog}'s role:
+ * package-private, static methods, no state of its own.
+ *
+ * <p><b>Column types come from schema metadata, not from a live query.</b> An earlier design for
+ * this round ran {@code SELECT * FROM t LIMIT 1} and fed the {@code ResultSet} to
+ * {@link CassandraTable}'s constructor to reuse its (then-unextracted) {@code getType(int)}. That
+ * was overturned: an unqualified {@code LIMIT 1} is a cross-node range scan on Cassandra (a known
+ * anti-pattern, not just "one extra round trip"), annotation reading user data is a side effect
+ * this SPI should not have, and it would have tangled {@code CassandraTable}'s session ownership
+ * (it closes the session it's given once its result set is exhausted) into a method that never
+ * meant to hand off that ownership. {@code TableMetadata.getColumns()} ->
+ * {@code ColumnMetadata.getType()} gives the same {@code DataType} that a live query's
+ * {@code ColumnDefinition.getType()} would, so {@link CassandraTable#getType(DataType)} (extracted
+ * for exactly this reuse — see {@code CassandraTableTypeEquivalenceTest}) still applies unchanged.
+ *
+ * <p>No relationships this round: Cassandra has no driver-readable foreign-key/reference construct
+ * between tables — same "nothing to honestly report" position {@code ODataCatalog} and
+ * {@code SharepointOnlineCatalog} take when a source has no candidate they can verify.
+ */
+final class CassandraCatalog {
+   private CassandraCatalog() {
+   }
+
+   static TabularCatalog listDatasets(CqlSession session) throws Exception {
+      KeyspaceMetadata ks = boundKeyspace(session);
+      List<TabularDatasetRef> datasets = new ArrayList<>();
+
+      for(TableMetadata table : ks.getTables().values()) {
+         datasets.add(new TabularDatasetRef(table.getName().asInternal()));
+      }
+
+      return new TabularCatalog(datasets, List.of());
+   }
+
+   static TabularDatasetSchema describeDataset(CqlSession session, String datasetId)
+      throws Exception
+   {
+      KeyspaceMetadata ks = boundKeyspace(session);
+      TableMetadata table = ks.getTables().get(CqlIdentifier.fromInternal(datasetId));
+
+      if(table == null) {
+         throw new Exception("Table '" + datasetId + "' not found in keyspace '" +
+            ks.getName().asInternal() + "'.");
+      }
+
+      List<TabularColumn> columns = describeColumns(table);
+      List<String> keyColumns = primaryKeyColumnNames(table);
+
+      // No explicit column list and no LIMIT: TabularUtil.getMaxRows applies the row cap
+      // independently in CassandraRuntime.runQuery (CassandraRuntime.java:45), and an explicit
+      // column list would freeze today's columns into the generated CQL, breaking silently once
+      // the table's own columns change. table.getName() is already the CqlIdentifier this
+      // TableMetadata carries — asCql(true) is called on it directly rather than re-deriving one
+      // via CqlIdentifier.fromInternal(datasetId), which would just be a needless
+      // asInternal()->fromInternal() round trip of the same identifier.
+      String cql = "SELECT * FROM " + table.getName().asCql(true);
+
+      return new TabularDatasetSchema(datasetId, columns, keyColumns,
+         Map.of("queryString", cql));
+   }
+
+   /**
+    * The keyspace the session is bound to, resolved to its live schema metadata.
+    *
+    * @throws Exception if the session has no bound keyspace (defensive — {@code getSession}
+    *                    always calls {@code .withKeyspace(...)}), or if that keyspace is not
+    *                    visible in the driver's metadata (unknown keyspace, or a permission
+    *                    restriction the driver represents by simply omitting it rather than
+    *                    raising an error of its own).
+    */
+   private static KeyspaceMetadata boundKeyspace(CqlSession session) throws Exception {
+      CqlIdentifier ksId = session.getKeyspace().orElseThrow(() ->
+         new Exception("Session has no bound keyspace."));
+
+      return session.getMetadata().getKeyspace(ksId).orElseThrow(() ->
+         new Exception("Keyspace '" + ksId.asInternal() +
+            "' not found or not visible with the configured credentials."));
+   }
+
+   private static List<TabularColumn> describeColumns(TableMetadata table) {
+      List<TabularColumn> columns = new ArrayList<>();
+
+      for(ColumnMetadata col : table.getColumns().values()) {
+         columns.add(new TabularColumn(col.getName().asInternal(),
+            CoreTool.getDataType(CassandraTable.getType(col.getType()))));
+      }
+
+      return columns;
+   }
+
+   /**
+    * The dataset's full primary key — partition key columns, then clustering columns, in that
+    * order — not the partition key alone. A partition key by itself does not identify a single
+    * row when the table has clustering columns; the full primary key does. Mirrors OData's
+    * {@code keyColumns}, which reports the complete {@code <Key>}, not part of it.
+    */
+   private static List<String> primaryKeyColumnNames(TableMetadata table) {
+      List<String> names = new ArrayList<>();
+
+      for(ColumnMetadata col : table.getPartitionKey()) {
+         names.add(col.getName().asInternal());
+      }
+
+      for(ColumnMetadata col : table.getClusteringColumns().keySet()) {
+         names.add(col.getName().asInternal());
+      }
+
+      return names;
+   }
+}

--- a/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraRuntime.java
+++ b/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraRuntime.java
@@ -98,6 +98,8 @@ public class CassandraRuntime extends TabularRuntime implements TabularCatalogPr
       CassandraDataSource ds = (CassandraDataSource) dataSource;
       requireKeyspace(ds);
 
+      // A4: no catch around session establishment. A connection or permission failure here must
+      // propagate as an exception, not be absorbed into an empty catalog — do not add one.
       try(CqlSession session = getSession(ds)) {
          return CassandraCatalog.listDatasets(session);
       }
@@ -110,6 +112,8 @@ public class CassandraRuntime extends TabularRuntime implements TabularCatalogPr
       CassandraDataSource ds = (CassandraDataSource) dataSource;
       requireKeyspace(ds);
 
+      // A4: no catch around session establishment. A connection or permission failure here must
+      // propagate as an exception, not be absorbed into an empty schema — do not add one.
       try(CqlSession session = getSession(ds)) {
          return CassandraCatalog.describeDataset(session, datasetId);
       }

--- a/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraRuntime.java
+++ b/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraRuntime.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLContext;
 import java.net.InetSocketAddress;
 
-public class CassandraRuntime extends TabularRuntime {
+public class CassandraRuntime extends TabularRuntime implements TabularCatalogProvider {
    public XTableNode runQuery(TabularQuery query, VariableTable params) {
       CassandraQuery query0 = (CassandraQuery) query;
       CassandraDataSource ds = (CassandraDataSource) query.getDataSource();
@@ -91,6 +91,41 @@ public class CassandraRuntime extends TabularRuntime {
       return getCluster(ds)
          .withKeyspace(ds.getKeyspace())
          .build();
+   }
+
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      CassandraDataSource ds = (CassandraDataSource) dataSource;
+      requireKeyspace(ds);
+
+      try(CqlSession session = getSession(ds)) {
+         return CassandraCatalog.listDatasets(session);
+      }
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      CassandraDataSource ds = (CassandraDataSource) dataSource;
+      requireKeyspace(ds);
+
+      try(CqlSession session = getSession(ds)) {
+         return CassandraCatalog.describeDataset(session, datasetId);
+      }
+   }
+
+   /**
+    * A4: an unconfigured keyspace must throw, not silently enumerate nothing (and must not be
+    * confused with "the keyspace exists but has no tables", which is a different, legal, empty
+    * result). Checked before {@link #getSession} is even called, so a blank/null keyspace never
+    * reaches the driver at all.
+    */
+   private static void requireKeyspace(CassandraDataSource ds) throws Exception {
+      if(ds.getKeyspace() == null || ds.getKeyspace().isBlank()) {
+         throw new Exception("Data source '" + ds.getName() +
+            "' has no keyspace configured; cannot enumerate its tables.");
+      }
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(CassandraRuntime.class.getName());

--- a/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraTable.java
+++ b/connectors/inetsoft-cassandra/src/main/java/inetsoft/uql/cassandra/CassandraTable.java
@@ -120,7 +120,22 @@ public class CassandraTable extends XTableNode {
     */
    @Override
    public Class<?> getType(int col) {
-      switch(types[col].getProtocolCode()) {
+      return getType(types[col]);
+   }
+
+   /**
+    * Maps a Cassandra {@link DataType} to the Java class {@link #getObject(int)} returns values
+    * as. Extracted verbatim from the former body of {@link #getType(int)} — case labels, return
+    * values, and the {@code default} are unchanged — so that a schema-only caller (one with a
+    * {@code DataType} from {@code ColumnMetadata.getType()} but no live {@link ResultSet} to build
+    * a {@code CassandraTable} from) can reuse the identical mapping instead of duplicating it.
+    * {@link #getType(int)} now delegates here rather than switching directly, so this one switch
+    * is the sole copy in the module; see
+    * {@code CassandraTableTypeEquivalenceTest} for the regression test that stands in place of the
+    * "this file does not change" guarantee this extraction gives up.
+    */
+   static Class<?> getType(DataType type) {
+      switch(type.getProtocolCode()) {
       case ProtocolConstants.DataType.BIGINT:
       case ProtocolConstants.DataType.COUNTER:
          return Long.class;

--- a/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraCatalogTest.java
+++ b/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraCatalogTest.java
@@ -1,0 +1,240 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.cassandra;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.schema.*;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers charter assertions A1-A4 against {@link CassandraCatalog}, driven entirely off mocked
+ * driver interfaces ({@code CqlSession}/{@code Metadata}/{@code KeyspaceMetadata}/
+ * {@code TableMetadata}/{@code ColumnMetadata} are all interfaces in driver 4.x — see
+ * docs/teams/2026-09-01-tabular-catalog-cassandra/04-build.md — so no {@code MockedStatic} seam is
+ * needed the way SharePoint's Graph SDK required). {@code CqlIdentifier} is a real (final) value
+ * type throughout, never mocked.
+ */
+@Tag("connector")
+class CassandraCatalogTest {
+
+   @Test
+   void listDatasets_returnsAllTablesInKeyspace() throws Exception {
+      TableMetadata users = table("users", List.of(), Map.of());
+      TableMetadata orders = table("orders", List.of(), Map.of());
+      CqlSession session = sessionBoundTo("myks", List.of(users, orders));
+
+      TabularCatalog catalog = CassandraCatalog.listDatasets(session);
+
+      assertEquals(2, catalog.datasets().size());
+      assertEquals(List.of("users", "orders"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+      assertEquals(List.of(), catalog.relationships());
+   }
+
+   @Test
+   void listDatasets_datasetIdIsBareTableName_noKeyspaceQualifier() throws Exception {
+      TableMetadata users = table("users", List.of(), Map.of());
+      CqlSession session = sessionBoundTo("myks", List.of(users));
+
+      TabularCatalog catalog = CassandraCatalog.listDatasets(session);
+
+      assertEquals("users", catalog.datasets().get(0).id());
+      assertFalse(catalog.datasets().get(0).id().contains("."));
+   }
+
+   @Test
+   void listDatasets_keyspaceNotVisibleWithConfiguredCredentials_throws() {
+      CqlSession session = mock(CqlSession.class);
+      CqlIdentifier ksId = CqlIdentifier.fromInternal("myks");
+      Metadata metadata = mock(Metadata.class);
+      when(session.getKeyspace()).thenReturn(Optional.of(ksId));
+      when(session.getMetadata()).thenReturn(metadata);
+      // Driver represents "not visible" as an empty Optional, not an exception — see
+      // CassandraCatalog.boundKeyspace's javadoc.
+      when(metadata.getKeyspace(ksId)).thenReturn(Optional.empty());
+
+      Exception ex = assertThrows(Exception.class, () -> CassandraCatalog.listDatasets(session));
+      assertTrue(ex.getMessage().contains("myks"));
+   }
+
+   @Test
+   void describeDataset_paramsHasLowercaseQueryStringKey_valueIsExecutableSelect()
+      throws Exception
+   {
+      TableMetadata users = table("users",
+         List.of(column("user_id", ProtocolConstants.DataType.INT)), Map.of());
+      CqlSession session = sessionBoundTo("myks", List.of(users));
+
+      TabularDatasetSchema schema = CassandraCatalog.describeDataset(session, "users");
+
+      // Reverse: not "Query", not "queryStr", not the @Property(label=) text "Enter Query" — must
+      // be exactly the CassandraQuery bean property name TabularUtil.getPropertyMap derives.
+      assertEquals(Map.of("queryString", "SELECT * FROM users"), schema.params());
+   }
+
+   @Test
+   void describeDataset_uppercaseTableName_generatesQuotedCql() throws Exception {
+      // A2's reverse case: a lowercase-only fixture would pass even with the polarity of
+      // asCql(boolean) backwards.
+      TableMetadata mixedCase = table("Users",
+         List.of(column("user_id", ProtocolConstants.DataType.INT)), Map.of());
+      CqlSession session = sessionBoundTo("myks", List.of(mixedCase));
+
+      TabularDatasetSchema schema = CassandraCatalog.describeDataset(session, "Users");
+
+      assertEquals("SELECT * FROM \"Users\"", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_lowercaseTableName_noQuotesEmitted() throws Exception {
+      TableMetadata users = table("users",
+         List.of(column("user_id", ProtocolConstants.DataType.INT)), Map.of());
+      CqlSession session = sessionBoundTo("myks", List.of(users));
+
+      TabularDatasetSchema schema = CassandraCatalog.describeDataset(session, "users");
+
+      assertEquals("SELECT * FROM users", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_keyColumnsIsPartitionKeyPlusClusteringColumns_inOrder() throws Exception {
+      ColumnMetadata tenantId = column("tenant_id", ProtocolConstants.DataType.INT);
+      ColumnMetadata region = column("region", ProtocolConstants.DataType.VARCHAR);
+      ColumnMetadata createdAt = column("created_at", ProtocolConstants.DataType.TIMESTAMP);
+      ColumnMetadata payload = column("payload", ProtocolConstants.DataType.VARCHAR);
+
+      TableMetadata events = mock(TableMetadata.class);
+      when(events.getName()).thenReturn(CqlIdentifier.fromInternal("events"));
+      // Partition key has two columns and there are clustering columns — the case where
+      // "partition key alone" and "full primary key" actually differ.
+      when(events.getPartitionKey()).thenReturn(List.of(tenantId, region));
+      Map<ColumnMetadata, ClusteringOrder> clustering = new LinkedHashMap<>();
+      clustering.put(createdAt, ClusteringOrder.DESC);
+      when(events.getClusteringColumns()).thenReturn(clustering);
+      Map<CqlIdentifier, ColumnMetadata> allColumns = new LinkedHashMap<>();
+      allColumns.put(tenantId.getName(), tenantId);
+      allColumns.put(region.getName(), region);
+      allColumns.put(createdAt.getName(), createdAt);
+      allColumns.put(payload.getName(), payload);
+      when(events.getColumns()).thenReturn(allColumns);
+
+      CqlSession session = sessionBoundTo("myks", List.of(events));
+
+      TabularDatasetSchema schema = CassandraCatalog.describeDataset(session, "events");
+
+      assertEquals(List.of("tenant_id", "region", "created_at"), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_columnTypesComeFromCassandraTableGetType_notANewSwitch() throws Exception {
+      // UUID is one of the eight Class<?> values CoreTool.getDataType has no dedicated branch
+      // for, so it falls to STRING (see docs/teams/2026-09-01-tabular-catalog-cassandra/04-build.md
+      // §"known coarsening"). If this ever produced anything other than STRING, either
+      // CassandraTable.getType(DataType) stopped being the thing that ran, or a second, competing
+      // mapping was added here in violation of A3.
+      TableMetadata t = table("t", List.of(
+         column("id", ProtocolConstants.DataType.BIGINT),
+         column("token", ProtocolConstants.DataType.UUID)), Map.of());
+      CqlSession session = sessionBoundTo("myks", List.of(t));
+
+      TabularDatasetSchema schema = CassandraCatalog.describeDataset(session, "t");
+
+      Map<String, String> typesByName = schema.columns().stream()
+         .collect(java.util.stream.Collectors.toMap(TabularColumn::name, TabularColumn::type));
+      assertEquals(XSchema.LONG, typesByName.get("id"));
+      assertEquals(XSchema.STRING, typesByName.get("token"));
+   }
+
+   @Test
+   void describeDataset_tableNotFound_throws() throws Exception {
+      CqlSession session = sessionBoundTo("myks", List.of());
+
+      Exception ex = assertThrows(Exception.class,
+         () -> CassandraCatalog.describeDataset(session, "no_such_table"));
+      assertTrue(ex.getMessage().contains("no_such_table"));
+   }
+
+   // ---- fixtures ----------------------------------------------------------------------------
+
+   private static CqlSession sessionBoundTo(String keyspace, List<TableMetadata> tables) {
+      CqlSession session = mock(CqlSession.class);
+      CqlIdentifier ksId = CqlIdentifier.fromInternal(keyspace);
+      when(session.getKeyspace()).thenReturn(Optional.of(ksId));
+
+      Metadata metadata = mock(Metadata.class);
+      when(session.getMetadata()).thenReturn(metadata);
+
+      KeyspaceMetadata ks = mock(KeyspaceMetadata.class);
+      when(ks.getName()).thenReturn(ksId);
+      Map<CqlIdentifier, TableMetadata> tableMap = new LinkedHashMap<>();
+
+      for(TableMetadata table : tables) {
+         tableMap.put(table.getName(), table);
+      }
+
+      when(ks.getTables()).thenReturn(tableMap);
+      when(metadata.getKeyspace(ksId)).thenReturn(Optional.of(ks));
+
+      return session;
+   }
+
+   private static TableMetadata table(String name, List<ColumnMetadata> columns,
+                                      Map<String, String> unused)
+   {
+      TableMetadata table = mock(TableMetadata.class);
+      CqlIdentifier tableName = CqlIdentifier.fromInternal(name);
+      when(table.getName()).thenReturn(tableName);
+      when(table.getPartitionKey()).thenReturn(List.of());
+      when(table.getClusteringColumns()).thenReturn(Map.of());
+
+      Map<CqlIdentifier, ColumnMetadata> columnMap = new LinkedHashMap<>();
+
+      for(ColumnMetadata col : columns) {
+         columnMap.put(col.getName(), col);
+      }
+
+      when(table.getColumns()).thenReturn(columnMap);
+
+      return table;
+   }
+
+   private static ColumnMetadata column(String name, int protocolCode) {
+      ColumnMetadata col = mock(ColumnMetadata.class);
+      when(col.getName()).thenReturn(CqlIdentifier.fromInternal(name));
+      DataType type = mock(DataType.class);
+      when(type.getProtocolCode()).thenReturn(protocolCode);
+      when(col.getType()).thenReturn(type);
+
+      return col;
+   }
+}

--- a/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraCatalogTest.java
+++ b/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraCatalogTest.java
@@ -39,10 +39,10 @@ import static org.mockito.Mockito.*;
 /**
  * Covers charter assertions A1-A4 against {@link CassandraCatalog}, driven entirely off mocked
  * driver interfaces ({@code CqlSession}/{@code Metadata}/{@code KeyspaceMetadata}/
- * {@code TableMetadata}/{@code ColumnMetadata} are all interfaces in driver 4.x — see
- * docs/teams/2026-09-01-tabular-catalog-cassandra/04-build.md — so no {@code MockedStatic} seam is
- * needed the way SharePoint's Graph SDK required). {@code CqlIdentifier} is a real (final) value
- * type throughout, never mocked.
+ * {@code TableMetadata}/{@code ColumnMetadata} are all interfaces in driver 4.x (confirmed against
+ * the driver jar directly, not assumed), so no {@code MockedStatic} seam is needed the way
+ * SharePoint's Graph SDK required. {@code CqlIdentifier} is a real (final) value type throughout,
+ * never mocked.
  */
 @Tag("connector")
 class CassandraCatalogTest {
@@ -158,10 +158,11 @@ class CassandraCatalogTest {
    @Test
    void describeDataset_columnTypesComeFromCassandraTableGetType_notANewSwitch() throws Exception {
       // UUID is one of the eight Class<?> values CoreTool.getDataType has no dedicated branch
-      // for, so it falls to STRING (see docs/teams/2026-09-01-tabular-catalog-cassandra/04-build.md
-      // §"known coarsening"). If this ever produced anything other than STRING, either
-      // CassandraTable.getType(DataType) stopped being the thing that ran, or a second, competing
-      // mapping was added here in violation of A3.
+      // for, so it falls to STRING — a known, accepted coarsening (annotated collection/UUID/
+      // blob/inet/tuple/UDT columns all read as "string"), not a bug this test should catch. If
+      // this ever produced anything other than STRING, either CassandraTable.getType(DataType)
+      // stopped being the thing that ran, or a second, competing mapping was added here in
+      // violation of A3.
       TableMetadata t = table("t", List.of(
          column("id", ProtocolConstants.DataType.BIGINT),
          column("token", ProtocolConstants.DataType.UUID)), Map.of());

--- a/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraRuntimeCatalogTest.java
+++ b/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraRuntimeCatalogTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.cassandra;
+
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.credential.*;
+import org.junit.jupiter.api.*;
+import org.springframework.context.ApplicationContext;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers charter assertion A4's "blank/null keyspace" path through {@link CassandraRuntime}'s new
+ * SPI methods — the one part of A4 that is provably testable without a real cluster, since
+ * {@code requireKeyspace} runs before {@link CassandraRuntime#getSession} is ever called. Both
+ * data sources here point at a reserved, documentation-only address
+ * (RFC 5737 TEST-NET-2, 198.51.100.1) that is guaranteed never to be dialed: if the guard did not
+ * run first, {@code getSession} would attempt a real connection and fail with a driver
+ * connection exception instead, not this method's own message — {@link Assertions#assertTimeout}
+ * additionally bounds the wait, since a real (doomed) connection attempt would take substantially
+ * longer than an in-process check.
+ */
+class CassandraRuntimeCatalogTest {
+   private static final String UNROUTABLE_HOST = "198.51.100.1";
+
+   @BeforeAll
+   static void mockService() {
+      CredentialService credentialService = mock(CredentialService.class);
+      when(credentialService.createCredential(CredentialType.PASSWORD))
+         .thenReturn(mock(LocalPasswordCredential.class));
+      when(credentialService.createCredential(CredentialType.PASSWORD, false))
+         .thenReturn(mock(LocalPasswordCredential.class));
+      ApplicationContext context = mock(ApplicationContext.class);
+      when(context.getBean(CredentialService.class)).thenReturn(credentialService);
+      ConfigurationContext.getContext().setApplicationContext(context);
+   }
+
+   @AfterAll
+   static void resetContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+   }
+
+   @Test
+   void listDatasets_blankKeyspace_throwsBeforeConnecting() {
+      CassandraDataSource ds = new CassandraDataSource();
+      ds.setHost(UNROUTABLE_HOST);
+      ds.setKeyspace("");
+      CassandraRuntime runtime = new CassandraRuntime();
+
+      Exception ex = assertTimeout(Duration.ofSeconds(2),
+         () -> assertThrows(Exception.class, () -> runtime.listDatasets(ds)));
+
+      assertTrue(ex.getMessage().contains("no keyspace configured"));
+   }
+
+   @Test
+   void describeDataset_nullKeyspace_throwsBeforeConnecting() {
+      CassandraDataSource ds = new CassandraDataSource();
+      ds.setHost(UNROUTABLE_HOST);
+      // keyspace left null — the field's default, never set.
+      CassandraRuntime runtime = new CassandraRuntime();
+
+      Exception ex = assertTimeout(Duration.ofSeconds(2),
+         () -> assertThrows(Exception.class, () -> runtime.describeDataset(ds, "any_table")));
+
+      assertTrue(ex.getMessage().contains("no keyspace configured"));
+   }
+}

--- a/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraTableTypeEquivalenceTest.java
+++ b/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraTableTypeEquivalenceTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.cassandra;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.*;
+import com.datastax.oss.driver.api.core.data.TupleValue;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.awt.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The equivalence test charter §6's C1 amendment requires as the price of letting
+ * {@link CassandraTable}'s {@code DataType -> Class<?>} switch be extracted into
+ * {@code CassandraTable.getType(DataType)} instead of staying frozen verbatim inside
+ * {@code getType(int)}. C1 used to protect this mapping by forbidding any edit to the file; now
+ * that an edit is allowed (in exactly the one shape docs/teams/2026-09-01-tabular-catalog-cassandra
+ * permits — extract-and-delegate, no changed branch), this test is the replacement protection: it
+ * pins the pre-extraction behavior for every protocol code the switch names.
+ *
+ * <p>Deliberately asserts through the public instance method {@link CassandraTable#getType(int)}
+ * — the one {@code CassandraRuntime.runQuery} actually calls — rather than against the package-
+ * private static {@code CassandraTable.getType(DataType)} directly. A test that only exercised the
+ * static function would still pass even if {@code getType(int)} were wired to delegate to the
+ * wrong thing (or not delegate at all), because it would never call the delegating method.
+ *
+ * <p>Every fall-through group the switch declares gets two separate cases here on purpose
+ * (BIGINT/COUNTER, UUID/TIMEUUID, ASCII/VARCHAR) — that's exactly where a careless extraction
+ * silently drops one of the two labels. {@code UDT} is not named in the switch at all; it stands
+ * in for the {@code default} branch.
+ */
+class CassandraTableTypeEquivalenceTest {
+
+   @ParameterizedTest(name = "protocol code {0} -> {1}")
+   @MethodSource("everyProtocolCodeNamedInTheSwitch")
+   void getType_matchesThePreExtractionMapping(int protocolCode, Class<?> expected)
+      throws Exception
+   {
+      CassandraTable table = singleColumnTable(protocolCode);
+
+      assertEquals(expected, table.getType(0));
+   }
+
+   static Stream<Arguments> everyProtocolCodeNamedInTheSwitch() {
+      return Stream.of(
+         Arguments.of(ProtocolConstants.DataType.BIGINT, Long.class),
+         Arguments.of(ProtocolConstants.DataType.COUNTER, Long.class),
+         Arguments.of(ProtocolConstants.DataType.INT, Integer.class),
+         Arguments.of(ProtocolConstants.DataType.VARINT, BigInteger.class),
+         Arguments.of(ProtocolConstants.DataType.DECIMAL, BigDecimal.class),
+         Arguments.of(ProtocolConstants.DataType.DOUBLE, Double.class),
+         Arguments.of(ProtocolConstants.DataType.FLOAT, Float.class),
+         Arguments.of(ProtocolConstants.DataType.BOOLEAN, Boolean.class),
+         Arguments.of(ProtocolConstants.DataType.TIMESTAMP, java.util.Date.class),
+         Arguments.of(ProtocolConstants.DataType.LIST, java.util.List.class),
+         Arguments.of(ProtocolConstants.DataType.MAP, java.util.Map.class),
+         Arguments.of(ProtocolConstants.DataType.SET, java.util.Set.class),
+         Arguments.of(ProtocolConstants.DataType.UUID, UUID.class),
+         Arguments.of(ProtocolConstants.DataType.TIMEUUID, UUID.class),
+         Arguments.of(ProtocolConstants.DataType.BLOB, Image.class),
+         Arguments.of(ProtocolConstants.DataType.INET, InetAddress.class),
+         Arguments.of(ProtocolConstants.DataType.TUPLE, TupleValue.class),
+         Arguments.of(ProtocolConstants.DataType.ASCII, String.class),
+         Arguments.of(ProtocolConstants.DataType.VARCHAR, String.class),
+         // Not named in the switch — exercises the default branch.
+         Arguments.of(ProtocolConstants.DataType.UDT, Object.class)
+      );
+   }
+
+   /**
+    * Builds a real {@link CassandraTable} — not a mock of it — around a single mocked column, so
+    * the assertion in the test method above goes through the real {@code getType(int)} body,
+    * including its cached {@code types[]} array built by the constructor from
+    * {@code ResultSet.getColumnDefinitions()}.
+    */
+   private static CassandraTable singleColumnTable(int protocolCode) throws Exception {
+      DataType type = mock(DataType.class);
+      when(type.getProtocolCode()).thenReturn(protocolCode);
+
+      ColumnDefinition column = mock(ColumnDefinition.class);
+      when(column.getName()).thenReturn(CqlIdentifier.fromInternal("col"));
+      when(column.getType()).thenReturn(type);
+
+      ColumnDefinitions columns = mock(ColumnDefinitions.class);
+      when(columns.size()).thenReturn(1);
+      when(columns.get(0)).thenReturn(column);
+
+      ResultSet result = mock(ResultSet.class);
+      when(result.getColumnDefinitions()).thenReturn(columns);
+
+      CqlSession session = mock(CqlSession.class);
+
+      return new CassandraTable(result, session, 0);
+   }
+}

--- a/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraTableTypeEquivalenceTest.java
+++ b/connectors/inetsoft-cassandra/src/test/java/inetsoft/uql/cassandra/CassandraTableTypeEquivalenceTest.java
@@ -39,13 +39,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * The equivalence test charter §6's C1 amendment requires as the price of letting
- * {@link CassandraTable}'s {@code DataType -> Class<?>} switch be extracted into
- * {@code CassandraTable.getType(DataType)} instead of staying frozen verbatim inside
- * {@code getType(int)}. C1 used to protect this mapping by forbidding any edit to the file; now
- * that an edit is allowed (in exactly the one shape docs/teams/2026-09-01-tabular-catalog-cassandra
- * permits — extract-and-delegate, no changed branch), this test is the replacement protection: it
- * pins the pre-extraction behavior for every protocol code the switch names.
+ * The price of letting {@link CassandraTable}'s {@code DataType -> Class<?>} switch be extracted
+ * into {@code CassandraTable.getType(DataType)} instead of staying frozen verbatim inside
+ * {@code getType(int)}. This mapping used to be protected by forbidding any edit to the file at
+ * all; the edit made here is allowed only in one shape — extract-and-delegate, case labels and
+ * return values unchanged — and this test is the replacement protection for the guarantee that
+ * shape gives up: it pins the pre-extraction behavior for every protocol code the switch names.
  *
  * <p>Deliberately asserts through the public instance method {@link CassandraTable#getType(int)}
  * — the one {@code CassandraRuntime.runQuery} actually calls — rather than against the package-

--- a/connectors/inetsoft-odata/src/main/java/inetsoft/uql/odata/ODataCatalog.java
+++ b/connectors/inetsoft-odata/src/main/java/inetsoft/uql/odata/ODataCatalog.java
@@ -155,7 +155,8 @@ final class ODataCatalog {
          }
       }
 
-      return new TabularDatasetSchema(entitySetName, List.copyOf(columns), List.copyOf(keyColumns));
+      return new TabularDatasetSchema(entitySetName, List.copyOf(columns), List.copyOf(keyColumns),
+         Map.of("entity", entitySetName));
    }
 
    /**

--- a/connectors/inetsoft-odata/src/test/java/inetsoft/uql/odata/ODataCatalogTest.java
+++ b/connectors/inetsoft-odata/src/test/java/inetsoft/uql/odata/ODataCatalogTest.java
@@ -29,6 +29,7 @@ import org.w3c.dom.NodeList;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -74,6 +75,18 @@ class ODataCatalogTest {
       assertEquals(new TabularColumn("Price", XSchema.DOUBLE), columns.get(2));
 
       assertEquals(List.of("ID"), products.keyColumns());
+   }
+
+   @Test
+   void describeYieldsParamsKeyedByEntityQueryProperty() throws Exception {
+      // Charter D2: the params key must be the ODataQuery bean property name ("entity", from
+      // getEntity()/setEntity()), not the @Property(label="Entity") display text and not some
+      // other name like "entitySet". If the implementation drifted to either of those, or forgot
+      // to populate params at all, this fails on the exact Map equality below.
+      ODataCatalogSnapshot snapshot = ODataCatalog.parse(schemaNode("catalog.metadata.xml"));
+
+      TabularDatasetSchema products = snapshot.schemasByEntitySet().get("Products");
+      assertEquals(Map.of("entity", "Products"), products.params());
    }
 
    @Test

--- a/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveAnnotationClassTest.java
+++ b/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveAnnotationClassTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A direct anchor on the one structural fact charter assertion #1
- * (`docs/teams/2026-08-28-onedrive-tabular-target/`) rests on: core's own
+ * A direct anchor on the one structural fact this connector's "must be classified as a FILE
+ * datasource" requirement rests on: core's own
  * {@code WizDatasourceAnnotationClassTest.aBrowsableQueryIsAFileSource} already proves that ANY
  * {@code SelectableTabularQuery} subclass is classified {@code "FILE"}, using a local fake --
  * core cannot import this connector's classes to test the classifier against them directly. This

--- a/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveTabularContractTest.java
+++ b/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveTabularContractTest.java
@@ -40,13 +40,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Confirms charter assertion #5 (this run's `docs/teams/2026-08-28-onedrive-tabular-target/`):
- * {@code create_worksheet_table} builds a real OneDrive-backed table through the already-generic
- * {@code TabularQueryContractSupport.applyQueryContract} -- OneDrive needs no StyleBI-side change
- * for this, because {@code OneDriveQuery.path} is a plain {@code String} property, so
- * {@code applyQueryContract} routes it through its ordinary bean-property-write branch rather than
- * the {@code java.io.File}-typed one. Lives beside {@code OneDriveRuntimeTests} rather than in
- * core's own {@code TabularQueryContractSupportTest} (which tests the mechanism itself against its
+ * Confirms that {@code create_worksheet_table} builds a real OneDrive-backed table through the
+ * already-generic {@code TabularQueryContractSupport.applyQueryContract} -- OneDrive needs no
+ * StyleBI-side change for this, because {@code OneDriveQuery.path} is a plain {@code String}
+ * property, so {@code applyQueryContract} routes it through its ordinary bean-property-write
+ * branch rather than the {@code java.io.File}-typed one. Lives beside
+ * {@code OneDriveRuntimeTests} rather than in core's own
+ * {@code TabularQueryContractSupportTest} (which tests the mechanism itself against its
  * own fake fixtures) because this test's whole point is that OneDrive's REAL property names round-
  * trip through it -- something only a real (non-mock) {@code OneDriveQuery} can prove.
  */

--- a/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
+++ b/connectors/inetsoft-sharepoint-online/src/main/java/inetsoft/uql/sharepoint/SharepointOnlineCatalog.java
@@ -23,6 +23,7 @@ import inetsoft.uql.tabular.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Assembles {@link SharepointOnlineRuntime}'s {@link TabularCatalogProvider} answers out of the
@@ -117,6 +118,7 @@ final class SharepointOnlineCatalog {
 
       return new TabularDatasetSchema(datasetId,
          Arrays.stream(columns).map(n -> new TabularColumn(n.getName(), n.getType())).toList(),
-         List.of());       // keyColumns — no system key column surfaces through getListColumns
+         List.of(),        // keyColumns — no system key column surfaces through getListColumns
+         Map.of("site", parsed.site(), "list", parsed.list()));
    }
 }

--- a/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineCatalogTest.java
+++ b/connectors/inetsoft-sharepoint-online/src/test/java/inetsoft/uql/sharepoint/SharepointOnlineCatalogTest.java
@@ -29,6 +29,7 @@ import org.mockito.MockedStatic;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static inetsoft.uql.sharepoint.SharepointGraphTestSupport.*;
@@ -183,6 +184,50 @@ class SharepointOnlineCatalogTest {
          // key (the system ID column doesn't surface through this mapping — see class javadoc).
          assertNotNull(schema.keyColumns());
          assertTrue(schema.keyColumns().isEmpty());
+      }
+   }
+
+   @Test
+   void describeDataset_paramsAreSiteAndListNotTheComposedId() throws Exception {
+      // Charter A1 reverse: dataset.source (the escaped, composed id) must not leak into params.
+      // If the implementation took the lazy route of Map.of("id", datasetId), or used the wrong
+      // key names, this Map equality fails outright.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder rootBuilder = siteBuilder(client, "root");
+      stubColumns(rootBuilder, "list-1", List.of(column("Title", c -> c.text = new TextColumn())));
+
+      String datasetId = SharepointDatasetId.compose("root", "list-1");
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         TabularDatasetSchema schema =
+            SharepointOnlineCatalog.describeDataset(fakeDataSource(), datasetId);
+
+         assertEquals(Map.of("site", "root", "list", "list-1"), schema.params());
+      }
+   }
+
+   @Test
+   void describeDataset_paramsCarryUnescapedSiteNotTheEscapedIdFragment() throws Exception {
+      // A site id containing a dot (the common case — see SharepointDatasetId's javadoc on why
+      // real Graph site ids are hostnames) gets percent-escaped inside the composed id. params
+      // must carry the connector's real, UNESCAPED property value ("contoso.sharepoint.com"), not
+      // the escaped fragment ("contoso%2Esharepoint%2Ecom") that SharepointDatasetId uses
+      // internally to satisfy the no-dot id contract. This is the id-encoding-leak check from
+      // charter A1's reverse clause, applied to the specific case that motivated the escaping
+      // scheme in the first place.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      SiteRequestBuilder siteBuilder = siteBuilder(client, "contoso.sharepoint.com");
+      stubColumns(siteBuilder, "Sales List",
+         List.of(column("Title", c -> c.text = new TextColumn())));
+
+      String datasetId = SharepointDatasetId.compose("contoso.sharepoint.com", "Sales List");
+
+      try(MockedStatic<GraphServiceClient> mocked = mockClientFactory(client)) {
+         TabularDatasetSchema schema =
+            SharepointOnlineCatalog.describeDataset(fakeDataSource(), datasetId);
+
+         assertEquals("contoso.sharepoint.com", schema.params().get("site"));
+         assertEquals("Sales List", schema.params().get("list"));
       }
    }
 }

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
@@ -30,8 +30,8 @@ package inetsoft.uql.tabular;
  * {@code TabularQuerySchema} / a {@code @PropertyEditor(tagsMethod=...)} enumeration: those exist to
  * tell an LLM how to FILL a query's parameters, they carry budgets set for a tool call
  * (a 200-candidate cap, a 5s timeout), and for OData the tags path reaches the service document
- * (names only), not $metadata. See
- * docs/teams/2026-08-28-tabular-metadata-annotation-entry/09-design-defect-schema-builder-misuse.md.
+ * (names only), not $metadata — routing this SPI through that path would silently truncate or
+ * under-describe a catalog that this interface's own contract requires to be complete.
  *
  * An implementation answers from the connector's OWN native metadata endpoint, and every
  * connector-specific representation (an EDMX Document, a table dictionary row, ...) stays inside

--- a/core/src/main/java/inetsoft/uql/tabular/TabularDatasetSchema.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularDatasetSchema.java
@@ -18,6 +18,7 @@
 package inetsoft.uql.tabular;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The columns of one dataset.
@@ -27,6 +28,27 @@ import java.util.List;
  *                  rather than returning an empty list — see TabularCatalogProvider.
  * @param keyColumns names, from {@code columns}, that the source declares as this dataset's key;
  *                  empty when the source declares none. Never null.
+ * @param params    binding parameters for this dataset, keyed by the connector's own query bean
+ *                  property names (the same names {@code TabularUtil.getPropertyMap} derives from
+ *                  its getters/setters, not a {@code @Property(label=...)} display string) so a
+ *                  caller with this dataset's parameter contract in hand can match them up without
+ *                  any translation table. Empty when the connector's target identity needs no such
+ *                  parameters (e.g. the dataset id is itself the one property value a query needs)
+ *                  or the connector has not implemented this yet. Never null — use the 3-arg
+ *                  constructor below, which defaults to {@link Map#of()}, rather than passing null.
  */
 public record TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
-                                   List<String> keyColumns) {}
+                                   List<String> keyColumns, Map<String, String> params) {
+   /**
+    * Compatibility constructor for callers written before {@code params} existed — every existing
+    * connector-test construction site and any connector that has not opted into target binding
+    * parameters yet. Defaults to an empty map, which {@code TabularCatalogService} treats
+    * identically to "the connector said nothing": the COMMON extension's {@code params} key is
+    * omitted entirely, not written empty.
+    */
+   public TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
+                               List<String> keyColumns)
+   {
+      this(datasetId, columns, keyColumns, Map.of());
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -268,6 +268,12 @@ public class TabularCatalogService {
       }
 
       for(Map.Entry<String, String> e : params.entrySet()) {
+         // Key and value are NOT symmetric here. A blank key is never legitimate -- a bean property
+         // name cannot be blank -- so isBlank() is right for it. A blank VALUE can be entirely
+         // legitimate: a connector may report an optional property whose empty value means "unset"
+         // (e.g. OData's own Select/Filter/Expand). This method cannot tell an identity param from
+         // an optional one -- it does not know the connector's property semantics -- so rejecting a
+         // blank value here would reject a correct connector, not just a broken one.
          if(e.getKey() == null || e.getKey().isBlank() || e.getValue() == null) {
             throw new Exception("Data source '" + dsName + "' target '" + target +
                "' returned a params entry with a blank key or null value.");

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -174,6 +174,7 @@ public class TabularCatalogService {
       validateDatasetIdEchoed(dsName, target, schema);
       validateColumnNames(dsName, target, schema.columns());
       validateKeyColumns(dsName, target, schema);
+      validateParams(dsName, target, schema.params());
 
       return toDataset(dsName, xrepository.getDataSource(dsName).getType(), schema, objectMapper);
    }
@@ -253,6 +254,23 @@ public class TabularCatalogService {
             throw new Exception("Data source '" + dsName + "' target '" + target +
                "' declared key column '" + keyColumn + "', which is not one of its own reported " +
                "columns.");
+         }
+      }
+   }
+
+   private static void validateParams(String dsName, String target, Map<String, String> params)
+      throws Exception
+   {
+      if(params == null) {
+         return;   // Same "defensive but not enforced" treatment as validateKeyColumns: the
+                    // compatibility constructor already guarantees non-null, this only guards
+                    // against a third party calling the 4-arg constructor directly with null.
+      }
+
+      for(Map.Entry<String, String> e : params.entrySet()) {
+         if(e.getKey() == null || e.getKey().isBlank() || e.getValue() == null) {
+            throw new Exception("Data source '" + dsName + "' target '" + target +
+               "' returned a params entry with a blank key or null value.");
          }
       }
    }
@@ -340,7 +358,7 @@ public class TabularCatalogService {
          null : schema.keyColumns());
       dataset.setFields(fields);
       dataset.setCustomExtensions(
-         List.of(buildDatasetExtension(dsName, datasourceSubtype, objectMapper)));
+         List.of(buildDatasetExtension(dsName, datasourceSubtype, schema.params(), objectMapper)));
       return dataset;
    }
 
@@ -364,8 +382,17 @@ public class TabularCatalogService {
     * {@code datasourceType}) that this is not a SQL table — see charter assertion B7. The literal
     * {@code "tabular"} must match wiz's {@code TABULAR_DATASOURCE_TYPE} exactly; there is no shared
     * constant between the two repositories.
+    *
+    * {@code params}, when non-empty, is the connector's own query-bean property names mapped to
+    * the string values that identify (METADATA targets) or help re-read (FILE targets — see wiz's
+    * {@code parseOptions}) this dataset — see {@link TabularDatasetSchema#params()}. An empty map
+    * (the compatibility constructor's default, or a connector that has not opted in) omits the
+    * {@code "params"} key entirely rather than writing it out empty or null, so wiz's reader can't
+    * tell "no params" apart from "not implemented yet" — which is exactly the point: both mean the
+    * same thing to a consumer that only wants to know whether it has something to bind with.
     */
    private static OsiCustomExtension buildDatasetExtension(String dsName, String datasourceSubtype,
+                                                            Map<String, String> params,
                                                             ObjectMapper objectMapper)
    {
       try {
@@ -374,6 +401,10 @@ public class TabularCatalogService {
          extData.put("path", dsName);
          extData.put("datasourceType", "tabular");
          extData.put("datasourceSubtype", datasourceSubtype);
+
+         if(params != null && !params.isEmpty()) {
+            extData.put("params", params);
+         }
 
          OsiCustomExtension ext = new OsiCustomExtension();
          ext.setVendorName("COMMON");

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogDatasetExtensionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogDatasetExtensionTest.java
@@ -28,8 +28,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Charter assertion B7, isolated from the rest of {@link TabularCatalogServiceTest}: a METADATA
@@ -59,5 +61,38 @@ class TabularCatalogDatasetExtensionTest {
       assertEquals("Rest/Northwind", data.get("dsName").asText());
       assertEquals("Rest/Northwind", data.get("path").asText());
       assertEquals("OData", data.get("datasourceSubtype").asText());
+   }
+
+   /**
+    * Reconcile §2's ruling made explicit: {@code Map.of()} (what the 3-arg compatibility
+    * constructor above produces) and "no params" are the same state. If the implementation wrote
+    * {@code extData.put("params", schema.params())} without the non-empty guard, this fails
+    * because the JSON would carry {@code "params": {}} instead of omitting the key.
+    */
+   @Test
+   void datasetCommonExtensionOmitsParamsKeyWhenSchemaHasNone() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"));
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Rest/Northwind", "OData", schema, new ObjectMapper());
+
+      OsiCustomExtension ext = dataset.getCustomExtensions().get(0);
+      JsonNode data = new ObjectMapper().readTree(ext.getData());
+      assertFalse(data.has("params"), "params key must be absent, not an empty object");
+   }
+
+   @Test
+   void datasetCommonExtensionCarriesParamsFromSchema() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"),
+         Map.of("entity", "Products"));
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Rest/Northwind", "OData", schema, new ObjectMapper());
+
+      OsiCustomExtension ext = dataset.getCustomExtensions().get(0);
+      JsonNode data = new ObjectMapper().readTree(ext.getData());
+      assertEquals("Products", data.get("params").get("entity").asText());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -401,6 +401,56 @@ class TabularCatalogServiceContractValidationTest {
       assertEquals("Quantity", dataset.getFields().get(0).getName());
    }
 
+   // ----- params: blank key or null value must be rejected -----
+
+   @Test
+   void describeTable_paramsBlankKey_throwsNamedException() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of(),
+         mapWithBadEntry("   ", "Products"));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("params"));
+   }
+
+   @Test
+   void describeTable_paramsNullValue_throwsNamedExceptionNotNpe() throws Exception {
+      // Same false-positive concern as describeTable_nullColumnType_throwsNamedExceptionNotNpe:
+      // if validateParams iterated entrySet() without a null check, a null value alone wouldn't
+      // NPE (Map.of can't hold null, so the fixture below has to build the map by hand), but
+      // asserting "not NPE" here pins that the check is an explicit condition, not an accident of
+      // how the fixture happens to construct its map.
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of(),
+         mapWithBadEntry("entity", null));
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Products", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.describeTable(DS_NAME, "Products"));
+
+      assertFalse(ex instanceof NullPointerException);
+      assertFalse(ex instanceof UnsupportedDatasourceException);
+      assertTrue(ex.getMessage().contains(DS_NAME));
+      assertTrue(ex.getMessage().toLowerCase().contains("params"));
+   }
+
+   // Map.of() rejects a null value outright, so a HashMap is built by hand to get one past the
+   // record constructor and into validateParams.
+   private static Map<String, String> mapWithBadEntry(String key, String value) {
+      Map<String, String> params = new java.util.HashMap<>();
+      params.put(key, value);
+      return params;
+   }
+
    @Test
    void describeTable_nullColumnType_throwsNamedExceptionNotNpe() throws Exception {
       // Set.of(...).contains(null) throws NullPointerException — XSCHEMA_TYPE_CONSTANTS is a


### PR DESCRIPTION
## Problem

A tabular source annotated through `TabularCatalogProvider` produced a table that nothing could query. `TabularCatalogService` wrote the dataset's columns, keys, and type into the annotated document, but nothing about how to reach the target again — so an agent holding the retrieval result had no way to fill the connector's query bean.

OData happened to work: its dataset id is the entity set name, which is also the value its single `entity` property takes, so matching by name succeeded by coincidence. SharePoint Online could not. Its target needs two properties (`site`, `list`) and its id is an escaped composite carrying GUIDs, so the identity was unrecoverable outside the connector. Annotation succeeded and the resulting table was unusable.

That gap belongs to the SPI, not to either connector: any target needing more than one property, or whose id is not itself a property value, lands in it.

## Fix

`TabularDatasetSchema` gains a `params` component — the parameters a connector's own query bean needs in order to read this dataset again, keyed by that bean's property names. `describeDataset` already resolves the id at that point, so reporting them costs no extra call. A three-argument constructor remains for a connector with nothing to report; empty and absent are the same thing to the caller, and `null` is not a third state.

`TabularCatalogService` maps them into the dataset's COMMON extension under `params`, the slot ServerFile already uses for the same purpose, and validates them alongside the existing contract checks: a blank key or a null value raises a named exception identifying the connector, dataset, and field. The key is omitted entirely when a connector reports nothing, rather than written as an empty object.

OData reports `{entity: <entity set>}`; SharePoint Online reports `{site: ..., list: ...}` carrying the unescaped values, not fragments of the composed id. Keys are the bean property names as derived from the getter, not the `@Property(label=...)` display text — a mismatch there produces a contract key that does not exist and fails later at the agent rather than at annotation.

The dataset id is unchanged, as are the no-dot invariant and SharePoint's id escaping. Neither connector's existing methods are touched.

## Testing

49 tests across the six affected classes. Each new test was checked against a reverted implementation to confirm it fails, and by assertion rather than by an incidental error.

Companion change in wiz: inetsoft-technology/stylebi-wiz#2040.


---

## Also in this PR: Cassandra as the third implementer

Added after the review above, on the same branch.

### Problem

The SPI had two implementers and both report *identifiers* — OData an entity set name, SharePoint a site and a list — which the connector turns into a request. Nothing had yet exercised a connector whose query bean takes a free-form statement, so it was unproven that the same "report parameters keyed by the bean's own property names" mechanism covers that shape. Cassandra is also the first target with a real composite key to report.

The connector itself had no catalog capability at all: it enumerated keyspaces for the connection dialog and discarded the `KeyspaceMetadata` it already held, and had no code reading tables or columns.

### Fix

`CassandraRuntime` implements `TabularCatalogProvider`, delegating to a new `CassandraCatalog` that reads schema metadata for the keyspace the data source is already bound to. A dataset is a table in that keyspace, so its id needs no qualifier. `keyColumns` reports partition key followed by clustering columns — the full primary key, since the partition key alone does not identify a row. The reported binding parameter is `queryString`, whose value is `SELECT * FROM <table>`; row capping stays with `runQuery`'s existing `TabularUtil.getMaxRows`, so no `LIMIT` is emitted.

Identifiers are quoted through `CqlIdentifier.asCql(true)`, which quotes only when required. Cassandra folds unquoted identifiers to lower case, so this is tested in both directions — a mixed-case table must come out quoted and a lower-case one must not. Testing only the first would pass against an implementation that always quotes.

An unconfigured keyspace throws before a session is opened, so it cannot be confused with a keyspace that legitimately has no tables. Session establishment is left uncaught deliberately, so a connection or permission failure surfaces as an error rather than an empty catalog.

`CassandraTable.getType(int)`'s `DataType -> Class` switch is extracted verbatim into a static function that the schema path reuses; the instance method now delegates. Duplicating the switch instead would let the type an annotation reports drift from the type the query returns. A parameterized test asserts, through `getType(int)`, that every protocol code the switch names still maps as before — it stands in for the "this file does not change" guarantee the extraction gives up.

### Testing

31 new tests, all shown to fail against a reverted implementation. No Cassandra cluster is available: the schema path is covered through driver interfaces, and the keyspace guard is proven to short-circuit by pointing a real runtime at an unroutable address. Permission and connection failures are correct by reading and not covered by a test — verifying them would mean dialing an unreachable host and waiting out the driver's timeout, buying a timing dependency in CI to confirm the absence of a catch block.

Three limitations are recorded in `docs/tabular/stylebi-tabular-wiz-integration.md`: eight column types coarsen to `string` through the shared `CoreTool.getDataType` chain, a table name containing `.` fails annotation at the service layer, and the emitted starting query is unrestricted.
