### PR TITLE
Bug #76386, keep the column-values-as-colors option when fixing visual frames

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
@@ -900,6 +900,13 @@ public class GraphUtil {
       DataRef dref = ref.getDataRef();
 
       if(type == ChartConstants.AESTHETIC_COLOR) {
+         // the user explicitly opted into using the column values as colors. this is a
+         // valid ColorFrame for both dimension and measure refs, so don't normalize it
+         // away, otherwise the option is discarded as soon as it's applied.
+         if(frame instanceof ColorValueColorFrame) {
+            return false;
+         }
+
          if(isCategorical(dref)) {
             if(!(frame instanceof CategoricalFrame)) {
                String col = dref instanceof VSDimensionRef ?

--- a/core/src/test/java/inetsoft/report/composition/graph/GraphUtilFixVisualFrameTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/GraphUtilFixVisualFrameTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.graph;
+
+import inetsoft.graph.aesthetic.*;
+import inetsoft.report.composition.region.ChartConstants;
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.uql.viewsheet.graph.aesthetic.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class GraphUtilFixVisualFrameTest {
+   @Test
+   void colorValueFrameIsPreservedForDimension() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+
+      VSAestheticRef color = createColorRef(createDimensionRef());
+      CategoricalColorFrameWrapper wrapper = new CategoricalColorFrameWrapper();
+      wrapper.setColorValueFrame(true);
+      color.setVisualFrameWrapper(wrapper);
+      info.setColorField(color);
+
+      assertInstanceOf(ColorValueColorFrame.class, color.getVisualFrame(),
+                       "wrapper should hand out a ColorValueColorFrame when the option is on");
+
+      boolean changed = GraphUtil.fixVisualFrame(
+         color, ChartConstants.AESTHETIC_COLOR, GraphTypes.CHART_BAR, info);
+
+      assertFalse(changed, "a ColorValueColorFrame should not be normalized away");
+      assertSame(wrapper, color.getVisualFrameWrapper(), "the wrapper should not be replaced");
+      assertTrue(((CategoricalColorFrameWrapper) color.getVisualFrameWrapper()).isColorValueFrame(),
+                 "the colorValueFrame option should survive");
+   }
+
+   @Test
+   void colorValueFrameIsPreservedForMeasure() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+
+      VSAestheticRef color = createColorRef(new VSChartAggregateRef());
+      CategoricalColorFrameWrapper wrapper = new CategoricalColorFrameWrapper();
+      wrapper.setColorValueFrame(true);
+      color.setVisualFrameWrapper(wrapper);
+      info.setColorField(color);
+
+      boolean changed = GraphUtil.fixVisualFrame(
+         color, ChartConstants.AESTHETIC_COLOR, GraphTypes.CHART_BAR, info);
+
+      assertFalse(changed, "a ColorValueColorFrame should not be replaced by a linear color frame");
+      assertSame(wrapper, color.getVisualFrameWrapper());
+      assertTrue(((CategoricalColorFrameWrapper) color.getVisualFrameWrapper()).isColorValueFrame());
+   }
+
+   @Test
+   void wrongFrameTypeIsStillNormalizedForDimension() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+
+      VSAestheticRef color = createColorRef(createDimensionRef());
+      // a size frame on the color region is not a valid color frame and must be fixed
+      color.setVisualFrame(new CategoricalSizeFrame());
+      info.setColorField(color);
+
+      boolean changed = GraphUtil.fixVisualFrame(
+         color, ChartConstants.AESTHETIC_COLOR, GraphTypes.CHART_BAR, info);
+
+      assertTrue(changed, "an invalid color frame should still be normalized");
+      assertInstanceOf(CategoricalColorFrame.class, color.getVisualFrame());
+   }
+
+   @Test
+   void plainCategoricalColorFrameIsLeftAlone() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+
+      VSAestheticRef color = createColorRef(createDimensionRef());
+      CategoricalColorFrameWrapper wrapper = new CategoricalColorFrameWrapper();
+      color.setVisualFrameWrapper(wrapper);
+      info.setColorField(color);
+
+      boolean changed = GraphUtil.fixVisualFrame(
+         color, ChartConstants.AESTHETIC_COLOR, GraphTypes.CHART_BAR, info);
+
+      assertFalse(changed);
+      assertSame(wrapper, color.getVisualFrameWrapper());
+      assertFalse(((CategoricalColorFrameWrapper) color.getVisualFrameWrapper()).isColorValueFrame());
+   }
+
+   private static VSChartDimensionRef createDimensionRef() {
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue("Color");
+      return dim;
+   }
+
+   private static VSAestheticRef createColorRef(inetsoft.uql.erm.DataRef dataRef) {
+      VSAestheticRef color = new VSAestheticRef();
+      color.setDataRef(dataRef);
+      return color;
+   }
+}


### PR DESCRIPTION
## Problem

With `custom.chart.frames=ColorValueColorFrame` set in sree properties, in the composer:

1. Edit a chart's color aesthetic → Edit Color
2. **Uncheck** "Use Column Values as Colors", Apply → works
3. **Re-check** it, Apply → **not applied**; the chart keeps the categorical palette and the checkbox comes back unchecked

## Root cause

`GraphUtil.fixVisualFrame()` normalizes an aesthetic ref's frame against the bound column. For a color aesthetic it accepts only `CategoricalColorFrame` (dimension ref) or `LinearColorFrame` (measure ref); anything else is replaced, and `ref.setVisualFrame(...)` → `VisualFrameWrapper.wrap()` builds a **brand-new** `CategoricalColorFrameWrapper` whose `colorValueFrame` defaults to `false`.

`ColorValueColorFrame` extends `ColorFrame` and implements `CategoricalFrame`, but is not a `CategoricalColorFrame`, so it always tripped that replacement — and it happened on the very same request that set the flag. `ChartInfoModelBuilder.updateChartInfo()`:

```java
aesService.updateVisualFrames(model, ocinfo, ncinfo);   // sets colorValueFrame = true
GraphUtil.fixVisualFrames(ncinfo);                      // ...and this discards it
```

That is exactly the reported asymmetry:

| Action | Frame from `CategoricalColorFrameWrapper.getVisualFrame()` | `fixVisualFrame` | Result |
|---|---|---|---|
| Uncheck | `CategoricalColorFrame` | no-op | applies |
| Re-check | `ColorValueColorFrame` | wrapper replaced, flag lost | silently reverts |

It also explains why a saved `.vso` renders correctly on open: `colorValueFrame` round-trips through XML, and `fixVisualFrames` is not on the plain-load path — only on the edit paths.

## Fix

A guard at the top of the `AESTHETIC_COLOR` branch that leaves an explicitly chosen `ColorValueColorFrame` alone, for both dimension and measure refs. This also stops the flag being dropped by the other `fixVisualFrames` callers (`ChangeChartRefService`, `ChartPropertyDialogService`, `DateComparisonDialogService`, `ChartVSAssembly`).

Returning `false` is the "frame unchanged" signal that `fixVisualFrame`/`fixVisualFrames` report to callers, and it keeps the guard clear of the `SHAPE`/`SIZE`/`TEXT` branches.

## Testing

New `GraphUtilFixVisualFrameTest` (4 cases): the option survives for a dimension ref and for a measure ref; an invalid color frame (e.g. a size frame on the color region) is still normalized to `CategoricalColorFrame`; a plain `CategoricalColorFrameWrapper` is untouched.

Confirmed to be a real regression test — with the guard reverted, both preservation cases fail (`expected: <false> but was: <true>`) while the two normalization cases still pass.

- Full `community/core` suite: 4667 run, 0 failures, 67 skipped
- `categorical-color-pane` TL specs: 17/17 (no TS changed; sanity check)
- Manual: reproduced the original failure, then verified off→on now repaints from the column hex values, stays checked on re-open, and survives save/reload. Regression-checked dragging a different dimension/measure onto Color and switching chart types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
