### PR TITLE
Fix set_print_layout 500: PrintInfo.getSize() NPEs on a never-set size

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/PrintInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/PrintInfo.java
@@ -19,6 +19,8 @@ package inetsoft.uql.viewsheet.vslayout;
 
 import inetsoft.graph.internal.DimensionD;
 import inetsoft.report.Margin;
+import inetsoft.report.Size;
+import inetsoft.report.internal.PaperSize;
 import inetsoft.uql.asset.AssetObject;
 import inetsoft.util.Tool;
 import org.slf4j.Logger;
@@ -38,6 +40,10 @@ public class PrintInfo implements AssetObject {
     * Constructor.
     */
    public PrintInfo() {
+      // Every other field already reads back safely (0/null) when never set; size is the one
+      // getters dereference directly, so it starts populated rather than joining them as a
+      // second, narrower null-check downstream would require.
+      size = defaultSize();
    }
 
    /**
@@ -74,7 +80,14 @@ public class PrintInfo implements AssetObject {
     */
    public DimensionD getSize() {
       double ratio = 1 / getUnitRatio(); //Convert inches to current unit
-      return new DimensionD(size.getWidth() * ratio, size.getHeight() * ratio);
+      DimensionD stored = size == null ? defaultSize() : size;
+      return new DimensionD(stored.getWidth() * ratio, stored.getHeight() * ratio);
+   }
+
+   /** Letter, in inches -- the same unit {@link #size} is always stored in. */
+   private static DimensionD defaultSize() {
+      Size letter = PaperSize.getSize(0);
+      return new DimensionD(letter.width, letter.height);
    }
 
    /**

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoSizeUnitsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoSizeUnitsTest.java
@@ -106,4 +106,29 @@ class PrintInfoSizeUnitsTest {
       assertEquals(1, PrintInfo.getUnitRatio("inches"), 1e-12);
       assertEquals(1, PrintInfo.getUnitRatio(null), 1e-12, "an unknown unit must not scale");
    }
+
+   /**
+    * getSize() used to dereference {@code size} unconditionally, so a PrintInfo that was
+    * never given one -- the no-arg constructor's own prior state, and anything persisted
+    * before this default existed -- NPE'd on every read. A getter must not throw on an
+    * object's own never-populated field; a sensible default (Letter, matching the rest of the
+    * codebase's fallback paper size) is what every other caller building a PrintInfo already
+    * assumes when nothing more specific was requested.
+    */
+   @Test
+   void getSizeOnAFreshlyConstructedPrintInfoDoesNotThrowAndReturnsALetterDefault() {
+      PrintInfo info = new PrintInfo();
+
+      assertEquals(8.5, info.getSize().getWidth(), 1e-9);
+      assertEquals(11, info.getSize().getHeight(), 1e-9);
+   }
+
+   /** Explicitly nulling size (the multi-arg constructor, or setSize(null)) must be equally safe. */
+   @Test
+   void getSizeFallsBackToTheDefaultWhenSizeIsExplicitlyNulledOut() {
+      PrintInfo info = new PrintInfo("Letter", null, 1f, 1f, 1f, 1f, "inches");
+
+      assertEquals(8.5, info.getSize().getWidth(), 1e-9);
+      assertEquals(11, info.getSize().getHeight(), 1e-9);
+   }
 }

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
@@ -209,6 +209,41 @@ public class ViewsheetPropertyDialogServiceTest {
       assertEquals(7, result.revision());
    }
 
+   /**
+    * The reported bug: a print layout whose {@code PrintInfo} was never given a size (e.g.
+    * persisted before {@link PrintInfo}'s no-arg constructor started defaulting one, or built via
+    * the multi-arg constructor with a null {@code size}) must not 500 the read that every
+    * {@code set_print_layout} call starts with -- it must read back with a sensible default
+    * instead.
+    */
+   @Test
+   public void readSideToleratesAPrintLayoutWithNoStoredSize() throws Exception {
+      ViewsheetPropertyDialogService readService = new ViewsheetPropertyDialogService(
+         coreLifecycleService, viewsheetService, layoutService, viewsheetSettingsService,
+         vsAssemblyInfoHandler, securityEngine, null, deviceRegistry);
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getViewsheetInfo()).thenReturn(new ViewsheetInfo());
+      when(viewsheet.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+
+      PrintInfo persistedInfo = new PrintInfo("Letter", null, 1f, 1f, 1f, 1f, "inches");
+      PrintLayout persistedLayout = new PrintLayout();
+      persistedLayout.setPrintInfo(persistedInfo);
+      LayoutInfo layoutInfo = new LayoutInfo();
+      layoutInfo.setPrintLayout(persistedLayout);
+      when(viewsheet.getLayoutInfo()).thenReturn(layoutInfo);
+      when(viewsheetService.getAssetRepository()).thenReturn(assetRepository);
+      when(deviceRegistry.getDevices()).thenReturn(new DeviceInfo[0]);
+
+      // Must not throw -- this is the reported set_print_layout 500.
+      ViewsheetPropertyDialogModel result = readService.getViewsheetInfo("Viewsheet1", null);
+
+      assertEquals("Letter", result.screensPane().getPrintLayout().getPaperSize());
+      assertEquals(8.5, result.screensPane().getPrintLayout().getCustomWidth(), 1e-9);
+      assertEquals(11.0, result.screensPane().getPrintLayout().getCustomHeight(), 1e-9);
+   }
+
    @Mock ViewsheetService viewsheetService;
    @Mock ViewsheetSettingsService viewsheetSettingsService;
    @Mock CoreLifecycleService coreLifecycleService;


### PR DESCRIPTION
## Summary
- `PrintInfo.getSize()` unconditionally dereferenced its private `size` field, which the no-arg constructor never initialized. Any `PrintInfo` reaching `getSize()` without a prior `setSize()` call — including one deserialized from persisted XML lacking `width`/`height` attributes (`writeAttributes` only emits them when `size != null`; `parseAttributes` only restores `size` when both are present) — threw `NullPointerException` on every read.
- `ViewsheetPropertyDialogService.getViewsheetInfo()` calls `getSize()` unconditionally whenever a viewsheet has a print layout, and `PrintDeviceLayoutPropertyService.setPrintLayout()` (`set_print_layout`) calls that method as the *first* step of its read-merge-write, before the caller's own patch is ever applied — so every `set_print_layout` call 500'd regardless of input.
- Distinct from bug 76325 (PR #4879): that fix guards a null `unit` string hitting a `switch` statement; this is an unguarded null field dereference on a different field (`size`). Confirmed by reading #4879's actual diff — it never touches `size`.

## Fix
- Null-guard `getSize()` to fall back to a sensible default (Letter, via the existing `PaperSize` helper) instead of throwing.
- Initialize `size` to the same default in the no-arg constructor, as defense in depth — every other field on this class already reads back safely when never set; `size` was the one exception. This also incidentally closes `PrintInfo.clone()`'s null-size NPE, which its own `try/catch` was silently swallowing into a `null` return.
- No separate guard needed at the three other call sites sharing the same unguarded `getSize().getWidth()/getHeight()` pattern (`VSLayoutService.getPrintPageSize`, `VsToReportConverter`'s method of the same name, and `ViewsheetPropertyDialogService.setViewsheetInfo`'s `oldPageSize` computation) — all three are automatically closed by this fix since none dereference the private field directly.

## Caveat — please read before assuming this fully closes the original report
This closes a confirmed, independently-reproducible defect on the exact code path `set_print_layout` exercises (see regression tests). It does **not** fully confirm it explains the originally reported tester repro: `get_layout`'s own read shares the identical `getViewsheetInfo()` call, and per the original report, it returned a real `paperSize` immediately before/after the failing `set_print_layout` calls — which is only possible if `getSize()` did *not* throw at that moment on that same object. That timing question needs a live re-test to resolve (no live browser/composer-chat session was available this run) and is independent of whether this fix is correct and necessary — it is.

## Test plan
- [x] `PrintInfoSizeUnitsTest` (2 new cases: bare-constructed `PrintInfo`, and explicit `null` via the multi-arg constructor) — both assert the Letter default rather than throwing.
- [x] `ViewsheetPropertyDialogServiceTest` (1 new case: `getViewsheetInfo()` read succeeds and returns the default size for a persisted print layout with a null `PrintInfo.size`).
- [x] Full `inetsoft.uql.viewsheet.vslayout.**`, `inetsoft.web.composer.vs.**`, `inetsoft.web.wiz.**` packages: 2895 passing, 0 failures, 2 pre-existing skips (unrelated).

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>