### PR TITLE
Bug #76402, re-sync ThreadLocal-cached Calendars to week.start on every use

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -621,6 +621,7 @@ public class ValueOfColumn extends AbstractColumn {
    private Date getPreQuarterSameWeek(Date date) {
       long weekIndexOfQuarter = getWeekIndexOfQuarter(date);
       Calendar calendar = jcalendars.get();
+      calendar.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
       calendar.setTime(date);
       calendar.add(Calendar.MONTH, -3);
       Date firstWeekOfQuarter = DateComparisonUtil.getQuarterFirstWeek(calendar.getTime(),
@@ -641,6 +642,7 @@ public class ValueOfColumn extends AbstractColumn {
 
    private Date getPreMonthSameWeek(Date date) {
       Calendar calendar = jcalendars.get();
+      calendar.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
       calendar.setTime(date);
       int weekOfMonth = calendar.get(Calendar.WEEK_OF_MONTH);
       calendar.set(Calendar.DATE, 1);
@@ -676,6 +678,11 @@ public class ValueOfColumn extends AbstractColumn {
          }
 
          Calendar jcalendar = jcalendars.get();
+         // jcalendars is a static ThreadLocal, so a pooled thread's Calendar is
+         // constructed once (with the JVM default locale's first day of week) and
+         // reused for the lifetime of the thread across unrelated requests -- it must
+         // be re-synced to the live week.start setting on every use, not just once.
+         jcalendar.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
          int minimalDaysInFirstWeek = jcalendar.getMinimalDaysInFirstWeek();
          jcalendar.setMinimalDaysInFirstWeek(7);
 

--- a/core/src/main/java/inetsoft/report/filter/SortOrder.java
+++ b/core/src/main/java/inetsoft/report/filter/SortOrder.java
@@ -690,6 +690,14 @@ public class SortOrder implements Comparer, Cloneable, Comparator, XConstants {
       Calendar calendar = cal0.get();
       Calendar c1 = cal1.get();
       Calendar c2 = cal2.get();
+      // cal0/cal1/cal2 are static ThreadLocals constructed with Calendar.getInstance() (the
+      // JVM default locale's first day of week) and never re-synced -- without this, a pooled
+      // thread keeps whichever first day of week was in effect (or the JVM default) the first
+      // time it ever ran this comparator, for its entire lifetime, regardless of week.start.
+      int firstDayOfWeek = Tool.getFirstDayOfWeek();
+      calendar.setFirstDayOfWeek(firstDayOfWeek);
+      c1.setFirstDayOfWeek(firstDayOfWeek);
+      c2.setFirstDayOfWeek(firstDayOfWeek);
       int result = 999;
       int year1, month1, day1, hour1, minute1, second1, millisecond1;
       int weekday1, weeks1;

--- a/core/src/main/java/inetsoft/uql/asset/DateRangeRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/DateRangeRef.java
@@ -1409,14 +1409,19 @@ public final class DateRangeRef extends ExpressionRef implements AssetObject,
    };
 
    private static DateTimeProcessor getDateTimeProcessor() {
-      int firstDayOfWeek = Tool.getFirstDayOfWeek();
+      DateTimeProcessor processor = calendars.get();
 
-      if(firstDayOfWeek != DateRangeRef.firstDayOfWeek) {
+      // calendars is a ThreadLocal, so staleness must be tracked per cached instance, not
+      // via a shared static "last known" value -- a single shared flag lets whichever
+      // pooled thread happens to notice the week.start change first mask the change from
+      // every other thread, leaving their own stale per-thread instance uninvalidated
+      // forever.
+      if(processor.getFirstDay() != Tool.getFirstDayOfWeek()) {
          calendars.remove();
-         DateRangeRef.firstDayOfWeek = firstDayOfWeek;
+         processor = calendars.get();
       }
 
-      return calendars.get();
+      return processor;
    }
 
    private static ThreadLocal<DateTimeProcessor> calendars = new ThreadLocal() {
@@ -1435,5 +1440,4 @@ public final class DateRangeRef extends ExpressionRef implements AssetObject,
    private boolean strictDataType = false;
    private Integer forceDcToDateWeekOfMonth;
    private transient String dbversion;
-   private static int firstDayOfWeek = Integer.MIN_VALUE;
 }

--- a/core/src/main/java/inetsoft/uql/asset/DateTimeProcessor.java
+++ b/core/src/main/java/inetsoft/uql/asset/DateTimeProcessor.java
@@ -303,6 +303,15 @@ class DateTimeProcessor {
       return (javaDay - 1) == 0 ? 7 : (javaDay - 1);
    }
 
+   /**
+    * The first day of week (Tool.getFirstDayOfWeek()) this processor was constructed with.
+    * Used by DateRangeRef to detect a stale cached (ThreadLocal) instance after a week.start
+    * change.
+    */
+   int getFirstDay() {
+      return firstDay;
+   }
+
    private long time;
    private int year, month, day, weekday, hour, minute;
    private ZonedDateTime dateTime = ZonedDateTime.now();

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
@@ -401,6 +401,7 @@ public class DateComparisonFormat extends Format {
       Calendar cal = new GregorianCalendar();
       cal.setTime(date);
       cal.setMinimalDaysInFirstWeek(7);
+      cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
 
       // week-of-year is MMW (month and week-of-month)
       if(datePart == Calendar.WEEK_OF_YEAR) {

--- a/core/src/main/java/inetsoft/util/script/CalcDateTime.java
+++ b/core/src/main/java/inetsoft/util/script/CalcDateTime.java
@@ -760,6 +760,10 @@ public class CalcDateTime {
       int option = ((Number) optionobj).intValue();
       double interval = ((Number) intervalobj).doubleValue();
       Calendar cal = CoreTool.calendar.get();
+      // CoreTool.calendar is a shared ThreadLocal never synced to week.start by its own
+      // initialValue() -- must set it before any WEEK_OF_YEAR read, not just before the
+      // WEEK_DATE_GROUP case further below (that was too late: weeks below already needs it).
+      cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
       cal.clear();
       cal.setTime(d);
       int year, month, weeks, day, hour, minute, second, millisecond;


### PR DESCRIPTION
## Summary

Fixes [Bug #76402](https://issues.inetsoft.com/issues/76402) (relates to #75352, Year-SameWeek date comparison data wrong).

Several places cache a `Calendar` (directly or via `DateTimeProcessor`) per-thread in a `static ThreadLocal` for performance, but only partially (or never) re-sync its first-day-of-week setting to the live `week.start` property before computing `WEEK_OF_YEAR`/`WEEK_OF_MONTH` fields. Because thread-pool workers are reused across unrelated requests, a pooled thread keeps whichever first-day-of-week was in effect (or the JVM default) the first time it ever ran the affected code — for its entire lifetime — producing random, persistent, cross-session incorrect week bucketing whenever `week.start` differs from that.

`DateRangeRef.getDateTimeProcessor()` had an additional genuine concurrency bug: it tried to invalidate the calling thread's cached `DateTimeProcessor` by comparing the live `Tool.getFirstDayOfWeek()` against a single **shared static** "last known value" field, while the cache itself is a **per-thread** `ThreadLocal`. Whichever thread noticed a `week.start` change first would update the shared flag, which then made every *other* thread's own comparison falsely pass — permanently masking the change from them. Fixed by tracking staleness per cached instance (`DateTimeProcessor` now exposes the first-day-of-week it was built with) instead of via one JVM-wide flag racing against per-thread state.

- `DateRangeRef` / `DateTimeProcessor`: fixed the shared-static-flag race described above.
- `ValueOfColumn`: DC "previous year/quarter/week" comparison calc never synced its cached calendar at all.
- `SortOrder`: the `WEEK_DATE_GROUP` comparator that decides whether two dates share a week bucket read `WEEK_OF_YEAR` before syncing.
- `CalcDateTime.date()`: the core date-bucketing function synced *after* the bucket index was already computed from the stale value.
- `DateComparisonFormat`: MMWeek-encoded axis label decoding never synced at all.

## Test plan

- [x] Rebuilt `core` and manually reproduced the original bug (rapidly changing `week.start` and reopening/refreshing a Same-Week date comparison chart cycled between a correct rendering and multiple distinct incorrect ones within a handful of reopens).
- [x] Confirmed the fix resolves it under repeated stress-testing (many rapid `week.start` changes + reopens, no incorrect rendering observed).
- [ ] Existing `DCMergeDatePartFilterTest` / `StandardPeriodsTest` suites (not yet re-run in CI as part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)