### PR TITLE
L3 chart binding & aesthetics parity: close agent-path gaps

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/graph/SwapXYBindingProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/SwapXYBindingProcessor.java
@@ -82,7 +82,7 @@ public class SwapXYBindingProcessor extends ChangeChartProcessor {
          int type = !multi ? cinfo.getChartType() : agg.getChartType();
 
          if(!GraphTypes.supportsInvertedChart(type)) {
-            throw new IllegalStateException(
+            throw new IllegalArgumentException(
                "This chart type does not support swapping axes -- '" + ref.getName() +
                "' would be discarded moving from the y shelf to x, instead of swapped.");
          }

--- a/core/src/main/java/inetsoft/report/internal/graph/SwapXYBindingProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/SwapXYBindingProcessor.java
@@ -47,6 +47,48 @@ public class SwapXYBindingProcessor extends ChangeChartProcessor {
       this.desc = desc;
    }
 
+   /**
+    * Refuses a swap that {@link #swapChartXYFields()} would otherwise silently corrupt.
+    *
+    * <p>That method's own {@code y}-to-{@code x} loop {@code continue}s past a measure whose
+    * chart type does not {@link GraphTypes#supportsInvertedChart}, which drops the field from
+    * the binding entirely rather than moving it -- a genuine data-loss shape (live-confirmed
+    * 2026-09-01, L3-Group2 G2-1/G2-2: swapping axes on a {@code mekko} chart silently deleted a
+    * bound measure, returning {@code ok:true} with no warning). The native Composer's own
+    * {@code chart-editor-toolbar.component.ts} ({@code isSwapVisible()}) hides the swap button
+    * for exactly the chart-type family this would corrupt, so a human cannot reach this state —
+    * but {@link inetsoft.web.binding.controller.SwapXYBindingService#swapXYBinding} is a shared
+    * {@code @ClusterProxy} service reachable by any caller that skips the button, the wiz agent
+    * path included. This is a map-only no-op: {@link #swapMapXYFields()} preserves every field
+    * unconditionally (it partitions by measure/dimension, never drops one), so only the
+    * {@code cinfo instanceof MapInfo} branch of {@link #process()} is exempt.
+    *
+    * @throws IllegalStateException naming the field that would be dropped, before anything is
+    *                               mutated — call this before {@link #process()}, not after.
+    */
+   public void requireInvertible() {
+      if(cinfo instanceof MapInfo) {
+         return;
+      }
+
+      boolean multi = cinfo.isMultiStyles();
+
+      for(ChartRef ref : cinfo.getYFields()) {
+         if(!ref.isMeasure()) {
+            continue;
+         }
+
+         ChartAggregateRef agg = (ChartAggregateRef) ref;
+         int type = !multi ? cinfo.getChartType() : agg.getChartType();
+
+         if(!GraphTypes.supportsInvertedChart(type)) {
+            throw new IllegalStateException(
+               "This chart type does not support swapping axes -- '" + ref.getName() +
+               "' would be discarded moving from the y shelf to x, instead of swapped.");
+         }
+      }
+   }
+
    public void process() {
       String tip = cinfo instanceof VSChartInfo ? ((VSChartInfo) cinfo).getToolTipValue()
          : cinfo.getToolTip();

--- a/core/src/main/java/inetsoft/report/internal/graph/SwapXYBindingProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/SwapXYBindingProcessor.java
@@ -63,8 +63,8 @@ public class SwapXYBindingProcessor extends ChangeChartProcessor {
     * unconditionally (it partitions by measure/dimension, never drops one), so only the
     * {@code cinfo instanceof MapInfo} branch of {@link #process()} is exempt.
     *
-    * @throws IllegalStateException naming the field that would be dropped, before anything is
-    *                               mutated — call this before {@link #process()}, not after.
+    * @throws IllegalArgumentException naming the field that would be dropped, before anything is
+    *                                  mutated — call this before {@link #process()}, not after.
     */
    public void requireInvertible() {
       if(cinfo instanceof MapInfo) {

--- a/core/src/main/java/inetsoft/web/binding/controller/SwapXYBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/SwapXYBindingService.java
@@ -158,9 +158,13 @@ public class SwapXYBindingService {
     */
    private void fixInfo(ChartVSAssemblyInfo info, Viewsheet vs) {
       VSChartInfo cinfo = info.getVSChartInfo();
-      fixFields(cinfo);
       ChartDescriptor desc = info.getChartDescriptor();
-      new SwapXYBindingProcessor(cinfo, desc).process();
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(cinfo, desc);
+      // L3-Group2 G2-1/G2-2: checked before fixFields mutates anything, so a chart type that
+      // cannot invert a bound measure refuses the whole swap instead of silently dropping it.
+      processor.requireInvertible();
+      fixFields(cinfo);
+      processor.process();
    }
 
    private void fixFields(VSChartInfo cinfo) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
@@ -80,6 +80,24 @@ public final class AestheticChannels {
    public static String requireFieldChannel(String channel, boolean relationChart,
                                             boolean sizeSupported)
    {
+      return requireFieldChannel(channel, relationChart, sizeSupported, true);
+   }
+
+   /**
+    * @param relationChart        see {@link #requireFieldChannel(String, boolean)}.
+    * @param sizeSupported        see {@link #requireFieldChannel(String, boolean, boolean)}.
+    * @param colorShapeSupported  whether the target chart type renders {@code color}/{@code
+    *                             shape} as field-driven aesthetics — {@code false} for a
+    *                             contour chart ({@code !GraphTypes.isContour(chartType)}).
+    *                             A contour chart's colour is chart-level density shading, not a
+    *                             per-point/per-category binding, and it has no point markers for
+    *                             shape to vary at all — live-confirmed 2026-09-01 (L3-Group3
+    *                             G3-1/G3-2): both channels accepted a field and stored it, but
+    *                             the render showed no per-category variation for either.
+    */
+   public static String requireFieldChannel(String channel, boolean relationChart,
+                                            boolean sizeSupported, boolean colorShapeSupported)
+   {
       String name = normalize(channel);
 
       if(NODE_CHANNELS.contains(name)) {
@@ -96,6 +114,14 @@ public final class AestheticChannels {
          throw new IllegalArgumentException(
             "Channel 'size' is not supported on this chart type — it accepts no size aesthetic " +
             "and a binding here would never be rendered. Field channels: " +
+            String.join(", ", FIELD_CHANNELS) + ".");
+      }
+
+      if(("color".equals(name) || "shape".equals(name)) && !colorShapeSupported) {
+         throw new IllegalArgumentException(
+            "Channel '" + channel + "' is not supported on a contour chart — colour there is " +
+            "chart-level density shading, not a field-driven aesthetic, and there are no point " +
+            "markers for shape to vary. A binding here would never be rendered. Field channels: " +
             String.join(", ", FIELD_CHANNELS) + ".");
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -83,7 +83,9 @@ public class ChartAestheticAgentService {
       // it — so it costs a resolve, not a mutate.
       boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
       boolean sizeSupported = isSizeSupported(sessionToken, user, assemblyName);
-      String name = AestheticChannels.requireFieldChannel(channel, relationChart, sizeSupported);
+      boolean colorShapeSupported = isColorShapeSupported(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFieldChannel(
+         channel, relationChart, sizeSupported, colorShapeSupported);
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
@@ -106,7 +108,9 @@ public class ChartAestheticAgentService {
    {
       boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
       boolean sizeSupported = isSizeSupported(sessionToken, user, assemblyName);
-      String name = AestheticChannels.requireFieldChannel(channel, relationChart, sizeSupported);
+      boolean colorShapeSupported = isColorShapeSupported(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFieldChannel(
+         channel, relationChart, sizeSupported, colorShapeSupported);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
             (chart, model) -> ChartAestheticMutator.clearField(model, name, relationChart));
@@ -149,7 +153,8 @@ public class ChartAestheticAgentService {
       ChartVSAssembly chart = requireChart(rvs, assemblyName);
       return ChartAestheticMutator.describe((ChartBindingModel) binding.createModel(chart),
                                             isRelationChart(chart),
-                                            perMeasureFrameChannels(chart));
+                                            perMeasureFrameChannels(chart),
+                                            isSizeSupported(chart), isColorShapeSupported(chart));
    }
 
    /**
@@ -277,6 +282,19 @@ public class ChartAestheticAgentService {
    private static boolean isSizeSupported(ChartVSAssembly chart) {
       VSChartInfo info = chart.getVSChartInfo();
       return info == null || GraphTypes.supportsSize(info.getChartType());
+   }
+
+   private boolean isColorShapeSupported(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      return isColorShapeSupported(requireChart(rvs, assemblyName));
+   }
+
+   /** No chart type yet (unbound chart) means no type is forbidding color/shape. */
+   private static boolean isColorShapeSupported(ChartVSAssembly chart) {
+      VSChartInfo info = chart.getVSChartInfo();
+      return info == null || !GraphTypes.isContour(info.getChartType());
    }
 
    private void apply(String sessionToken, Principal user, String assemblyName, String channel,

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -112,6 +112,7 @@ public class ChartAestheticAgentService {
       boolean colorShapeSupported = isColorShapeSupported(sessionToken, user, assemblyName);
       String name = AestheticChannels.requireFieldChannel(
          channel, relationChart, sizeSupported, colorShapeSupported);
+      requireNotMultiAesthetic(sessionToken, user, assemblyName);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
             (chart, model) -> ChartAestheticMutator.clearField(model, name, relationChart));
@@ -301,9 +302,11 @@ public class ChartAestheticAgentService {
    /**
     * Refuses a field write while the chart is already multi-style, instead of corrupting it.
     *
-    * <p>{@code ChartAestheticMutator.setField} writes to the chart-level field slot
-    * unconditionally — it has no equivalent of the per-measure {@code aggr.setShapeField(...)}
-    * path {@code VSFrameVisitor}'s rendering strategies read from once
+    * <p>{@code ChartAestheticMutator.setField} and {@code clearField} both write to the
+    * chart-level field slot unconditionally (the latter via the identical {@code assign(model,
+    * name, null)} call) — neither has an equivalent of the per-measure
+    * {@code aggr.setShapeField(...)} path {@code VSFrameVisitor}'s rendering strategies read from
+    * once
     * {@code info.isMultiAesthetic()} is true ({@code frameField}'s own comment on this class
     * documents that split). Writing there while already multi-style does not merely go
     * unrendered the way an unsupported channel does — it leaves the chart's runtime graph

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -316,8 +316,22 @@ public class ChartAestheticAgentService {
     * set_chart_type}'s own {@code multi} redistributes an existing chart-level field into each
     * measure correctly, the same transition a human toggling the Composer's own checkbox
     * triggers. Only writing a field while multi-style is already on has no such handling, so
-    * this refuses exactly that state rather than attempting a fix at the render layer whose
-    * root cause remains open (see the L3 parity report's own note on G2-5).
+    * this refuses exactly that state rather than attempting a fix at the render layer.
+    *
+    * <p><b>This guard is not a workaround for a gap the native UI also has</b> — it is the exact
+    * state the Composer's own Aesthetic Pane cannot construct. Every field editor there
+    * ({@code color-field-mc.component.ts} et al.) reads/writes through an {@code @Input() aggr}
+    * ({@code ChartAggregateRef}) when one is supplied, falling back to the chart-level
+    * {@code bindingModel} field only when it is not ({@code if(this.aggr) this.aggr.colorField =
+    * ref; else this.bindingModel[...] = ref;}); {@code aesthetic-pane.component.ts}'s own
+    * {@code currAggregate} getter returns {@code null} whenever {@code !this.multiStyles}
+    * and a real per-measure ref whenever it is {@code true} — so a human can never reach the
+    * chart-level write path while multi-style is on. The corrupting state this guard refuses is
+    * therefore reachable only by a caller (this tool included, before this fix) that bypasses the
+    * button the way {@link SwapXYBindingProcessor#requireInvertible} documents for the G2-1/G2-2
+    * swap-axes case. The render-layer defect this exposes is consequently real but UI-unreachable
+    * — a standalone StyleBI engine issue, not a wiz/native parity gap, and out of this lane's
+    * scope to fix.
     */
    private void requireNotMultiAesthetic(String sessionToken, Principal user, String assemblyName)
       throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -86,6 +86,7 @@ public class ChartAestheticAgentService {
       boolean colorShapeSupported = isColorShapeSupported(sessionToken, user, assemblyName);
       String name = AestheticChannels.requireFieldChannel(
          channel, relationChart, sizeSupported, colorShapeSupported);
+      requireNotMultiAesthetic(sessionToken, user, assemblyName);
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
@@ -295,6 +296,43 @@ public class ChartAestheticAgentService {
    private static boolean isColorShapeSupported(ChartVSAssembly chart) {
       VSChartInfo info = chart.getVSChartInfo();
       return info == null || !GraphTypes.isContour(info.getChartType());
+   }
+
+   /**
+    * Refuses a field write while the chart is already multi-style, instead of corrupting it.
+    *
+    * <p>{@code ChartAestheticMutator.setField} writes to the chart-level field slot
+    * unconditionally — it has no equivalent of the per-measure {@code aggr.setShapeField(...)}
+    * path {@code VSFrameVisitor}'s rendering strategies read from once
+    * {@code info.isMultiAesthetic()} is true ({@code frameField}'s own comment on this class
+    * documents that split). Writing there while already multi-style does not merely go
+    * unrendered the way an unsupported channel does — it leaves the chart's runtime graph
+    * unable to render *at all*, and unlike every other guard in this class, undoing the write
+    * (or the {@code set_chart_type(multi:true)} that preceded it) does not recover it: the
+    * corruption is in cached render state {@code undo} does not roll back, confirmed live
+    * 2026-09-01 by reverting both edits and finding {@code get_viewsheet_image} still failing.
+    *
+    * <p>The safe order — bind the field, then turn multi-style on — already works: {@code
+    * set_chart_type}'s own {@code multi} redistributes an existing chart-level field into each
+    * measure correctly, the same transition a human toggling the Composer's own checkbox
+    * triggers. Only writing a field while multi-style is already on has no such handling, so
+    * this refuses exactly that state rather than attempting a fix at the render layer whose
+    * root cause remains open (see the L3 parity report's own note on G2-5).
+    */
+   private void requireNotMultiAesthetic(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      ChartVSAssembly chart = requireChart(rvs, assemblyName);
+      VSChartInfo info = chart.getVSChartInfo();
+
+      if(info != null && info.isMultiAesthetic()) {
+         throw new IllegalArgumentException(
+            "This chart is multi-style, and binding a field here while multi-style is already " +
+            "on corrupts the chart's rendering with no way to undo it. Turn multi-style off " +
+            "(set_chart_type with multi:false), bind the field, then turn multi-style back on " +
+            "— that order redistributes the field into each measure correctly.");
+      }
    }
 
    private void apply(String sessionToken, Principal user, String assemblyName, String channel,

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -1010,19 +1010,42 @@ public final class ChartAestheticMutator {
    public static Map<String, Object> describe(ChartBindingModel model, boolean relationChart,
                                               Collection<String> perMeasureFrameChannels)
    {
+      return describe(model, relationChart, perMeasureFrameChannels, true, true);
+   }
+
+   /**
+    * @param sizeSupported       see {@link AestheticChannels#requireFieldChannel(String,
+    *                            boolean, boolean, boolean)}. When {@code false}, {@code size}'s
+    *                            {@code acceptsField} reports {@code false} too — otherwise this
+    *                            read and {@code set_aesthetic_field}'s own write-time refusal
+    *                            disagree about whether the channel is writable (live-confirmed
+    *                            2026-09-01, L3-Group4 G4-4: a mekko chart's {@code size} channel
+    *                            reported {@code acceptsField:true} here, then
+    *                            {@code set_aesthetic_field} refused the identical write).
+    * @param colorShapeSupported see {@link AestheticChannels#requireFieldChannel(String, boolean,
+    *                            boolean, boolean)}. Same reasoning, for {@code color}/{@code
+    *                            shape} on a contour chart (L3-Group3 G3-1/G3-2).
+    */
+   public static Map<String, Object> describe(ChartBindingModel model, boolean relationChart,
+                                              Collection<String> perMeasureFrameChannels,
+                                              boolean sizeSupported, boolean colorShapeSupported)
+   {
       Map<String, Object> out = new LinkedHashMap<>();
 
       for(String channel : AestheticChannels.FIELD_CHANNELS) {
-         out.put(channel, channelView(model, channel, perMeasureFrameChannels));
+         out.put(channel, channelView(model, channel, perMeasureFrameChannels,
+                                       sizeSupported, colorShapeSupported));
       }
 
       for(String channel : AestheticChannels.FRAME_CHANNELS) {
-         out.computeIfAbsent(channel, name -> channelView(model, name, perMeasureFrameChannels));
+         out.computeIfAbsent(channel, name -> channelView(
+            model, name, perMeasureFrameChannels, sizeSupported, colorShapeSupported));
       }
 
       if(relationChart) {
          for(String channel : AestheticChannels.NODE_CHANNELS) {
-            out.put(channel, channelView(model, channel, perMeasureFrameChannels));
+            out.put(channel, channelView(model, channel, perMeasureFrameChannels,
+                                          sizeSupported, colorShapeSupported));
          }
       }
 
@@ -1071,6 +1094,42 @@ public final class ChartAestheticMutator {
    private static boolean acceptsField(String channel) {
       return AestheticChannels.FIELD_CHANNELS.contains(channel) ||
          AestheticChannels.NODE_CHANNELS.contains(channel);
+   }
+
+   /**
+    * Whether the <em>current chart type</em> actually renders a field bound to this channel —
+    * as opposed to {@link #acceptsField(String)}, which only asks whether the channel has a
+    * field slot in the model at all, independent of chart type. This is what the reported
+    * {@code "acceptsField"} view property must reflect: it feeds a caller's decision to call
+    * {@code set_aesthetic_field}, and that write enforces exactly this same
+    * {@code sizeSupported}/{@code colorShapeSupported} gate ({@link
+    * AestheticChannels#requireFieldChannel(String, boolean, boolean, boolean)}) — reporting
+    * {@code acceptsField(channel)}'s structural answer here instead let the two disagree
+    * (live-confirmed 2026-09-01, L3-Group4 G4-4: {@code get_chart_aesthetics} reported
+    * {@code size.acceptsField:true} on a mekko chart, then {@code set_aesthetic_field} refused
+    * the identical write).
+    *
+    * @param sizeSupported       see {@link #describe(ChartBindingModel, boolean, Collection,
+    *                            boolean, boolean)}.
+    * @param colorShapeSupported see {@link #describe(ChartBindingModel, boolean, Collection,
+    *                            boolean, boolean)}.
+    */
+   private static boolean rendersField(String channel, boolean sizeSupported,
+                                       boolean colorShapeSupported)
+   {
+      if(!acceptsField(channel)) {
+         return false;
+      }
+
+      if("size".equals(channel)) {
+         return sizeSupported;
+      }
+
+      if("color".equals(channel) || "shape".equals(channel)) {
+         return colorShapeSupported;
+      }
+
+      return true;
    }
 
    /**
@@ -1130,13 +1189,27 @@ public final class ChartAestheticMutator {
    private static Map<String, Object> channelView(ChartBindingModel model, String channel,
                                                   Collection<String> perMeasureFrameChannels)
    {
+      return channelView(model, channel, perMeasureFrameChannels, true, true);
+   }
+
+   /**
+    * @param sizeSupported       see {@link #describe(ChartBindingModel, boolean, Collection,
+    *                            boolean, boolean)}.
+    * @param colorShapeSupported see {@link #describe(ChartBindingModel, boolean, Collection,
+    *                            boolean, boolean)}.
+    */
+   private static Map<String, Object> channelView(ChartBindingModel model, String channel,
+                                                  Collection<String> perMeasureFrameChannels,
+                                                  boolean sizeSupported,
+                                                  boolean colorShapeSupported)
+   {
       Map<String, Object> view = new LinkedHashMap<>();
       AestheticInfo info = frameField(model, channel);
 
       view.put("field", fieldNameOf(info));
       view.put("frame",
                VisualFrameAliases.describe(frameOf(model, channel, perMeasureFrameChannels)));
-      view.put("acceptsField", acceptsField(channel));
+      view.put("acceptsField", rendersField(channel, sizeSupported, colorShapeSupported));
       view.put("acceptsFrame", acceptsFrame(channel));
 
       Map<String, Object> perMeasure =

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -199,9 +199,19 @@ public final class ChartBindingMutator {
     * {@code Util.getOrganizationMaxColumn()}. {@code chartInfo == null} skips the check: there is
     * no live chart to total against (the no-chartInfo overloads used by unit tests and any other
     * caller that only has a bare {@code ChartBindingModel}).
+    *
+    * <p>The check only fires on <b>net growth</b> of this shelf ({@code newShelfCount >
+    * oldShelfCount}). A net-neutral or net-decreasing edit is always allowed, regardless of the
+    * chart's pre-existing total — mirroring how native's own add/remove split behaves:
+    * {@code VSChartDndService.addColumns} caps a drag-drop add, but
+    * {@code VSChartDndService.removeColumns} has no limit check at all. Without this guard, a
+    * chart that is already over budget (grandfathered, or the org limit lowered by an admin after
+    * the chart was created) would become permanently unable to have any shelf edited through this
+    * path — even a strict shrink — because the absolute post-edit total would still read over
+    * limit.
     */
    private static void requireColumnLimit(VSChartInfo chartInfo, int oldShelfCount, int newShelfCount) {
-      if(chartInfo == null) {
+      if(chartInfo == null || newShelfCount <= oldShelfCount) {
          return;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -18,7 +18,10 @@
 package inetsoft.web.wiz.binding;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.Util;
 import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.graph.VSMapInfo;
 import inetsoft.web.binding.model.BDimensionRefModel;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
@@ -50,7 +53,7 @@ public final class ChartBindingMutator {
 
    public static void setShelf(ChartBindingModel model, String shelf, List<FieldRef> fields) {
       try {
-         setShelf(model, shelf, fields, null, null, null);
+         setShelf(model, shelf, fields, null, null, null, null);
       }
       catch(RuntimeException e) {
          throw e; // preserve e.g. requireType's IllegalArgumentException as-is
@@ -71,6 +74,21 @@ public final class ChartBindingMutator {
                                DataRefModelFactoryService refModelService)
       throws Exception
    {
+      setShelf(model, shelf, fields, rvs, source, refModelService, null);
+   }
+
+   /**
+    * @param chartInfo      the chart's live {@code VSChartInfo}, so this write can be checked
+    *                       against the org's column-count limit before it lands — the same
+    *                       check {@code VSChartDndService.addColumns} makes for a drag-drop add.
+    *                       {@code null} skips the check (matching the no-chartInfo overloads,
+    *                       used where no live chart/session is available, e.g. unit tests).
+    */
+   public static void setShelf(ChartBindingModel model, String shelf, List<FieldRef> fields,
+                               RuntimeViewsheet rvs, SourceInfo source,
+                               DataRefModelFactoryService refModelService, VSChartInfo chartInfo)
+      throws Exception
+   {
       String name = shelf == null ? "" : shelf.trim().toLowerCase();
 
       if(SINGLE_SHELVES.contains(name)) {
@@ -86,6 +104,8 @@ public final class ChartBindingMutator {
             String.join(", ", SHELVES) + ". Single-field shelves (open, high, low, close, path, " +
             "source, target, start, end, milestone) use set_chart_single_shelf.");
       }
+
+      requireColumnLimit(chartInfo, readShelf(model, name).size(), fields == null ? 0 : fields.size());
 
       List<ChartRefModel> refs = new ArrayList<>();
 
@@ -121,7 +141,7 @@ public final class ChartBindingMutator {
     */
    public static void setSingleShelf(ChartBindingModel model, String shelf, FieldRef field) {
       try {
-         setSingleShelf(model, shelf, field, null, null, null);
+         setSingleShelf(model, shelf, field, null, null, null, null);
       }
       catch(RuntimeException e) {
          throw e; // preserve e.g. requireSingleShelf's IllegalArgumentException as-is
@@ -137,7 +157,24 @@ public final class ChartBindingMutator {
                                      DataRefModelFactoryService refModelService)
       throws Exception
    {
+      setSingleShelf(model, shelf, field, rvs, source, refModelService, null);
+   }
+
+   /**
+    * @param chartInfo see {@link #setShelf(ChartBindingModel, String, List, RuntimeViewsheet,
+    *                  SourceInfo, DataRefModelFactoryService, VSChartInfo)}'s {@code chartInfo}.
+    */
+   public static void setSingleShelf(ChartBindingModel model, String shelf, FieldRef field,
+                                     RuntimeViewsheet rvs, SourceInfo source,
+                                     DataRefModelFactoryService refModelService,
+                                     VSChartInfo chartInfo)
+      throws Exception
+   {
       String name = requireSingleShelf(shelf);
+      int oldCount = readSingleShelf(model, name) == null ? 0 : 1;
+      int newCount = field == null ? 0 : 1;
+      requireColumnLimit(chartInfo, oldCount, newCount);
+
       ChartRefModel ref = field == null
          ? null : FieldRefFactory.toChartRef(field, rvs, source, refModelService);
 
@@ -152,6 +189,27 @@ public final class ChartBindingMutator {
       case "start" -> model.setStartField(ref);
       case "end" -> model.setEndField(ref);
       default -> model.setMilestoneField(ref);
+      }
+   }
+
+   /**
+    * Refuses a shelf write that would push the chart's total bound-field count (every shelf plus
+    * every aesthetic channel, mirroring {@code VSChartInfo.getFields()} — the same total
+    * {@code VSChartDndService.addColumns} checks for a drag-drop add) past
+    * {@code Util.getOrganizationMaxColumn()}. {@code chartInfo == null} skips the check: there is
+    * no live chart to total against (the no-chartInfo overloads used by unit tests and any other
+    * caller that only has a bare {@code ChartBindingModel}).
+    */
+   private static void requireColumnLimit(VSChartInfo chartInfo, int oldShelfCount, int newShelfCount) {
+      if(chartInfo == null) {
+         return;
+      }
+
+      int geoSize = chartInfo instanceof VSMapInfo ? ((VSMapInfo) chartInfo).getGeoFieldCount() : 0;
+      int total = chartInfo.getFields().length + geoSize - oldShelfCount + newShelfCount;
+
+      if(total > Util.getOrganizationMaxColumn()) {
+         throw new IllegalArgumentException(Util.getColumnLimitMessage());
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -94,7 +94,8 @@ public class ChartBindingService {
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
          applySource(model, sourceTable);
          ChartBindingMutator.setShelf(
-            model, shelf, fields, rvs, chart.getSourceInfo(), refModelService);
+            model, shelf, fields, rvs, chart.getSourceInfo(), refModelService,
+            chart.getVSChartInfo());
 
          ChangeChartRefEvent event = new ChangeChartRefEvent();
          event.setName(assemblyName);
@@ -240,7 +241,8 @@ public class ChartBindingService {
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
          applySource(model, sourceTable);
          ChartBindingMutator.setSingleShelf(
-            model, shelf, field, rvs, chart.getSourceInfo(), refModelService);
+            model, shelf, field, rvs, chart.getSourceInfo(), refModelService,
+            chart.getVSChartInfo());
 
          ChangeChartRefEvent event = new ChangeChartRefEvent();
          event.setName(assemblyName);

--- a/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
@@ -76,6 +76,48 @@ class SwapXYBindingProcessorTest {
       assertDoesNotThrow(processor::requireInvertible);
    }
 
+   /**
+    * The per-measure branch of {@code requireInvertible} ({@code multi ? agg.getChartType() :
+    * cinfo.getChartType()}): once the chart is multi-style, each measure's OWN chart type governs
+    * invertibility, not the chart-level type. Here the chart-level type is bar (invertible) but
+    * the bound measure's own type is mekko (not) -- the check must still refuse, proving it reads
+    * the per-measure type once multi-style is on.
+    */
+   @Test
+   void refusesASwapOnAMultiStyleChartWhenTheMeasuresOwnTypeCannotInvert() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+      info.setMultiStyles(true);
+      info.addXField(new VSChartDimensionRef());
+      VSChartAggregateRef measure = new VSChartAggregateRef();
+      measure.setChartType(GraphTypes.CHART_MEKKO);
+      info.addYField(measure);
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertThrows(IllegalArgumentException.class, processor::requireInvertible);
+   }
+
+   /**
+    * The mirror case: chart-level type is mekko (not invertible) but the bound measure's own
+    * type, once multi-style is on, is bar (invertible) -- the check must allow it, proving it is
+    * not simply falling back to the chart-level type.
+    */
+   @Test
+   void allowsASwapOnAMultiStyleChartWhenTheMeasuresOwnTypeCanInvert() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_MEKKO);
+      info.setMultiStyles(true);
+      info.addXField(new VSChartDimensionRef());
+      VSChartAggregateRef measure = new VSChartAggregateRef();
+      measure.setChartType(GraphTypes.CHART_BAR);
+      info.addYField(measure);
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertDoesNotThrow(processor::requireInvertible);
+   }
+
    @Test
    void skipsTheCheckEntirelyForAMapChart() {
       // swapMapXYFields partitions x/y by measure/dimension unconditionally and never drops a

--- a/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.internal.graph;
+
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSMapInfo;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * L3-Group2, findings G2-1/G2-2: {@code SwapXYBindingService.swapXYBinding} — a shared,
+ * {@code @ClusterProxy} service both the native Composer's swap button and the wiz agent's
+ * {@code swap_chart_axes} call — had no {@code GraphTypes}-based gate at all before this fix,
+ * so a chart type {@link SwapXYBindingProcessor#swapChartXYFields()} cannot invert (e.g.
+ * {@code mekko}) silently dropped a bound measure moving from {@code y} to {@code x} instead of
+ * swapping it. Live-confirmed 2026-09-01: {@code swap_chart_axes} on a mekko chart returned
+ * {@code ok:true} and deleted the {@code y} shelf's measure outright.
+ */
+@WizAgentTestSupport
+class SwapXYBindingProcessorTest {
+   @Test
+   void refusesASwapThatWouldDropAYMeasureOnAMekkoChart() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_MEKKO);
+      info.addXField(new VSChartDimensionRef());
+      info.addYField(new VSChartAggregateRef());
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertThrows(IllegalStateException.class, processor::requireInvertible);
+   }
+
+   @Test
+   void allowsASwapOnAChartTypeThatSupportsInversion() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+      info.addXField(new VSChartDimensionRef());
+      info.addYField(new VSChartAggregateRef());
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertDoesNotThrow(processor::requireInvertible);
+   }
+
+   @Test
+   void allowsASwapWhenYHoldsOnlyDimensions() {
+      // A dimension moving from y to x is never dropped -- swapChartXYFields' skip-and-continue
+      // only applies to the measure branch -- so mekko is fine here despite not inverting.
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_MEKKO);
+      info.addXField(new VSChartAggregateRef());
+      info.addYField(new VSChartDimensionRef());
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertDoesNotThrow(processor::requireInvertible);
+   }
+
+   @Test
+   void skipsTheCheckEntirelyForAMapChart() {
+      // swapMapXYFields partitions x/y by measure/dimension unconditionally and never drops a
+      // field -- the finding is specific to swapChartXYFields, so a MapInfo is exempt.
+      VSMapInfo info = new VSMapInfo();
+      info.addYField(new VSChartAggregateRef());
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertDoesNotThrow(processor::requireInvertible);
+   }
+}

--- a/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
@@ -87,4 +87,81 @@ class SwapXYBindingProcessorTest {
 
       assertDoesNotThrow(processor::requireInvertible);
    }
+
+   /**
+    * L3-Group2 G2-2 (the geo/all-measure half of the same finding, re-examined): recorded as
+    * "blocked, unverified" because the connected live environment had no geo-typed column to
+    * construct a real {@code VSMapInfo} chart against. The claim itself: "a map needs a dimension
+    * somewhere on x/y to draw from, and swapping two all-measure shelves cannot introduce one" --
+    * i.e. a map with zero dimensions on x/y (all-measure) stays zero-dimension after a swap. That
+    * claim is true but not a *new* problem the swap causes: dimension *count* is conserved by
+    * {@code swapMapXYFields()} (proven below and in the mixed-binding test above) -- it only moves
+    * dimensions between x and y, never creates or destroys one. A zero-dimension map is invalid
+    * before the swap and stays invalid after it, exactly as bad either way; the swap itself is a
+    * safe no-op in this case (no exception, no further corruption), not a data-loss vector like
+    * G2-1's mekko case. Whether a human or the agent can even construct a zero-dimension map chart
+    * in the first place is a binding-construction question, not a swap-axes one, and is out of
+    * this finding's scope.
+    */
+   @Test
+   void swapMapXYFieldsIsASafeNoOpWhenBothShelvesAreAllMeasure() {
+      VSMapInfo info = new VSMapInfo();
+      VSChartAggregateRef xMeasure = new VSChartAggregateRef();
+      xMeasure.setColumnValue("population");
+      VSChartAggregateRef yMeasure = new VSChartAggregateRef();
+      yMeasure.setColumnValue("sales");
+      info.addXField(xMeasure);
+      info.addYField(yMeasure);
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+
+      assertDoesNotThrow(processor::process);
+      assertEquals(1, info.getXFields().length);
+      assertEquals(1, info.getYFields().length);
+      assertTrue(java.util.Arrays.asList(info.getXFields()).contains(xMeasure));
+      assertTrue(java.util.Arrays.asList(info.getYFields()).contains(yMeasure));
+   }
+
+   /**
+    * The other half of G2-2's re-examination: proves the general claim (dimension swap, measure
+    * passthrough, nothing dropped) with fields on both shelves, matching the original finding's
+    * "x/y fields with measures" scenario -- REFUTED, not a gap: no live-session or plugin-side
+    * change needed.
+    */
+   @Test
+   void swapMapXYFieldsPreservesEveryFieldForAMixedDimensionAndMeasureBinding() {
+      VSMapInfo info = new VSMapInfo();
+      VSChartDimensionRef xDim = new VSChartDimensionRef();
+      xDim.setGroupColumnValue("state");
+      VSChartAggregateRef xMeasure = new VSChartAggregateRef();
+      xMeasure.setColumnValue("population");
+      VSChartDimensionRef yDim = new VSChartDimensionRef();
+      yDim.setGroupColumnValue("county");
+      VSChartAggregateRef yMeasure = new VSChartAggregateRef();
+      yMeasure.setColumnValue("sales");
+
+      info.addXField(xDim);
+      info.addXField(xMeasure);
+      info.addYField(yDim);
+      info.addYField(yMeasure);
+
+      SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
+      processor.process();
+
+      // Every original field is still present somewhere -- none discarded.
+      java.util.List<inetsoft.uql.viewsheet.graph.ChartRef> after = new java.util.ArrayList<>();
+      after.addAll(java.util.Arrays.asList(info.getXFields()));
+      after.addAll(java.util.Arrays.asList(info.getYFields()));
+      assertEquals(4, after.size(), "no field should be dropped by a map axis swap");
+      assertTrue(after.contains(xDim));
+      assertTrue(after.contains(xMeasure));
+      assertTrue(after.contains(yDim));
+      assertTrue(after.contains(yMeasure));
+
+      // Dimensions swap shelves; measures stay put -- the map-specific swap semantic.
+      assertTrue(java.util.Arrays.asList(info.getXFields()).contains(yDim));
+      assertTrue(java.util.Arrays.asList(info.getYFields()).contains(xDim));
+      assertTrue(java.util.Arrays.asList(info.getXFields()).contains(xMeasure));
+      assertTrue(java.util.Arrays.asList(info.getYFields()).contains(yMeasure));
+   }
 }

--- a/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/SwapXYBindingProcessorTest.java
@@ -47,7 +47,7 @@ class SwapXYBindingProcessorTest {
 
       SwapXYBindingProcessor processor = new SwapXYBindingProcessor(info, null);
 
-      assertThrows(IllegalStateException.class, processor::requireInvertible);
+      assertThrows(IllegalArgumentException.class, processor::requireInvertible);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/AestheticChannelsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/AestheticChannelsTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * L3-Group3, findings G3-1/G3-2: {@code AestheticChannels.requireFieldChannel} gated {@code size}
+ * on {@code sizeSupported} but had no equivalent gate for {@code color}/{@code shape} on a
+ * contour chart — a contour chart's colour is chart-level density shading, not a per-point/
+ * per-category field binding, and it has no point markers for shape to vary at all.
+ * Live-confirmed 2026-09-01: both channels accepted and stored a field on a {@code
+ * scatter_contour} chart, but the render showed no per-category variation for either — the
+ * exact "stored but silently never rendered" shape the existing {@code size} guard exists to
+ * prevent.
+ */
+@Tag("core")
+class AestheticChannelsTest {
+   @Test
+   void refusesColorOnAContourChart() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> AestheticChannels.requireFieldChannel("color", false, true, false));
+      assertTrue(thrown.getMessage().toLowerCase().contains("contour"), thrown.getMessage());
+   }
+
+   @Test
+   void refusesShapeOnAContourChart() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> AestheticChannels.requireFieldChannel("shape", false, true, false));
+      assertTrue(thrown.getMessage().toLowerCase().contains("contour"), thrown.getMessage());
+   }
+
+   @Test
+   void allowsColorAndShapeOnAnOrdinaryChart() {
+      assertEquals("color", AestheticChannels.requireFieldChannel("color", false, true, true));
+      assertEquals("shape", AestheticChannels.requireFieldChannel("shape", false, true, true));
+   }
+
+   @Test
+   void sizeAndColorShapeGatesAreIndependent() {
+      // A contour chart also doesn't support size (GraphTypes.supportsSize), but the two gates
+      // must be checked independently -- refusing size for the wrong reason (colorShapeSupported)
+      // would name the wrong channel in the message.
+      Exception sizeRefused = assertThrows(
+         IllegalArgumentException.class,
+         () -> AestheticChannels.requireFieldChannel("size", false, false, false));
+      assertTrue(sizeRefused.getMessage().contains("size"), sizeRefused.getMessage());
+
+      Exception colorRefused = assertThrows(
+         IllegalArgumentException.class,
+         () -> AestheticChannels.requireFieldChannel("color", false, false, false));
+      assertTrue(colorRefused.getMessage().contains("color"), colorRefused.getMessage());
+   }
+
+   @Test
+   void textAndSizeAreUnaffectedByTheContourGate() {
+      assertEquals("text", AestheticChannels.requireFieldChannel("text", false, true, false));
+      assertEquals("size", AestheticChannels.requireFieldChannel("size", false, true, false));
+   }
+
+   @Test
+   void theThreeAndFourArgOverloadsAgreeWhenUnrestricted() {
+      assertEquals(AestheticChannels.requireFieldChannel("color", false, true),
+                   AestheticChannels.requireFieldChannel("color", false, true, true));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -292,6 +292,47 @@ class ChartAestheticAgentServiceTest {
       assertTrue(((String) options.get("nodeChannelsNote")).contains("relation charts"));
    }
 
+   // ── multi-style corruption guard (L3-Group2 finding G2-5) ─────────────────────────────────
+   //
+   // Live-confirmed 2026-09-01: writing a field while a chart is already multi-style corrupts
+   // its runtime graph so get_viewsheet_image fails, and unlike every other guard in this class
+   // the corruption survives undoing both the field write and the multi-style toggle that
+   // preceded it. The docstring already told a caller to bind the field first, then turn multi-
+   // style on -- this makes the unsafe order (multi-style already on, then bind) fail loud
+   // instead of silently corrupting the chart.
+
+   @Test
+   void refusesSettingAFieldWhileTheChartIsAlreadyMultiStyle() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(multiStyleChartAssembly()), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.setField("tok", principal(), "Chart1", "color",
+                                new FieldRef("Region", "dimension", null, null, null), null, ""));
+      assertTrue(thrown.getMessage().toLowerCase().contains("multi-style"), thrown.getMessage());
+   }
+
+   @Test
+   void allowsSettingAFieldWhenTheChartIsNotMultiStyle() throws Exception {
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(new ChartBindingModel(), aesthetics)
+         .setField("tok", principal(), "Chart1", "color",
+                  new FieldRef("Region", "dimension", null, null, null), null, "");
+
+      assertEquals("Region", captureEvent(aesthetics).getModel().getColorField().getFullName());
+   }
+
+   private static ChartVSAssembly multiStyleChartAssembly() {
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiAesthetic()).thenReturn(true);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      return chart;
+   }
+
    private static ChartVSAssembly relationChartAssembly() {
       VSChartInfo info = mock(VSChartInfo.class);
       when(info.getChartType()).thenReturn(GraphTypes.CHART_NETWORK);

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -325,6 +325,37 @@ class ChartAestheticAgentServiceTest {
       assertEquals("Region", captureEvent(aesthetics).getModel().getColorField().getFullName());
    }
 
+   /**
+    * PR #4921 round-1 finding 2: {@code clearField} calls the identical chart-level
+    * {@code assign(model, name, null)} write {@code setField} does (see
+    * {@code ChartAestheticMutator.clearField}), so it corrupts a multi-style chart the same way —
+    * but the guard was only wired onto {@code setField}. This proves it is now wired onto
+    * {@code clearField} too.
+    */
+   @Test
+   void refusesClearingAFieldWhileTheChartIsAlreadyMultiStyle() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(multiStyleChartAssembly()), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.clearField("tok", principal(), "Chart1", "color", ""));
+      assertTrue(thrown.getMessage().toLowerCase().contains("multi-style"), thrown.getMessage());
+   }
+
+   @Test
+   void allowsClearingAFieldWhenTheChartIsNotMultiStyle() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      ChartAestheticMutator.setField(existing, "color",
+                                     new FieldRef("Region", "dimension", null, null, null));
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(existing, aesthetics).clearField("tok", principal(), "Chart1", "color", "");
+
+      assertNull(captureEvent(aesthetics).getModel().getColorField());
+   }
+
    private static ChartVSAssembly multiStyleChartAssembly() {
       VSChartInfo info = mock(VSChartInfo.class);
       when(info.isMultiAesthetic()).thenReturn(true);

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
@@ -1741,4 +1741,69 @@ class ChartAestheticMutatorTest {
                  "the refusal has to name the way to get the value they want: " +
                  thrown.getMessage());
    }
+
+   // ── acceptsField vs. set_aesthetic_field agreement (L3-Group4 finding G4-4) ───────────────
+   //
+   // get_chart_aesthetics' acceptsField used to answer only "does this channel have a field
+   // slot at all" (AestheticChannels.FIELD_CHANNELS membership), independent of chart type --
+   // disagreeing with set_aesthetic_field's own sizeSupported/colorShapeSupported-gated refusal.
+   // Live-confirmed 2026-09-01: a mekko chart's size channel reported acceptsField:true here,
+   // then set_aesthetic_field refused the identical write.
+
+   @Test
+   void acceptsFieldReportsFalseForSizeWhenTheChartTypeDoesNotSupportIt() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> size = (Map<String, Object>) ChartAestheticMutator.describe(
+         model, false, AestheticChannels.FRAME_CHANNELS, false, true).get("size");
+
+      assertEquals(false, size.get("acceptsField"),
+                   "must agree with set_aesthetic_field's own sizeSupported refusal");
+   }
+
+   @Test
+   void acceptsFieldReportsFalseForColorAndShapeOnAContourChart() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      Map<String, Object> described = ChartAestheticMutator.describe(
+         model, false, AestheticChannels.FRAME_CHANNELS, true, false);
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color = (Map<String, Object>) described.get("color");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> shape = (Map<String, Object>) described.get("shape");
+
+      assertEquals(false, color.get("acceptsField"),
+                   "must agree with set_aesthetic_field's own colorShapeSupported refusal");
+      assertEquals(false, shape.get("acceptsField"),
+                   "must agree with set_aesthetic_field's own colorShapeSupported refusal");
+   }
+
+   @Test
+   void acceptsFieldStaysTrueForTextRegardlessOfSizeOrColorShapeSupport() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> text = (Map<String, Object>) ChartAestheticMutator.describe(
+         model, false, AestheticChannels.FRAME_CHANNELS, false, false).get("text");
+
+      assertEquals(true, text.get("acceptsField"),
+                   "text isn't gated by either sizeSupported or colorShapeSupported");
+   }
+
+   @Test
+   void theThreeArgDescribeDefaultsToUnrestrictedAcceptsField() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> size = (Map<String, Object>) ChartAestheticMutator.describe(
+         model, false, AestheticChannels.FRAME_CHANNELS).get("size");
+
+      assertEquals(true, size.get("acceptsField"),
+                   "callers that don't pass chart-type context keep the old, unrestricted answer");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -19,7 +19,9 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.sree.SreeEnv;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartGeoRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.graph.VSMapInfo;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
@@ -336,6 +338,176 @@ class ChartBindingMutatorTest {
          assertTrue(thrown.getMessage().toLowerCase().contains("column")
                     || thrown.getMessage().contains("1"), thrown.getMessage());
          assertNull(ChartBindingMutator.readSingleShelf(model, "close"));
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   // ── net-growth-only column limit (PR #4921 round-1 finding 1) ────────────
+   //
+   // requireColumnLimit compared the ABSOLUTE post-edit total against the org limit, so a chart
+   // already over budget (grandfathered, or the limit lowered by an admin after creation) became
+   // permanently unable to have ANY shelf edited via the wiz path -- even a strict shrink --
+   // because native's VSChartDndService.removeColumns has no limit check at all while addColumns
+   // does. Live-confirmed 2026-09-01: shrinking a 5-field shelf to 4 fields under max.col.count=3
+   // still threw. The fix gates the check on net growth of the shelf being written.
+
+   @Test
+   void allowsANetDecreaseOnAShelfEvenWhenTheChartIsAlreadyOverTheLimit() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "3");
+         // The chart is already over budget: 5 fields on x alone, against a limit of 3.
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+
+         // Shrink x from 5 fields to 4 -- a strict decrease -- and it must be allowed even though
+         // the chart's total (before and after) is still over the limit of 3.
+         ChartBindingMutator.setShelf(
+            model, "x",
+            List.of(new FieldRef("A", "dimension", null, null, null),
+                    new FieldRef("B", "dimension", null, null, null),
+                    new FieldRef("C", "dimension", null, null, null),
+                    new FieldRef("D", "dimension", null, null, null)),
+            null, null, null, chartInfo);
+
+         assertEquals(4, model.getXFields().size());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
+   void allowsANetNeutralEditOnAShelfEvenWhenTheChartIsAlreadyOverTheLimit() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "1");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+
+         // Same field count in, same count out -- no growth at all -- must be allowed despite
+         // the chart already sitting at twice the limit.
+         ChartBindingMutator.setShelf(
+            model, "x",
+            List.of(new FieldRef("A", "dimension", null, null, null),
+                    new FieldRef("B", "dimension", null, null, null)),
+            null, null, null, chartInfo);
+
+         assertEquals(2, model.getXFields().size());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
+   void stillRefusesANetIncreaseThatPushesAnAlreadyOverLimitChartFurtherOver() throws Exception {
+      // Net growth must still be checked -- the fix only exempts neutral/decreasing edits, not
+      // every edit on an over-limit chart.
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "3");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+
+         Exception thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChartBindingMutator.setShelf(
+               model, "x",
+               List.of(new FieldRef("A", "dimension", null, null, null),
+                       new FieldRef("B", "dimension", null, null, null),
+                       new FieldRef("C", "dimension", null, null, null),
+                       new FieldRef("D", "dimension", null, null, null),
+                       new FieldRef("E", "dimension", null, null, null),
+                       new FieldRef("F", "dimension", null, null, null)),
+               null, null, null, chartInfo));
+
+         assertTrue(thrown.getMessage().toLowerCase().contains("column")
+                    || thrown.getMessage().contains("3"), thrown.getMessage());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   // ── VSMapInfo geo-field branch (PR #4921 round-1 finding 4) ───────────────
+   //
+   // requireColumnLimit adds VSMapInfo.getGeoFieldCount() to the chart's own getFields().length
+   // total, since a map's geo fields are not part of getFields() at all -- this exercises that
+   // branch, which no prior test in this class touched.
+
+   @Test
+   void countsGeoFieldsTowardTheLimitOnAMapChart() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "2");
+         VSMapInfo chartInfo = new VSMapInfo();
+         chartInfo.addYField(new VSChartAggregateRef());
+         chartInfo.addGeoField(new VSChartGeoRef());
+         ChartBindingModel model = new ChartBindingModel();
+
+         // 1 y field + 1 geo field + 1 new x field = 3, over a limit of 2 -- refused only because
+         // the geo field is counted; without it the total would be 2 and would pass.
+         Exception thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChartBindingMutator.setShelf(
+               model, "x", List.of(new FieldRef("Region", "dimension", null, null, null)),
+               null, null, null, chartInfo));
+
+         assertTrue(thrown.getMessage().toLowerCase().contains("column")
+                    || thrown.getMessage().contains("2"), thrown.getMessage());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
+   void allowsAMapChartWriteWhenGeoAndFieldsTogetherStayWithinTheLimit() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "3");
+         VSMapInfo chartInfo = new VSMapInfo();
+         chartInfo.addYField(new VSChartAggregateRef());
+         chartInfo.addGeoField(new VSChartGeoRef());
+         ChartBindingModel model = new ChartBindingModel();
+
+         ChartBindingMutator.setShelf(
+            model, "x", List.of(new FieldRef("Region", "dimension", null, null, null)),
+            null, null, null, chartInfo);
+
+         assertEquals(1, model.getXFields().size());
       }
       finally {
          SreeEnv.setProperty("max.col.count", original);

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -320,6 +320,44 @@ class ChartBindingMutatorTest {
    }
 
    @Test
+   void growingAShelfDoesNotDoubleCountItsOwnPriorFieldsAgainstTheLimit() throws Exception {
+      // Unlike replacingAShelfDoesNotDoubleCountItsOwnPriorFields (a net-neutral edit that now
+      // short-circuits through requireColumnLimit's net-growth-only early return before ever
+      // reaching the subtraction below), this drives an actual GROWTH of the shelf
+      // (newShelfCount > oldShelfCount) so the "- oldShelfCount" term in
+      //   chartInfo.getFields().length + geoSize - oldShelfCount + newShelfCount
+      // is the thing standing between pass and fail. chartInfo already carries the shelf's own
+      // 2 prior fields (mirroring the model's 2), so a version of the formula that forgot to
+      // subtract oldShelfCount would double-count them: 2 + 3 = 5 > 3, refused. Correctly
+      // subtracting them gives 2 - 2 + 3 = 3, which is exactly at the limit and must be allowed.
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "3");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addXField(new VSChartAggregateRef());
+         chartInfo.addXField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+         model.getXFields().add(new ChartDimensionRefModel());
+         model.getXFields().add(new ChartDimensionRefModel());
+
+         // Grow x from 2 fields to 3 -- a strict increase -- which must be allowed because the
+         // shelf's own 2 prior fields are subtracted back out before comparing to the limit.
+         ChartBindingMutator.setShelf(
+            model, "x",
+            List.of(new FieldRef("A", "dimension", null, null, null),
+                    new FieldRef("B", "dimension", null, null, null),
+                    new FieldRef("C", "dimension", null, null, null)),
+            null, null, null, chartInfo);
+
+         assertEquals(3, model.getXFields().size());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
    void refusesASingleShelfWriteThatWouldExceedTheOrgColumnLimit() throws Exception {
       String original = SreeEnv.getProperty("max.col.count");
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -17,11 +17,14 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.sree.SreeEnv;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.wiz.binding.model.FieldRef;
-import org.junit.jupiter.api.Tag;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,7 +32,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Tag("core")
+@WizAgentTestSupport
 class ChartBindingMutatorTest {
    @Test
    void setsTheXShelfFromFieldRefs() {
@@ -229,5 +232,113 @@ class ChartBindingMutatorTest {
          () -> ChartBindingMutator.setSort(model, "y", "Sales", null,
             new DimensionSortRanking.Sort("asc", null, null)));
       assertTrue(thrown.getMessage().contains("Sales"));
+   }
+
+   // ── org column-count limit (L3-Group1 finding G1-1) ───────────────────────
+   //
+   // VSChartDndService.addColumns refuses a drag-drop add that would push a chart's total
+   // bound-field count past Util.getOrganizationMaxColumn() -- the agent path had no equivalent
+   // check at all, live-confirmed 2026-09-01 by binding 286 fields to one chart's x shelf in a
+   // single call with zero rejection. These exercise the new check via the chartInfo-carrying
+   // overloads only -- the no-chartInfo overloads every other test in this class uses are
+   // untouched (chartInfo == null skips the check by design, matching a caller with no live
+   // chart to total against).
+
+   @Test
+   void refusesAShelfWriteThatWouldExceedTheOrgColumnLimit() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "2");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addYField(new VSChartAggregateRef());
+         chartInfo.addYField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+
+         Exception thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChartBindingMutator.setShelf(
+               model, "x", List.of(new FieldRef("Region", "dimension", null, null, null)),
+               null, null, null, chartInfo));
+
+         assertTrue(thrown.getMessage().toLowerCase().contains("column")
+                    || thrown.getMessage().contains("2"), thrown.getMessage());
+         assertTrue(model.getXFields().isEmpty(),
+                    "the refused write must not have mutated the model");
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
+   void allowsAShelfWriteWithinTheOrgColumnLimit() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "2");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addYField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+
+         ChartBindingMutator.setShelf(
+            model, "x", List.of(new FieldRef("Region", "dimension", null, null, null)),
+            null, null, null, chartInfo);
+
+         assertEquals(1, model.getXFields().size());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
+   void replacingAShelfDoesNotDoubleCountItsOwnPriorFields() throws Exception {
+      // The check must subtract the shelf's OWN current size before adding the new size --
+      // otherwise re-setting a shelf to the same field count it already has would look like
+      // growth and eventually refuse a no-op write.
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "1");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addXField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+         model.getXFields().add(new ChartDimensionRefModel());
+
+         ChartBindingMutator.setShelf(
+            model, "x", List.of(new FieldRef("Region", "dimension", null, null, null)),
+            null, null, null, chartInfo);
+
+         assertEquals(1, model.getXFields().size());
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
+   }
+
+   @Test
+   void refusesASingleShelfWriteThatWouldExceedTheOrgColumnLimit() throws Exception {
+      String original = SreeEnv.getProperty("max.col.count");
+
+      try {
+         SreeEnv.setProperty("max.col.count", "1");
+         VSChartInfo chartInfo = new VSChartInfo();
+         chartInfo.addYField(new VSChartAggregateRef());
+         ChartBindingModel model = new ChartBindingModel();
+
+         Exception thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChartBindingMutator.setSingleShelf(
+               model, "close", new FieldRef("Price", "measure", "Sum", null, null),
+               null, null, null, chartInfo));
+
+         assertTrue(thrown.getMessage().toLowerCase().contains("column")
+                    || thrown.getMessage().contains("1"), thrown.getMessage());
+         assertNull(ChartBindingMutator.readSingleShelf(model, "close"));
+      }
+      finally {
+         SreeEnv.setProperty("max.col.count", original);
+      }
    }
 }


### PR DESCRIPTION
## Summary
- StyleBI-side fixes closing the wiz-agent path's parity gaps against the native Composer UI/backend for chart binding, chart type/multi-style, axis swap, and aesthetic field binding (L3 lane).
- G1-1: `Util.getOrganizationMaxColumn()` column-limit check on chart shelf writes.
- G2-1/G2-2 (non-geo half): `SwapXYBindingProcessor.requireInvertible()` refuses a swap that would silently drop a bound `y` measure (e.g. on a mekko chart) instead of swapping it.
- G3-1/G3-2/G4-4: `AestheticChannels`/`ChartAestheticMutator` gate color/shape on contour charts and make `get_chart_aesthetics`'s `acceptsField` agree with `set_aesthetic_field`'s own gate.
- G2-5: `ChartAestheticAgentService.requireNotMultiAesthetic` refuses a chart-level aesthetic-field write once multi-style is already on, before the runtime is touched.
- **G2-2 (geo/all-measure half): REFUTED.** Adds a JUnit test constructing a `VSMapInfo` directly (the connected live environment has no geo-typed data to construct a real map chart against) proving `swapMapXYFields()` conserves dimension count and never drops a field.
- **G2-5 follow-up**: confirms the containment fix is sufficient by tracing the native Composer's own Aesthetic Pane field editors — a human can never reach the corrupting chart-level write path once multi-style is on, matching the fix's own gate exactly. The render-layer defect the guard prevents is real but UI-unreachable, out of this lane's scope.
- Merges the latest `stylebi-wiz-main-rebase` into this branch — clean merge, no conflicts.

## Test plan
- [x] `./mvnw -pl core compile` clean
- [x] `./mvnw -pl core test-compile` clean
- [x] `./mvnw -pl core test -Dtest="inetsoft.web.wiz.**,inetsoft.report.internal.graph.**,inetsoft.uql.viewsheet.graph.**"` — 2904/2904 passing (1 skipped, 0 failures, 0 errors)
- See the paired wiz-repo PR (stylebi-wiz#2061) and `docs/parity/L3-chart-binding-aesthetics/L3-parity-report.md` there for the full live-verification evidence per finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)