### PR TITLE
fix(wiz): wire GroupingService into edit(op:"group_as_tab") for Tab creation

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
+import inetsoft.uql.viewsheet.TabVSAssembly;
 import inetsoft.uql.viewsheet.TitledVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -26,6 +27,7 @@ import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
 import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
 import inetsoft.web.composer.vs.objects.controller.ComposerGroupService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
+import inetsoft.web.composer.vs.objects.controller.GroupingService;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.event.*;
 import inetsoft.report.composition.RuntimeViewsheet;
@@ -62,6 +64,7 @@ public class ViewsheetEditService {
                                VSObjectPropertyService propertyService,
                                ViewsheetReadService reader,
                                ComposerGroupService groups,
+                               GroupingService grouping,
                                VSRefreshService refreshService)
    {
       this.sessions = sessions;
@@ -70,14 +73,15 @@ public class ViewsheetEditService {
       this.propertyService = propertyService;
       this.reader = reader;
       this.groups = groups;
+      this.grouping = grouping;
       this.refreshService = refreshService;
    }
 
    /** Ops this service understands, named in the error when an unknown one arrives. */
    static final List<String> OPS = List.of(
       "move", "resize", "resize_title", "add", "remove", "rename", "copy", "cut", "paste",
-      "set_z_index", "set_lock", "set_title", "group", "ungroup", "move_from_container",
-      "align", "distribute", "refresh", "refresh_viewsheet");
+      "set_z_index", "set_lock", "set_title", "group", "group_as_tab", "ungroup",
+      "move_from_container", "align", "distribute", "refresh", "refresh_viewsheet");
 
    public void apply(String sessionToken, Principal user, EditRequest request, String linkUri)
       throws Exception
@@ -97,6 +101,7 @@ public class ViewsheetEditService {
       case "set_lock" -> setLock(sessionToken, user, request);
       case "set_title" -> setTitle(sessionToken, user, request);
       case "group" -> group(sessionToken, user, request, linkUri);
+      case "group_as_tab" -> groupAsTab(sessionToken, user, request, linkUri);
       case "ungroup" -> ungroup(sessionToken, user, request, linkUri);
       case "move_from_container" -> moveFromContainer(sessionToken, user, request, linkUri);
       case "align", "distribute" -> arrange(sessionToken, user, request, linkUri, op);
@@ -441,6 +446,47 @@ public class ViewsheetEditService {
                                 linkUri, user, dispatcher));
    }
 
+   /**
+    * Creates a Tab combining the given assemblies -- the container the native Composer's
+    * "combine components into a tabbed view" gesture produces. {@code group}'s
+    * {@code ComposerGroupService} is architecturally incapable of producing one (it only ever
+    * builds a {@code GroupContainer}); {@link GroupingService#groupComponents} is pairwise, so
+    * the first two names form the tab and each subsequent name is folded into that same tab by
+    * calling it again against the first assembly, which by then already resolves to a member of
+    * the tab.
+    */
+   private void groupAsTab(String sessionToken, Principal user, EditRequest request,
+                           String linkUri) throws Exception
+   {
+      List<String> names = request.assemblies();
+
+      if(names == null || names.size() < 2) {
+         throw new IllegalArgumentException(
+            "Edit op 'group_as_tab' requires 'assemblies' with at least two assembly names.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         Viewsheet vs = rvs.getViewsheet();
+         VSAssembly first = requireVSAssembly(rvs, vs, names.get(0));
+
+         for(int i = 1; i < names.size(); i++) {
+            VSAssembly next = requireVSAssembly(rvs, vs, names.get(i));
+            grouping.groupComponents(rvs, first, next, false, linkUri, dispatcher);
+         }
+      });
+   }
+
+   private VSAssembly requireVSAssembly(RuntimeViewsheet rvs, Viewsheet vs, String name) {
+      requireExisting(rvs, name);
+      VSAssembly assembly = vs == null ? null : (VSAssembly) vs.getAssembly(name);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + name + "'.");
+      }
+
+      return assembly;
+   }
+
    private void ungroup(String sessionToken, Principal user, EditRequest request, String linkUri)
       throws Exception
    {
@@ -448,6 +494,22 @@ public class ViewsheetEditService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          requireExisting(rvs, request.assembly());
+
+         Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+         VSAssembly assembly = vs == null ? null : (VSAssembly) vs.getAssembly(request.assembly());
+
+         // group_as_tab produces a TabVSAssembly, not a GroupContainerVSAssembly --
+         // ComposerGroupService.ungroup only unwraps the latter and silently no-ops on
+         // anything else, which would otherwise make this op accept a Tab name and do nothing.
+         if(assembly instanceof TabVSAssembly) {
+            throw new IllegalArgumentException(
+               "'" + request.assembly() + "' is a Tab, not a Group -- edit(op:'ungroup') only " +
+               "reverses the GroupContainer that group creates; it does not undo a Tab created " +
+               "by group_as_tab. To take an assembly out of the tab, use " +
+               "edit(op:'move_from_container') on it instead -- the tab is removed " +
+               "automatically once only one assembly remains in it.");
+         }
+
          groups.ungroup(runtimeId, request.assembly(), linkUri, user, dispatcher);
       });
    }
@@ -761,5 +823,6 @@ public class ViewsheetEditService {
    private final VSObjectPropertyService propertyService;
    private final ViewsheetReadService reader;
    private final ComposerGroupService groups;
+   private final GroupingService grouping;
    private final VSRefreshService refreshService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -22,6 +22,7 @@ import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.controller.ComposerGroupService;
+import inetsoft.web.composer.vs.objects.controller.GroupingService;
 import inetsoft.web.composer.vs.objects.event.AddNewVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ChangeVSObjectLayerEvent;
 import inetsoft.web.composer.vs.objects.event.LockVSObjectEvent;
@@ -32,6 +33,7 @@ import inetsoft.web.viewsheet.controller.VSRefreshService;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
+import inetsoft.uql.viewsheet.TabVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -594,6 +596,71 @@ class ViewsheetEditServiceTest {
       verify(groups).ungroup(eq("rt1"), eq("Group1"), anyString(), any(Principal.class), any());
    }
 
+   /**
+    * PVA-013: ungroup on a Tab (created by group_as_tab) must fail loud rather than silently
+    * doing nothing. {@code ComposerGroupService.ungroup} only unwraps a GroupContainerVSAssembly
+    * and returns null on anything else, so without this guard the op would report success while
+    * leaving the tab untouched.
+    */
+   @Test
+   void ungroupOnATabFailsLoudInsteadOfSilentlyDoingNothing() {
+      ComposerGroupService groups = mock(ComposerGroupService.class);
+      RuntimeViewsheet rvs = runtimeWith("Tab1", mock(TabVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(new AssemblyNode(
+         "Tab1", "Tab", 0, 0, 200, 200, 0, null, true)), mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request("ungroup", "Tab1"), ""));
+
+      assertTrue(thrown.getMessage().contains("Tab1"));
+      assertTrue(thrown.getMessage().contains("Tab"));
+   }
+
+   @Test
+   void groupAsTabRejectsFewerThanTwoAssemblies() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), arrange("group_as_tab", List.of("A"), null), ""));
+      assertTrue(thrown.getMessage().contains("two"));
+   }
+
+   /**
+    * The first two names form the tab; each additional name is folded into that same tab by
+    * calling GroupingService again against the first assembly, which by then is already a member
+    * of the tab -- see GroupingService.groupComponents's "target/targetContainer is already a
+    * Tab" branch.
+    */
+   @Test
+   void groupAsTabCallsGroupingComponentsOnceForFirstPairAndOncePerAdditionalName()
+      throws Exception
+   {
+      GroupingService grouping = mock(GroupingService.class);
+      VSAssembly a = mock(ChartVSAssembly.class);
+      VSAssembly b = mock(ChartVSAssembly.class);
+      VSAssembly c = mock(ChartVSAssembly.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(b);
+      when(vs.getAssembly("C")).thenReturn(c);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Chart", 0, 0, 100, 100, 0, null, true),
+         new AssemblyNode("B", "Chart", 100, 0, 100, 100, 0, null, true),
+         new AssemblyNode("C", "Chart", 200, 0, 100, 100, 0, null, true));
+      ViewsheetEditService service = serviceWithRuntimeAndGrouping(rvs, reader, grouping);
+
+      service.apply("tok", principal(),
+                    arrange("group_as_tab", List.of("A", "B", "C"), null), "");
+
+      verify(grouping).groupComponents(eq(rvs), eq(a), eq(b), eq(false), anyString(), any());
+      verify(grouping).groupComponents(eq(rvs), eq(a), eq(c), eq(false), anyString(), any());
+      verifyNoMoreInteractions(grouping);
+   }
+
    private static MoveVSObjectEvent[] capturedMoves(ComposerObjectService objects)
       throws Exception
    {
@@ -902,7 +969,8 @@ class ViewsheetEditServiceTest {
       return new ViewsheetEditService(sessions, mock(ComposerObjectService.class),
                                       mock(ClipboardControllerService.class),
                                       mock(VSObjectPropertyService.class), reader,
-                                      mock(ComposerGroupService.class), refreshService);
+                                      mock(ComposerGroupService.class),
+                                      mock(GroupingService.class), refreshService);
    }
 
    /** Runs the mutation against a supplied runtime, for the guards that inspect the assembly. */
@@ -940,6 +1008,7 @@ class ViewsheetEditServiceTest {
       return new ViewsheetEditService(sessions, objects, mock(ClipboardControllerService.class),
                                       propertyService, reader,
                                       mock(ComposerGroupService.class),
+                                      mock(GroupingService.class),
                                       mock(VSRefreshService.class));
    }
 
@@ -947,6 +1016,40 @@ class ViewsheetEditServiceTest {
                                                    ClipboardControllerService clipboard,
                                                    ViewsheetReadService reader,
                                                    ComposerGroupService groups)
+   {
+      return serviceWith(objects, clipboard, reader, groups, mock(GroupingService.class));
+   }
+
+   /** Runs the mutation against a supplied runtime, for group_as_tab's GroupingService calls. */
+   private static ViewsheetEditService serviceWithRuntimeAndGrouping(RuntimeViewsheet rvs,
+                                                                     ViewsheetReadService reader,
+                                                                     GroupingService grouping)
+   {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new ViewsheetEditService(sessions, mock(ComposerObjectService.class),
+                                      mock(ClipboardControllerService.class),
+                                      mock(VSObjectPropertyService.class), reader,
+                                      mock(ComposerGroupService.class), grouping,
+                                      mock(VSRefreshService.class));
+   }
+
+   private static ViewsheetEditService serviceWith(ComposerObjectService objects,
+                                                   ClipboardControllerService clipboard,
+                                                   ViewsheetReadService reader,
+                                                   ComposerGroupService groups,
+                                                   GroupingService grouping)
    {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
 
@@ -963,6 +1066,6 @@ class ViewsheetEditServiceTest {
 
       return new ViewsheetEditService(sessions, objects, clipboard,
                                      mock(VSObjectPropertyService.class), reader, groups,
-                                     mock(VSRefreshService.class));
+                                     grouping, mock(VSRefreshService.class));
    }
 }


### PR DESCRIPTION
## Summary

- No `mcp__composer-chat__*` tool could create a `Tab` viewsheet assembly. `edit(op:"group")` only ever reached `ComposerGroupService.groupComponents`, which unconditionally builds a `GroupContainerVSAssembly` -- there was no path to a `Tab`. `GroupingService.groupComponents` (the service native Composer's own tab-combining gesture uses, already a plain injectable bean) was never wired into `ViewsheetEditService`.
- Adds a new op, `group_as_tab`, that resolves the requested assembly names and calls `GroupingService.groupComponents` pairwise -- the first two names form the tab, and each additional name folds into that same tab (its first assembly is by then already a tab member, which routes into `GroupingService`'s "append to existing tab" branch).
- Closes the resulting ungroup-symmetry gap: `ComposerGroupService.ungroup` only unwraps a `GroupContainerVSAssembly` and silently returns `null` on anything else, so once a Tab can be created, `edit(op:"ungroup")` on it would report success while doing nothing. `edit(op:"ungroup")` now fails loud with a named error when the target is a Tab, pointing the caller at `move_from_container` instead (which already correctly collapses a Tab once only one child remains).

This is the server half of a two-repo fix; the `stylebi-wiz`/`plugin/composer` PR that exposes `group_as_tab` through the plugin depends on this landing first.

## Test plan

- [x] `./mvnw test -pl core -Dtest=ViewsheetEditServiceTest` -- 50/50 pass, including 3 new tests: `group_as_tab` rejects <2 assemblies, `group_as_tab` calls `GroupingService.groupComponents` once per pair with `selection=false`, `ungroup` on a Tab fails loud instead of silently no-oping.
- [x] `./mvnw test -pl core -Dtest=ViewsheetEditServiceTest,ViewsheetAssemblyAgentControllerTest,WorksheetAgentControllerTest,ComposerGroupServiceTest,GroupingServiceTest,LayoutOptionDialogServiceTest,ComposerBindingControllerTest` -- 197/197 pass (every test file in the repo that references `ComposerGroupService`, `GroupingService`, or constructs `ViewsheetEditService` directly, since its constructor signature changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)