### PR TITLE
Bug #76401, guard against a null data source registry root in getEntries

### DIFF
--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -1662,7 +1662,8 @@ public class DataSourceRegistry implements MessageListener {
    public AssetEntry[] getEntries(String prefix) {
       ArrayList<AssetEntry> result;
       result = new ArrayList<>();
-      AssetEntry[] allEntries = getRoot().getEntries();
+      AssetFolder root = getRoot();
+      AssetEntry[] allEntries = root == null ? new AssetEntry[0] : root.getEntries();
 
       for(AssetEntry entry : allEntries) {
          if(entry.getPath().startsWith(prefix)) {
@@ -1683,7 +1684,8 @@ public class DataSourceRegistry implements MessageListener {
     */
    public AssetEntry[] getEntries(String prefix, AssetEntry.Type type) {
       ArrayList<AssetEntry> result = new ArrayList<>();
-      AssetEntry[] allEntries = getRoot().getEntries();
+      AssetFolder root = getRoot();
+      AssetEntry[] allEntries = root == null ? new AssetEntry[0] : root.getEntries();
 
       for(AssetEntry entry : allEntries) {
          if(entry.getPath().startsWith(prefix) && entry.getType() == type &&


### PR DESCRIPTION
## Summary

Importing an org-scoped asset export during `storage init` failed with an NPE in `DeployService.importAssets`. This is the community half of the fix; see the enterprise PR for the root cause.

## Root Cause

`DataSourceRegistry.getRoot()` returns `null` when the `QUERY_SCOPE` / `DATA_SOURCE_FOLDER` `"/"` root entry has not been created for the current organization. Both `getEntries()` overloads dereferenced it unconditionally:

```java
AssetEntry[] allEntries = getRoot().getEntries();
```

The resulting NPE propagated into `XPartition.getPartitionNames()` and `XLogicalModel.getLogicalModelNames()`, which catch it, log `Failed to get extended partition/logical model names`, and **return `null`**. Their `updateReference()` callers then do `for(String name : names)` and fail with a second NPE — `Cannot read the array length because "<local2>" is null` — which aborts the import of every `XPARTITION_` and `XLOGICALMODEL_` asset in the zip.

The reason the root was missing in the first place is fixed separately in the enterprise repo.

## Fix

Null-guard both `getEntries()` overloads, returning an empty array when the root is absent. This matches the null tolerance already present elsewhere in the same class — `setObject()` and `getFullNames()` both check `root != null`.

This is defense in depth: with the enterprise fix in place the root always exists on this path. The guard ensures a missing root can never again convert into a hard NPE that aborts an entire import.

## Test Plan

Verified against a real reproduction stack using the enterprise `storage init` container (250 MB / 1620-entry org-scoped export):

- **Control**, image without the fix, gallery zip alone: reproduces the reported failure — 11 x `getRoot() is null`, 4 x `"<local2>" is null`, and 4 failed asset imports (`Examples/Orders^Order View`, `DWH/Assistance_PRD^PV_Assistance`, `Examples/Orders^Order Model`, `DWH/Assistance_PRD^Assistance` — the 2 partitions + 2 logical models).
- **Fixed**, gallery zip alone: `Storage initialized successfully`, exit 0, zero occurrences of `getRoot() is null`, `"<local2>" is null`, `Failed to import asset file`, or `Failed to remove object`.
- **Fixed**, host-org zip + gallery zip, then `server`: both zips import cleanly, server reaches `healthy`, portal returns HTTP 200.

Regression checks:

- `./mvnw test -pl community/core` — 1788 tests, 0 failures, 0 errors, 44 skipped.
- All callers of both `getEntries()` overloads were enumerated (`DataSourceRegistry` internal call sites, `DataSourceService`, `XDataModel`, `XLogicalModel`, `XPartition`). Every one treats the result as an array whose length may legitimately be zero, so returning `new AssetEntry[0]` instead of throwing is safe in each case.

Fixes Redmine #76401.