### PR TITLE
fix(pva-015): stop re-deriving runtime id in ChangeChartTypeService's nested proxy calls

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ChangeChartTypeService.java
@@ -65,19 +65,19 @@ public class ChangeChartTypeService {
       VSBindingService bindingFactory,
       RuntimeViewsheetRef runtimeViewsheetRef, CoreLifecycleService coreLifecycleService,
       ChartRefModelFactoryService chartRefService,
-      ChangeSeparateStatusController changeSeparateController,
+      ChangeSeparateStatusServiceProxy changeSeparateStatusService,
       VSAssemblyInfoHandler assemblyInfoHandler, VSChartHandler chartHandler,
-      VSBindingTreeController bindingTreeController,
+      VSBindingTreeControllerServiceProxy vsBindingTreeService,
       ViewsheetService viewsheetService)
    {
       this.bindingFactory = bindingFactory;
       this.runtimeViewsheetRef = runtimeViewsheetRef;
       this.coreLifecycleService = coreLifecycleService;
       this.chartRefService = chartRefService;
-      this.changeSeparateController = changeSeparateController;
+      this.changeSeparateStatusService = changeSeparateStatusService;
       this.assemblyInfoHandler = assemblyInfoHandler;
       this.chartHandler = chartHandler;
-      this.bindingTreeController = bindingTreeController;
+      this.vsBindingTreeService = vsBindingTreeService;
       this.viewsheetService = viewsheetService;
    }
 
@@ -150,7 +150,7 @@ public class ChangeChartTypeService {
       if(oldType == newType) {
          new ChangeChartTypeProcessor(oldType, newType,
                                       omulti, nmulti, ref, cinfo, false, desc).processMultiChanged();
-         handleMulti(name, omulti, nmulti, separate, chart, principal, dispatcher, linkUri);
+         handleMulti(id, name, omulti, nmulti, separate, chart, principal, dispatcher, linkUri);
 
          if(ostackMeasures == nstackMeasures) {
             // clearRuntime() above discarded the runtime aesthetic fields, and this is the only
@@ -242,7 +242,7 @@ public class ChangeChartTypeService {
       box.get().updateAssembly(chart.getAbsoluteName());
       new ChangeChartProcessor().fixSizeFrame(ninfo.getVSChartInfo());
       ChangeChartProcessor.fixTarget(oinfo.getVSChartInfo(), cinfo, desc);
-      handleMulti(name, omulti, nmulti, separate, chart, principal, dispatcher, linkUri);
+      handleMulti(id, name, omulti, nmulti, separate, chart, principal, dispatcher, linkUri);
       plotDesc.setStackMeasures(nstackMeasures);
 
       if(GraphTypes.isGantt(cinfo.getChartType()) || GraphTypes.isTreemap(cinfo.getChartType()) ||
@@ -284,21 +284,21 @@ public class ChangeChartTypeService {
       if(GraphTypes.isMap(newType)) {
          RefreshBindingTreeEvent refreshBindingTreeEvent = new RefreshBindingTreeEvent();
          refreshBindingTreeEvent.setName(name);
-         bindingTreeController.getBinding(refreshBindingTreeEvent, principal, dispatcher);
+         vsBindingTreeService.getBinding(id, refreshBindingTreeEvent, principal, dispatcher);
       }
 
       return null;
    }
 
 
-   private void handleMulti(String name, boolean omulti, boolean nmulti, boolean separate,
-                            ChartVSAssembly chart, Principal principal,
+   private void handleMulti(String id, String name, boolean omulti, boolean nmulti,
+                            boolean separate, ChartVSAssembly chart, Principal principal,
                             CommandDispatcher dispatcher, String linkUri)
       throws Exception
    {
       if(omulti != nmulti && chart != null) {
          ChangeSeparateStatusEvent cevent = new ChangeSeparateStatusEvent(name, nmulti, separate);
-         changeSeparateController.changeSeparateStatus(cevent, principal, dispatcher, linkUri);
+         changeSeparateStatusService.changeSeparateStatus(id, cevent, principal, dispatcher, linkUri);
       }
    }
 
@@ -359,9 +359,9 @@ public class ChangeChartTypeService {
    private final RuntimeViewsheetRef runtimeViewsheetRef;
    private final CoreLifecycleService coreLifecycleService;
    private final ChartRefModelFactoryService chartRefService;
-   private final ChangeSeparateStatusController changeSeparateController;
+   private final ChangeSeparateStatusServiceProxy changeSeparateStatusService;
    private final VSAssemblyInfoHandler assemblyInfoHandler;
-   private final VSBindingTreeController bindingTreeController;
+   private final VSBindingTreeControllerServiceProxy vsBindingTreeService;
    private final VSChartHandler chartHandler;
    private final ViewsheetService viewsheetService;
    private static final Logger LOG =

--- a/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/binding/controller/ChangeChartTypeServiceTest.java
@@ -55,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -178,6 +179,44 @@ class ChangeChartTypeServiceTest {
          c -> c instanceof MessageCommand m && m.getType() == MessageCommand.Type.ERROR));
    }
 
+   /**
+    * PVA-015 regression. The map-retype branch used to re-derive its runtime id from the
+    * message-scoped {@code RuntimeViewsheetRef} via {@code VSBindingTreeController.getBinding}
+    * instead of reusing the {@code id} {@code changeChartType} was already given as its own
+    * {@code @ClusterProxyKey} parameter. That re-derived id came back null whenever the call ran
+    * through the cluster proxy's "not local" routing path on a session's first clustered write,
+    * which crashed downstream with an Ignite affinity-key NPE. Calling
+    * {@code VSBindingTreeControllerServiceProxy} directly with the known id removes that
+    * dependency: this harness's {@code RuntimeViewsheetRef} is {@code null}, so a regression that
+    * reintroduces the old lookup would NPE here instead of merely being unasserted.
+    */
+   @Test
+   void aMapRetypeRefreshesTheBindingTreeWithTheKnownRuntimeId() throws Exception {
+      Harness harness = new Harness(plainBarChart());
+
+      harness.retypeTo(GraphTypes.CHART_MAP);
+
+      verify(harness.vsBindingTreeService)
+         .getBinding(eq("rid"), any(), any(), eq(harness.dispatcher));
+   }
+
+   /**
+    * PVA-015 regression, second call site. {@code handleMulti}'s multi-style toggle made the
+    * identical mistake via {@code ChangeSeparateStatusController.changeSeparateStatus}, reached
+    * whenever a retype also flips {@code isMulti()} -- not map-specific. Same fix, same shape of
+    * proof: the call must use the id {@code changeChartType} already has, not one re-derived from
+    * the (here {@code null}) {@code RuntimeViewsheetRef}.
+    */
+   @Test
+   void aMultiStyleToggleUsesTheKnownRuntimeId() throws Exception {
+      Harness harness = new Harness(plainBarChart());
+
+      harness.retypeToWithMulti(GraphTypes.CHART_BAR, true);
+
+      verify(harness.changeSeparateStatusService)
+         .changeSeparateStatus(eq("rid"), any(), any(), eq(harness.dispatcher), anyString());
+   }
+
    /** Bar, with a measure on color: the pie migration has nowhere to move it to. */
    private static ChartVSAssembly measureOnColorBarChart() {
       VSChartInfo info = new DefaultVSChartInfo();
@@ -249,8 +288,8 @@ class ChangeChartTypeServiceTest {
          service = new ChangeChartTypeService(
             mock(VSBindingService.class), null, mock(CoreLifecycleService.class),
             mock(ChartRefModelFactoryService.class),
-            mock(ChangeSeparateStatusController.class), mock(VSAssemblyInfoHandler.class),
-            mock(VSChartHandler.class), mock(VSBindingTreeController.class), viewsheetService);
+            changeSeparateStatusService, mock(VSAssemblyInfoHandler.class),
+            mock(VSChartHandler.class), vsBindingTreeService, viewsheetService);
       }
 
       /**
@@ -273,11 +312,30 @@ class ChangeChartTypeServiceTest {
          }
       }
 
+      /** Same-type retype with a multi-style flip, to reach {@code handleMulti} in isolation. */
+      private void retypeToWithMulti(int type, boolean multi) throws Exception {
+         ChangeChartTypeEvent event = new ChangeChartTypeEvent();
+         event.setName(chart.getAbsoluteName());
+         event.setType(type);
+         event.setMulti(multi);
+
+         try(MockedStatic<GraphTypeUtil> types =
+                mockStatic(GraphTypeUtil.class, CALLS_REAL_METHODS))
+         {
+            types.when(() -> GraphTypeUtil.checkChartStylePermission(anyInt())).thenReturn(true);
+            service.changeChartType("rid", event, mock(Principal.class), dispatcher, "");
+         }
+      }
+
       private final ChartVSAssembly chart;
       private final RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       private final ViewsheetSandbox box = mock(ViewsheetSandbox.class);
       private final ViewsheetService viewsheetService = mock(ViewsheetService.class);
       private final CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+      private final VSBindingTreeControllerServiceProxy vsBindingTreeService =
+         mock(VSBindingTreeControllerServiceProxy.class);
+      private final ChangeSeparateStatusServiceProxy changeSeparateStatusService =
+         mock(ChangeSeparateStatusServiceProxy.class);
       private final ChangeChartTypeService service;
    }
 }


### PR DESCRIPTION
## Summary

- `ChangeChartTypeService.changeChartType`'s map-retype branch and its `handleMulti`/multi-style-toggle branch each made a nested in-process call into another controller (`VSBindingTreeController.getBinding`, `ChangeSeparateStatusController.changeSeparateStatus`) that re-derives its runtime id from the message-scoped `RuntimeViewsheetRef` instead of reusing the `id` that `changeChartType` already has as its own `@ClusterProxyKey` parameter.
- When the outer `changeChartType` proxy call resolves "not local" (typically on a session's first clustered write), `ServiceProxyContext` tears down and rebuilds the thread's STOMP message context from a snapshot that can lack the `sheetRuntimeId` attribute. `RuntimeViewsheetRef.getRuntimeId()` then silently returns `null`, which reaches `RuntimeSheetCache.getAffinityKey` and crashes with Ignite's `NullPointerException("Ouch! Argument cannot be null: key")`. A retry works because routing then resolves "local" and the message context is never rebuilt.
- Fix: call `VSBindingTreeControllerServiceProxy`/`ChangeSeparateStatusServiceProxy` directly with the id `changeChartType` already has, bypassing the ambient `RuntimeViewsheetRef` lookup, for both call sites.
- Out of scope (per diagnosis): hardening `RuntimeSheetCache.isLocal`/`getAffinityKey` itself, which is shared by ~236 other generated proxy call sites — left untouched to keep blast radius to the two confirmed call sites.

## Test plan

- [x] `ChangeChartTypeServiceTest`: added `aMapRetypeRefreshesTheBindingTreeWithTheKnownRuntimeId` and `aMultiStyleToggleUsesTheKnownRuntimeId`, both asserting the nested proxy call uses the harness's known `"rid"` (with a `null` `RuntimeViewsheetRef`, so a regression reintroducing the old lookup fails/NPEs here). Verified these two tests fail against a temporarily-reverted fix and pass against the real fix.
- [x] `./mvnw -o -pl core test -Dtest=ChangeChartTypeServiceTest` — 8/8 pass
- [x] `./mvnw -o -pl core test -Dtest=ChangeChartTypeServiceTest,ChangeChartTypeProcessorTest,ChartBindingServiceTest` — 79/79 pass (no collateral breakage in callers/related processor tests)
- [x] `./mvnw -o -pl core test-compile` — full module compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)