### PR TITLE
fix(wiz): route edit op:"refresh" through refreshVsAssembly, not refreshVsAssemblyView (PVA-010)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -33,6 +33,7 @@ import inetsoft.web.composer.vs.objects.event.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.web.viewsheet.controller.VSRefreshService;
+import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.RenderWaitSupport;
@@ -517,9 +518,10 @@ public class ViewsheetEditService {
    /**
     * PVA-010: forces the named assembly to re-execute its query and re-render, picking up a
     * worksheet-side change (e.g. a ranking/aggregate edit) made after the chart was already
-    * bound — the same mechanism {@code VSRefreshService.refreshVsAssemblyView} already performs
-    * for the Composer's own UI refresh (its own {@code TableDataVSAssembly} reload included), just
-    * not previously reachable from any composer-chat tool.
+    * bound — the same mechanism {@code VSRefreshService.refreshVsAssembly} (reached via
+    * {@code /vs/refresh/assembly}) already performs for the Composer's own UI when the binding
+    * pane changes an assembly's binding, including resetting the sandbox and re-executing the
+    * assembly's query, not merely re-rendering it.
     */
    private void refresh(String sessionToken, Principal user, EditRequest request, String linkUri)
       throws Exception
@@ -528,8 +530,11 @@ public class ViewsheetEditService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          requireExisting(rvs, request.assembly());
-         refreshService.refreshVsAssemblyView(runtimeId, request.assembly(), dispatcher, linkUri,
-                                              user);
+         RefreshVSAssemblyEvent event = RefreshVSAssemblyEvent.builder()
+            .vsRuntimeId(runtimeId)
+            .assemblyName(request.assembly())
+            .build();
+         refreshService.refreshVsAssembly(runtimeId, event, dispatcher, linkUri, user);
       });
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -30,6 +30,7 @@ import inetsoft.web.composer.vs.objects.event.MoveVSObjectEvent;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.web.viewsheet.controller.VSRefreshService;
+import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
@@ -158,9 +159,11 @@ class ViewsheetEditServiceTest {
     * Regression for Bug PVA-010: a worksheet-side change made after a chart is already bound
     * (e.g. a ranking/aggregate edit) does not propagate to the chart's render, and nothing under
     * {@code plugin/composer/src/tools} could force a requery scoped to one assembly --
-    * {@code refresh_data} is worksheet-scoped only. {@code edit op:"refresh"} wraps the same
-    * mechanism {@code VSRefreshService.refreshVsAssemblyView} already performs for the
-    * Composer's own UI refresh.
+    * {@code refresh_data} is worksheet-scoped only. {@code edit op:"refresh"} must reach
+    * {@code VSRefreshService.refreshVsAssembly} (the requery path the Composer UI itself uses
+    * when a binding-pane change touches an assembly), not the render-only
+    * {@code refreshVsAssemblyView} sibling, which never resets the sandbox or re-executes the
+    * query.
     */
    @Test
    void refreshDelegatesToVSRefreshServiceForTheNamedAssembly() throws Exception {
@@ -170,8 +173,12 @@ class ViewsheetEditServiceTest {
 
       service.apply("tok", principal(), request("refresh", "Chart1"), "linkUri1");
 
-      verify(refreshService).refreshVsAssemblyView(eq("rt1"), eq("Chart1"), any(),
-                                                    eq("linkUri1"), any(Principal.class));
+      ArgumentCaptor<RefreshVSAssemblyEvent> captor =
+         ArgumentCaptor.forClass(RefreshVSAssemblyEvent.class);
+      verify(refreshService).refreshVsAssembly(eq("rt1"), captor.capture(), any(),
+                                               eq("linkUri1"), any(Principal.class));
+      assertEquals("Chart1", captor.getValue().getAssemblyName());
+      verify(refreshService, never()).refreshVsAssemblyView(any(), any(), any(), any(), any());
    }
 
    @Test
@@ -188,7 +195,7 @@ class ViewsheetEditServiceTest {
    /**
     * Regression for bug PSM-004 (fix C): no agent-API endpoint reached the sheet-level
     * {@code /vs/refresh} the Composer UI's own Refresh toolbar button uses -- {@code edit
-    * op:"refresh"} only ever reaches the per-assembly {@code refreshVsAssemblyView}. Asserts
+    * op:"refresh"} only ever reaches the per-assembly {@code refreshVsAssembly}. Asserts
     * {@code refresh_viewsheet} calls the whole-sheet {@code refreshViewsheet} instead, and that
     * it needs no {@code assembly} (a sibling of {@code refresh}, not a synonym).
     */
@@ -203,7 +210,7 @@ class ViewsheetEditServiceTest {
       ArgumentCaptor<VSRefreshEvent> captor = ArgumentCaptor.forClass(VSRefreshEvent.class);
       verify(refreshService).refreshViewsheet(eq("rt1"), captor.capture(), any(Principal.class),
                                               any(), eq("linkUri1"));
-      verify(refreshService, never()).refreshVsAssemblyView(any(), any(), any(), any(), any());
+      verify(refreshService, never()).refreshVsAssembly(any(), any(), any(), any(), any());
       assertFalse(captor.getValue().confirmed());
    }
 


### PR DESCRIPTION
## Summary
- `ViewsheetEditService.refresh` (`core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java`) called `VSRefreshService.refreshVsAssemblyView` -- the wrong one of two similarly-named sibling methods. That method only recomputes an assembly's info/format and re-pushes the render; it never calls `ViewsheetSandbox.reset(...)` or re-executes the bound query, so a worksheet-side change (e.g. `set_ranking` applied after a chart was already bound) never propagated to `edit(op:"refresh")`'s result, even though `{ok:true}` was returned.
- Fixed by constructing a `RefreshVSAssemblyEvent` and calling `VSRefreshService.refreshVsAssembly` instead -- the same `/vs/refresh/assembly` path the Composer UI's own binding-pane "assembly changed" cascade uses, which resets the sandbox and re-executes the assembly's query via `CoreLifecycleService.execute(...)`.
- Updated the method's javadoc to describe the corrected mechanism, and updated `ViewsheetEditServiceTest.refreshDelegatesToVSRefreshServiceForTheNamedAssembly` (previously asserting the wrong delegate) to verify `refreshVsAssembly` is called with the right `RefreshVSAssemblyEvent`, plus the neighboring `refreshViewsheetDelegatesToTheWholeSheetRefresh` test's `never()` assertion (unaffected in behavior, just naming the correct sibling method).

Root cause and full analysis: `docs/teams/2026-08-31-test-composer-plugin/case-PVA-010-refresh-op-stale-query/01-diagnosis.md` in the `stylebi-wiz` repo.

## Test plan
- [x] `./mvnw -pl core -Dtest=ViewsheetEditServiceTest test` -- all 50 tests pass, including the two updated assertions.
- [x] `./mvnw -pl core -Dtest=inetsoft.web.wiz.**` test -- 2840 tests pass (1 skipped), 0 failures/errors -- no regressions in the wiz package this change lives in.
- [x] `./mvnw -pl core -Dtest=VSRefreshServiceEmbedAssemblyTest,CoreLifecycleServiceEmbedSizeTest test` -- unaffected sibling-method tests still pass.
- [ ] Live verification against a running StyleBI instance (bind a chart, `set_ranking` + `save_worksheet()`, `edit(op:"refresh")`, confirm `get_viewsheet_image` shows requeried data) was **not** performed in this session -- no `composer-chat` MCP tools were available to this agent. This should be confirmed once a build with this fix is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)