### PR TITLE
fix(wiz): resolve a Table highlight's omitted region to a real data cell, not the header (PVA-017)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -287,16 +287,33 @@ public class AssemblyHighlightService {
       // highlight somewhere they did not ask for.
       // A null model means the assembly has no highlight dialog at all; that is the caller's
       // answer, and re-reading a different cell of it would only produce the same null.
-      if(region == null && model != null && fieldNames(model).isEmpty()) {
-         HighlightDialogModel atData =
-            readAt(runtimeId, assemblyName, firstDataCell(runtimeId, assemblyName, user), user);
+      if(region == null && model != null) {
+         // `fieldNames(model).isEmpty()` is the general "we're stuck on the header" signal, and
+         // it is reliable for a Crosstab (its fields are computed dpath-aware, so a header cell
+         // genuinely reports none). It is NOT reliable for a plain Table:
+         // HighlightService.getRefsForVSAssembly's Table branch reports the table's entire base
+         // column list regardless of row/col, so `fields` comes back non-empty even at (0,0) —
+         // the fall-forward below would never fire and the header would be highlighted silently.
+         // For a Table, check the header extent directly instead.
+         boolean tableAtHeader = model.isTableAssembly() &&
+            isHeaderCell(target, firstDataCell(runtimeId, assemblyName, user));
 
-         if(!fieldNames(atData).isEmpty()) {
-            return atData;
+         if(tableAtHeader || fieldNames(model).isEmpty()) {
+            HighlightDialogModel atData =
+               readAt(runtimeId, assemblyName, firstDataCell(runtimeId, assemblyName, user), user);
+
+            if(!fieldNames(atData).isEmpty()) {
+               return atData;
+            }
          }
       }
 
       return model;
+   }
+
+   /** Whether {@code cell} falls inside the assembly's own reported header extent. */
+   private static boolean isHeaderCell(Region cell, Region firstDataCell) {
+      return cell.row() < firstDataCell.row() || cell.col() < firstDataCell.col();
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -293,6 +293,91 @@ class AssemblyHighlightServiceTest {
                    "must fall forward to (1, 2), the cell getFirstDataCell actually reported");
    }
 
+   /**
+    * PVA-017: a plain {@code Table}'s header cell (0,0) reports a NON-EMPTY field list —
+    * {@code HighlightService.getRefsForVSAssembly}'s Table branch returns the table's entire base
+    * column selection regardless of row/col, unlike a Crosstab's dpath-aware computation — so
+    * {@code fieldNames(model).isEmpty()} never fires and the existing Crosstab fall-forward is
+    * blind to this case. {@code read()} must also check the header extent directly for a Table,
+    * the same way it already works for a Crosstab whose header is genuinely empty.
+    *
+    * <p>Before the fix this returned the header-anchored model (row/col still (0,0)), and a
+    * highlight built from it silently painted the header instead of a data row.
+    */
+   @Test
+   void fallsForwardToADataCellOnATableEvenWhenTheHeaderReportsNonEmptyFields() throws Exception {
+      HighlightDialogModel headerWithFields = model();
+      headerWithFields.setTableAssembly(true);
+
+      HighlightDialogModel dataCell = model();
+      dataCell.setTableAssembly(true);
+      Harness h = harness(headerWithFields);
+      when(h.highlights.getFirstDataCell(anyString(), eq("Table1"), any(Principal.class)))
+         .thenReturn(new int[]{ 1, 0 });
+      when(h.highlights.getHighlightDialogModel(anyString(), anyString(), eq(1), eq(0), any(),
+                                                anyBoolean(), anyBoolean(), any(Principal.class)))
+         .thenReturn(dataCell);
+
+      h.service.list("tok", principal(), "Table1", null);
+
+      verify(h.highlights).getHighlightDialogModel(eq("rt1"), eq("Table1"), eq(1), eq(0), isNull(),
+                                                   eq(false), eq(false), any(Principal.class));
+   }
+
+   /**
+    * PVA-017, {@code applyRow:true} mode: {@code set()} must resolve to the same real data cell
+    * as the non-{@code applyRow} case, not the header — {@code HighlightDialogService} derives its
+    * row-level {@code dataPath} from whatever row/col {@code read()} resolved, so this is the same
+    * upstream defect wearing a different mode.
+    */
+   @Test
+   void resolvesToADataRowOnATableForApplyRowTooEvenWhenTheHeaderReportsNonEmptyFields()
+      throws Exception
+   {
+      HighlightDialogModel headerWithFields = model();
+      headerWithFields.setTableAssembly(true);
+      headerWithFields.setShowRow(true);
+
+      HighlightDialogModel dataCell = model();
+      dataCell.setTableAssembly(true);
+      dataCell.setShowRow(true);
+      Harness h = harness(headerWithFields);
+      when(h.highlights.getFirstDataCell(anyString(), eq("Table1"), any(Principal.class)))
+         .thenReturn(new int[]{ 1, 0 });
+      when(h.highlights.getHighlightDialogModel(anyString(), anyString(), eq(1), eq(0), any(),
+                                                anyBoolean(), anyBoolean(), any(Principal.class)))
+         .thenReturn(dataCell);
+
+      h.service.set("tok", principal(), "Table1", null, highlightApplyRow("RowHighlight"), false,
+                    "");
+
+      verify(h.highlights).setHighlightDialogModel(eq("rt1"), eq("Table1"), eq(dataCell),
+                                                    anyString(), any(Principal.class), any());
+   }
+
+   /**
+    * Control: a Crosstab's already-correct behavior (fall forward only when the header's field
+    * list is actually empty) must be unchanged by the Table-only header-extent check above.
+    */
+   @Test
+   void stillFallsForwardOnACrosstabByTheExistingEmptyFieldsSignal() throws Exception {
+      HighlightDialogModel header = new HighlightDialogModel();
+      header.setFields(new DataRefModel[0]);
+      header.setHighlights(new HighlightModel[0]);
+
+      HighlightDialogModel dataCell = model();
+      Harness h = harness(header);
+      when(h.highlights.getFirstDataCell(anyString(), eq("Crosstab1"), any(Principal.class)))
+         .thenReturn(new int[]{ 1, 1 });
+      when(h.highlights.getHighlightDialogModel(anyString(), anyString(), eq(1), eq(1), any(),
+                                                anyBoolean(), anyBoolean(), any(Principal.class)))
+         .thenReturn(dataCell);
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Crosstab1", null);
+
+      assertEquals(List.of("Region", "Revenue"), listed.get("fields"));
+   }
+
    /** An explicit region is never second-guessed — moving it would highlight the wrong cell. */
    @Test
    void doesNotSecondGuessARegionTheCallerNamed() throws Exception {


### PR DESCRIPTION
## Summary

`set_highlight` (and `list_highlights`/`delete_highlight`) on a plain worksheet-bound `Table`,
called with `row`/`col` omitted, silently resolved to the HEADER cell `(0,0)` instead of falling
forward to a real data cell — for both `applyRow:true` and plain (per-cell) highlight modes.
The identical call shape on a `Crosstab` already works correctly.

Root cause: `AssemblyHighlightService.read()` only falls forward from the header to the first
real data cell when the header cell's `fields` list is empty
(`AssemblyHighlightService.java:290`, pre-fix). That's a reliable "we're on the header" signal
for a `Crosstab` (`HighlightService.getRefsForVSAssembly`'s Crosstab branch is `dpath`-aware and
genuinely returns nothing for a header path), but false for a plain `Table`: its branch
(`HighlightService.java:469-477`) returns the table's entire base column selection regardless of
`row`/`col`/`dpath`, so the header cell's `fields` come back non-empty and the fall-forward never
fires. `model.getRow()/getCol()` stay `(0,0)`, and `HighlightDialogService.updateHighlights`
later derives the stored `TableDataPath` (both the per-cell and the `applyToRowHighlight` paths)
from that same header-anchored row/col.

## Fix

Confined to the agent-only service (`AssemblyHighlightService.read()`), per the diagnosis's
lower-blast-radius option: add a direct header-extent check gated on `model.isTableAssembly()`
(true only for `TableVSAssemblyInfo`, never for `CrosstabVSAssemblyInfo`), comparing the target
cell against the assembly's own reported first-data-cell extent
(`HighlightDialogService.getFirstDataCell`). When a Table's omitted region lands inside the
header, it now falls forward to the real first data cell the same way a Crosstab already does.
`HighlightService.getRefsForVSAssembly` (the shared helper also used by the Composer UI's native
Highlight/Hyperlink dialogs) is untouched — no UI blast radius.

## Test plan

- [x] `AssemblyHighlightServiceTest` — 27/27 pass, including two new regression tests
      (`fallsForwardToADataCellOnATableEvenWhenTheHeaderReportsNonEmptyFields`,
      `resolvesToADataRowOnATableForApplyRowTooEvenWhenTheHeaderReportsNonEmptyFields`) and one
      new control test confirming Crosstab's existing correct behavior is unchanged
      (`stillFallsForwardOnACrosstabByTheExistingEmptyFieldsSignal`).
- [x] Broader regression scope: `AssemblyHighlightServiceTest` +
      `HighlightServiceTest` + `HighlightDialogServiceTest` + `ViewsheetAssemblyAgentControllerTest`
      — 79/79 pass.
- [x] Full `inetsoft.web.wiz.viewsheet` package — 585/585 pass.
- [ ] Live verification against a running StyleBI instance was not possible in this session (no
      `mcp__...composer-chat__*` tools available) — this fix requires a server rebuild+restart to
      take effect, noted as typically a human-driven step.

Diagnosis: `stylebi-wiz` `docs/teams/2026-08-31-test-composer-plugin/case-PVA-017-table-highlight-header-paint/01-diagnosis.md`.
Bug filed as PVA-017 in `docs/bug-reports/plugin-composer-viewsheet-assembly-lifecycle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)