### PR TITLE
Add create_viewsheet endpoint, widen attach_base_worksheet to logicalModel/physicalTable

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -206,11 +206,21 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
     * Lighter than update() — skips clearCache() and embedded viewsheet processing.
     */
    public void reloadBaseWorksheet(AssetRepository rep, Principal user) throws Exception {
-      if(wentry == null || !wentry.isWorksheet()) {
+      if(wentry == null) {
          return;
       }
 
-      Worksheet ws = (Worksheet) rep.getSheet(wentry, user, true, AssetContent.ALL);
+      Worksheet ws;
+
+      if(wentry.isWorksheet()) {
+         ws = (Worksheet) rep.getSheet(wentry, user, true, AssetContent.ALL);
+      }
+      else if(isDirectSource()) {
+         ws = getWorksheet(rep, wentry, user);
+      }
+      else {
+         return;
+      }
 
       if(ws != null) {
          ws.getWorksheetInfo().setDesignMaxRows(vinfo.getDesignMaxRows());

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -229,6 +229,19 @@ public class SheetOpenService {
             "pairing code and run connect_sheet again.");
       }
 
+      // Same class of bug openBaseWorksheet guards against (see its own guard and comment
+      // above): a pane-scoped session is a write handle for ONE script location, and minting a
+      // new whole-sheet (editorContext = null) session from it -- as the code below does --
+      // would launder that narrow grant into unscoped whole-sheet authority on a runtime the
+      // pane's grant never named. Must come before the runtime is touched or any grant is minted.
+      if(actingSession.editorContext() != null) {
+         throw new IllegalArgumentException(
+            "This session is scoped to one script location, not to the whole sheet, so it cannot " +
+            "create a new viewsheet: doing so would turn a single-expression grant into a whole-sheet " +
+            "write handle. Ask the user to re-pair from the sheet toolbar ('Connect to Claude') and " +
+            "call create_viewsheet from that session.");
+      }
+
       if(actingSession.socketSessionId() == null) {
          throw new IllegalArgumentException(
             "The connected session has no active browser connection to create a viewsheet in; " +

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -17,16 +17,21 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeSheet;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetService;
+import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityProvider;
+import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.command.OpenComposerAssetCommand;
 import inetsoft.web.wiz.pairing.JoinSession;
 import inetsoft.web.wiz.pairing.SheetAgentBroadcastService;
+import inetsoft.web.wiz.pairing.SheetRuntimeAccess;
 import inetsoft.web.wiz.pairing.SheetSessionService;
 import inetsoft.web.wiz.pairing.SheetType;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,13 +61,17 @@ public class SheetOpenService {
                             SheetSessionService sheetSessions,
                             WorksheetService worksheetService,
                             SecurityProvider securityProvider,
-                            SheetAgentBroadcastService broadcast)
+                            SheetAgentBroadcastService broadcast,
+                            ViewsheetService viewsheetService,
+                            SheetRuntimeAccess runtimeAccess)
    {
       this.viewsheetSessions = viewsheetSessions;
       this.sheetSessions = sheetSessions;
       this.worksheetService = worksheetService;
       this.securityProvider = securityProvider;
       this.broadcast = broadcast;
+      this.viewsheetService = viewsheetService;
+      this.runtimeAccess = runtimeAccess;
    }
 
    /**
@@ -190,9 +199,104 @@ public class SheetOpenService {
       return wsSession;
    }
 
+   /**
+    * {@code create_viewsheet}. Mints a brand-new viewsheet runtime bound to {@code dataSource}
+    * (or, when {@code null}, defaults to the acting session's own worksheet), and pairs the
+    * caller to it directly by reusing the ACTING session's already-live browser socket -- the
+    * exact mechanism {@link #openBaseWorksheet} already uses to avoid a second pairing code,
+    * applied in the reverse (worksheet/either sheet type -> new viewsheet) direction.
+    *
+    * <p>Unlike {@link #openBaseWorksheet}, the acting session may be EITHER sheet type -- a
+    * worksheet or a viewsheet -- so it is resolved through the generic, type-agnostic
+    * {@link SheetSessionService#resolve}, not {@link ViewsheetSessionService}.
+    *
+    * @param fromSessionToken the already-paired session (worksheet or viewsheet) whose browser
+    *                         connection the new session reuses
+    * @param dataSource       the worksheet/logical-model/physical-table entry to build from, or
+    *                         {@code null} to default to the acting session's own worksheet (only
+    *                         valid when the acting session IS a worksheet session)
+    * @throws IllegalArgumentException on every refusal, with a message naming the specific
+    *                                  problem and, where there is one, the next tool to call.
+    */
+   public JoinSession createViewsheet(String fromSessionToken, Principal user,
+                                      AssetEntry dataSource) throws Exception
+   {
+      JoinSession actingSession = sheetSessions.resolve(fromSessionToken, agentKey(user));
+
+      if(actingSession == null) {
+         throw new IllegalArgumentException(
+            "Invalid or expired session: " + fromSessionToken + ". Ask the user for a fresh " +
+            "pairing code and run connect_sheet again.");
+      }
+
+      if(actingSession.socketSessionId() == null) {
+         throw new IllegalArgumentException(
+            "The connected session has no active browser connection to create a viewsheet in; " +
+            "ask the user to re-pair (run connect_sheet again) before calling create_viewsheet.");
+      }
+
+      if(dataSource == null) {
+         if(actingSession.sheetType() != SheetType.WORKSHEET) {
+            throw new IllegalArgumentException(
+               "No data source was given and the connected session is not a worksheet, so " +
+               "there is nothing to default to. Pass type/path (and datasource/table for a " +
+               "physical table) naming the source to build the new viewsheet from.");
+         }
+
+         RuntimeSheet actingWs = runtimeAccess.getSheetForPairing(
+            SheetType.WORKSHEET, actingSession.runtimeId(), user);
+         dataSource = actingWs == null ? null : actingWs.getEntry();
+
+         if(dataSource == null || dataSource.getPath() == null) {
+            throw new IllegalArgumentException(
+               "The connected worksheet has not been saved yet, so it has no path to build a " +
+               "viewsheet from. Save it first (save_worksheet), or pass type/path explicitly.");
+         }
+      }
+
+      boolean canCreate = securityProvider.checkPermission(
+         user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS);
+
+      if(!canCreate) {
+         throw new IllegalArgumentException(
+            "You do not have permission to create a viewsheet in the Visual Composer.");
+      }
+
+      String runtimeId = viewsheetService.openTemporaryViewsheet(null, dataSource, user, null);
+
+      // The acting session's own socket/owner, exactly like openBaseWorksheet mints the reverse
+      // direction -- no new pairing code, and the new session is opened whole-sheet (null
+      // editorContext), matching how a freshly-created viewsheet has always been opened.
+      JoinSession vsSession = sheetSessions.open(runtimeId, actingSession.ownerIdentity(),
+                                                  SheetType.VIEWSHEET,
+                                                  actingSession.socketSessionId(),
+                                                  actingSession.socketUserName(), null);
+
+      OpenComposerAssetCommand command = OpenComposerAssetCommand.builder()
+         .assetId(dataSource.toIdentifier())
+         .viewsheet(true)
+         .runtimeId(runtimeId)
+         .build();
+
+      broadcast.sendToComposer(actingSession.socketSessionId(), command);
+
+      return vsSession;
+   }
+
+   private static String agentKey(Principal agent) {
+      if(agent instanceof XPrincipal p) {
+         IdentityID id = IdentityID.getIdentityIDFromKey(p.getName());
+         return id != null ? id.convertToKey() : p.getName();
+      }
+
+      return agent != null ? agent.getName() : null;
+   }
+
    private final ViewsheetSessionService viewsheetSessions;
    private final SheetSessionService sheetSessions;
    private final WorksheetService worksheetService;
    private final SecurityProvider securityProvider;
    private final SheetAgentBroadcastService broadcast;
+   private final ViewsheetService viewsheetService;
+   private final SheetRuntimeAccess runtimeAccess;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -300,6 +300,18 @@ public class SheetOpenService {
                                                   actingSession.socketSessionId(),
                                                   actingSession.socketUserName(), null);
 
+      // Tells the Composer tab bar an agent is now attached to this runtime -- the same
+      // best-effort notification openBaseWorksheet sends for its own attach path (see its own
+      // comment); create_viewsheet is a third real entry point that attaches a session, so it
+      // needs the same call for the tab-bar indicator to be consistent across all three.
+      try {
+         broadcast.sendAgentActive(vsSession);
+      }
+      catch(Exception ex) {
+         LOG.warn("Viewsheet created, but notifying the tab bar failed (runtimeId={})",
+                  runtimeId, ex);
+      }
+
       OpenComposerAssetCommand command = OpenComposerAssetCommand.builder()
          .assetId(dataSource.toIdentifier())
          .viewsheet(true)

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -157,6 +157,82 @@ public class ViewsheetAssemblyAgentController {
                               session.sheetType().name().toLowerCase(), session.editorContext());
    }
 
+   /**
+    * Request body for the create-viewsheet endpoint.
+    *
+    * @param fromSessionToken the already-paired session (worksheet or viewsheet) whose browser
+    *                         connection the new session reuses
+    * @param path             see {@link AttachBaseWorksheetRequest#path}
+    * @param scope            see {@link AttachBaseWorksheetRequest#scope}
+    * @param type             see {@link AttachBaseWorksheetRequest#type}; when this and
+    *                         {@code path}/{@code datasource}/{@code table} are all {@code null},
+    *                         defaults to the acting session's own worksheet (requires the acting
+    *                         session to be a worksheet session)
+    * @param datasource       see {@link AttachBaseWorksheetRequest#datasource}
+    * @param table            see {@link AttachBaseWorksheetRequest#table}
+    */
+   public record CreateViewsheetRequest(String fromSessionToken, String path, String scope,
+                                        String type, String datasource, String table) {}
+
+   /**
+    * {@code create_viewsheet}. Mints a brand-new viewsheet, bound to a worksheet/logical
+    * model/physical table, and pairs the caller to it directly — no new pairing code needed, and
+    * the browser visually follows along in the currently-open Composer window — by reusing the
+    * ALREADY-PAIRED session named by {@code fromSessionToken} (worksheet or viewsheet, either is
+    * accepted). If none of type/path/datasource/table are given, defaults to the acting session's
+    * own worksheet (only valid when that session is a worksheet session that has already been
+    * saved).
+    *
+    * <p>Closes the create half of PVA-007/bug 76332 that {@code attach_base_worksheet} (#4900)
+    * explicitly deferred.</p>
+    *
+    * @throws PairingException naming the specific problem: no acting session, no live browser
+    *                          connection on it, an unresolvable data source, or a permission
+    *                          failure.
+    */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/create")
+   public JoinResponse createViewsheet(@RequestBody CreateViewsheetRequest body, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(!(user instanceof XPrincipal xp)) {
+         throw new PairingException("Cannot create viewsheet: agent principal is not an " +
+                                    "XPrincipal (" + user.getClass().getName() + ")");
+      }
+
+      AssetEntry dataSource = null;
+
+      if(body != null && (body.type() != null || body.path() != null ||
+         body.datasource() != null || body.table() != null))
+      {
+         try {
+            dataSource = resolveDataSourceEntry(body.type(), body.path(), body.scope(),
+               body.datasource(), body.table(), xp,
+               () -> inetsoft.uql.asset.internal.AssetUtil.getAssetRepository(false));
+         }
+         catch(PairingException e) {
+            throw e;
+         }
+         catch(Exception e) {
+            throw new PairingException("Failed to create viewsheet: " + e.getMessage(), e);
+         }
+      }
+
+      JoinSession session;
+
+      try {
+         session = openService.createViewsheet(
+            body == null ? null : body.fromSessionToken(), user, dataSource);
+      }
+      catch(IllegalArgumentException e) {
+         throw new PairingException(e.getMessage(), e);
+      }
+
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase(), session.editorContext());
+   }
+
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/model")
    public ViewsheetModel model(@PathVariable String sessionToken, Principal user)
       throws PairingException
@@ -1024,8 +1100,8 @@ public class ViewsheetAssemblyAgentController {
     *                          never a generic message.
     */
    private AssetEntry resolveDataSourceEntry(String type, String path, String scope,
-                                             String datasource, String table,
-                                             XPrincipal xp, AssetRepository rep)
+                                             String datasource, String table, XPrincipal xp,
+                                             java.util.function.Supplier<AssetRepository> repSupplier)
       throws Exception
    {
       String effectiveType = type == null || type.isBlank() ? "worksheet" : type;
@@ -1050,6 +1126,15 @@ public class ViewsheetAssemblyAgentController {
          // deliberately skips the permission check, which would be wrong here: this is a
          // caller-supplied path naming an arbitrary asset, and only checking existence would let
          // an agent confirm a worksheet's presence/absence without being able to read it.
+         //
+         // repSupplier is not resolved until a validated request actually needs it -- create_
+         // viewsheet's caller resolves a repository via a real (non-mocked, non-trivial) static
+         // lookup that can itself throw when the server isn't fully up, and that failure must
+         // never pre-empt a plain missing-field refusal (confirmed by a failing test: without
+         // this, a physicalTable request missing 'table' surfaced a ShutdownException instead of
+         // the "requires 'table'" message, because the repository was being fetched unconditionally
+         // before any field was even checked).
+         AssetRepository rep = repSupplier.get();
          Object resolved;
 
          try {
@@ -1082,6 +1167,7 @@ public class ViewsheetAssemblyAgentController {
          // null result means either the model does not exist, has no fields, or the caller cannot
          // read it -- all three collapse to the same refusal, matching the worksheet branch's own
          // "not found or no permission" phrasing rather than distinguishing them.
+         AssetRepository rep = repSupplier.get();
          AssetEntry[] probe;
 
          try {
@@ -1110,7 +1196,7 @@ public class ViewsheetAssemblyAgentController {
                "type:\"physicalTable\" requires 'table' naming the physical table.");
          }
 
-         return resolvePhysicalTableEntry(datasource.trim(), table.trim(), xp, rep);
+         return resolvePhysicalTableEntry(datasource.trim(), table.trim(), xp, repSupplier.get());
       }
       else {
          throw new PairingException(
@@ -1235,7 +1321,8 @@ public class ViewsheetAssemblyAgentController {
       try {
          entry = resolveDataSourceEntry(body == null ? null : body.type(),
             body == null ? null : body.path(), body == null ? null : body.scope(),
-            body == null ? null : body.datasource(), body == null ? null : body.table(), xp, rep);
+            body == null ? null : body.datasource(), body == null ? null : body.table(), xp,
+            () -> rep);
       }
       catch(PairingException e) {
          throw e;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
@@ -987,12 +988,207 @@ public class ViewsheetAssemblyAgentController {
    /**
     * Request body for the attach-base-worksheet endpoint.
     *
-    * @param path  path of an existing worksheet asset to attach as this viewsheet's base
-    *              (e.g. {@code "Sample Queries/customers"} or {@code "My Folder/agent_ws_1"}).
-    * @param scope optional scope to resolve {@code path} in — {@code "global"} (default) for the
-    *              shared repository, {@code "user"} for the caller's private folder.
+    * @param path       path of an existing worksheet or logical-model asset to attach as this
+    *                   viewsheet's base (e.g. {@code "Sample Queries/customers"} for a worksheet,
+    *                   {@code "MyDataSource/MyModel"} for a logical model). Not used for
+    *                   {@code type:"physicalTable"} -- use {@code datasource}/{@code table}
+    *                   instead.
+    * @param scope      optional scope to resolve {@code path} in — {@code "global"} (default) for
+    *                   the shared repository, {@code "user"} for the caller's private folder.
+    *                   Ignored for {@code type:"physicalTable"}.
+    * @param type       {@code "worksheet"} (the default, for backward compatibility with every
+    *                   caller that predates this field), {@code "logicalModel"}, or
+    *                   {@code "physicalTable"}. {@code "query"} is a deprecated source type and is
+    *                   not supported here.
+    * @param datasource data source name. Required when {@code type} is {@code "physicalTable"}.
+    * @param table      physical table name within {@code datasource}. Required when {@code type}
+    *                   is {@code "physicalTable"}.
     */
-   public record AttachBaseWorksheetRequest(String path, String scope) {}
+   public record AttachBaseWorksheetRequest(String path, String scope, String type,
+                                            String datasource, String table) {
+      /** Backward-compatible 2-arg form: every pre-existing caller implies type:"worksheet". */
+      public AttachBaseWorksheetRequest(String path, String scope) {
+         this(path, scope, null, null, null);
+      }
+   }
+
+   /**
+    * Resolves a caller-named data source into a permission-checked {@link AssetEntry}, for
+    * whichever of the three source types the agent surface supports: {@code worksheet} (the
+    * default), {@code logicalModel}, or {@code physicalTable}. {@code query}
+    * ({@code AssetEntry.Type.QUERY}) is deliberately not supported — it is a deprecated source
+    * type. Shared by {@link #attachBaseWorksheet} and {@code create_viewsheet} — do not duplicate
+    * this resolution logic elsewhere.
+    *
+    * @throws PairingException naming the specific missing/invalid field or resolution failure —
+    *                          never a generic message.
+    */
+   private AssetEntry resolveDataSourceEntry(String type, String path, String scope,
+                                             String datasource, String table,
+                                             XPrincipal xp, AssetRepository rep)
+      throws Exception
+   {
+      String effectiveType = type == null || type.isBlank() ? "worksheet" : type;
+      IdentityID uname = IdentityID.getIdentityIDFromKey(xp.getName());
+
+      if("worksheet".equals(effectiveType)) {
+         if(path == null || path.isBlank()) {
+            throw new PairingException(
+               "Provide a 'path' naming the worksheet asset to attach " +
+               "(e.g. \"Sample Queries/customers\").");
+         }
+
+         int assetScope = "user".equalsIgnoreCase(scope)
+            ? AssetRepository.USER_SCOPE : AssetRepository.GLOBAL_SCOPE;
+         IdentityID owner = assetScope == AssetRepository.USER_SCOPE ? uname : null;
+         AssetEntry entry = new AssetEntry(assetScope, AssetEntry.Type.WORKSHEET, path.trim(),
+                                           owner, uname.orgID);
+
+         // permission=true so this actually enforces read access, unlike the superficially
+         // similar getSheet(entry, null, false, ...) probe used elsewhere in this codebase for
+         // freshness checks (e.g. ComposerViewsheetService.checkWorksheetChanged) -- that call
+         // deliberately skips the permission check, which would be wrong here: this is a
+         // caller-supplied path naming an arbitrary asset, and only checking existence would let
+         // an agent confirm a worksheet's presence/absence without being able to read it.
+         Object resolved;
+
+         try {
+            resolved = rep.getSheet(entry, xp, true, AssetContent.ALL, false);
+         }
+         catch(Exception e) {
+            throw new PairingException(
+               "no worksheet named '" + path + "' was found, or you lack permission to read it", e);
+         }
+
+         if(resolved == null) {
+            throw new PairingException(
+               "no worksheet named '" + path + "' was found, or you lack permission to read it");
+         }
+
+         return entry;
+      }
+      else if("logicalModel".equals(effectiveType)) {
+         if(path == null || path.isBlank()) {
+            throw new PairingException(
+               "Provide a 'path' naming the logical model, e.g. \"MyDataSource/MyModel\".");
+         }
+
+         AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
+                                           path.trim(), null, uname.orgID);
+
+         // Unlike a worksheet/viewsheet, a logical model is not an AbstractSheet -- rep.getSheet()
+         // does not apply. rep.getEntries(entry, user, ResourceAction.READ) IS the permission +
+         // existence probe here: it is READ-gated by the ResourceAction argument, and an empty/
+         // null result means either the model does not exist, has no fields, or the caller cannot
+         // read it -- all three collapse to the same refusal, matching the worksheet branch's own
+         // "not found or no permission" phrasing rather than distinguishing them.
+         AssetEntry[] probe;
+
+         try {
+            probe = rep.getEntries(entry, xp, ResourceAction.READ);
+         }
+         catch(Exception e) {
+            throw new PairingException(
+               "no logical model named '" + path + "' was found, or you lack permission to read it", e);
+         }
+
+         if(probe == null || probe.length == 0) {
+            throw new PairingException(
+               "no logical model named '" + path + "' was found, or you lack permission to read it");
+         }
+
+         return entry;
+      }
+      else if("physicalTable".equals(effectiveType)) {
+         if(datasource == null || datasource.isBlank()) {
+            throw new PairingException(
+               "type:\"physicalTable\" requires 'datasource' naming the data source.");
+         }
+
+         if(table == null || table.isBlank()) {
+            throw new PairingException(
+               "type:\"physicalTable\" requires 'table' naming the physical table.");
+         }
+
+         return resolvePhysicalTableEntry(datasource.trim(), table.trim(), xp, rep);
+      }
+      else {
+         throw new PairingException(
+            "Unknown type \"" + type + "\" -- must be \"worksheet\", \"logicalModel\", or " +
+            "\"physicalTable\" (\"query\" is a deprecated source type and is not supported here).");
+      }
+   }
+
+   /**
+    * Resolves a physical table by (datasource, table) name to its own {@link AssetEntry}, by
+    * BROWSING the datasource's tree via {@link AssetRepository#getEntries} rather than
+    * hand-constructing a {@code PHYSICAL_TABLE} entry's {@code SourceInfo} properties
+    * (prefix/source/type/catalog/schema/...) — those are populated by the repository's own
+    * JDBC-metadata walk (see {@code AbstractAssetEngine.createPhysicalEntry}) and are not safe to
+    * reproduce by hand: a hand-built entry with the wrong properties would look accepted and
+    * silently render nothing, the same failure class as PWA-006/PWA-007.
+    *
+    * @throws PairingException if no table named {@code table} is found under {@code datasource},
+    *                          or the caller lacks permission to read it
+    */
+   private AssetEntry resolvePhysicalTableEntry(String datasource, String table, XPrincipal xp,
+                                                AssetRepository rep) throws Exception
+   {
+      AssetEntry root = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.DATA_SOURCE,
+                                       datasource, null);
+      AssetEntry found = findPhysicalTableEntry(root, table, xp, rep, 0);
+
+      if(found == null) {
+         throw new PairingException(
+            "no physical table named '" + table + "' was found in data source '" + datasource +
+            "', or you lack permission to read it");
+      }
+
+      return found;
+   }
+
+   /**
+    * Recursively walks a physical-table datasource tree (tables may be nested under
+    * catalog/schema folders of arbitrary depth) looking for a leaf table entry matching
+    * {@code table} by name. {@code depth} bounds the walk against a structurally malformed tree
+    * (e.g. a folder reporting itself as its own child) rather than looping forever — a real
+    * datasource tree is never this deep.
+    */
+   private AssetEntry findPhysicalTableEntry(AssetEntry folder, String table, XPrincipal xp,
+                                             AssetRepository rep, int depth) throws Exception
+   {
+      if(depth > 10) {
+         throw new PairingException(
+            "physical table lookup for '" + table + "' did not terminate within a reasonable " +
+            "folder depth");
+      }
+
+      AssetEntry[] children = rep.getEntries(folder, xp, ResourceAction.READ);
+
+      if(children == null) {
+         return null;
+      }
+
+      for(AssetEntry child : children) {
+         if(child.isPhysicalTable() &&
+            (table.equals(child.getName()) || table.equals(child.getProperty("source"))))
+         {
+            return child;
+         }
+      }
+
+      for(AssetEntry child : children) {
+         if(child.isFolder() && !child.isPhysicalTable()) {
+            AssetEntry found = findPhysicalTableEntry(child, table, xp, rep, depth + 1);
+
+            if(found != null) {
+               return found;
+            }
+         }
+      }
+
+      return null;
+   }
 
    /**
     * {@code attach_base_worksheet}. Attaches an existing, named worksheet asset as this paired
@@ -1028,47 +1224,24 @@ public class ViewsheetAssemblyAgentController {
             "open_base_worksheet to inspect the current one.");
       }
 
-      String path = body != null && body.path() != null ? body.path().trim() : null;
-
-      if(path == null || path.isEmpty()) {
-         throw new PairingException("Provide a 'path' naming the worksheet asset to attach " +
-                                    "(e.g. \"Sample Queries/customers\").");
-      }
-
       if(!(user instanceof XPrincipal xp)) {
          throw new PairingException("Cannot attach base worksheet: agent principal is not an " +
                                     "XPrincipal (" + user.getClass().getName() + ")");
       }
 
-      IdentityID uname = IdentityID.getIdentityIDFromKey(user.getName());
-      int assetScope = body.scope() != null && "user".equalsIgnoreCase(body.scope())
-         ? AssetRepository.USER_SCOPE
-         : AssetRepository.GLOBAL_SCOPE;
-      IdentityID owner = assetScope == AssetRepository.USER_SCOPE ? uname : null;
-      AssetEntry entry = new AssetEntry(assetScope, AssetEntry.Type.WORKSHEET, path,
-                                        owner, uname.orgID);
-
       AssetRepository rep = rvs.getAssetRepository();
-
-      // permission=true so this actually enforces read access, unlike the superficially similar
-      // getSheet(entry, null, false, ...) probe used elsewhere in this codebase for freshness
-      // checks (e.g. ComposerViewsheetService.checkWorksheetChanged) -- that call deliberately
-      // skips the permission check, which would be wrong here: this is a caller-supplied path
-      // naming an arbitrary asset, and only checking existence would let an agent confirm a
-      // worksheet's presence/absence without being able to read it.
-      Object resolved;
+      AssetEntry entry;
 
       try {
-         resolved = rep.getSheet(entry, xp, true, AssetContent.ALL, false);
+         entry = resolveDataSourceEntry(body == null ? null : body.type(),
+            body == null ? null : body.path(), body == null ? null : body.scope(),
+            body == null ? null : body.datasource(), body == null ? null : body.table(), xp, rep);
+      }
+      catch(PairingException e) {
+         throw e;
       }
       catch(Exception e) {
-         throw new PairingException(
-            "no worksheet named '" + path + "' was found, or you lack permission to read it", e);
-      }
-
-      if(resolved == null) {
-         throw new PairingException(
-            "no worksheet named '" + path + "' was found, or you lack permission to read it");
+         throw new PairingException("Failed to attach base worksheet: " + e.getMessage(), e);
       }
 
       try {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -239,8 +239,11 @@ public class ViewsheetAssemblyAgentController {
          throw new PairingException(e.getMessage(), e);
       }
 
+      // sheetLabel: null, same as openBaseWorksheet -- the newly-created viewsheet is untitled and
+      // unsaved, so there is no resolvable human-readable identity for it yet.
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext());
+                              session.sheetType().name().toLowerCase(), session.editorContext(),
+                              null);
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/model")

--- a/core/src/test/java/inetsoft/uql/viewsheet/ViewsheetTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/ViewsheetTest.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.util.XSourceInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for {@link Viewsheet#reloadBaseWorksheet}. Before this widening, it only
+ * ever populated {@link Viewsheet#getBaseWorksheet()} for a worksheet-type base entry -- a
+ * logical-model or physical-table {@code wentry} silently no-op'd (the guard returned early),
+ * even though {@link Viewsheet#isDirectSource()}/the private {@code getWorksheet} helper already
+ * know how to resolve those two types (used, before this change, only by
+ * {@link Viewsheet#repopulateWorksheet}/{@link Viewsheet#update}).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ViewsheetTest {
+
+   private static AssetEntry columnEntry(String entity, String attribute, String dtype) {
+      AssetEntry col = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.COLUMN,
+                                      entity + "/" + attribute, null);
+      col.setProperty("entity", entity);
+      col.setProperty("attribute", attribute);
+      col.setProperty("dtype", dtype);
+      return col;
+   }
+
+   @Test
+   void reloadBaseWorksheetStillHandlesPlainWorksheet() throws Exception {
+      AssetEntry wentry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+      Viewsheet vs = new Viewsheet(wentry);
+
+      Worksheet ws = new Worksheet();
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(eq(wentry), any(), eq(true), eq(AssetContent.ALL))).thenReturn(ws);
+
+      vs.reloadBaseWorksheet(rep, mock(Principal.class));
+
+      assertNotNull(vs.getBaseWorksheet(), "the pre-existing worksheet-type case must keep working");
+   }
+
+   @Test
+   void reloadBaseWorksheetPopulatesDirectSourceForLogicalModel() throws Exception {
+      AssetEntry wentry = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL, "MyDataSource/MyModel", null);
+      wentry.setProperty("prefix", "MyDataSource");
+      wentry.setProperty("source", "MyModel");
+      wentry.setProperty("type", String.valueOf(XSourceInfo.MODEL));
+      Viewsheet vs = new Viewsheet(wentry);
+
+      // isLogicModel() resolution goes two levels deep: entries of the model itself, then
+      // entries of each of THOSE (Viewsheet.createTableAssembly, entry.isLogicModel() branch).
+      AssetEntry tableLevelEntry = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL, "MyDataSource/MyModel/Orders", null);
+      AssetEntry columnLevelEntry = columnEntry("Orders", "ORDER_ID", "string");
+
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getEntries(eq(wentry), any(), eq(ResourceAction.READ)))
+         .thenReturn(new AssetEntry[] { tableLevelEntry });
+      when(rep.getEntries(eq(tableLevelEntry), any(), eq(ResourceAction.READ)))
+         .thenReturn(new AssetEntry[] { columnLevelEntry });
+
+      vs.reloadBaseWorksheet(rep, mock(Principal.class));
+
+      Worksheet resultWs = vs.getBaseWorksheet();
+      assertNotNull(resultWs, "a logical-model base entry must populate a synthesized worksheet");
+      assertNotNull(resultWs.getAssembly("MyModel"),
+         "the synthesized worksheet should carry one table assembly named after the model");
+   }
+
+   @Test
+   void reloadBaseWorksheetPopulatesDirectSourceForPhysicalTable() throws Exception {
+      AssetEntry wentry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.PHYSICAL_TABLE, "Examples/Orders", null);
+      wentry.setProperty("prefix", "Examples");
+      wentry.setProperty("source", "Orders");
+      wentry.setProperty("type", String.valueOf(XSourceInfo.PHYSICAL_TABLE));
+      Viewsheet vs = new Viewsheet(wentry);
+
+      AssetEntry columnLevelEntry = columnEntry("Orders", "ORDER_ID", "string");
+
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getEntries(eq(wentry), any(), eq(ResourceAction.READ)))
+         .thenReturn(new AssetEntry[] { columnLevelEntry });
+
+      vs.reloadBaseWorksheet(rep, mock(Principal.class));
+
+      Worksheet resultWs = vs.getBaseWorksheet();
+      assertNotNull(resultWs, "a physical-table base entry must populate a synthesized worksheet");
+      assertNotNull(resultWs.getAssembly("Orders"),
+         "the synthesized worksheet should carry one table assembly named after the table");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -406,6 +406,41 @@ class SheetOpenServiceTest {
       assertEquals("vs-runtime-new", sent.runtimeId());
    }
 
+   /**
+    * agent-sheet-visibility: create_viewsheet is a third real entry point that attaches a
+    * session (alongside SheetJoinService.join and openBaseWorksheet), so it needs the same
+    * sendAgentActive notification for the Composer tab-bar "agent connected" indicator to be
+    * consistent across all three. Mirrors notifiesTheTabBarThatAnAgentIsNowAttachedToTheNewWorksheet.
+    */
+   @Test
+   void notifiesTheTabBarThatAnAgentIsNowAttachedToTheNewViewsheet() throws Exception {
+      AssetEntry wsEntry = new AssetEntry(
+         inetsoft.uql.asset.AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
+         "Sample Queries/customers", null);
+      SheetOpenService service = createViewsheetService(SheetType.WORKSHEET, wsEntry, true);
+
+      JoinSession created = service.createViewsheet("tok-acting", principal(), null);
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendAgentActive(sent.capture());
+      assertEquals(created.runtimeId(), sent.getValue().runtimeId());
+   }
+
+   /** A broken tab-bar notification must not fail the create -- best-effort, independent try/catch. */
+   @Test
+   void tabBarNotifyFailureDoesNotFailTheCreate() throws Exception {
+      AssetEntry wsEntry = new AssetEntry(
+         inetsoft.uql.asset.AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
+         "Sample Queries/customers", null);
+      SheetOpenService service = createViewsheetService(SheetType.WORKSHEET, wsEntry, true);
+      doThrow(new RuntimeException("socket gone")).when(broadcast).sendAgentActive(any());
+
+      JoinSession created = service.createViewsheet("tok-acting", principal(), null);
+
+      assertNotNull(created);
+      assertEquals("vs-runtime-new", created.runtimeId());
+   }
+
    @Test
    void createViewsheetAcceptsExplicitDataSourceFromAViewsheetSession() throws Exception {
       AssetEntry lmEntry = new AssetEntry(
@@ -499,6 +534,7 @@ class SheetOpenServiceTest {
          any(), any(AssetEntry.class), any(Principal.class), any());
       verify(sheetSessions, never()).open(anyString(), anyString(), any(SheetType.class),
                                           any(), any(), any());
+      verify(broadcast, never()).sendAgentActive(any());
       verify(broadcast, never()).sendToComposer(anyString(), any());
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -69,6 +69,12 @@ class SheetOpenServiceTest {
    /** Populated by {@code serviceWithBase} so a refusal test can assert NO session was minted. */
    private SheetSessionService sheetSessions;
 
+   /** Populated by {@code serviceWithBase} -- createViewsheet tests stub/verify against this. */
+   private inetsoft.analytic.composition.ViewsheetService viewsheetService;
+
+   /** Populated by {@code serviceWithBase} -- createViewsheet's "default to acting worksheet" tests. */
+   private inetsoft.web.wiz.pairing.SheetRuntimeAccess runtimeAccess;
+
    /**
     * The principal that owns the paired viewsheet runtime — i.e. the user's browser session.
     * Deliberately a different object from {@link #principal()}, the agent: the two are the same
@@ -323,7 +329,9 @@ class SheetOpenServiceTest {
 
       SheetOpenService service = new SheetOpenService(
          viewsheetSessions, realSessions, realWorksheetService, securityProvider,
-         mock(SheetAgentBroadcastService.class));
+         mock(SheetAgentBroadcastService.class),
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(inetsoft.web.wiz.pairing.SheetRuntimeAccess.class));
 
       JoinSession opened = service.openBaseWorksheet("tok-vs", principal(), true);
 
@@ -336,6 +344,182 @@ class SheetOpenServiceTest {
       JoinSession stillFound = realSessions.findOpen(OWNER, SheetType.WORKSHEET);
       assertNotNull(stillFound);
       assertEquals("ws-runtime-new", stillFound.runtimeId());
+   }
+
+   // ── createViewsheet ──────────────────────────────────────────────────────
+   // create_viewsheet: closes the create half of PVA-007/bug 76332 that PR #4900 explicitly
+   // deferred. Mints a new viewsheet runtime and pairs the caller to it directly, by reusing the
+   // ACTING session's (worksheet or viewsheet) already-live browser socket -- the same
+   // no-new-pairing-code mechanism openBaseWorksheet already uses, in reverse.
+
+   @Test
+   void createViewsheetDefaultsToActingWorksheetWhenNoDataSourceGiven() throws Exception {
+      AssetEntry wsEntry = new AssetEntry(
+         inetsoft.uql.asset.AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
+         "Sample Queries/customers", null);
+      SheetOpenService service = createViewsheetService(SheetType.WORKSHEET, wsEntry, true);
+
+      JoinSession created = service.createViewsheet("tok-acting", principal(), null);
+
+      assertEquals(SheetType.VIEWSHEET, created.sheetType());
+      assertEquals("vs-runtime-new", created.runtimeId());
+      verify(viewsheetService).openTemporaryViewsheet(isNull(), eq(wsEntry),
+         any(Principal.class), isNull());
+      ArgumentCaptor<Object> command = ArgumentCaptor.forClass(Object.class);
+      verify(broadcast).sendToComposer(eq("sock-1"), command.capture());
+      OpenComposerAssetCommand sent = (OpenComposerAssetCommand) command.getValue();
+      assertTrue(sent.viewsheet());
+      assertEquals("vs-runtime-new", sent.runtimeId());
+   }
+
+   @Test
+   void createViewsheetAcceptsExplicitDataSourceFromAViewsheetSession() throws Exception {
+      AssetEntry lmEntry = new AssetEntry(
+         inetsoft.uql.asset.AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
+         "MyDataSource/MyModel", null);
+      // acting session is a VIEWSHEET session -- proves the explicit-dataSource path does not
+      // require the acting session to be a worksheet, unlike the defaulting path.
+      SheetOpenService service = createViewsheetService(SheetType.VIEWSHEET, null, true);
+
+      JoinSession created = service.createViewsheet("tok-acting", principal(), lmEntry);
+
+      assertEquals(SheetType.VIEWSHEET, created.sheetType());
+      verify(viewsheetService).openTemporaryViewsheet(isNull(), eq(lmEntry),
+         any(Principal.class), isNull());
+      verify(runtimeAccess, never()).getSheetForPairing(any(), any(), any());
+   }
+
+   @Test
+   void createViewsheetRefusesWhenActingSessionIsUnresolvable() {
+      SheetOpenService service = createViewsheetService(SheetType.WORKSHEET, null, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createViewsheet("not-a-real-token", principal(), null));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("invalid or expired"),
+                thrown.getMessage());
+   }
+
+   @Test
+   void createViewsheetRefusesWhenActingSessionHasNoSocket() {
+      AssetEntry wsEntry = new AssetEntry(
+         inetsoft.uql.asset.AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
+         "Sample Queries/customers", null);
+      SheetOpenService service = createViewsheetService(SheetType.WORKSHEET, wsEntry, true, null);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createViewsheet("tok-acting", principal(), null));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("browser connection"),
+                thrown.getMessage());
+   }
+
+   @Test
+   void createViewsheetRefusesWhenNoDataSourceAndActingSessionIsNotWorksheet() {
+      SheetOpenService service = createViewsheetService(SheetType.VIEWSHEET, null, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createViewsheet("tok-acting", principal(), null));
+
+      assertTrue(thrown.getMessage().contains("nothing to default to"), thrown.getMessage());
+   }
+
+   @Test
+   void createViewsheetRefusesWhenActingWorksheetIsUnsaved() {
+      // getEntry() returning null is exactly what an untitled (never-saved) worksheet's own
+      // runtime carries -- there is no repository path yet to build a viewsheet from.
+      SheetOpenService service = createViewsheetService(SheetType.WORKSHEET, null, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createViewsheet("tok-acting", principal(), null));
+
+      assertTrue(thrown.getMessage().contains("has not been saved"), thrown.getMessage());
+   }
+
+   @Test
+   void createViewsheetRefusesWhenTheAgentLacksViewsheetPermission() {
+      AssetEntry lmEntry = new AssetEntry(
+         inetsoft.uql.asset.AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
+         "MyDataSource/MyModel", null);
+      SheetOpenService service = createViewsheetService(SheetType.VIEWSHEET, null, false);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createViewsheet("tok-acting", principal(), lmEntry));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("permission"), thrown.getMessage());
+   }
+
+   /**
+    * Purpose-built harness for {@code createViewsheet} -- {@code openBaseWorksheet}'s own
+    * {@code serviceWithBase} is tailored to that method's very different fixture shape
+    * (viewsheet-session-specific mocks) and is not a good fit here.
+    *
+    * @param actingType     the acting session's own sheet type
+    * @param actingWsEntry  the acting session's own worksheet AssetEntry, as
+    *                       {@code RuntimeSheet.getEntry()} would return it -- only consulted when
+    *                       {@code actingType} is {@code WORKSHEET}; {@code null} simulates an
+    *                       unsaved (untitled) worksheet
+    * @param hasPermission  whether the agent has {@code ResourceType.VIEWSHEET} ACCESS
+    */
+   private SheetOpenService createViewsheetService(SheetType actingType, AssetEntry actingWsEntry,
+                                                    boolean hasPermission)
+   {
+      return createViewsheetService(actingType, actingWsEntry, hasPermission, "sock-1");
+   }
+
+   private SheetOpenService createViewsheetService(SheetType actingType, AssetEntry actingWsEntry,
+                                                    boolean hasPermission, String socketSessionId)
+   {
+      JoinSession actingSession = new JoinSession(
+         "tok-acting", "acting-runtime-1", OWNER, actingType, 0L,
+         SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+         socketSessionId, SOCKET_USER, null);
+
+      SheetSessionService sheetSessions = mock(SheetSessionService.class);
+      this.sheetSessions = sheetSessions;
+      when(sheetSessions.resolve(eq("tok-acting"), eq(OWNER))).thenReturn(actingSession);
+
+      JoinSession newVsSession = new JoinSession(
+         "tok-vs-new", "vs-runtime-new", OWNER, SheetType.VIEWSHEET, 0L,
+         SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+         socketSessionId, SOCKET_USER, null);
+      when(sheetSessions.open(eq("vs-runtime-new"), eq(OWNER), eq(SheetType.VIEWSHEET),
+                              eq(socketSessionId), eq(SOCKET_USER), isNull()))
+         .thenReturn(newVsSession);
+
+      runtimeAccess = mock(inetsoft.web.wiz.pairing.SheetRuntimeAccess.class);
+
+      if(actingType == SheetType.WORKSHEET) {
+         inetsoft.report.composition.RuntimeSheet actingWs =
+            mock(inetsoft.report.composition.RuntimeSheet.class);
+         when(actingWs.getEntry()).thenReturn(actingWsEntry);
+         when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq("acting-runtime-1"),
+                                               any(Principal.class)))
+            .thenReturn(actingWsEntry == null ? null : actingWs);
+      }
+
+      viewsheetService = mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      try {
+         when(viewsheetService.openTemporaryViewsheet(isNull(), any(AssetEntry.class),
+                                                       any(Principal.class), isNull()))
+            .thenReturn("vs-runtime-new");
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      SecurityProvider securityProvider = mock(SecurityProvider.class);
+      when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.VIEWSHEET),
+                                            eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(hasPermission);
+
+      broadcast = mock(SheetAgentBroadcastService.class);
+      worksheetService = mock(WorksheetService.class);
+
+      return new SheetOpenService(mock(ViewsheetSessionService.class), sheetSessions,
+                                  worksheetService, securityProvider, broadcast, viewsheetService,
+                                  runtimeAccess);
    }
 
    // ── harness ───────────────────────────────────────────────────────────────
@@ -434,8 +618,11 @@ class SheetOpenServiceTest {
          broadcast = broadcastService == null
             ? mock(SheetAgentBroadcastService.class) : broadcastService;
 
+         viewsheetService = mock(inetsoft.analytic.composition.ViewsheetService.class);
+         runtimeAccess = mock(inetsoft.web.wiz.pairing.SheetRuntimeAccess.class);
+
          return new SheetOpenService(viewsheetSessions, sheetSessions, worksheetService,
-                                      securityProvider, broadcast);
+                                      securityProvider, broadcast, viewsheetService, runtimeAccess);
       }
       catch(Exception e) {
          throw new IllegalStateException(e);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -436,6 +436,38 @@ class SheetOpenServiceTest {
       assertTrue(thrown.getMessage().contains("has not been saved"), thrown.getMessage());
    }
 
+   /**
+    * Mirrors {@link #refusesAPaneScopedSessionRatherThanMintingAWholeSheetOne} for the reverse
+    * direction: {@code createViewsheet} used to resolve its acting session through the generic,
+    * pane-scope-blind {@link SheetSessionService#resolve} and then mint a brand-new whole-sheet
+    * (editorContext = null) viewsheet session from it -- laundering a single-expression grant
+    * into unscoped whole-sheet write authority on a runtime the pane's grant never named.
+    *
+    * <p>The three {@code never()} assertions are the substance: refusing with a message while
+    * still opening the runtime, or still minting the session, would leave the hole open.
+    */
+   @Test
+   void createViewsheetRefusesAPaneScopedActingSessionRatherThanMintingAWholeSheetOne()
+      throws Exception
+   {
+      SheetOpenService service = createViewsheetService(
+         SheetType.WORKSHEET, null, true, "sock-1",
+         new inetsoft.web.wiz.pairing.EditorContext("assemblyMain", "Chart1", null, null));
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createViewsheet("tok-acting", principal(), null));
+
+      assertTrue(thrown.getMessage().contains("scoped to one script location"),
+                thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("create_viewsheet"), thrown.getMessage());
+
+      verify(viewsheetService, never()).openTemporaryViewsheet(
+         any(), any(AssetEntry.class), any(Principal.class), any());
+      verify(sheetSessions, never()).open(anyString(), anyString(), any(SheetType.class),
+                                          any(), any(), any());
+      verify(broadcast, never()).sendToComposer(anyString(), any());
+   }
+
    @Test
    void createViewsheetRefusesWhenTheAgentLacksViewsheetPermission() {
       AssetEntry lmEntry = new AssetEntry(
@@ -470,11 +502,24 @@ class SheetOpenServiceTest {
    private SheetOpenService createViewsheetService(SheetType actingType, AssetEntry actingWsEntry,
                                                     boolean hasPermission, String socketSessionId)
    {
+      return createViewsheetService(actingType, actingWsEntry, hasPermission, socketSessionId,
+                                    null);
+   }
+
+   /**
+    * @param editorContext the acting session's own scope -- {@code null} for the ordinary
+    *                      whole-sheet session every other test here uses, non-null for the
+    *                      pane-scoped session {@code createViewsheet} must refuse.
+    */
+   private SheetOpenService createViewsheetService(SheetType actingType, AssetEntry actingWsEntry,
+                                                    boolean hasPermission, String socketSessionId,
+                                                    inetsoft.web.wiz.pairing.EditorContext editorContext)
+   {
       try {
          JoinSession actingSession = new JoinSession(
             "tok-acting", "acting-runtime-1", OWNER, actingType, 0L,
             SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
-            socketSessionId, SOCKET_USER, null);
+            socketSessionId, SOCKET_USER, editorContext);
 
          SheetSessionService sheetSessions = mock(SheetSessionService.class);
          this.sheetSessions = sheetSessions;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -470,56 +470,55 @@ class SheetOpenServiceTest {
    private SheetOpenService createViewsheetService(SheetType actingType, AssetEntry actingWsEntry,
                                                     boolean hasPermission, String socketSessionId)
    {
-      JoinSession actingSession = new JoinSession(
-         "tok-acting", "acting-runtime-1", OWNER, actingType, 0L,
-         SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
-         socketSessionId, SOCKET_USER, null);
-
-      SheetSessionService sheetSessions = mock(SheetSessionService.class);
-      this.sheetSessions = sheetSessions;
-      when(sheetSessions.resolve(eq("tok-acting"), eq(OWNER))).thenReturn(actingSession);
-
-      JoinSession newVsSession = new JoinSession(
-         "tok-vs-new", "vs-runtime-new", OWNER, SheetType.VIEWSHEET, 0L,
-         SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
-         socketSessionId, SOCKET_USER, null);
-      when(sheetSessions.open(eq("vs-runtime-new"), eq(OWNER), eq(SheetType.VIEWSHEET),
-                              eq(socketSessionId), eq(SOCKET_USER), isNull()))
-         .thenReturn(newVsSession);
-
-      runtimeAccess = mock(inetsoft.web.wiz.pairing.SheetRuntimeAccess.class);
-
-      if(actingType == SheetType.WORKSHEET) {
-         inetsoft.report.composition.RuntimeSheet actingWs =
-            mock(inetsoft.report.composition.RuntimeSheet.class);
-         when(actingWs.getEntry()).thenReturn(actingWsEntry);
-         when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq("acting-runtime-1"),
-                                               any(Principal.class)))
-            .thenReturn(actingWsEntry == null ? null : actingWs);
-      }
-
-      viewsheetService = mock(inetsoft.analytic.composition.ViewsheetService.class);
-
       try {
+         JoinSession actingSession = new JoinSession(
+            "tok-acting", "acting-runtime-1", OWNER, actingType, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+            socketSessionId, SOCKET_USER, null);
+
+         SheetSessionService sheetSessions = mock(SheetSessionService.class);
+         this.sheetSessions = sheetSessions;
+         when(sheetSessions.resolve(eq("tok-acting"), eq(OWNER))).thenReturn(actingSession);
+
+         JoinSession newVsSession = new JoinSession(
+            "tok-vs-new", "vs-runtime-new", OWNER, SheetType.VIEWSHEET, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+            socketSessionId, SOCKET_USER, null);
+         when(sheetSessions.open(eq("vs-runtime-new"), eq(OWNER), eq(SheetType.VIEWSHEET),
+                                 eq(socketSessionId), eq(SOCKET_USER), isNull()))
+            .thenReturn(newVsSession);
+
+         runtimeAccess = mock(inetsoft.web.wiz.pairing.SheetRuntimeAccess.class);
+
+         if(actingType == SheetType.WORKSHEET) {
+            inetsoft.report.composition.RuntimeSheet actingWs =
+               mock(inetsoft.report.composition.RuntimeSheet.class);
+            when(actingWs.getEntry()).thenReturn(actingWsEntry);
+            when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq("acting-runtime-1"),
+                                                  any(Principal.class)))
+               .thenReturn(actingWsEntry == null ? null : actingWs);
+         }
+
+         viewsheetService = mock(inetsoft.analytic.composition.ViewsheetService.class);
          when(viewsheetService.openTemporaryViewsheet(isNull(), any(AssetEntry.class),
                                                        any(Principal.class), isNull()))
             .thenReturn("vs-runtime-new");
+
+         SecurityProvider securityProvider = mock(SecurityProvider.class);
+         when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.VIEWSHEET),
+                                               eq("*"), eq(ResourceAction.ACCESS)))
+            .thenReturn(hasPermission);
+
+         broadcast = mock(SheetAgentBroadcastService.class);
+         worksheetService = mock(WorksheetService.class);
+
+         return new SheetOpenService(mock(ViewsheetSessionService.class), sheetSessions,
+                                     worksheetService, securityProvider, broadcast,
+                                     viewsheetService, runtimeAccess);
       }
       catch(Exception e) {
          throw new IllegalStateException(e);
       }
-
-      SecurityProvider securityProvider = mock(SecurityProvider.class);
-      when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.VIEWSHEET),
-                                            eq("*"), eq(ResourceAction.ACCESS)))
-         .thenReturn(hasPermission);
-
-      broadcast = mock(SheetAgentBroadcastService.class);
-      worksheetService = mock(WorksheetService.class);
-
-      return new SheetOpenService(mock(ViewsheetSessionService.class), sheetSessions,
-                                  worksheetService, securityProvider, broadcast, viewsheetService,
-                                  runtimeAccess);
    }
 
    // ── harness ───────────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -776,6 +776,78 @@ class ViewsheetAssemblyAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // create_viewsheet -- closes the create half of PVA-007/bug 76332 that
+   // attach_base_worksheet (PR #4900) explicitly deferred.
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void createViewsheetPassesNoDataSourceWhenBodyNamesNone() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      JoinSession created = new JoinSession("tok-vs-new", "vs-runtime-new", "alice~;~host-org",
+         SheetType.VIEWSHEET, 0L, SheetSessionService.TTL_MILLIS,
+         JoinSession.ConnectionMode.PAIRED, "sock-1", "alice-browser", null);
+
+      SheetOpenService openService = mock(SheetOpenService.class);
+      when(openService.createViewsheet(eq("tok-acting"), eq(agent), isNull()))
+         .thenReturn(created);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      ViewsheetAssemblyAgentController.JoinResponse response = controller.createViewsheet(
+         new ViewsheetAssemblyAgentController.CreateViewsheetRequest(
+            "tok-acting", null, null, null, null, null),
+         agent);
+
+      assertEquals("viewsheet", response.sheetType());
+      assertEquals("vs-runtime-new", response.runtimeId());
+      verify(openService).createViewsheet(eq("tok-acting"), eq(agent), isNull());
+   }
+
+   /**
+    * Field-presence validation in resolveDataSourceEntry() runs BEFORE any repository access, so
+    * this is fully testable without a live AssetRepository -- unlike a real logicalModel/
+    * physicalTable resolution, which needs one and is exercised instead by
+    * attach_base_worksheet's own tests against a mocked AssetRepository (both endpoints share
+    * this exact resolveDataSourceEntry() code path, so that coverage carries over).
+    */
+   @Test
+   void createViewsheetRefusesPhysicalTableMissingTableBeforeCallingSheetOpenService() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SheetOpenService openService = mock(SheetOpenService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.createViewsheet(
+            new ViewsheetAssemblyAgentController.CreateViewsheetRequest(
+               "tok-acting", null, null, "physicalTable", "Examples", null),
+            agent));
+      assertTrue(ex.getMessage().contains("table"));
+      verifyNoInteractions(openService);
+   }
+
+   @Test
+   void createViewsheetWrapsAnIllegalArgumentExceptionFromSheetOpenServiceAsPairingException()
+      throws Exception
+   {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SheetOpenService openService = mock(SheetOpenService.class);
+      when(openService.createViewsheet(any(), any(), any()))
+         .thenThrow(new IllegalArgumentException("no data source was given and..."));
+
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.createViewsheet(
+            new ViewsheetAssemblyAgentController.CreateViewsheetRequest(
+               "tok-acting", null, null, null, null, null),
+            agent));
+      assertTrue(ex.getMessage().contains("no data source was given"));
+   }
+
+   // ---------------------------------------------------------------------------
    // save -- PVA-001: no save-as for a first-time (never-saved) viewsheet
    // ---------------------------------------------------------------------------
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -1119,6 +1119,218 @@ class ViewsheetAssemblyAgentControllerTest {
             new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("  ", null), agent));
    }
 
+   /** Still behaves exactly as before when type is omitted -- backward compatible default. */
+   @Test
+   void attachBaseWorksheetDefaultsToWorksheetTypeWhenOmitted() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getSheet(any(), eq(agent), eq(true), eq(AssetContent.ALL), eq(false)))
+         .thenReturn(mock(inetsoft.uql.asset.Worksheet.class));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      controller.attachBaseWorksheet("tok",
+         new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+            "Sample Queries/customers", null),
+         agent);
+
+      ArgumentCaptor<AssetEntry> entryCaptor = ArgumentCaptor.forClass(AssetEntry.class);
+      verify(vs).setBaseEntry(entryCaptor.capture());
+      assertEquals(AssetEntry.Type.WORKSHEET, entryCaptor.getValue().getType());
+   }
+
+   @Test
+   void attachBaseWorksheetAcceptsLogicalModelType() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      AssetRepository rep = mock(AssetRepository.class);
+      // A non-empty getEntries() result IS the permission+existence probe for logicalModel --
+      // no getSheet() call applies (a logical model is not an AbstractSheet).
+      when(rep.getEntries(any(), eq(agent), eq(inetsoft.sree.security.ResourceAction.READ)))
+         .thenReturn(new AssetEntry[] {
+            new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
+                           "MyDataSource/MyModel/Orders", null)
+         });
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+      when(rvs.getID()).thenReturn("rt-vs-lm");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      controller.attachBaseWorksheet("tok",
+         new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+            "MyDataSource/MyModel", null, "logicalModel", null, null),
+         agent);
+
+      ArgumentCaptor<AssetEntry> entryCaptor = ArgumentCaptor.forClass(AssetEntry.class);
+      InOrder order = inOrder(vs);
+      order.verify(vs).setBaseEntry(entryCaptor.capture());
+      order.verify(vs).reloadBaseWorksheet(eq(rep), eq(agent));
+
+      assertEquals(AssetEntry.Type.LOGIC_MODEL, entryCaptor.getValue().getType());
+      assertEquals("MyDataSource/MyModel", entryCaptor.getValue().getPath());
+   }
+
+   /** Flat case: the datasource's own root getEntries() call returns the matching table directly. */
+   @Test
+   void attachBaseWorksheetAcceptsPhysicalTableTypeFlat() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+
+      AssetEntry tableEntry = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.PHYSICAL_TABLE, "Examples/Orders", null);
+      tableEntry.setProperty("source", "Orders");
+
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getEntries(any(), eq(agent), eq(inetsoft.sree.security.ResourceAction.READ)))
+         .thenReturn(new AssetEntry[] { tableEntry });
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+      when(rvs.getID()).thenReturn("rt-vs-pt");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      controller.attachBaseWorksheet("tok",
+         new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+            null, null, "physicalTable", "Examples", "Orders"),
+         agent);
+
+      ArgumentCaptor<AssetEntry> entryCaptor = ArgumentCaptor.forClass(AssetEntry.class);
+      verify(vs).setBaseEntry(entryCaptor.capture());
+      assertSame(tableEntry, entryCaptor.getValue(),
+         "must attach the REAL repository-returned entry, never a hand-constructed one");
+   }
+
+   /** Nested case: the root returns a folder first; the resolver must recurse into it. */
+   @Test
+   void attachBaseWorksheetAcceptsPhysicalTableTypeNested() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+
+      AssetEntry schemaFolder = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.PHYSICAL_FOLDER, "Examples/dbo", null);
+      AssetEntry tableEntry = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.PHYSICAL_TABLE, "Examples/dbo/Orders", null);
+      tableEntry.setProperty("source", "dbo.Orders");
+
+      AssetRepository rep = mock(AssetRepository.class);
+      when(rep.getEntries(any(), eq(agent), eq(inetsoft.sree.security.ResourceAction.READ)))
+         .thenAnswer(inv -> {
+            AssetEntry folder = inv.getArgument(0);
+
+            if(folder.getPath().equals("Examples")) {
+               return new AssetEntry[] { schemaFolder };
+            }
+            if(folder.getPath().equals("Examples/dbo")) {
+               return new AssetEntry[] { tableEntry };
+            }
+            return new AssetEntry[0];
+         });
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(rep);
+      when(rvs.getID()).thenReturn("rt-vs-pt-nested");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      controller.attachBaseWorksheet("tok",
+         new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+            null, null, "physicalTable", "Examples", "Orders"),
+         agent);
+
+      ArgumentCaptor<AssetEntry> entryCaptor = ArgumentCaptor.forClass(AssetEntry.class);
+      verify(vs).setBaseEntry(entryCaptor.capture());
+      assertSame(tableEntry, entryCaptor.getValue());
+   }
+
+   @Test
+   void attachBaseWorksheetRefusesPhysicalTableMissingTable() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(mock(AssetRepository.class));
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+               null, null, "physicalTable", "Examples", null),
+            agent));
+      assertTrue(ex.getMessage().contains("table"));
+   }
+
+   @Test
+   void attachBaseWorksheetRefusesUnknownType() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getAssetRepository()).thenReturn(mock(AssetRepository.class));
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest(
+               "x", null, "query", null, null),
+            agent));
+      assertTrue(ex.getMessage().contains("worksheet"));
+   }
+
    // ---------------------------------------------------------------------------
    // Task 6 (layout implementation plan) -- wiring assertions for the eight new
    // layout endpoints. Each test only checks that the right service is called with the


### PR DESCRIPTION
## Summary
- Closes the create half of PVA-007/bug 76332 -- `SheetOpenService.createViewsheet` mints a new viewsheet and pairs it by reusing the acting session's existing browser socket, the same no-new-pairing-code mechanism `openBaseWorksheet` already uses in the reverse direction. Companion plugin PR: https://github.com/inetsoft-technology/stylebi-wiz/pull/2070
- Widens the already-shipped `attach_base_worksheet` (PR #4900) to accept `type: "logicalModel"|"physicalTable"` in addition to the existing worksheet path, via a shared `resolveDataSourceEntry` helper reused by both endpoints.
- Widens `Viewsheet.reloadBaseWorksheet` to populate `getBaseWorksheet()` for a direct-source (logical-model/physical-table) base entry, not just a worksheet one -- it previously silently no-op'd on those two types.
- `physicalTable` resolves by recursively BROWSING the datasource's tree via `AssetRepository.getEntries()` (tables may nest under catalog/schema folders of arbitrary depth), never by hand-constructing a `PHYSICAL_TABLE` entry's `SourceInfo` properties -- those are populated by the repository's own JDBC-metadata walk and a hand-built entry with the wrong properties would look accepted and silently render nothing.
- `query` (`AssetEntry.Type.QUERY`) intentionally not supported -- a deprecated source type.
- `create_viewsheet` requires an already-paired session (worksheet or viewsheet); with no explicit data source it defaults to the acting session's own worksheet (refusing loudly if that worksheet has never been saved).

## Test plan
- [x] `ViewsheetTest` (new): `reloadBaseWorksheet` cases for worksheet/logicalModel/physicalTable
- [x] `ViewsheetAssemblyAgentControllerTest`: widened `attach_base_worksheet` cases (logicalModel, physicalTable flat + nested-under-schema-folder, missing-field refusals, unknown type, type-omitted backward compat) + new `create_viewsheet` cases
- [x] `SheetOpenServiceTest`: new `createViewsheet` cases (defaults to acting worksheet, explicit data source from either acting-session type, unresolvable session, no socket, unsaved worksheet, permission refusal)
- [x] Full `inetsoft.web.wiz` + `inetsoft.uql.viewsheet` suites: 2999 tests, 0 failures, 0 errors, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)