### PR TITLE
fix(security): newChain() must enable security so its chain is reachable

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -237,6 +237,22 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
       provider = CompositeSecurityProvider.create(authcChain, authzChain);
       authcChain.addAuthenticationChangeListener(authzChain);
       authcChain.addAuthenticationChangeListener(this::fireAuthenticationChange);
+
+      // getSecurityProvider()/getAuthenticationChain()/getAuthorizationChain() only ever return
+      // the "provider" field built above when isSecurityEnabled() is true (see
+      // getSecurityProvider()) -- without this, a caller that builds a chain here and
+      // immediately reads it back (e.g. AuthenticationProviderService/AuthorizationProviderService
+      // bootstrapping the first provider into an empty chain) would still see an empty Optional,
+      // because "security.enabled" was never flipped. Mirrors what enableSecurity() already does
+      // for its own newly-built-chain path.
+      if(!isSecurityEnabled()) {
+         try {
+            setSecurityEnabled(true);
+         }
+         catch(IOException e) {
+            LOG.error("Failed to persist security.enabled after initializing a new provider chain", e);
+         }
+      }
    }
 
    private void setSecurityEnabled(boolean enabled) throws IOException {

--- a/core/src/test/java/inetsoft/sree/security/SecurityEngineLifecycleTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityEngineLifecycleTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.*;
  *  [Chain optional]     composite provider exposes AuthenticationChain           -> optional present
  *  [Chain optional]     composite provider exposes AuthorizationChain            -> optional present
  *  [Identity validity]  identity lookup delegates by identity type               -> true when provider resolves it
+ *  [Bootstrap disabled] newChain() with security.enabled=false makes chain visible -> optional present, security enabled
  *
  * Test design:
  *  - use the Spring context required by SecurityEngine and chain construction
@@ -163,6 +164,33 @@ class SecurityEngineLifecycleTest {
          // authorization accessor: composite provider should expose the backing AuthorizationChain
          Arguments.of((Function<SecurityEngine, Optional<?>>) SecurityEngine::getAuthorizationChain)
       );
+   }
+
+   // [Scenario: bootstrap from disabled security] newChain() on a deployment where
+   // security.enabled is "false" (its default/common state, e.g. a fresh deployment with an empty
+   // authentication chain) must make the freshly-built chain visible through
+   // getAuthenticationChain()/getAuthorizationChain() -- not just build it and leave it
+   // unreachable. Regression test for a bug where AuthenticationProviderService/
+   // AuthorizationProviderService's "create the first provider into an empty chain" fallback
+   // called newChain() and then immediately re-read getAuthenticationChain(), which stayed
+   // Optional.empty() forever because getSecurityProvider() gates on isSecurityEnabled(), and
+   // newChain() never flipped "security.enabled" to "true" the way enableSecurity() does --
+   // deterministically throwing "Could not initialize security." on every such call.
+   // Setup: security.enabled is explicitly "false" and no provider/vprovider is configured yet.
+   @ParameterizedTest
+   @MethodSource("chainAccessorCases")
+   void chainAccessors_afterNewChainWithSecurityDisabled_returnPresentOptional(
+      Function<SecurityEngine, Optional<?>> accessor)
+   {
+      SreeEnv.setProperty("security.enabled", "false");
+      assertFalse(engine.isSecurityEnabled());
+
+      engine.newChain();
+
+      assertTrue(engine.isSecurityEnabled(),
+                 "newChain() must enable security so the chain it just built is reachable");
+      Optional<?> actual = accessor.apply(engine);
+      assertTrue(actual.isPresent());
    }
 
    // [Scenario: identity validity] identity lookup delegates by identity type -> true when provider resolves it


### PR DESCRIPTION
## Summary
- `AuthenticationProviderService.addAuthenticationProvider()` and `AuthorizationProviderService.addAuthorizationProvider()` both fall back to `SecurityEngine.newChain()` when creating the first provider into an empty chain, then immediately re-read `getAuthenticationChain()`/`getAuthorizationChain()` to attach the new provider.
- Both accessors route through `getSecurityProvider()`, which only returns the real `provider` field when `security.enabled` is `"true"` — but `newChain()` built the chain without ever setting that property. The very next read came back `Optional.empty()`, so both call sites threw `"Could not initialize security."` deterministically, 100% of the time, whenever `security.enabled` was `"false"` (the default/common state on a fresh or security-not-yet-configured deployment). Confirmed live via the `stylebi-wiz` admin plugin's `apply_provider_changes`, which surfaced this as a `rollback-failed` status.
- Fix: `newChain()` now also sets `security.enabled=true` after building the chain, mirroring what `enableSecurity()` already does for its own newly-built-chain branch. This fixes the root cause once for **all three** callers of `newChain()`, not just the two buggy ones — `SecurityEngine.SecurityInitCallable` (cluster broadcast on remote nodes) already sets `security.enabled=true` immediately before calling `newChain()`, so the added call there is a harmless no-op re-write of the same value.

## Why this option over calling `enableSecurity()` from the fallback
`enableSecurity()` was considered as the fix site instead, but rejected:
- It requires an admin password to already be configured (`AdminCredentialUtil.getRequiredAdminPassword()` in `SecurityConfigController`, its only other caller) — not guaranteed true when a caller is just adding the first auth provider.
- It does a synchronous, up-to-30s cluster-wide broadcast (`initRemoteNodes`) as a side effect — disproportionate for what should be a local, in-process fallback.
- It declares `throws Exception`, incompatible with the `Supplier` used by `orElseGet(...)` at both call sites without extra wrapping.
- It would have fixed only `AuthenticationProviderService`, leaving `AuthorizationProviderService`'s identical bug (same shape, same root cause, found while auditing all `newChain()` callers) unaddressed.

Patching `newChain()` itself is smaller, has no other caller relying on `security.enabled` staying `false`, and closes the bug for both known call sites plus any future one.

## Test plan
- [x] Added `chainAccessors_afterNewChainWithSecurityDisabled_returnPresentOptional` to `SecurityEngineLifecycleTest` (real Spring-context `SecurityEngine`, not mocked) — sets `security.enabled=false`, calls `newChain()`, asserts `isSecurityEnabled()` is now `true` and both `getAuthenticationChain()`/`getAuthorizationChain()` are present.
- [x] Verified the new test fails without the fix (`git stash` the main-source change, re-ran — 2/2 parameterized cases failed with `expected: <true> but was: <false>`), then confirmed it passes with the fix restored.
- [x] `mvn -pl core test -Dtest=SecurityEngineLifecycleTest,SecurityEngineAuthenticationTest,SecurityEnginePermissionTest,AuthenticationProviderServiceTest,AuthenticationChainTest,AuthorizationChainTest,CompositeSecurityProviderTest` — 82/82 pass.
- [x] `mvn -pl core -am compile` — clean compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)