### PR TITLE
Bug #76389, keep unclipped comparison-year data in Year/Week Compare-All date comparisons

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -650,8 +650,15 @@ public class DateComparisonUtil {
          // absent (see Bug #76388: DayOfWeek facets 5-7 have real data for every period
          // except the last, and excluding them entirely from every period is wrong; the
          // per-facet sub-chart already correctly shows only the periods that actually have
-         // data for it once this exclusion doesn't run first).
-         final Set<Object> validParts = info.isFacet() ? Collections.emptySet() :
+         // data for it once this exclusion doesn't run first). Also skip this for
+         // "Compare Data Of: All" (isCompareAll()) -- that mode intentionally shows every
+         // part of each comparison period unclipped, so a part the in-progress current
+         // period hasn't reached yet (e.g. December while the current year is only a few
+         // months in) is not an orphan -- it's real historical data for the prior periods
+         // and must still render. Applying the heuristic there silently dropped whole
+         // weeks/months of valid comparison-year data. (Bug #76389)
+         final Set<Object> validParts = info.isFacet() || dcInfo.isCompareAll() ?
+            Collections.emptySet() :
             computeValidParts(data, periodCol, partCol, startDate);
 
          for(Scale scale : egraph.getCoordinate().getScales()) {


### PR DESCRIPTION
## Summary

In a chart with Date Comparison configured as Standard Periods (Previous 2 Years, granularity Week, "Compare Data Of: All"), the legend correctly lists all comparison years (e.g. 2019/2020/2021), but only the most recent year's bars actually rendered — older years' weeks that the current, still-in-progress year hadn't chronologically reached yet (e.g. December) were silently dropped from both the chart and its underlying data.

## Root Cause

`DateComparisonUtil.computeValidParts()` implements an "orphaned cell" heuristic: it collects the set of x-axis part values (e.g. week-of-year) present in the most-recent comparison period's rows, and treats any part value from *any* period that isn't in that set as an orphan to hide — intended to avoid showing a "future" axis position the current, in-progress year hasn't reached yet (see Bug #75351).

This heuristic is invoked from two places:
- `DateComparisonUtil.applyDateRange()`, which applies a `ValidPartsSelector` that actually excludes those rows from the rendered chart.
- `DateComparisonFormat`, which blanks the axis label text for orphaned cells.

For **"Compare Data Of: All"** (`DateComparisonInfo.isCompareAll()`), this is wrong: that mode is defined to show every part of every comparison period unclipped — there's no "as of today" alignment concept. So a week the current year hasn't reached yet is *not* an orphan when a comparison year has real historical data there; it's legitimate data that must render. The heuristic doesn't account for this, so it strips it anyway.

Verified live against the shipped `Year_Week` sample viewsheet: the current year (2021) had only 17 weeks of data (Jan–Apr), so *all* of 2019's and 2020's December weeks — real historical rows well inside the query's date range — were hidden.

## Fix

Skip the orphaned-cell heuristic when `dcInfo.isCompareAll()` is true, in both places it runs:
- `DateComparisonUtil.applyDateRange()`: force `validParts` to an empty set (the existing convention for "no filtering") instead of calling `computeValidParts(...)`.
- `DateComparisonFormat`: added a new `compareAll` constructor parameter (the original constructor now delegates to it with `compareAll=false`, so existing callers/tests are unaffected) and use it in `initPartDate()` the same way.
- `GraphFormatUtil.java`: updated the one production call site to pass `dateComparison.isCompareAll()`.

Added `DateComparisonFormatCompareAllTest` as a regression test.

## Test Plan

- [x] Reproduced the bug live against a running dev server using the shipped `Year_Week` viewsheet (Chart3: Previous 2 Years / Week / Compare All / Change & Value) — confirmed 2019/2020's December weeks were missing before the fix.
- [x] Applied the fix, rebuilt, restarted the server, and confirmed the same chart now renders 2019 (5 December weeks), 2020 (1 December week), and 2021 (17 weeks) correctly.
- [x] New unit test `DateComparisonFormatCompareAllTest` passes.
- [x] Existing related tests (`DateComparisonIntervalConditionTest`, `DcFormatTableLensTest`, `VSChartShowDataServiceTest`) still pass.
- [x] `mvnw clean test-compile -pl core -am` succeeds.

Fixes Redmine #76389.