### PR TITLE
Fix PCB-004: set_table_fields/add_table_field silently accept a shelf write with no source table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -74,6 +74,8 @@ public class TableBindingService {
          VSAssembly assembly = vs.getAssembly(assemblyName);
          inetsoft.uql.asset.SourceInfo source = assembly instanceof DataVSAssembly data
             ? data.getSourceInfo() : null;
+         requireSourceForFieldWrite(assemblyName, shelf, source,
+                                    fields == null ? 0 : fields.size());
          TableBindingMutator.setShelf(model, shelf, fields, rvs, source, refModelService);
 
          ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
@@ -218,9 +220,32 @@ public class TableBindingService {
                         FieldRef field, Integer position) throws Exception
    {
       applyWithContext(sessionToken, user, assemblyName,
-         (model, rvs, source) ->
+         (model, rvs, source) -> {
+            requireSourceForFieldWrite(assemblyName, shelf, source, field == null ? 0 : 1);
             TableBindingMutator.addField(model, shelf, field, position, rvs, source,
-                                         refModelService));
+                                         refModelService);
+         });
+   }
+
+   /**
+    * Refuses a non-empty shelf write to an assembly with no source: {@link
+    * TableBindingMutator}'s shelf builders have no source-conditioned branch, so the write would
+    * be applied and reported as success, then render nothing because there is no source to
+    * query. Scoped to callers that add fields to a shelf ({@link #setShelf}/{@link #addField});
+    * {@link #removeField}/{@link #moveField} must not call this — a sourceless assembly can never
+    * have anything on its shelves to remove or move in the first place, once this guard is in
+    * place on the calls that put fields there.
+    */
+   private static void requireSourceForFieldWrite(String assemblyName, String shelf,
+                                                   inetsoft.uql.asset.SourceInfo source,
+                                                   int fieldCount)
+   {
+      if(source == null && fieldCount > 0) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' has no source table yet, so binding " + fieldCount +
+            " field(s) to its '" + shelf + "' shelf would render nothing -- shelves with no " +
+            "source have nothing to query. Call set_table_source first.");
+      }
    }
 
    public void removeField(String sessionToken, Principal user, String assemblyName,

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -337,4 +337,68 @@ class BindingAgentControllerTest {
       assertTrue(thrown.getMessage().contains("Sales"), thrown.getMessage());
       verifyNoInteractions(aestheticService);
    }
+
+   /**
+    * PCB-004: set_table_fields does not go through resolveSourceTable/BindableColumns.requireSource
+    * like the chart callers above -- its own request carries no {@code table} param to resolve
+    * against, so the guard lives directly in {@link TableBindingService#setShelf}. Driven through
+    * a real (not mocked) {@code TableBindingService} to confirm the exception surfaces through the
+    * controller endpoint the plugin actually calls, not just at the service-unit level.
+    */
+   @Test
+   void setTableFieldsRefusesWhenAssemblyHasNoSource() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+
+      inetsoft.uql.viewsheet.CrosstabVSAssembly assembly =
+         mock(inetsoft.uql.viewsheet.CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(null);
+      inetsoft.uql.viewsheet.Viewsheet vs = mock(inetsoft.uql.viewsheet.Viewsheet.class);
+      when(vs.getAssembly("Crosstab1")).thenReturn(assembly);
+      inetsoft.report.composition.RuntimeViewsheet rvs =
+         mock(inetsoft.report.composition.RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      doAnswer(invocation -> {
+         ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+         mutation.run(rvs, "rt1", null);
+         return null;
+      }).when(sessions).mutate(anyString(), any(Principal.class), any());
+
+      inetsoft.web.binding.service.VSBindingService binding =
+         mock(inetsoft.web.binding.service.VSBindingService.class);
+      when(binding.createModel(assembly))
+         .thenReturn(new inetsoft.web.binding.model.table.CrosstabBindingModel());
+
+      TableBindingService tableService = new TableBindingService(
+         sessions, binding, mock(inetsoft.web.binding.controller.VSBindingModelService.class),
+         mock(inetsoft.web.binding.service.DataRefModelFactoryService.class));
+
+      // A plausible column name present on some other worksheet table, with none marked
+      // "current" -- the exact "no source set yet" shape BindableColumns.require() is documented
+      // to let through, so this listing must not be what refuses the write; the assembly's real
+      // SourceInfo is.
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), eq("Crosstab1"), any(Principal.class))).thenReturn(
+         List.of(new inetsoft.web.wiz.binding.model.BindableTable("ORDERS", null,
+            List.of(new inetsoft.web.wiz.binding.model.BindableField("Region", "string", null)))));
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), mock(ChartBindingService.class),
+         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
+         mock(SelectionBindingService.class));
+
+      BindingAgentController.TableShelfRequest request =
+         new BindingAgentController.TableShelfRequest(
+            "Crosstab1", "rows", List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.setTableFields("tok", request, principal()));
+
+      assertTrue(thrown.getMessage().contains("Crosstab1"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("set_table_source"), thrown.getMessage());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -53,8 +53,10 @@ class TableBindingServiceTest {
       CrosstabBindingModel existing = new CrosstabBindingModel();
       existing.getName2Labels().put("Region", "Sales Region");
       VSBindingModelService bindings = mock(VSBindingModelService.class);
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
 
-      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+      harness(assembly, existing, bindings)
          .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
 
       ApplyVSAssemblyInfoEvent event = capture(bindings);
@@ -72,8 +74,10 @@ class TableBindingServiceTest {
    @Test
    void leavesTrapCheckingOn() throws Exception {
       VSBindingModelService bindings = mock(VSBindingModelService.class);
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
 
-      harness(mock(CrosstabVSAssembly.class), new CrosstabBindingModel(), bindings)
+      harness(assembly, new CrosstabBindingModel(), bindings)
          .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
 
       assertTrue(capture(bindings).isCheckTrap());
@@ -99,8 +103,10 @@ class TableBindingServiceTest {
    void addAndRemoveDelegate() throws Exception {
       CrosstabBindingModel existing = new CrosstabBindingModel();
       VSBindingModelService bindings = mock(VSBindingModelService.class);
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
 
-      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+      harness(assembly, existing, bindings)
          .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null);
 
       assertEquals(1, ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
@@ -304,6 +310,104 @@ class TableBindingServiceTest {
          Exception.class,
          () -> service.setShelf("tok", principal(), "Calc1", "rows", List.of(dim("Region"))));
       assertTrue(thrown.getMessage().contains("cell layout"));
+   }
+
+   // ── no-source refusal ─────────────────────────────────────────────────────
+   //
+   // set_table_fields/add_table_field must refuse a non-empty shelf write on an assembly with
+   // no source, rather than silently applying it and rendering nothing — see setSource's javadoc
+   // above for why nothing else here catches this.
+
+   @Test
+   void setShelfRefusesWhenAssemblyHasNoSource() {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(null);
+      TableBindingService service =
+         serviceWith(sessionsFor(assembly), new CrosstabBindingModel(),
+                     mock(VSBindingModelService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region"))));
+      assertTrue(thrown.getMessage().contains("Crosstab1"));
+      assertTrue(thrown.getMessage().contains("set_table_source"));
+   }
+
+   @Test
+   void setShelfClearingAnEmptyShelfIsNotRefusedEvenWithNoSource() throws Exception {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(null);
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(assembly, new CrosstabBindingModel(), bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of());
+
+      assertEquals(0,
+         ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
+   }
+
+   @Test
+   void setShelfProceedsWhenAssemblyHasASource() throws Exception {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(assembly, new CrosstabBindingModel(), bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
+
+      assertEquals(1,
+         ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
+   }
+
+   @Test
+   void addFieldRefusesWhenAssemblyHasNoSource() {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(null);
+      TableBindingService service =
+         serviceWith(sessionsFor(assembly), new CrosstabBindingModel(),
+                     mock(VSBindingModelService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null));
+      assertTrue(thrown.getMessage().contains("Crosstab1"));
+      assertTrue(thrown.getMessage().contains("set_table_source"));
+   }
+
+   @Test
+   void addFieldProceedsWhenAssemblyHasASource() throws Exception {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(assembly, new CrosstabBindingModel(), bindings)
+         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null);
+
+      assertEquals(1,
+         ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
+   }
+
+   /**
+    * The guard is scoped to {@link TableBindingService#setShelf}/{@link
+    * TableBindingService#addField}'s own call sites, not pushed into {@code applyWithContext}
+    * itself — {@link TableBindingService#moveField} shares that plumbing and must not be refused
+    * on a sourceless assembly, since by construction a sourceless assembly's shelves can never
+    * have anything on them to move once setShelf/addField are guarded.
+    */
+   @Test
+   void moveFieldIsNotRefusedEvenWithNoSource() throws Exception {
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(existing, "rows", List.of(dim("Region"), dim("Year")));
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(null);
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(assembly, existing, bindings)
+         .moveField("tok", principal(), "Crosstab1", "rows", "cols", "Year", null);
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals(1, posted.getRows().size());
+      assertEquals(1, posted.getCols().size());
    }
 
    private static CrosstabBindingModel withTables(String... names) {


### PR DESCRIPTION
## Summary

`TableBindingService.setShelf` accepted and applied a non-empty shelf-field write on a crosstab/table assembly whose `SourceInfo` was `null` (no source table set via `set_table_source` yet) — no error, no check. The write silently succeeded and the assembly rendered empty. Unlike PCB-002's 3 fixed callers (`setChartShelf`/`setChartSingleShelf`/`setAestheticField`, which call `resolveSourceTable`/`BindableColumns.requireSource`), `setTableFields` never called that mechanism at all, and its own request (`TableShelfRequest`) carries no `table` parameter to resolve ambiguity from — so the fix is a flat "is a source already set" precondition check rather than a port of `resolveSourceTable`.

`TableBindingService.addField` (`add_table_field`) has the identical unguarded pattern via `applyWithContext`. Fixed in the same PR, with the guard scoped specifically to `addField`'s own call site rather than pushed into the shared `applyWithContext` helper — `removeField`/`moveField` must not get this guard (a sourceless assembly's shelves can never have anything on them to remove/move once `setShelf`/`addField` are guarded), confirmed by a regression test (`moveFieldIsNotRefusedEvenWithNoSource`).

## Root cause

- `BindingAgentController.setTableFields` → `TableBindingService.setShelf` (`core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java`) reads the assembly's real `SourceInfo` and passes it straight into `TableBindingMutator.setShelf` with no null check; the mutator has no source-conditioned branch at all.
- The column-existence check that does run first (`BindableColumns.require`) cannot catch this case by design: with no table marked current, it falls back to matching a column name across every worksheet table.

## Fix

- `TableBindingService.setShelf`: refuse a non-empty field write when `source == null` (empty/clearing writes still allowed).
- `TableBindingService.addField`: same guard, applied only at `addField`'s own call site inside `applyWithContext`'s lambda (not inside `applyWithContext` itself, to avoid regressing `removeField`/`moveField`).
- Updated 3 existing `TableBindingServiceTest` tests that previously passed only because their mocks were unstubbed (defaulting `getSourceInfo()` to `null`) to stub a real `SourceInfo`, so they keep testing what they're meant to test.
- New regression tests: no-source refusal / empty-write carve-out / has-source success for both `setShelf` and `addField`, a `moveField` non-regression test, and a `BindingAgentControllerTest` end-to-end test driving the real (unmocked) `TableBindingService` through the controller endpoint the plugin calls.

Full investigation: `docs/teams/2026-09-01-bugs-composer-groupG/PCB-004/01-diagnosis.md` and `02-refute.md` (verdict: SURVIVED) in the `stylebi-wiz` repo.

## Test plan

- [x] `./mvnw -pl community/core -o test -Dtest=TableBindingServiceTest,BindingAgentControllerTest` — 33 tests, all green