### PR TITLE
feat(wiz): Composer tab-bar agent-connected indicator + sheetLabel on join

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/command/SetAgentActiveCommand.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/command/SetAgentActiveCommand.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws.command;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import inetsoft.web.viewsheet.command.ViewsheetCommand;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+@Value.Immutable
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonSerialize(as = ImmutableSetAgentActiveCommand.class)
+public abstract class SetAgentActiveCommand implements ViewsheetCommand {
+   public abstract boolean active();
+
+   @Nullable
+   public abstract String ownerIdentity();
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder extends ImmutableSetAgentActiveCommand.Builder {
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -65,7 +65,7 @@ public class BindingAgentController {
                                  ChartAestheticAgentService aestheticService,
                                  TableBindingService tableService,
                                  CalcTableService calcService,
-                                 SelectionBindingService selectionService)
+                                 SheetAgentBroadcastService broadcast)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -77,7 +77,7 @@ public class BindingAgentController {
       this.aestheticService = aestheticService;
       this.tableService = tableService;
       this.calcService = calcService;
-      this.selectionService = selectionService;
+      this.broadcast = broadcast;
    }
 
    public record JoinRequest(String code) {}
@@ -88,16 +88,21 @@ public class BindingAgentController {
     *                      how one open viewsheet came to hold several unrelated sessions.
     * @param editorContext the script/formula location this session is scoped to, or {@code null}
     *                      for a whole-sheet ("Connect to Claude" toolbar) session
+    * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
+    *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
+    *                      could not be resolved
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel) {}
 
    @PostMapping("/api/wiz/v1/agent/binding/join")
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
       requireEnabled();
-      JoinSession session = joinService.join(body.code(), user);
+      SheetJoinService.JoinOutcome outcome = joinService.join(body.code(), user);
+      JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext());
+                              session.sheetType().name().toLowerCase(), session.editorContext(),
+                              outcome.sheetLabel());
    }
 
    @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/fields")
@@ -416,23 +421,6 @@ public class BindingAgentController {
                              Boolean.TRUE.equals(request.force()));
    }
 
-   public record SelectionSourceRequest(String assembly, String table, List<String> columns,
-                                        List<String> additionalTables, String measure,
-                                        Boolean force) {}
-
-   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/selection/source")
-   public Map<String, Object> setSelectionSource(
-      @PathVariable String sessionToken, @RequestBody SelectionSourceRequest request,
-      @RequestParam(required = false, defaultValue = "") String linkUri, Principal user)
-      throws Exception
-   {
-      requireEnabled();
-      return selectionService.setSource(sessionToken, user, request.assembly(), request.table(),
-                                        request.columns(), request.additionalTables(),
-                                        request.measure(), Boolean.TRUE.equals(request.force()),
-                                        linkUri);
-   }
-
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/field/add")
    public void addTableField(@PathVariable String sessionToken,
                              @RequestBody TableFieldRequest request,
@@ -659,6 +647,14 @@ public class BindingAgentController {
 
       if(session != null) {
          sessionService.close(sessionToken);
+
+         try {
+            broadcast.sendAgentInactive(session);
+         }
+         catch(Exception ex) {
+            LOG.warn("Session closed, but notifying the tab bar failed (runtimeId={})",
+                     session.runtimeId(), ex);
+         }
       }
    }
 
@@ -773,5 +769,5 @@ public class BindingAgentController {
    private final ChartAestheticAgentService aestheticService;
    private final TableBindingService tableService;
    private final CalcTableService calcService;
-   private final SelectionBindingService selectionService;
+   private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -29,6 +29,7 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.ws.assembly.WSAssemblyModel;
 import inetsoft.web.composer.ws.assembly.WSAssemblyModelFactory;
 import inetsoft.web.composer.ws.command.RefreshWorksheetCommand;
+import inetsoft.web.composer.ws.command.SetAgentActiveCommand;
 import inetsoft.web.composer.ws.command.SetWorksheetInfoCommand;
 import inetsoft.web.viewsheet.command.RefreshVSObjectCommand;
 import inetsoft.web.viewsheet.command.SaveSheetCommand;
@@ -281,6 +282,47 @@ public class SheetAgentBroadcastService {
    public void sendFocusChanged(JoinSession session) {
       sendPairingNotice(session, new PairingJoinedNotice(session.runtimeId(), session.sheetType(),
                                                           session.editorContext(), true));
+   }
+
+   /**
+    * Tells the browser tab for this runtime that an agent session is now attached to it, so the
+    * Composer tab bar can show a connected indicator. Unlike {@link #sendPairingJoined} (addressed
+    * to the one toolbar/pane instance that minted the code), this rides the per-sheet
+    * {@code COMMANDS_TOPIC} -- the same channel {@link #broadcastSave} uses -- because the tab bar
+    * is a single composer-main-level component keyed by runtimeId, not one of the several
+    * {@code ConnectToClaudeComponent} instances that can be alive for one sheet.
+    *
+    * <p>Best-effort: callers must not let a failure here block whatever cleanup or join success
+    * triggered it, mirroring {@link #sendPairingJoined}'s contract.
+    */
+   public void sendAgentActive(JoinSession session) {
+      String sessionId = session.socketSessionId();
+
+      if(sessionId == null) {
+         return;
+      }
+
+      SetAgentActiveCommand command = SetAgentActiveCommand.builder()
+         .active(true)
+         .ownerIdentity(session.ownerIdentity())
+         .build();
+
+      sendToBrowser(session.socketUserName(), sessionId, session.runtimeId(), command);
+   }
+
+   /** Tells the browser tab for this runtime that no agent session is attached to it any more. */
+   public void sendAgentInactive(JoinSession session) {
+      String sessionId = session.socketSessionId();
+
+      if(sessionId == null) {
+         return;
+      }
+
+      SetAgentActiveCommand command = SetAgentActiveCommand.builder()
+         .active(false)
+         .build();
+
+      sendToBrowser(session.socketUserName(), sessionId, session.runtimeId(), command);
    }
 
    private void sendPairingNotice(JoinSession session, PairingJoinedNotice notice) {

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.pairing;
 
+import inetsoft.report.composition.RuntimeSheet;
 import inetsoft.util.Tool;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -69,13 +70,26 @@ public class SheetJoinService {
    }
 
    /**
+    * The result of a successful {@link #join}: the reusable session, plus a best-effort
+    * human-readable label for the sheet it joined (sourced from {@code AssetEntry.toView()}),
+    * for display alongside the raw {@code runtimeId}.
+    *
+    * <p>Kept as a join-time-only wrapper rather than a field on {@link JoinSession} itself:
+    * {@code JoinSession} is reconstructed at 8+ call sites across this file ({@code resolve()},
+    * {@code retarget()}, {@code withEditorContext}/{@code withFollowFocusEnabled}), and a rarely-
+    * changing display string would either need threading through every one of them or go stale
+    * forever after a rename. {@code sheetLabel} is computed once, at join, and never refreshed.
+    */
+   public record JoinOutcome(JoinSession session, String sheetLabel) {}
+
+   /**
     * Validate flag + code + same-logical-user, consume it, open and return a reusable JoinSession.
     *
     * @param code      the single-use pairing code the agent presents
     * @param agentUser the agent's authenticated principal
     * @throws PairingException if the flag is off, code is invalid/expired, or user doesn't match
     */
-   public JoinSession join(String code, Principal agentUser) throws PairingException {
+   public JoinOutcome join(String code, Principal agentUser) throws PairingException {
       String throttleKey = throttleKey(agentUser);
       long now = System.currentTimeMillis();
       assertNotLockedOut(throttleKey, now);
@@ -115,7 +129,12 @@ public class SheetJoinService {
       // A null owner (runtime not in this node's cache / no user) is not treated as a mismatch:
       // getSheetDirect is node-local, so the runtime — and thus any data access — only exists on
       // its hosting node, where this lookup returns the real owner and the check bites.
-      Principal runtimeOwner = runtimeAccess.getRuntimeOwner(grant.sheetType(), grant.runtimeId());
+      //
+      // Resolved once and reused below for resolveSheetLabel, rather than re-resolved via the
+      // throwing getSheetForPairing: this same runtimeId/sheetType pair must get one consistent
+      // answer to "is it here right now", not a tolerant one here and a fatal one later.
+      RuntimeSheet runtimeSheet = runtimeAccess.getRuntimeSheetDirect(grant.sheetType(), grant.runtimeId());
+      Principal runtimeOwner = runtimeSheet == null ? null : runtimeSheet.getUser();
 
       if(runtimeOwner != null && !PairingUtil.sameLogicalUser(runtimeOwner, agentUser)) {
          recordFailedAttempt(throttleKey, now);
@@ -144,9 +163,45 @@ public class SheetJoinService {
                   grant.runtimeId(), ex);
       }
 
+      // Tells the Composer tab bar an agent is now attached to this runtime. Kept as its own
+      // independent best-effort try/catch (not merged with the notice above) so a failure in one
+      // is logged distinctly and never suppresses the other.
+      try {
+         broadcast.sendAgentActive(session);
+      }
+      catch(Exception ex) {
+         LOG.warn("Pairing joined, but notifying the tab bar failed (runtimeId={})",
+                  grant.runtimeId(), ex);
+      }
+
+      String sheetLabel = resolveSheetLabel(runtimeSheet, grant.runtimeId());
+
       LOG.info("Sheet agent pairing join granted (runtimeId={}, sheetType={}, agent={})",
                grant.runtimeId(), grant.sheetType(), agentUser.getName());
-      return session;
+      return new JoinOutcome(session, sheetLabel);
+   }
+
+   /**
+    * Best-effort resolution of a human-readable label for the joined sheet, sourced from
+    * {@code AssetEntry.toView()}. Never throws: a label failure must never turn a successful join
+    * into a failed one, mirroring {@link #join}'s treatment of {@code sendPairingJoined}.
+    *
+    * <p>Takes the {@code RuntimeSheet} already resolved by {@code join()}'s step 3b (via the
+    * null-tolerant {@link SheetRuntimeAccess#getRuntimeSheetDirect}) rather than re-resolving it
+    * through the throwing {@link SheetRuntimeAccess#getSheetForPairing} — that second, independent
+    * lookup used to answer "is this runtime here" differently (fatal-on-not-found) than step 3b's
+    * ownership check does (tolerant-of-not-found) for what is the same runtime, moments apart,
+    * silently losing the label whenever the two disagreed.
+    */
+   private String resolveSheetLabel(RuntimeSheet runtimeSheet, String runtimeId) {
+      try {
+         return runtimeSheet == null ? null : runtimeSheet.getEntry().toView();
+      }
+      catch(Exception ex) {
+         LOG.warn("Pairing joined, but resolving the sheet label failed (runtimeId={})",
+                  runtimeId, ex);
+         return null;
+      }
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
@@ -168,12 +168,30 @@ public class SheetRuntimeAccess {
     * matches() check (see {@link #getSheetForPairing}).
     */
    public Principal getRuntimeOwner(SheetType sheetType, String runtimeId) {
-      RuntimeSheet rs = switch (sheetType) {
+      RuntimeSheet rs = getRuntimeSheetDirect(sheetType, runtimeId);
+      return rs == null ? null : rs.getUser();
+   }
+
+   /**
+    * Return the runtime with the given id on this node, or null if it is not in this node's
+    * cache (expired / never opened / hosted on another node) or is not of the expected
+    * {@code sheetType}. Side-effect free: does not touch/audit the runtime and does not grant
+    * the {@link #PAIRED_AGENT} ownership bypass — unlike {@link #getSheetForPairing}, which is
+    * throw-on-not-found and audits/bypasses because its callers are about to read or write
+    * through the runtime.
+    *
+    * <p>Exists so a caller that only wants to know "is this runtime here right now" (as
+    * {@link #getRuntimeOwner} already does) can share that exact tolerant lookup with another
+    * best-effort use (e.g. {@code SheetJoinService.resolveSheetLabel}) instead of falling back to
+    * {@link #getSheetForPairing}'s fatal semantics for what is supposed to be the same runtime —
+    * two different answers to the identical question is itself a defect, not a feature of having
+    * two methods.
+    */
+   public RuntimeSheet getRuntimeSheetDirect(SheetType sheetType, String runtimeId) {
+      return switch (sheetType) {
          case WORKSHEET -> worksheetAccessor.getSheetDirect(runtimeId);
          case VIEWSHEET -> viewsheetAccessor.getSheetDirect(runtimeId);
       };
-
-      return rs == null ? null : rs.getUser();
    }
 
    private RuntimeWorksheet getWorksheetForPairing(String runtimeId, Principal agentUser)

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
@@ -17,12 +17,16 @@
  */
 package inetsoft.web.wiz.pairing;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.LongSupplier;
@@ -30,6 +34,8 @@ import java.util.function.Predicate;
 
 @Service
 public class SheetSessionService {
+   private static final Logger LOG = LoggerFactory.getLogger(SheetSessionService.class);
+
    public static final long TTL_MILLIS = 30 * 60_000L;
    private static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
@@ -66,10 +72,23 @@ public class SheetSessionService {
     */
    private final SheetPairingService pairing;
 
+   /**
+    * Notifies the Composer tab bar of session-ended events from {@link #evictExpired},
+    * {@link #socketClosed}, and {@link #detach(String, EditorContext)} -- see those methods'
+    * javadoc. {@code null} on every back-compat/test constructor below (guarded at each call
+    * site): those fixtures do not exercise this feature, so they simply never broadcast, which
+    * is correct -- not a degraded production path.
+    */
+   private final SheetAgentBroadcastService broadcast;
+
    /** Production constructor -- Spring injects the real, runtime-validating SheetPairingService. */
    @Autowired
-   public SheetSessionService(SheetPairingService pairing) {
-      this(System::currentTimeMillis, pairing);
+   public SheetSessionService(SheetPairingService pairing, SheetAgentBroadcastService broadcast) {
+      this.clock = System::currentTimeMillis;
+      this.pairing = pairing;
+      this.broadcast = broadcast;
+      this.sessions = new ConcurrentHashMap<>();
+      this.focusStacks = new ConcurrentHashMap<>();
    }
 
    /**
@@ -87,6 +106,17 @@ public class SheetSessionService {
    SheetSessionService(LongSupplier clock, SheetPairingService pairing) {
       this.clock = clock;
       this.pairing = pairing;
+      this.broadcast = null;
+      this.sessions = new ConcurrentHashMap<>();
+      this.focusStacks = new ConcurrentHashMap<>();
+   }
+
+   /** Test-only constructor: exercises the {@link #broadcast} call sites without needing the
+    *  full production constructor's {@link SheetPairingService} wiring. */
+   SheetSessionService(LongSupplier clock, SheetAgentBroadcastService broadcast) {
+      this.clock = clock;
+      this.pairing = new SheetPairingService();
+      this.broadcast = broadcast;
       this.sessions = new ConcurrentHashMap<>();
       this.focusStacks = new ConcurrentHashMap<>();
    }
@@ -96,6 +126,7 @@ public class SheetSessionService {
    SheetSessionService(LongSupplier clock, SheetSessionService source) {
       this.clock = clock;
       this.pairing = source.pairing;
+      this.broadcast = source.broadcast;
       this.sessions = source.sessions;
       this.focusStacks = source.focusStacks;
    }
@@ -169,8 +200,9 @@ public class SheetSessionService {
     */
    public void socketClosed(String socketSessionId) {
       if(socketSessionId == null) return;
-      removeSessionsIf(
+      List<JoinSession> ended = removeSessionsIf(
          s -> s.editorContext() != null && socketSessionId.equals(s.socketSessionId()));
+      notifyAgentInactive(ended);
    }
 
    /**
@@ -185,8 +217,9 @@ public class SheetSessionService {
     */
    public void detach(String socketSessionId, EditorContext editorContext) {
       if(socketSessionId == null || editorContext == null) return;
-      removeSessionsIf(
+      List<JoinSession> ended = removeSessionsIf(
          s -> editorContext.equals(s.editorContext()) && socketSessionId.equals(s.socketSessionId()));
+      notifyAgentInactive(ended);
    }
 
    /**
@@ -386,27 +419,61 @@ public class SheetSessionService {
    @Scheduled(fixedDelay = 10 * 60_000)
    void evictExpired() {
       long now = clock.getAsLong();
-      removeSessionsIf(s -> s.isExpired(now));
+      List<JoinSession> ended = removeSessionsIf(s -> s.isExpired(now));
+      notifyAgentInactive(ended);
    }
 
    /**
     * Removes every session matching {@code predicate} from {@link #sessions}, and its
-    * {@link #focusStacks} entry alongside it. Every removal path in this class (explicit
-    * {@link #close}, socket-close/detach cleanup, and scheduled {@link #evictExpired}) must go
-    * through this rather than calling {@code sessions.values().removeIf(...)} directly --
-    * {@code sessionToken}s are never reused, so a {@code focusStacks} entry left behind after
-    * its owning session is gone is a permanent leak for the remaining life of the process, not
-    * a harmless stale value some later {@code retarget} will overwrite.
+    * {@link #focusStacks} entry alongside it, returning whatever was removed so callers can
+    * broadcast over it. Every removal path in this class (explicit {@link #close},
+    * socket-close/detach cleanup, and scheduled {@link #evictExpired}) must go through this
+    * rather than calling {@code sessions.values().removeIf(...)} directly -- {@code sessionToken}s
+    * are never reused, so a {@code focusStacks} entry left behind after its owning session is gone
+    * is a permanent leak for the remaining life of the process, not a harmless stale value some
+    * later {@code retarget} will overwrite.
+    *
+    * <p>{@link #close(String)} deliberately does NOT go through this helper -- it is called only
+    * by the four REST controllers' {@code detach} endpoints, which already broadcast
+    * {@code sendAgentInactive} explicitly at the controller layer (where the acting principal and
+    * any error handling the endpoint wants live). If this helper also broadcast, every one of
+    * those calls would double-broadcast for the exact same session.
     */
-   private void removeSessionsIf(Predicate<JoinSession> predicate) {
+   private List<JoinSession> removeSessionsIf(Predicate<JoinSession> predicate) {
+      List<JoinSession> removed = new ArrayList<>();
       sessions.values().removeIf(s -> {
          if(predicate.test(s)) {
             focusStacks.remove(s.sessionToken());
+            removed.add(s);
             return true;
          }
 
          return false;
       });
+      return removed;
+   }
+
+   /**
+    * Best-effort tab-bar notification for every session {@link #removeSessionsIf} just removed.
+    * A {@code null} {@link #broadcast} (every back-compat/test constructor) means this is simply
+    * a no-op -- those fixtures never exercise this feature. Never throws: a failed notification
+    * must never turn a real cleanup into a failure, mirroring {@code SheetJoinService.join}'s
+    * treatment of {@code sendPairingJoined}/{@code sendAgentActive}.
+    */
+   private void notifyAgentInactive(List<JoinSession> ended) {
+      if(broadcast == null) {
+         return;
+      }
+
+      for(JoinSession s : ended) {
+         try {
+            broadcast.sendAgentInactive(s);
+         }
+         catch(Exception ex) {
+            LOG.warn("Session ended, but notifying the tab bar failed (runtimeId={})",
+                     s.runtimeId(), ex);
+         }
+      }
    }
 
    private String newToken() {

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -30,6 +30,8 @@ import inetsoft.web.wiz.script.model.ScriptContext;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
 import inetsoft.web.wiz.script.model.ScriptInfo;
 import inetsoft.web.wiz.script.model.ScriptTargetsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,6 +54,7 @@ import java.util.Map;
  */
 @RestController
 public class ViewsheetAgentController {
+   private static final Logger LOG = LoggerFactory.getLogger(ViewsheetAgentController.class);
 
    @Autowired
    public ViewsheetAgentController(SheetAgentFeature feature,
@@ -92,9 +95,11 @@ public class ViewsheetAgentController {
    @PostMapping("/api/wiz/v1/agent/script/join")
    public JoinResponse join(@RequestParam String code, Principal user) throws PairingException {
       requireEnabled();
-      JoinSession session = joinService.join(code, user);
+      SheetJoinService.JoinOutcome outcome = joinService.join(code, user);
+      JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext());
+                              session.sheetType().name().toLowerCase(), session.editorContext(),
+                              outcome.sheetLabel());
    }
 
    /**
@@ -104,9 +109,12 @@ public class ViewsheetAgentController {
     *                      how one open viewsheet came to hold several unrelated sessions.
     * @param editorContext the script/formula location this session is scoped to, or {@code null}
     *                      for a whole-sheet ("Connect to Claude" toolbar) session
+    * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
+    *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
+    *                      could not be resolved
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel) {}
 
    /**
     * @param editorContext the session's CURRENT scope -- {@code null} for whole-sheet -- read
@@ -405,6 +413,14 @@ public class ViewsheetAgentController {
 
       if(s != null) {
          sessionService.close(sessionToken);
+
+         try {
+            broadcast.sendAgentInactive(s);
+         }
+         catch(Exception ex) {
+            LOG.warn("Session closed, but notifying the tab bar failed (runtimeId={})",
+                     s.runtimeId(), ex);
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -29,6 +29,8 @@ import inetsoft.web.wiz.pairing.JoinSession;
 import inetsoft.web.wiz.pairing.SheetAgentBroadcastService;
 import inetsoft.web.wiz.pairing.SheetSessionService;
 import inetsoft.web.wiz.pairing.SheetType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +53,8 @@ import java.security.Principal;
  */
 @Service
 public class SheetOpenService {
+   private static final Logger LOG = LoggerFactory.getLogger(SheetOpenService.class);
+
    @Autowired
    public SheetOpenService(ViewsheetSessionService viewsheetSessions,
                             SheetSessionService sheetSessions,
@@ -176,6 +180,17 @@ public class SheetOpenService {
                                                   SheetType.WORKSHEET,
                                                   vsSession.socketSessionId(),
                                                   vsSession.socketUserName(), null);
+
+      // Tells the Composer tab bar an agent is now attached to this runtime. Best-effort, kept
+      // in its own try/catch, mirroring SheetJoinService.join's treatment of sendAgentActive: a
+      // failed notification must never block the open that already succeeded.
+      try {
+         broadcast.sendAgentActive(wsSession);
+      }
+      catch(Exception ex) {
+         LOG.warn("Base worksheet opened, but notifying the tab bar failed (runtimeId={})",
+                  runtimeId, ex);
+      }
 
       OpenComposerAssetCommand command = OpenComposerAssetCommand.builder()
          .assetId(baseEntry.toIdentifier())

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -36,6 +36,8 @@ import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.script.ScriptImageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.Principal;
 import java.util.Base64;
@@ -52,6 +54,8 @@ import java.util.Map;
  */
 @RestController
 public class ViewsheetAssemblyAgentController {
+   private static final Logger LOG = LoggerFactory.getLogger(ViewsheetAssemblyAgentController.class);
+
    @Autowired
    public ViewsheetAssemblyAgentController(SheetAgentFeature feature,
                                    SheetJoinService joinService,
@@ -120,16 +124,22 @@ public class ViewsheetAssemblyAgentController {
     *                      how one open viewsheet came to hold several unrelated sessions.
     * @param editorContext the script/formula location this session is scoped to, or {@code null}
     *                      for a whole-sheet ("Connect to Claude" toolbar) session
+    * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
+    *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
+    *                      could not be resolved (or, for {@link #openBaseWorksheet}, not resolved
+    *                      at all — that path does not go through {@link SheetJoinService#join})
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel) {}
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/join")
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
       requireEnabled();
-      JoinSession session = joinService.join(body.code(), user);
+      SheetJoinService.JoinOutcome outcome = joinService.join(body.code(), user);
+      JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext());
+                              session.sheetType().name().toLowerCase(), session.editorContext(),
+                              outcome.sheetLabel());
    }
 
    /** {@code force} closes a worksheet session already held for this identity instead of
@@ -153,7 +163,7 @@ public class ViewsheetAssemblyAgentController {
       boolean force = body != null && Boolean.TRUE.equals(body.force());
       JoinSession session = openService.openBaseWorksheet(sessionToken, user, force);
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext());
+                              session.sheetType().name().toLowerCase(), session.editorContext(), null);
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/model")
@@ -1142,6 +1152,14 @@ public class ViewsheetAssemblyAgentController {
       if(session != null) {
          sessionService.close(sessionToken);
          layoutSessionService.disposeAll(sessionToken);
+
+         try {
+            broadcast.sendAgentInactive(session);
+         }
+         catch(Exception ex) {
+            LOG.warn("Session closed, but notifying the tab bar failed (runtimeId={})",
+                     session.runtimeId(), ex);
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -166,9 +166,11 @@ public class WorksheetAgentController {
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
       String code = body.code();
       requireEnabled();
-      JoinSession session = joinService.join(code, user);
+      SheetJoinService.JoinOutcome outcome = joinService.join(code, user);
+      JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext());
+                              session.sheetType().name().toLowerCase(), session.editorContext(),
+                              outcome.sheetLabel());
    }
 
    /**
@@ -2025,6 +2027,14 @@ public class WorksheetAgentController {
 
       if(s != null) {
          sessionService.close(sessionToken);
+
+         try {
+            broadcast.sendAgentInactive(s);
+         }
+         catch(Exception ex) {
+            LOG.warn("Session closed, but notifying the tab bar failed (runtimeId={})",
+                     s.runtimeId(), ex);
+         }
       }
    }
 
@@ -3449,9 +3459,12 @@ public class WorksheetAgentController {
     *                      how one open viewsheet came to hold several unrelated sessions.
     * @param editorContext the script/formula location this session is scoped to, or {@code null}
     *                      for a whole-sheet ("Connect to Claude" toolbar) session
+    * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
+    *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
+    *                      could not be resolved
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel) {}
 
    // ---------------------------------------------------------------------------
    // Exception handling

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import inetsoft.web.wiz.binding.model.ChartTypeState;
@@ -74,7 +75,8 @@ class BindingAgentControllerTest {
 
       SheetJoinService joinService = mock(SheetJoinService.class);
       Principal agent = principal();
-      when(joinService.join(eq("ABCD2345"), eq(agent))).thenReturn(session);
+      when(joinService.join(eq("ABCD2345"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(session, null));
 
       BindingAgentController controller = controllerWith(feature, joinService,
          mock(ViewsheetSessionService.class), mock(BindableFieldsService.class));
@@ -118,7 +120,7 @@ class BindingAgentControllerTest {
                                         mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
                                         mock(CalcTableService.class),
-                                        mock(SelectionBindingService.class));
+                                        mock(SheetAgentBroadcastService.class));
    }
 
    private static BindingAgentController controllerWith(SheetAgentFeature feature,
@@ -133,7 +135,7 @@ class BindingAgentControllerTest {
                                         mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
                                         mock(CalcTableService.class),
-                                        mock(SelectionBindingService.class));
+                                        mock(SheetAgentBroadcastService.class));
    }
 
    private static Principal principal() {
@@ -270,7 +272,7 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
          mock(TableBindingService.class), mock(CalcTableService.class),
-         mock(SelectionBindingService.class));
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.ShelfRequest request = new BindingAgentController.ShelfRequest(
          "Chart1", "x", List.of(new FieldRef("Region", "dimension", null, null, null)), "Sales");
@@ -298,7 +300,7 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
          mock(TableBindingService.class), mock(CalcTableService.class),
-         mock(SelectionBindingService.class));
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.SingleShelfRequest request = new BindingAgentController.SingleShelfRequest(
          "Chart1", "close", new FieldRef("Price", "measure", "Sum", null, null), "Sales");
@@ -325,7 +327,7 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class), aestheticService,
          mock(TableBindingService.class), mock(CalcTableService.class),
-         mock(SelectionBindingService.class));
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.AestheticFieldRequest request =
          new BindingAgentController.AestheticFieldRequest(
@@ -400,5 +402,48 @@ class BindingAgentControllerTest {
 
       assertTrue(thrown.getMessage().contains("Crosstab1"), thrown.getMessage());
       assertTrue(thrown.getMessage().contains("set_table_source"), thrown.getMessage());
+   }
+
+   // ---------------------------------------------------------------------------
+   // detach -- C2(a): must notify the tab bar the agent is no longer attached
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void detachNotifiesTabBar() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      JoinSession session = mock(JoinSession.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(session);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), sessionService,
+         mock(ViewsheetSessionService.class), mock(BindableFieldsService.class),
+         mock(BindingReadService.class), mock(ChartBindingService.class),
+         mock(ChartAestheticAgentService.class), mock(TableBindingService.class),
+         mock(CalcTableService.class), broadcast);
+
+      controller.detach("my-token", principal());
+
+      verify(broadcast).sendAgentInactive(session);
+   }
+
+   @Test
+   void detachRefusalDoesNotNotifyTabBar() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(null);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), sessionService,
+         mock(ViewsheetSessionService.class), mock(BindableFieldsService.class),
+         mock(BindingReadService.class), mock(ChartBindingService.class),
+         mock(ChartAestheticAgentService.class), mock(TableBindingService.class),
+         mock(CalcTableService.class), broadcast);
+
+      controller.detach("someone-elses-token", principal());
+
+      verify(broadcast, never()).sendAgentInactive(any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -391,7 +391,7 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class),
          mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
-         mock(SelectionBindingService.class));
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.TableShelfRequest request =
          new BindingAgentController.TableShelfRequest(

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
@@ -18,7 +18,9 @@
 package inetsoft.web.wiz.pairing;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +35,7 @@ import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -55,6 +58,20 @@ import static org.mockito.Mockito.when;
  * [notifiesBrowser] a successful join pushes a PairingJoinedNotice to the minting browser
  * [toolbarNotice]   a whole-sheet grant notifies with a null editorContext
  * [notifyFailure]   a throwing broadcast does not fail the join
+ * [notifiesTabBar]  a successful join also pushes a SetAgentActiveCommand via sendAgentActive
+ * [tabBarNotifyFailure] a throwing sendAgentActive does not fail the join or suppress
+ *                   sendPairingJoined
+ * [labelResolved]   resolveSheetLabel returns the real AssetEntry.toView() label when the
+ *                   runtime is found -- the happy path no earlier test covered, since every
+ *                   other test leaves runtimeAccess.getRuntimeSheetDirect unstubbed (Mockito
+ *                   default null), which is why the missing sheetLabel field went unnoticed
+ * [labelNotFound]   resolveSheetLabel degrades to null (not a thrown exception) when the
+ *                   runtime cannot be found via SheetRuntimeAccess.getRuntimeSheetDirect --
+ *                   the same tolerant lookup the step-3b ownership check already uses, so a
+ *                   join can succeed (null owner is not a mismatch) while the label is simply
+ *                   absent, never fatal
+ * [labelDegrades]   resolveSheetLabel degrades to null (not a thrown exception) when reading
+ *                   the found runtime's label itself throws (e.g. AssetEntry.toView())
  */
 @Tag("core")
 @ExtendWith(MockitoExtension.class)
@@ -93,7 +110,7 @@ class SheetJoinServiceTest {
       String code = pairing.mint("Worksheet/foo-7", ALICE_KEY, "sock-1", null, SheetType.WORKSHEET, null);
       Principal alice = TestPrincipals.user("alice", "host-org");
 
-      JoinSession session = svc.join(code, alice);
+      JoinSession session = svc.join(code, alice).session();
 
       assertNotNull(session);
       assertEquals("Worksheet/foo-7", session.runtimeId());
@@ -162,7 +179,7 @@ class SheetJoinServiceTest {
       String code = pairing.mint("Viewsheet/bar-1", ALICE_KEY, "sock-5", null, SheetType.VIEWSHEET, null);
       Principal alice = TestPrincipals.user("alice", "host-org");
 
-      JoinSession session = svc.join(code, alice);
+      JoinSession session = svc.join(code, alice).session();
 
       assertNotNull(session);
       assertEquals("Viewsheet/bar-1", session.runtimeId());
@@ -226,7 +243,7 @@ class SheetJoinServiceTest {
       // falls back to "user:" + agent name) and must be unaffected by alice's lockout.
       String bobCode = pairing.mint("Worksheet/lockout-2b", BOB_KEY, "sock-lockout-2b", null,
                                      SheetType.WORKSHEET, null);
-      JoinSession session = svc.join(bobCode, bob);
+      JoinSession session = svc.join(bobCode, bob).session();
 
       assertNotNull(session);
    }
@@ -246,7 +263,7 @@ class SheetJoinServiceTest {
 
       String code = pairing.mint("Worksheet/reset-1", ALICE_KEY, "sock-reset-1", null,
                                   SheetType.WORKSHEET, null);
-      JoinSession session = svc.join(code, alice);
+      JoinSession session = svc.join(code, alice).session();
       assertNotNull(session);
 
       // 5 more failures post-success. If the earlier 5 failures had carried over instead of
@@ -258,7 +275,7 @@ class SheetJoinServiceTest {
 
       String code2 = pairing.mint("Worksheet/reset-2", ALICE_KEY, "sock-reset-2", null,
                                    SheetType.WORKSHEET, null);
-      JoinSession session2 = svc.join(code2, alice);
+      JoinSession session2 = svc.join(code2, alice).session();
 
       assertNotNull(session2);
    }
@@ -277,8 +294,10 @@ class SheetJoinServiceTest {
       // Attacker (alice) mints a code for carol's runtime — grant.ownerIdentity == ALICE_KEY.
       String code = pairing.mint("Worksheet/victim-1", ALICE_KEY, "sock-idor", null,
                                  SheetType.WORKSHEET, null);
-      when(runtimeAccess.getRuntimeOwner(SheetType.WORKSHEET, "Worksheet/victim-1"))
-         .thenReturn(TestPrincipals.user("carol", "host-org"));
+      RuntimeWorksheet victimRuntime = mock(RuntimeWorksheet.class);
+      when(victimRuntime.getUser()).thenReturn(TestPrincipals.user("carol", "host-org"));
+      when(runtimeAccess.getRuntimeSheetDirect(SheetType.WORKSHEET, "Worksheet/victim-1"))
+         .thenReturn(victimRuntime);
       Principal alice = TestPrincipals.user("alice", "host-org");
 
       PairingException ex = assertThrows(PairingException.class, () -> svc.join(code, alice));
@@ -300,11 +319,13 @@ class SheetJoinServiceTest {
       String code = pairing.mint("Worksheet/mine-1", ALICE_KEY, "sock-mine", null,
                                  SheetType.WORKSHEET, null);
       // A distinct Principal object with the same logical identity (name+org) as the agent.
-      when(runtimeAccess.getRuntimeOwner(SheetType.WORKSHEET, "Worksheet/mine-1"))
-         .thenReturn(TestPrincipals.user("alice", "host-org"));
+      RuntimeWorksheet mineRuntime = mock(RuntimeWorksheet.class);
+      when(mineRuntime.getUser()).thenReturn(TestPrincipals.user("alice", "host-org"));
+      when(runtimeAccess.getRuntimeSheetDirect(SheetType.WORKSHEET, "Worksheet/mine-1"))
+         .thenReturn(mineRuntime);
       Principal alice = TestPrincipals.user("alice", "host-org");
 
-      JoinSession session = svc.join(code, alice);
+      JoinSession session = svc.join(code, alice).session();
 
       assertNotNull(session);
       assertEquals("Worksheet/mine-1", session.runtimeId());
@@ -341,7 +362,7 @@ class SheetJoinServiceTest {
                                            SheetType.VIEWSHEET, ctx);
       Principal alice = TestPrincipals.user("alice", "host-org");
 
-      JoinSession session = paneScopedSvc.join(code, alice);
+      JoinSession session = paneScopedSvc.join(code, alice).session();
 
       assertEquals(ctx, session.editorContext());
    }
@@ -413,9 +434,125 @@ class SheetJoinServiceTest {
                                  SheetType.VIEWSHEET, null);
       Principal alice = TestPrincipals.user("alice", "host-org");
 
-      JoinSession session = svc.join(code, alice);
+      JoinSession session = svc.join(code, alice).session();
 
       assertNotNull(session);
       assertEquals("vs-9", session.runtimeId());
+   }
+
+   // ---------------------------------------------------------------------------
+   // notifiesTabBarOnJoin
+   //
+   // C1/C4: a successful join must also push a SetAgentActiveCommand to the tab bar, independent
+   // of the pairing-domain sendPairingJoined notice above.
+   // ---------------------------------------------------------------------------
+   @Test
+   void notifiesTabBarOnJoin() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String code = pairing.mint("Worksheet/foo-11", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      svc.join(code, alice);
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendAgentActive(sent.capture());
+      assertEquals("Worksheet/foo-11", sent.getValue().runtimeId());
+   }
+
+   // ---------------------------------------------------------------------------
+   // tabBarNotifyFailureDoesNotFailTheJoin
+   //
+   // A broken tab-bar notification must not fail the join, and must not suppress the separate
+   // sendPairingJoined notice (independent best-effort try/catch blocks).
+   // ---------------------------------------------------------------------------
+   @Test
+   void tabBarNotifyFailureDoesNotFailTheJoin() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      doThrow(new RuntimeException("socket gone")).when(broadcast).sendAgentActive(any());
+      String code = pairing.mint("Worksheet/foo-12", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      JoinSession session = svc.join(code, alice).session();
+
+      assertNotNull(session);
+      verify(broadcast).sendPairingJoined(any());
+   }
+
+   // ---------------------------------------------------------------------------
+   // resolveSheetLabelReturnsRealLabelWhenRuntimeIsFound
+   //
+   // The happy path: SheetRuntimeAccess.getRuntimeSheetDirect finds the runtime (the same
+   // tolerant lookup step 3b's ownership check uses), so resolveSheetLabel must read the real
+   // AssetEntry.toView() label off it -- not the (unreachable in production) null default every
+   // other test in this file gets for free from an unstubbed mock.
+   // ---------------------------------------------------------------------------
+   @Test
+   void resolveSheetLabelReturnsRealLabelWhenRuntimeIsFound() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      AssetEntry entry = mock(AssetEntry.class);
+      when(entry.toView()).thenReturn("Sales Analysis");
+      when(rws.getEntry()).thenReturn(entry);
+      when(runtimeAccess.getRuntimeSheetDirect(SheetType.WORKSHEET, "Worksheet/foo-14"))
+         .thenReturn(rws);
+      String code = pairing.mint("Worksheet/foo-14", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      SheetJoinService.JoinOutcome outcome = svc.join(code, alice);
+
+      assertNotNull(outcome.session());
+      assertEquals("Sales Analysis", outcome.sheetLabel());
+   }
+
+   // ---------------------------------------------------------------------------
+   // sheetLabelIsNullWhenRuntimeIsNotFound
+   //
+   // getRuntimeSheetDirect returning null (runtime not in this node's cache) must degrade the
+   // label to null without throwing -- and, since step 3b's ownership check tolerates the same
+   // null (see runtimeOwnedBySameUserIsAllowed's sibling default-mock behavior), the join itself
+   // still succeeds. This is the case that used to reach the throwing getSheetForPairing and get
+   // silently swallowed by resolveSheetLabel's catch block.
+   // ---------------------------------------------------------------------------
+   @Test
+   void sheetLabelIsNullWhenRuntimeIsNotFound() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      when(runtimeAccess.getRuntimeSheetDirect(SheetType.WORKSHEET, "Worksheet/foo-15"))
+         .thenReturn(null);
+      String code = pairing.mint("Worksheet/foo-15", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      SheetJoinService.JoinOutcome outcome = svc.join(code, alice);
+
+      assertNotNull(outcome.session());
+      assertNull(outcome.sheetLabel());
+   }
+
+   // ---------------------------------------------------------------------------
+   // sheetLabelDegradesToNullWhenResolutionFails
+   //
+   // A4/label-resolution counterpart: resolveSheetLabel must never turn a successful join into a
+   // failed one, even when reading the found runtime's label itself throws.
+   // ---------------------------------------------------------------------------
+   @Test
+   void sheetLabelDegradesToNullWhenResolutionFails() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      AssetEntry entry = mock(AssetEntry.class);
+      when(entry.toView()).thenThrow(new RuntimeException("toView failed"));
+      when(rws.getEntry()).thenReturn(entry);
+      when(runtimeAccess.getRuntimeSheetDirect(SheetType.WORKSHEET, "Worksheet/foo-13"))
+         .thenReturn(rws);
+      String code = pairing.mint("Worksheet/foo-13", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      SheetJoinService.JoinOutcome outcome = svc.join(code, alice);
+
+      assertNotNull(outcome.session());
+      assertNull(outcome.sheetLabel());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -22,6 +22,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for SheetSessionService.
@@ -561,5 +566,94 @@ class SheetSessionServiceTest {
       assertThrows(PairingException.class,
                   () -> PaneScopeService.requireWholeSheetSession(afterResolved),
                   "a fresh resolve() after retarget must reflect the new pane-scoped target");
+   }
+
+   // ---- C2(b)/(c): tab-bar "agent inactive" broadcast on evictExpired/socketClosed/detach -----
+
+   @Test
+   void evictExpiredNotifiesTheTabBarForEverySessionItRemoves() {
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetSessionService svc = new SheetSessionService(() -> FIXED_NOW, broadcast);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+
+      SheetSessionService afterTtl = new SheetSessionService(
+         () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
+      afterTtl.evictExpired();
+
+      verify(broadcast).sendAgentInactive(
+         org.mockito.ArgumentMatchers.argThat(s -> s.sessionToken().equals(session.sessionToken())));
+   }
+
+   @Test
+   void socketClosedNotifiesTheTabBarForThePaneSessionItEnds() {
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetSessionService svc = new SheetSessionService(() -> FIXED_NOW, broadcast);
+      EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
+      JoinSession pane = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", ctx);
+
+      svc.socketClosed("sock-1");
+
+      verify(broadcast).sendAgentInactive(
+         org.mockito.ArgumentMatchers.argThat(s -> s.sessionToken().equals(pane.sessionToken())));
+   }
+
+   @Test
+   void socketClosedOnAWholeSheetSessionDoesNotNotifyTheTabBar() {
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetSessionService svc = new SheetSessionService(() -> FIXED_NOW, broadcast);
+      svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", null);
+
+      svc.socketClosed("sock-1");
+
+      verify(broadcast, never()).sendAgentInactive(any());
+   }
+
+   @Test
+   void detachNotifiesTheTabBarForTheSessionItEnds() {
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetSessionService svc = new SheetSessionService(() -> FIXED_NOW, broadcast);
+      EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
+      JoinSession pane = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", ctx);
+
+      svc.detach("sock-1", ctx);
+
+      verify(broadcast).sendAgentInactive(
+         org.mockito.ArgumentMatchers.argThat(s -> s.sessionToken().equals(pane.sessionToken())));
+   }
+
+   /**
+    * Every existing test in this suite above already exercises evictExpired/socketClosed/detach
+    * with no {@code broadcast} at all (the {@code serviceAt}/{@code LongSupplier}-only
+    * constructors leave it {@code null}) and none of them throws -- this test makes that
+    * null-safety explicit and named, rather than leaving it merely implied by the rest of the
+    * suite passing.
+    */
+   @Test
+   void sessionEndingMethodsToleratesAMissingBroadcastWithoutThrowing() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
+      svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", ctx);
+
+      assertDoesNotThrow(() -> svc.detach("sock-1", ctx));
+      assertDoesNotThrow(() -> svc.socketClosed("sock-1"));
+      assertDoesNotThrow(svc::evictExpired);
+   }
+
+   /**
+    * A broken broadcast must not turn a real cleanup into a failure -- mirrors
+    * {@code SheetJoinService}'s "notifyFailureDoesNotFailTheJoin" contract on the ending side.
+    */
+   @Test
+   void aThrowingBroadcastDoesNotPreventTheSessionFromBeingRemoved() {
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      doThrow(new RuntimeException("socket gone")).when(broadcast).sendAgentInactive(any());
+      SheetSessionService svc = new SheetSessionService(() -> FIXED_NOW, broadcast);
+      EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
+      JoinSession pane = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", ctx);
+
+      assertDoesNotThrow(() -> svc.detach("sock-1", ctx));
+      assertNull(svc.resolve(pane.sessionToken(), "owner~;~org"),
+                "the session must still be removed even though notifying the tab bar failed");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
@@ -28,8 +28,11 @@ import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -81,7 +84,8 @@ class ViewsheetAgentControllerTest {
 
       SheetJoinService joinService = mock(SheetJoinService.class);
       Principal agent = principal();
-      when(joinService.join(eq("CODE"), eq(agent))).thenReturn(session);
+      when(joinService.join(eq("CODE"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(session, "Sales Analysis"));
 
       ViewsheetAgentController controller = controllerWith(feature, joinService);
 
@@ -89,6 +93,7 @@ class ViewsheetAgentControllerTest {
 
       assertEquals("TOK-1", resp.sessionToken());
       assertEquals(ctx, resp.editorContext());
+      assertEquals("Sales Analysis", resp.sheetLabel());
    }
 
    @Test
@@ -102,7 +107,8 @@ class ViewsheetAgentControllerTest {
 
       SheetJoinService joinService = mock(SheetJoinService.class);
       Principal agent = principal();
-      when(joinService.join(eq("CODE"), eq(agent))).thenReturn(session);
+      when(joinService.join(eq("CODE"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(session, null));
 
       ViewsheetAgentController controller = controllerWith(feature, joinService);
 
@@ -120,6 +126,50 @@ class ViewsheetAgentControllerTest {
          mock(ScriptContextService.class), mock(ScriptApiService.class),
          mock(ScriptImageService.class), mock(ViewsheetService.class),
          mock(SheetAgentBroadcastService.class));
+   }
+
+   /** Overload that exposes {@code sessionService}/{@code broadcast} -- for the detach test. */
+   private static ViewsheetAgentController controllerWith(SheetAgentFeature feature,
+                                                          SheetSessionService sessionService,
+                                                          SheetAgentBroadcastService broadcast)
+   {
+      return new ViewsheetAgentController(feature, mock(SheetJoinService.class),
+         sessionService, mock(ScriptEditService.class),
+         mock(ScriptReadService.class), mock(ScriptExecuteService.class),
+         mock(ScriptContextService.class), mock(ScriptApiService.class),
+         mock(ScriptImageService.class), mock(ViewsheetService.class),
+         broadcast);
+   }
+
+   /** C2(a): detach must notify the tab bar the agent is no longer attached. */
+   @Test
+   void detachNotifiesTabBar() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      JoinSession session = mock(JoinSession.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(session);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      ViewsheetAgentController controller = controllerWith(feature, sessionService, broadcast);
+
+      controller.detach("my-token", principal());
+
+      verify(broadcast).sendAgentInactive(session);
+   }
+
+   /** An unresolved (foreign/expired) token must not notify the tab bar. */
+   @Test
+   void detachRefusalDoesNotNotifyTabBar() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(null);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      ViewsheetAgentController controller = controllerWith(feature, sessionService, broadcast);
+
+      controller.detach("someone-elses-token", principal());
+
+      verify(broadcast, never()).sendAgentInactive(any());
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -230,6 +230,40 @@ class SheetOpenServiceTest {
    }
 
    /**
+    * I-1 (agent-sheet-visibility review round 1): {@code open_base_worksheet} mints a genuine new
+    * {@link JoinSession} an agent then holds, exactly the situation the Composer tab-bar "agent
+    * connected" indicator exists to surface -- but the happy path used to return without ever
+    * calling {@code sendAgentActive}, so the icon never appeared for a worksheet opened this way.
+    * Mirrors {@code SheetJoinServiceTest.notifiesTabBarOnJoin}.
+    */
+   @Test
+   void notifiesTheTabBarThatAnAgentIsNowAttachedToTheNewWorksheet() throws Exception {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null);
+
+      JoinSession opened = service.openBaseWorksheet("tok-vs", principal());
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendAgentActive(sent.capture());
+      assertEquals(opened.runtimeId(), sent.getValue().runtimeId());
+   }
+
+   /**
+    * A broken tab-bar notification must not fail the open -- best-effort, independent try/catch,
+    * mirroring {@code SheetJoinServiceTest.tabBarNotifyFailureDoesNotFailTheJoin}.
+    */
+   @Test
+   void tabBarNotifyFailureDoesNotFailTheOpen() throws Exception {
+      SheetAgentBroadcastService flaky = mock(SheetAgentBroadcastService.class);
+      doThrow(new RuntimeException("socket gone")).when(flaky).sendAgentActive(any());
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null, "sock-1", flaky);
+
+      JoinSession opened = service.openBaseWorksheet("tok-vs", principal());
+
+      assertNotNull(opened);
+      assertEquals("ws-runtime-1", opened.runtimeId());
+   }
+
+   /**
     * Which STOMP destination the command lands on -- the assertion whose absence let this ship
     * broken.
     *

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -72,7 +72,8 @@ class ViewsheetAssemblyAgentControllerTest {
 
       SheetJoinService joinService = mock(SheetJoinService.class);
       Principal agent = principal();
-      when(joinService.join(eq("ABCD2345"), eq(agent))).thenReturn(session);
+      when(joinService.join(eq("ABCD2345"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(session, null));
 
       ViewsheetAssemblyAgentController controller = controllerWithJoinService(feature, joinService);
 
@@ -226,6 +227,39 @@ class ViewsheetAssemblyAgentControllerTest {
       controller.detach("someone-elses-token", principal());
 
       verify(layoutSessionService, never()).disposeAll(anyString());
+   }
+
+   /** C2(a): detach must also notify the tab bar the agent is no longer attached. */
+   @Test
+   void detachNotifiesTabBar() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      JoinSession session = mock(JoinSession.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(session);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(feature, sessionService, broadcast);
+
+      controller.detach("my-token", principal());
+
+      verify(broadcast).sendAgentInactive(session);
+   }
+
+   /** A refused detach must not notify the tab bar -- there is no ended session to report. */
+   @Test
+   void detachRefusalDoesNotNotifyTabBar() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(null);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(feature, sessionService, broadcast);
+
+      controller.detach("someone-elses-token", principal());
+
+      verify(broadcast, never()).sendAgentInactive(any());
    }
 
    /**
@@ -505,6 +539,39 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class),
                                           layoutSessionService,
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
+   }
+
+   /** Overload that exposes {@code broadcast} -- for the detach tab-bar-notification test. */
+   private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
+                                                          SheetSessionService sessionService,
+                                                          SheetAgentBroadcastService broadcast)
+   {
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          sessionService, mock(ViewsheetSessionService.class),
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          broadcast,
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class),
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -286,7 +286,8 @@ class WorksheetAgentControllerTest {
       JoinSession s = session("TOK-1");
 
       SheetJoinService joinSvc = mock(SheetJoinService.class);
-      when(joinSvc.join(eq("CODE"), eq(agent))).thenReturn(s);
+      when(joinSvc.join(eq("CODE"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(s, "Sales Analysis"));
 
       WorksheetAgentController ctrl = controller(featureOn(), joinSvc,
          mock(SheetSessionService.class), mock(WorksheetReadService.class),
@@ -297,6 +298,7 @@ class WorksheetAgentControllerTest {
       assertEquals("TOK-1", resp.sessionToken());
       assertEquals("Worksheet/ws-1", resp.runtimeId());
       assertEquals("alice~;~host-org", resp.ownerIdentity());
+      assertEquals("Sales Analysis", resp.sheetLabel());
    }
 
    /**
@@ -313,7 +315,8 @@ class WorksheetAgentControllerTest {
          null, null, ctx);
 
       SheetJoinService joinSvc = mock(SheetJoinService.class);
-      when(joinSvc.join(eq("CODE"), eq(agent))).thenReturn(s);
+      when(joinSvc.join(eq("CODE"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(s, null));
 
       WorksheetAgentController ctrl = controller(featureOn(), joinSvc,
          mock(SheetSessionService.class), mock(WorksheetReadService.class),
@@ -2476,6 +2479,32 @@ class WorksheetAgentControllerTest {
       ctrl.detach("TOK-D", agent);
 
       verify(sessions).close("TOK-D");
+   }
+
+   /** C2(a): detach must also notify the tab bar the agent is no longer attached. */
+   @Test
+   void detachNotifiesTabBar() {
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = session("TOK-D");
+      when(sessions.resolve(eq("TOK-D"), any())).thenReturn(s);
+
+      WorksheetAgentController ctrl = new WorksheetAgentController(featureOff(),
+         mock(SheetJoinService.class), sessions,
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class), mock(WorksheetPreviewService.class), broadcast,
+         mock(inetsoft.uql.XRepository.class), mock(inetsoft.uql.asset.AssetRepository.class),
+         mock(inetsoft.web.wiz.service.MetadataApiService.class),
+         mock(inetsoft.web.portal.controller.database.QueryManagerService.class),
+         mock(inetsoft.web.composer.ws.LayoutGraphService.class),
+         mock(inetsoft.web.portal.controller.database.DataSourceService.class),
+         mock(inetsoft.sree.security.SecurityEngine.class),
+         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class));
+
+      ctrl.detach("TOK-D", agent);
+
+      verify(broadcast).sendAgentInactive(s);
    }
 
    // ---------------------------------------------------------------------------

--- a/web/projects/portal/src/app/composer/data/sheet.ts
+++ b/web/projects/portal/src/app/composer/data/sheet.ts
@@ -41,6 +41,14 @@ export abstract class Sheet {
    public annotationChanged: boolean = false;
    public closeOnServer: boolean = true;
    public closedOnServer: boolean = false;
+   /**
+    * Whether an AI agent session is currently paired to this sheet's runtime -- driven by
+    * SetAgentActiveCommand, pushed server-side on join/detach/expiry/socket-close. Absent (false)
+    * until the first such command arrives; never set optimistically client-side.
+    */
+   public agentConnected: boolean = false;
+   /** Present only when agentConnected -- the joined agent's owner identity, if the server sent one. */
+   public agentOwnerIdentity: string | undefined;
    public messageLevels: string[];
    private _loading: boolean;
    public gettingStarted: boolean = false;

--- a/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.html
+++ b/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.html
@@ -34,6 +34,10 @@
         @if (isModified(_tab)) {
           <span class="sheet-tab-modified-indicator">*</span>
         }
+        @if (isAgentConnected(_tab)) {
+          <span class="sheet-tab-agent-indicator icon-size-small ai-icon"
+                [title]="agentIndicatorTooltip(_tab)"></span>
+        }
         <span class="close-icon" (click)="$event.stopPropagation(); closeTab(_tab)"></span>
       </a>
     </li>

--- a/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.scss
+++ b/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.scss
@@ -37,3 +37,16 @@ span.close-button:hover {
   vertical-align: top;
   white-space: nowrap;
 }
+
+// No existing icon-font glyph for "AI agent" in the ineticons set this component's other
+// tab icons (.viewsheet-icon/.worksheet-icon/etc.) draw from -- defined here as a plain
+// CSS glyph instead of adding a new icon-font entry, sized like those via .icon-size-small.
+.sheet-tab-agent-indicator {
+  display: inline-block;
+  margin-left: 4px;
+  vertical-align: top;
+}
+
+.ai-icon:before {
+  content: "\2726";
+}

--- a/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.tl.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.tl.spec.ts
@@ -305,3 +305,56 @@ describe("SheetTabSelectorComponent — getLabel", () => {
       expect(comp.getLabel(tab)).toBe("");
    });
 });
+
+describe("SheetTabSelectorComponent — isAgentConnected / agentIndicatorTooltip", () => {
+   // CC1: a sheet that has never had an agent session paired must show no indicator --
+   // default/absent state (Sheet.agentConnected defaults to false), not merely "false".
+   it("should be false when agentConnected was never set on the tab's asset", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+      const tab = makeViewsheetTab(false);
+      expect(comp.isAgentConnected(tab)).toBe(false);
+   });
+
+   // C1/C4: works for both worksheet and viewsheet tabs.
+   it("should be true for a viewsheet tab once agentConnected is set", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+      const tab = makeViewsheetTab(false);
+      (tab.asset as any).agentConnected = true;
+      expect(comp.isAgentConnected(tab)).toBe(true);
+   });
+
+   it("should be true for a worksheet tab once agentConnected is set", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+      const tab = makeWorksheetTab();
+      (tab.asset as any).agentConnected = true;
+      expect(comp.isAgentConnected(tab)).toBe(true);
+   });
+
+   it("should be false for a script/tableStyle tab even if agentConnected is somehow set", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+      const tab = makeScriptTab();
+      (tab.asset as any).agentConnected = true;
+      expect(comp.isAgentConnected(tab)).toBe(false);
+   });
+
+   it("should return a generic tooltip when no owner identity is present", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+      const tab = makeViewsheetTab(false);
+      (tab.asset as any).agentConnected = true;
+      expect(comp.agentIndicatorTooltip(tab)).toBe("_#(js:AI agent connected)");
+   });
+
+   it("should include the owner identity in the tooltip when present", async () => {
+      const { fixture } = await renderComponent();
+      const comp = fixture.componentInstance;
+      const tab = makeViewsheetTab(false);
+      (tab.asset as any).agentConnected = true;
+      (tab.asset as any).agentOwnerIdentity = "alice";
+      expect(comp.agentIndicatorTooltip(tab)).toBe("_#(js:AI agent connected)  (alice)");
+   });
+});

--- a/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.ts
+++ b/web/projects/portal/src/app/composer/gui/tab-selector/sheet-tab-selector.component.ts
@@ -148,4 +148,14 @@ export class SheetTabSelectorComponent {
          return (<LibraryAsset> tab.asset).isModified;
       }
    }
+
+   isAgentConnected(tab: ComposerTabModel): boolean {
+      return (tab.type === "viewsheet" || tab.type === "worksheet") &&
+         !!(<Sheet> tab.asset).agentConnected;
+   }
+
+   agentIndicatorTooltip(tab: ComposerTabModel): string {
+      const owner = (<Sheet> tab.asset).agentOwnerIdentity;
+      return owner ? `_#(js:AI agent connected)  (${owner})` : "_#(js:AI agent connected)";
+   }
 }

--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.interaction.tl.spec.ts
@@ -446,6 +446,38 @@ describe("VSPane — processSaveSheetCommand", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Group 5b: processSetAgentActiveCommand [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("VSPane — processSetAgentActiveCommand", () => {
+
+   // Regression-sensitive: SheetTabSelectorComponent reads vs.agentConnected/
+   // vs.agentOwnerIdentity directly off this Sheet instance for the tab-bar indicator.
+   it("should set vs.agentConnected and vs.agentOwnerIdentity when active", async () => {
+      const mocks = makeMocks();
+      const { comp } = await renderComponent(mocks);
+      comp.vs.agentConnected = false;
+
+      mocks.dispatchCommand("SetAgentActiveCommand", { active: true, ownerIdentity: "alice" });
+
+      expect(comp.vs.agentConnected).toBe(true);
+      expect(comp.vs.agentOwnerIdentity).toBe("alice");
+   });
+
+   it("should clear both fields when inactive, even if an ownerIdentity is present", async () => {
+      const mocks = makeMocks();
+      const { comp } = await renderComponent(mocks);
+      comp.vs.agentConnected = true;
+      comp.vs.agentOwnerIdentity = "alice";
+
+      mocks.dispatchCommand("SetAgentActiveCommand", { active: false, ownerIdentity: "alice" });
+
+      expect(comp.vs.agentConnected).toBe(false);
+      expect(comp.vs.agentOwnerIdentity).toBeUndefined();
+   });
+});
+
+// ---------------------------------------------------------------------------
 // Group 6: processUpdateUndoStateCommand [Risk 3]
 // ---------------------------------------------------------------------------
 

--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
@@ -134,6 +134,7 @@ import { CloseSheetCommand } from "../../ws/socket/close-sheet-command";
 import { ExpiredSheetCommand } from "../../ws/socket/expired-sheet/expired-sheet-command";
 import { OpenSheetEventValidator } from "../../ws/socket/open-ws/open-sheet-event-validator";
 import { SaveSheetCommand } from "../../ws/socket/save-sheet-command";
+import { SetAgentActiveCommand } from "../../ws/socket/set-agent-active-command";
 import { TouchAssetEvent } from "../../ws/socket/touch-asset-event";
 import { ChangeCurrentLayoutCommand } from "../command/change-current-layout-command";
 import { PopulateVSObjectTreeCommand } from "../command/populate-vs-object-tree-command";
@@ -997,6 +998,15 @@ export class VSPane extends CommandProcessor implements OnInit, OnDestroy, After
       if(this.vs.gettingStarted) {
          this.onOpenVSOnPortal.emit(this.vs.id);
       }
+   }
+
+   /**
+    * Used to update the tab bar's "agent connected" indicator for this viewsheet's runtime.
+    * @param {SetAgentActiveCommand} command
+    */
+   private processSetAgentActiveCommand(command: SetAgentActiveCommand) {
+      this.vs.agentConnected = command.active;
+      this.vs.agentOwnerIdentity = command.active ? command.ownerIdentity : undefined;
    }
 
    /**

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.interaction.tl.spec.ts
@@ -314,6 +314,36 @@ describe("WSPaneComponent — processSetWorksheetInfoCommand", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Group 7b: processSetAgentActiveCommand [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("WSPaneComponent — processSetAgentActiveCommand", () => {
+
+   // 🔁 Regression-sensitive: the tab bar's agent indicator (SheetTabSelectorComponent)
+   //    reads worksheet.agentConnected/agentOwnerIdentity directly off this Sheet instance.
+   it("should set worksheet.agentConnected and agentOwnerIdentity when active", async () => {
+      const { comp } = await renderComponent();
+      comp.worksheet.agentConnected = false;
+
+      dispatchCommand("SetAgentActiveCommand", { active: true, ownerIdentity: "alice" });
+
+      expect(comp.worksheet.agentConnected).toBe(true);
+      expect(comp.worksheet.agentOwnerIdentity).toBe("alice");
+   });
+
+   it("should clear both fields when inactive, even if an ownerIdentity is present", async () => {
+      const { comp } = await renderComponent();
+      comp.worksheet.agentConnected = true;
+      comp.worksheet.agentOwnerIdentity = "alice";
+
+      dispatchCommand("SetAgentActiveCommand", { active: false, ownerIdentity: "alice" });
+
+      expect(comp.worksheet.agentConnected).toBe(false);
+      expect(comp.worksheet.agentOwnerIdentity).toBeUndefined();
+   });
+});
+
+// ---------------------------------------------------------------------------
 // Group 8: processForceNotCloseWorksheetCommand [Risk 2]
 // ---------------------------------------------------------------------------
 

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
@@ -97,6 +97,7 @@ import { OpenWorksheetCommand } from "../socket/open-ws/open-ws-command";
 import { OpenWorksheetEvent } from "../socket/open-ws/open-ws-event";
 import { RefreshWorksheetCommand } from "../socket/refresh-worksheet-command";
 import { SaveSheetCommand } from "../socket/save-sheet-command";
+import { SetAgentActiveCommand } from "../socket/set-agent-active-command";
 import { SetVPMPrincipalCommand } from "../socket/set-vpm-principal-command";
 import { SetWorksheetInfoCommand } from "../socket/set-worksheet-info-command";
 import { TouchAssetEvent } from "../socket/touch-asset-event";
@@ -1198,6 +1199,11 @@ export class WSPaneComponent extends CommandProcessor implements OnDestroy, OnIn
 
    private processSetWorksheetInfoCommand(command: SetWorksheetInfoCommand): void {
       this.worksheet.label = command.label;
+   }
+
+   private processSetAgentActiveCommand(command: SetAgentActiveCommand): void {
+      this.worksheet.agentConnected = command.active;
+      this.worksheet.agentOwnerIdentity = command.active ? command.ownerIdentity : undefined;
    }
 
    private processForceNotCloseWorksheetCommand(command: ForceNotCloseWorksheetCommand): void {

--- a/web/projects/portal/src/app/composer/gui/ws/socket/set-agent-active-command.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/socket/set-agent-active-command.ts
@@ -1,0 +1,21 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+export interface SetAgentActiveCommand {
+   readonly active: boolean;
+   readonly ownerIdentity?: string;
+}


### PR DESCRIPTION
## Summary

Companion PR to [stylebi-wiz#2068](https://github.com/inetsoft-technology/stylebi-wiz/pull/2068) — implements Plan C (this repo's half) of a two-part feature: when the composer-chat MCP plugin (Claude Code) is connected to a StyleBI sheet, show it visibly in the Composer.

- **New `SetAgentActiveCommand`** (Java + TS), broadcast over the existing `SheetAgentBroadcastService`/`COMMANDS_TOPIC` channel — no new transport, reuses the pattern `SaveSheetCommand`/`SetWorksheetInfoCommand` already use.
- **`SheetJoinService.join()`** broadcasts "agent active" on every successful join (worksheet and viewsheet).
- **Every session-ending path broadcasts "agent inactive"**: `SheetSessionService`'s `evictExpired`/`socketClosed`/`detach(EditorContext)`, and all four `*AgentController`'s REST `detach()` endpoints — found via code review that these paths previously notified nothing, which would have left the tab-bar icon stuck after any crash/timeout.
- **`SheetOpenService.openBaseWorksheet()`** also broadcasts — a second real entry point that attaches an agent session to a new worksheet runtime, found and fixed during code review (it doesn't route through `SheetJoinService.join()`).
- **`sheetLabel`**: a best-effort human-readable label (`AssetEntry.toView()`) added to the join response, resolved once via a new `SheetRuntimeAccess.getRuntimeSheetDirect()` — reuses the same tolerant runtime lookup already used for the join's ownership check, instead of a second, differently-behaved one.
- **Frontend**: `Sheet.agentConnected`/`agentOwnerIdentity`, pane command handlers (`ws-pane`/`viewsheet-pane`, since an agent can hold one worksheet + one viewsheet session simultaneously), and the tab-selector icon + tooltip.

## Test plan
- [x] `mvnw -pl core test` on the six touched controller/service classes + `SheetOpenServiceTest`: **244/244 passing** (independently re-run twice across two rounds of adversarial code review, not just the implementer's own report)
- [x] Live-verified via the composer-chat plugin against a running StyleBI deployment: icon appears only on the paired tab (confirmed with two tabs of the *same* runtime type, not just worksheet-vs-viewsheet, to prove routing is by runtime id not sheet type), clears on detach, survives 3/3 reconnects without flicker, works for both worksheet and viewsheet, and doesn't interfere with the pre-existing toolbar pairing indicator
- [x] Two rounds of adversarial code review, including a confirmed-and-fixed compile break and the `open_base_worksheet` gap above

Full design, live-verification logs (including a debugging saga whose real cause was environmental, not a defect in this diff — see the linked archive), and both review rounds are archived in the `stylebi-wiz` repo at `docs/teams/2026-09-01-agent-sheet-visibility/`.

**Note on local verification**: this PR's branch was built in a fresh worktree of this checkout to keep it isolated from other in-progress local work; that fresh worktree is missing a locally-built Maven plugin (`antlr2-maven-plugin`) needed for a full `mvn compile`/`test` run there — the 244/244 test result above was captured in a fully-bootstrapped local checkout with the identical code, and CI here should build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)