### PR TITLE
Bug #76394, make the embedded viewsheet edit-script icon clickable

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetObjectPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetObjectPropertyDialogService.java
@@ -22,8 +22,10 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.uql.asset.ConfirmException;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.ViewsheetVSAssemblyInfo;
+import inetsoft.util.*;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.viewsheet.service.*;
@@ -52,11 +54,17 @@ public class ViewsheetObjectPropertyDialogService {
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
       Viewsheet vs = rvs.getViewsheet();
-      Viewsheet embeddedVs = (Viewsheet) vs.getAssembly(objectId);
-      ViewsheetVSAssemblyInfo info = (ViewsheetVSAssemblyInfo) embeddedVs.getVSAssemblyInfo();
 
       ViewsheetObjectPropertyDialogModel.Builder model =
          ViewsheetObjectPropertyDialogModel.builder();
+
+      // the assembly may be gone (deleted/renamed) or, for a name containing a dot,
+      // may resolve to something that is not an embedded viewsheet
+      if(!(vs.getAssembly(objectId) instanceof Viewsheet embeddedVs)) {
+         return model.build();
+      }
+
+      ViewsheetVSAssemblyInfo info = (ViewsheetVSAssemblyInfo) embeddedVs.getVSAssemblyInfo();
 
       GeneralPropPaneModel generalPropPaneModel = new GeneralPropPaneModel();
       SizePositionPaneModel sizePositionPaneModel = new SizePositionPaneModel();
@@ -99,7 +107,14 @@ public class ViewsheetObjectPropertyDialogService {
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
       Viewsheet vs = rvs.getViewsheet();
-      Viewsheet embeddedVs = (Viewsheet) vs.getAssembly(objectId);
+
+      if(!(vs.getAssembly(objectId) instanceof Viewsheet embeddedVs)) {
+         Tool.addUserMessage(new UserMessage(
+            Catalog.getCatalog().getString("viewer.viewsheet.editPropertyFailed"),
+            ConfirmException.ERROR, objectId));
+         return null;
+      }
+
       ViewsheetVSAssemblyInfo info = (ViewsheetVSAssemblyInfo) embeddedVs.getVSAssemblyInfo();
 
       GeneralPropPaneModel generalPropPaneModel = model.generalPropPaneModel();

--- a/web/projects/portal/src/app/composer/gui/vs/action/viewsheet-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/viewsheet-action-handler.directive.ts
@@ -108,6 +108,9 @@ export class ViewsheetActionHandlerDirective extends AbstractActionHandler imple
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);
+      },
+      (error: any) => {
+         console.error("Failed to get viewsheet property model: ", error);
       });
    }
 }

--- a/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.scss
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.scss
@@ -97,7 +97,10 @@
   position: absolute;
   top: 1px;
   left: 22px;
-  z-index: 9999;
+  // must sit above the embedded viewsheet's composer overlay (99997/99998), which
+  // covers the whole assembly and would otherwise swallow the click. Matches the
+  // .icon-container of the adjacent embedded-viewsheet link icon.
+  z-index: 99999;
 }
 
 .object-editor:hover .script-icon.embedded-vs-script {


### PR DESCRIPTION
Fixes the Composer JS (Edit Script) icon on an embedded Viewsheet assembly, which did nothing when clicked — no dialog, no request, no error message.

## Root cause

The icon rendered fine but never received the click. `VSViewsheet` draws a full-size `.top-level-composer-overlay` at **z-index 99998** across the whole assembly; the icon sat at **z-index 9999**, so the overlay was always the hit target.

Confirmed in the running Composer on `Examples/Hurricane` — `document.elementFromPoint()` over the icon returned `div.composer-overlay.top-level-composer-overlay`, and no HTTP request was issued at all. After raising the z-index the `GET .../viewsheet-object-property-dialog-model/Map1/...` fires and the dialog opens on the Script tab.

The adjacent jump-to-embedded-viewsheet link was never affected because it sits at 99999/100000 (`.icon-container` / `.viewsheet-link`). That asymmetry — dashboard icon clickable, JS icon not — is what made the failure look script-specific.

## Fix

`editable-object-container.component.scss` — raise `.javascript-icon.embedded-vs-script` to `z-index: 99999`, matching the `.icon-container` of the neighbouring link icon so both clear the overlay.

## Also included (hardening, neither caused this bug)

- **`ViewsheetObjectPropertyDialogService`** cast `vs.getAssembly(objectId)` to `Viewsheet` unguarded. A missing assembly threw NPE; a dotted name resolving to a non-Viewsheet assembly threw `ClassCastException`. Both the get and set paths now guard with `instanceof`, matching `TextPropertyDialogService`. The guard deliberately avoids adding a constructor parameter — Spring AOT pins the bean's constructor signature, and changing it breaks bean instantiation until AOT metadata is regenerated.
- **`ViewsheetActionHandlerDirective`** subscribed to the model fetch with no error callback; added one so failures are traceable.

Happy to trim the PR to the CSS fix alone if reviewers prefer the minimal change.

## Testing

Manually verified on `Examples/Hurricane` in the Composer: the JS icon on the `Map1` embedded viewsheet now opens the Properties dialog on the Script tab showing `Map1.setActionVisible('Brush', false);`, and the script persists on OK/Apply. `core` compiles clean; portal typechecks clean.

## Notes for reviewers

Two adjacent issues left alone as out of scope:
- The `setting-icon` in the same template (shown when an assembly has no script but has an open slide-out) is at z-index 101 via `.script-icon-position`, so it has the identical problem on an embedded viewsheet.
- `.object-editor:hover .script-icon.embedded-vs-script` is dead CSS — the element's class is `javascript-icon`, not `script-icon`, so the hover offset never applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)