### PR TITLE
fix(wiz): coerce array-typed raw property paths in PropertyPath (PVA-014)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -297,6 +298,23 @@ public final class PropertyPath {
          throw new IllegalArgumentException(
             "'" + path + "' does not accept '" + value + "'. Valid values: " +
             Arrays.toString(target.getEnumConstants()) + ".");
+      }
+
+      if(target.isArray()) {
+         if(!(value instanceof List<?> list)) {
+            throw new IllegalArgumentException(
+               "'" + path + "' expects a JSON array (" + simpleName(target) + "); '" + value +
+               "' is a single value, not an array.");
+         }
+
+         Class<?> componentType = target.getComponentType();
+         Object array = Array.newInstance(componentType, list.size());
+
+         for(int i = 0; i < list.size(); i++) {
+            Array.set(array, i, coerce(list.get(i), componentType, path + "[" + i + "]"));
+         }
+
+         return array;
       }
 
       throw new IllegalArgumentException(

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -212,6 +212,28 @@ class AssemblyPropertyServiceTest {
       assertTrue(thrown.getMessage().contains("shadow"), "must name the refused key: " + thrown.getMessage());
    }
 
+   /**
+    * The reported defect: {@code rangeValues}/{@code rangeColorValues} are {@code String[]}-typed
+    * and unaliased, so the raw dotted path is the only way to set them, and PropertyPath.coerce
+    * had no branch for an array-typed target -- every input shape failed identically regardless
+    * of value. This exercises the real nested GaugeAdvancedPaneModel/RangePaneModel path, not a
+    * synthetic PropertyPathTest fixture.
+    */
+   @Test
+   void setsGaugeRangeValuesViaRawPath() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      service.set("tok", principal(), "Gauge1",
+                  Map.of("gaugeAdvancedPaneModel.rangePaneModel.rangeValues",
+                         java.util.List.of("60", "90", "100")),
+                  "");
+
+      assertArrayEquals(
+         new String[]{ "60", "90", "100" },
+         model.getGaugeAdvancedPaneModel().getRangePaneModel().getRangeValues());
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
@@ -552,4 +552,76 @@ class PropertyPathTest {
       assertEquals("MiXeD Case", leaf.getTitle(),
                    "only names with a declared domain get canonicalized");
    }
+
+   // ── arrays ────────────────────────────────────────────────────────────────
+
+   /**
+    * Mirrors {@code RangePaneModel.rangeValues}/{@code rangeColorValues} — a {@code String[]}
+    * raw path with no alias, so this is the only way to reach it.
+    */
+   public static class StringArrayHolder {
+      public String[] getValues() { return values; }
+      public void setValues(String[] values) { this.values = values; }
+
+      private String[] values;
+   }
+
+   public static class IntArrayHolder {
+      public int[] getValues() { return values; }
+      public void setValues(int[] values) { this.values = values; }
+
+      private int[] values;
+   }
+
+   @Test
+   void setsAStringArrayFromAJsonArrayOfStrings() {
+      StringArrayHolder target = new StringArrayHolder();
+
+      PropertyPath.set(target, "values", List.of("60", "90", "100"));
+
+      assertArrayEquals(new String[]{ "60", "90", "100" }, target.getValues());
+   }
+
+   /**
+    * The exact reported defect: Jackson deserializes a JSON array of numbers into a
+    * {@code List<Integer>}, which must still coerce onto a {@code String[]} target.
+    */
+   @Test
+   void setsAStringArrayFromAJsonArrayOfNumbers() {
+      StringArrayHolder target = new StringArrayHolder();
+
+      PropertyPath.set(target, "values", List.of(60, 90, 100));
+
+      assertArrayEquals(new String[]{ "60", "90", "100" }, target.getValues());
+   }
+
+   @Test
+   void setsAStringArrayFromDecimalStrings() {
+      StringArrayHolder target = new StringArrayHolder();
+
+      PropertyPath.set(target, "values", List.of("60.0", "90.0", "100.0"));
+
+      assertArrayEquals(new String[]{ "60.0", "90.0", "100.0" }, target.getValues());
+   }
+
+   @Test
+   void refusesANonArrayValueForAnArrayTarget() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new StringArrayHolder(), "values", "60,90,100"));
+
+      assertTrue(thrown.getMessage().contains("values"), "name the property");
+      assertTrue(thrown.getMessage().contains("JSON array"), "name the expected shape");
+   }
+
+   @Test
+   void anArrayElementThatFailsCoercionNamesItsIndex() {
+      IntArrayHolder target = new IntArrayHolder();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(target, "values", List.of("60", "not-a-number", "100")));
+
+      assertTrue(thrown.getMessage().contains("values[1]"), "name the offending index");
+   }
 }


### PR DESCRIPTION
## Summary

- `PropertyPath.coerce()` had no branch for array-typed targets (`String[]`, etc.), so any raw dotted property path resolving to an array field — e.g. Gauge's `gaugeAdvancedPaneModel.rangePaneModel.rangeValues`/`rangeColorValues` — fell through every scalar/enum branch straight to the generic throw, unconditionally rejecting every input shape via `set_assembly_properties`, chart region-properties, and viewsheet-properties (all three share `PropertyPath.coerce()` as their single choke point).
- Adds an array branch (before the final generic throw) that treats the Jackson-deserialized `List<?>` as the target array's elements, recursively coercing each element through the existing `coerce()` method, and builds the correctly-typed array via `java.lang.reflect.Array`. This reuses every existing scalar-coercion rule (numeric-string↔number, boolean parsing, enum case-insensitivity, closed-domain checks) per element for free, and fails loud with a clear message if the input isn't a JSON array at all, or if a specific element fails coercion (names the offending index via `path[i]`).

## Root cause

`coerce()` walked `target.isInstance(value)`, boolean, numeric, `String`, and enum branches only; there was no `target.isArray()` branch, so any array-typed field was unreachable via raw path regardless of input shape (JSON string arrays, number arrays, comma-strings, decimal-string arrays — all rejected with the identical generic error).

## Test plan

- [x] `PropertyPathTest` — new tests: string array from JSON string array, from JSON number array (the exact reported defect), from decimal strings, rejection of a non-array value with a "expects a JSON array" message, and per-element coercion failure naming the offending index.
- [x] `AssemblyPropertyServiceTest` — new end-to-end test `setsGaugeRangeValuesViaRawPath()` exercising the real `GaugeAdvancedPaneModel`/`RangePaneModel` nesting for the reported `rangeValues` raw path.
- [x] `mvn -pl core test -Dtest=PropertyPathTest,AssemblyPropertyServiceTest` — 58 tests, 0 failures.
- [x] `mvn -pl core test -Dtest='inetsoft.web.wiz.viewsheet.**'` — full package, 579 tests, 0 failures (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)