### PR TITLE
Bug #76390 and #76391, don't drop or blank real historical data in Date Comparison

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonFormat.java
@@ -150,27 +150,32 @@ public class DateComparisonFormat extends Format {
             }
          }
 
-         // Remove orphaned cells (no current-year data) using the same heuristic as
-         // DateComparisonUtil.computeValidParts(). An empty validParts set means either
-         // no data, MergePartCell period without a date value, or per-part real-date
-         // layout — in all those cases no filtering is applied.
-         Set<Object> orphanedCells = new HashSet<>();
-         Set<Object> validParts = DateComparisonUtil.computeValidParts(data, dateCol, partCol, null);
-
-         if(!validParts.isEmpty()) {
-            Iterator<Map.Entry<Object, Set<Date>>> it = partDates.entrySet().iterator();
-
-            while(it.hasNext()) {
-               Map.Entry<Object, Set<Date>> entry = it.next();
-
-               if(!validParts.contains(entry.getKey())) {
-                  orphanedCells.add(entry.getKey());
-                  it.remove();
-               }
-            }
-         }
-
-         this.orphanedCells = orphanedCells;
+         // NOTE (Bug #76390): this used to remove "orphaned" part entries here --
+         // i.e. any partCol value not in DateComparisonUtil.computeValidParts(data,
+         // dateCol, partCol, null) -- and blank that part's axis label entirely,
+         // using the same "does this part have a row in the single most recent
+         // period" heuristic as DateComparisonUtil.applyDateRange()'s
+         // ValidPartsSelector. That heuristic is sound for ValidPartsSelector, which
+         // filters raw, not-yet-verified rows out of the plotted/exported dataset
+         // before anything here runs.
+         //
+         // But every entry partDates can ever contain is, by construction (see the
+         // loop above), already backed by a real row with a real plotted value --
+         // there is no "spurious future" data to discover and strip at this point.
+         // In a faceted date-comparison chart, one partCol value legitimately *is*
+         // one facet group, and different facet groups routinely finish carrying
+         // real data for the newest comparison period at different times (e.g. one
+         // WeekOfMonth bucket has already reached this year's data, another hasn't)
+         // -- that is ordinary, expected asymmetry, not a sign that a facet group's
+         // own historical entries are invalid. Applying the single dataset-wide
+         // "most recent period" heuristic here treated every part but the one
+         // holding the single latest date as fully orphaned and wiped its label
+         // outright, even though its underlying dates/bars (in partDates, and thus
+         // in the rendered chart) were completely correct. So this consumer no
+         // longer removes any partDates entries; the underlying row-level future
+         // exclusion Bug #75152/#76389 rely on is still enforced by
+         // DateComparisonUtil.applyDateRange()'s ValidPartsSelector, upstream of
+         // this class.
          this.partDates = partDates;
          this.partDates2 = partDates2;
          fixDisplayShortDate();
@@ -219,7 +224,6 @@ public class DateComparisonFormat extends Format {
    public void setGraphDataSelector(GraphtDataSelector selector) {
       this.selector = selector;
       partDates = null;
-      orphanedCells = new HashSet<>();
    }
 
    /**
@@ -284,11 +288,6 @@ public class DateComparisonFormat extends Format {
                                boolean onlyShowMostRecentDate)
    {
       initPartDate();
-
-      // Orphaned cells have no current-year data — suppress their labels entirely.
-      if(orphanedCells != null && orphanedCells.contains(obj)) {
-         return toAppendTo;
-      }
 
       Set<Date> dates = partDates.get(obj);
       dates = dates == null ? partDates2.get(obj) : dates;
@@ -448,7 +447,6 @@ public class DateComparisonFormat extends Format {
 
    private Map<Object, Set<Date>> partDates;
    private Map<Object, Set<Date>> partDates2;
-   private Set<Object> orphanedCells = new HashSet<>();
    private Map<Object, Format> preferFormat;
    private int datePart;
    private DataSet data;

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -712,15 +712,6 @@ public class DateComparisonUtil {
     * A part is not treated as orphaned merely because the most recent year's own rows have
     * no match for it -- that is ordinary data sparsity, not an unreached future bucket, and
     * older periods' real data for it must still render (Bug #76391).
-    *
-    * DateComparisonFormat.initPartDate() also calls this method directly, to drive the same
-    * heuristic at the pre-aggregated partDates level -- but as of Bug #76388, that caller is
-    * NOT gated on facet mode the way applyDateRange() below is. In facet mode this method's
-    * heuristic is wrong for the reason documented at the applyDateRange() call site (a facet
-    * lacking a row in the most recent period isn't a future bucket, it's an ordinary facet
-    * with less data), so initPartDate() can still misclassify facets 5+ as orphaned and blank
-    * their labels even after this fix, independent of Bug #76390's own, separate label-
-    * blanking defect in the same method. Not fixed here -- see PR #4936's discussion.
     */
    static Set<Object> computeValidParts(DataSet data, String periodCol,
                                         String partCol, Date startDate)
@@ -780,18 +771,71 @@ public class DateComparisonUtil {
       // do reach as valid too, so an older period's real data for it isn't dropped just
       // because the most recent period happens to have no row there. A part that sorts
       // strictly after that point is left excluded, preserving the future-bucket
-      // suppression this method was introduced for. (Bug #76391)
+      // suppression this method was introduced for. Scoped by the same startDate condition
+      // as the first pass, so a part appearing only in a row before startDate can't leak in
+      // here -- this loop's result should mean the same thing the first pass's scope means,
+      // not rely on every caller happening to already exclude those rows via a separate
+      // selector. (Bug #76391)
+      //
+      // For a MergePartCell (e.g. "12-1", "12-2" -- a month plus a tie-breaking sub-bucket
+      // for a week that spans two months), a strict tuple compare against maxPart is too
+      // narrow at the trailing edge: if the most recent period's own data reaches "12-1" but
+      // that year's calendar simply never produces a "12-2" split, "12-2" sorts after "12-1"
+      // and would stay excluded even though the most recent period plainly did reach month
+      // 12 -- the missing sub-bucket is calendar variation, not an unreached future month.
+      // Every family strictly before maxPart's own family is already fully valid from the
+      // plain tuple compare above (the leading component alone decides it), so only
+      // maxPart's own family can have this trailing-edge gap: also accept a part that
+      // shares maxPart's leading components (everything but the final, tie-breaking one),
+      // whatever its own trailing value. (Bug #76391)
+      List<Object> maxPartPrefix = mergePartCellPrefix(maxPart);
+
       if(maxPart != null) {
          for(int i = 0; i < data.getRowCount(); i++) {
+            Date date = toPeriodDate(data.getData(periodCol, i));
+
+            if(date == null || (startDate != null && date.before(startDate))) {
+               continue;
+            }
+
             Object part = data.getData(partCol, i);
 
-            if(Tool.compare(part, maxPart) <= 0) {
+            if(Tool.compare(part, maxPart) <= 0 ||
+               (maxPartPrefix != null && maxPartPrefix.equals(mergePartCellPrefix(part))))
+            {
                validParts.add(part);
             }
          }
       }
 
       return validParts;
+   }
+
+   /**
+    * A MergePartCell's own values, minus the final (tie-breaking sub-bucket) value -- e.g.
+    * ["12"] for both "12-1" and "12-2". Returns null for anything that isn't a MergePartCell
+    * with at least two component values, so callers can distinguish "no prefix to compare"
+    * from "empty prefix."
+    */
+   private static List<Object> mergePartCellPrefix(Object part) {
+      if(!(part instanceof MergePartCell)) {
+         return null;
+      }
+
+      MergePartCell cell = (MergePartCell) part;
+      int size = cell.getMergedRefs().size();
+
+      if(size < 2) {
+         return null;
+      }
+
+      List<Object> prefix = new ArrayList<>(size - 1);
+
+      for(int i = 0; i < size - 1; i++) {
+         prefix.add(cell.getValue(i));
+      }
+
+      return prefix;
    }
 
    /** Extract a comparable Date from a period column value (raw Date or MergePartCell). */

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -703,11 +703,15 @@ public class DateComparisonUtil {
    }
 
    /**
-    * Find which part cells (x-axis positions) have data from the most recent year.
-    * Cells without current-year data are orphaned and should be excluded from the axis.
-    * Returns the set of valid part cells (those with current-year data), or an empty set
-    * when the data is not in year-bucket layout (per-part real dates, or no repeated period
-    * value). An empty return means "no orphan filtering should be applied."
+    * Find which part cells (x-axis positions) have data from the most recent year, or sort
+    * at or before the last part that year's own rows reach. Cells beyond that point are
+    * orphaned (the most recent, possibly in-progress, period hasn't chronologically reached
+    * them yet) and should be excluded from the axis. Returns the set of valid part cells, or
+    * an empty set when the data is not in year-bucket layout (per-part real dates, or no
+    * repeated period value). An empty return means "no orphan filtering should be applied."
+    * A part is not treated as orphaned merely because the most recent year's own rows have
+    * no match for it -- that is ordinary data sparsity, not an unreached future bucket, and
+    * older periods' real data for it must still render (Bug #76391).
     *
     * DateComparisonFormat.initPartDate() also calls this method directly, to drive the same
     * heuristic at the pre-aggregated partDates level -- but as of Bug #76388, that caller is
@@ -753,12 +757,37 @@ public class DateComparisonUtil {
 
       Set<Object> validParts = new HashSet<>();
       final Date max = maxYearDate;
+      Object maxPart = null;
 
       for(int i = 0; i < data.getRowCount(); i++) {
          Date date = toPeriodDate(data.getData(periodCol, i));
 
          if(max.equals(date)) {
-            validParts.add(data.getData(partCol, i));
+            Object part = data.getData(partCol, i);
+            validParts.add(part);
+
+            if(maxPart == null || Tool.compare(part, maxPart) > 0) {
+               maxPart = part;
+            }
+         }
+      }
+
+      // The most recent period doesn't necessarily carry a row for every part it has
+      // chronologically reached -- ordinary data sparsity (e.g. a week with no matching
+      // records) is not the same as a part the period genuinely hasn't happened yet (the
+      // "future bucket" case this heuristic exists to suppress, Bug #75152/#76389). Treat
+      // any part that sorts at or before the latest part the most recent period's own rows
+      // do reach as valid too, so an older period's real data for it isn't dropped just
+      // because the most recent period happens to have no row there. A part that sorts
+      // strictly after that point is left excluded, preserving the future-bucket
+      // suppression this method was introduced for. (Bug #76391)
+      if(maxPart != null) {
+         for(int i = 0; i < data.getRowCount(); i++) {
+            Object part = data.getData(partCol, i);
+
+            if(Tool.compare(part, maxPart) <= 0) {
+               validParts.add(part);
+            }
          }
       }
 

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonFormatOrphanedFacetTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonFormatOrphanedFacetTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.graph.data.DataSet;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.graph.element.GraphtDataSelector;
+import inetsoft.test.*;
+import inetsoft.uql.XConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.text.FieldPosition;
+
+import static inetsoft.test.XTableUtil.date;
+
+/**
+ * Bug #76390: "Shared dc1.vso" Chart4 -- a faceted date-comparison chart (WeekOfMonth(Date)
+ * facet groups 11-1..11-5, colored/grouped by YearOfWeek(Date), comparing 2019/2020/2021).
+ * Only the first facet group's bars got a real calendar-date label; every bar in every
+ * subsequent facet group rendered a blank label, even though the underlying data (bar
+ * heights/values/colors) was byte-for-byte correct for all of them.
+ *
+ * Root cause: DateComparisonFormat.initPartDate() used to remove any partCol value not
+ * present in DateComparisonUtil.computeValidParts(data, dateCol, partCol, null) -- the same
+ * "does this part have a row in the single most recent comparison period" heuristic
+ * DateComparisonUtil.applyDateRange()'s ValidPartsSelector uses to drop rows from the
+ * plotted/exported dataset -- and blanked that part's label entirely (see the old
+ * "orphanedCells" mechanism, format()'s early return).
+ *
+ * That heuristic is a poor fit here: in a faceted chart, one partCol value legitimately *is*
+ * one facet group, and it is completely ordinary for different facet groups to finish
+ * carrying the newest comparison period's data at different times (e.g. only the November
+ * week-1 facet group has reached 2021 so far). Bug #76391 already fixed
+ * DateComparisonUtil.computeValidParts() itself for a *different* symptom (a sparse-but-
+ * already-reached bucket dropping older periods' real rows), but that fix does not rescue
+ * this scenario: it only widens validParts to parts that sort at-or-before the single part
+ * that reaches the newest period, and facet group 11-1 here is *both* the only part reaching
+ * 2021 *and* numerically the smallest part, so the ordinal widening adds nothing -- groups
+ * 11-2..11-5 would still come out orphaned under that fix alone.
+ *
+ * The actual fix for this bug (see DateComparisonFormat.initPartDate()) stops removing
+ * partDates entries at all in this class: every entry partDates can ever contain is, by
+ * construction, already backed by a real row with a real plotted value, so there is nothing
+ * "orphaned" left to discover and strip once a part has made it into that map -- the
+ * legitimate "hide a genuinely future/unreached bucket" behavior (Bug #75152/#76389) is
+ * still enforced upstream, at the row level, by
+ * DateComparisonUtil.applyDateRange()'s ValidPartsSelector.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class DateComparisonFormatOrphanedFacetTest {
+   /**
+    * Reproduces the exact "Shared dc1.vso" Chart4 shape: 5 WeekOfMonth facet groups
+    * (encoded as month*10+week, i.e. 111 = "11-1" .. 115 = "11-5", the same MergePartCell-
+    * style encoding DateComparisonUtilValidPartsTest uses), where every group has real,
+    * plotted rows for 2019/2020 and *only* group 111 (11-1) additionally has a row for the
+    * newest comparison year, 2021.
+    */
+   @Test
+   void facetGroupsWithoutTheNewestPeriodStillGetRealLabels() {
+      DataSet data = new DefaultDataSet(new Object[][] {
+         { "date", "part", "calc" },
+         { date("2019-11-03"), 111, 1.0 },
+         { date("2020-11-01"), 111, 1.0 },
+         { date("2021-11-07"), 111, 1.0 },   // only 11-1 reaches the newest year, 2021
+         { date("2019-11-10"), 112, 1.0 },
+         { date("2020-11-08"), 112, 1.0 },
+         { date("2019-11-17"), 113, 1.0 },
+         { date("2020-11-15"), 113, 1.0 },
+         { date("2019-11-24"), 114, 1.0 },
+         { date("2020-11-22"), 114, 1.0 },
+         { date("2019-11-05"), 115, 1.0 },
+         { date("2020-11-29"), 115, 1.0 },
+         });
+
+      GraphtDataSelector selector = (d, row, fields) -> true;
+      DateComparisonFormat fmt = new DateComparisonFormat(
+         data, selector, XConstants.YEAR_DATE_GROUP, DateComparisonInfo.WEEK, 0,
+         "part", "date", "calc", new Object[0], null, false, true);
+
+      String group1 = fmt.format(111, new StringBuffer(), new FieldPosition(0)).toString();
+      Assertions.assertFalse(group1.isEmpty(), "the first facet group must keep its label");
+      Assertions.assertTrue(group1.contains("2019") && group1.contains("2020") &&
+                             group1.contains("2021"),
+                             "the first facet group must show all 3 of its real dates: " +
+                             group1);
+
+      for(int part : new int[] { 112, 113, 114, 115 }) {
+         String label = fmt.format(part, new StringBuffer(), new FieldPosition(0)).toString();
+         Assertions.assertFalse(label.isEmpty(),
+                                 "facet group " + part + " has real 2019/2020 data and must " +
+                                 "not render a blank label merely because it hasn't reached " +
+                                 "2021 yet (Bug #76390)");
+         Assertions.assertTrue(label.contains("2019") && label.contains("2020"),
+                                "facet group " + part + " must show both of its real dates: " +
+                                label);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilValidPartsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilValidPartsTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.graph.data.DataSet;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.test.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Set;
+
+import static inetsoft.test.XTableUtil.date;
+
+/**
+ * Bug #76391: DateComparisonUtil.computeValidParts() used "does the most-recent comparison
+ * period's own data have a row for this part" as a proxy for "has the most-recent period
+ * chronologically reached this part yet". Those conditions only coincide when the most
+ * recent period's data is dense. When it is merely sparse -- a real bucket with zero
+ * matching rows -- the old algorithm dropped that bucket's data for *every* period,
+ * including older periods that have real, legitimate rows for it.
+ *
+ * The fix (see DateComparisonUtil.computeValidParts()) keeps a part valid whenever it sorts
+ * at or before the last part the most recent period's own rows actually reach, instead of
+ * requiring an exact row match. A part that sorts strictly beyond that point is still
+ * treated as an unreached "future" bucket and stays excluded, preserving the behavior
+ * Bug #75152/#76389 rely on.
+ *
+ * Part values below use the same "month * 10 + weekOfMonth" encoding
+ * DCMergeDatePartFilter.MergePartCell uses for a merged WeekOfMonth-of-Month part (see
+ * MergePartCell.getEquivalenceCell()), so plain boxed Integers already sort exactly the way
+ * the real MergePartCell values would via Tool.compare(). E.g. 7-1 -> 71, 9-2 -> 92,
+ * 12-2 -> 122.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class DateComparisonUtilValidPartsTest {
+   /**
+    * Reproduces Bug #76391: the most recent period (2020) is missing rows for 7-1 (71),
+    * 9-2 (92) and 12-2 (122) purely because those specific weeks happen to have no matching
+    * records -- 2020 otherwise has data all the way out to 12-3 (123), well past all three.
+    * Older periods (2018/2019) have real rows for those same buckets. None of them should be
+    * orphaned.
+    */
+   @Test
+   void sparseRecentPeriodDoesNotOrphanOlderPeriodsRealData() {
+      DataSet data = new DefaultDataSet(new Object[][] {
+         { "period", "part" },
+         { date("2018-01-01"), 71 },    // 2018: 7-1 (204 in the bug report)
+         { date("2019-01-01"), 71 },    // 2019: 7-1 (54)
+         { date("2019-01-01"), 92 },    // 2019: 9-2 (36)
+         { date("2019-01-01"), 112 },   // 2019: 11-2 (27) -- already survives today
+         { date("2019-01-01"), 122 },   // 2019: 12-2 (18)
+         { date("2020-01-01"), 32 },    // 2020: 3-2 -- already survives today
+         { date("2020-01-01"), 112 },   // 2020: 11-2 -- already survives today
+         { date("2020-01-01"), 123 },   // 2020: 12-3 -- 2020 reaches past December week 2
+         });
+
+      Set<Object> validParts = DateComparisonUtil.computeValidParts(data, "period", "part", null);
+
+      Assertions.assertEquals(Set.of(32, 71, 92, 112, 122, 123), validParts,
+                               "sparse gaps in the most recent period's own data must not " +
+                               "orphan older periods' real buckets");
+   }
+
+   /**
+    * Guards the legitimate use case computeValidParts exists for (Bug #75152/#76389): when
+    * the most recent period is genuinely in-progress and its own rows stop at May (part 51),
+    * a bucket in August (81) that only older, completed periods have data for is a real
+    * future bucket relative to the current period and must stay excluded.
+    */
+   @Test
+   void futureBucketsBeyondRecentPeriodsReachStayOrphaned() {
+      DataSet data = new DefaultDataSet(new Object[][] {
+         { "period", "part" },
+         { date("2018-01-01"), 51 },
+         { date("2018-01-01"), 81 },
+         { date("2019-01-01"), 51 },
+         { date("2019-01-01"), 81 },
+         { date("2020-01-01"), 51 },    // most recent period only reaches May
+         });
+
+      Set<Object> validParts = DateComparisonUtil.computeValidParts(data, "period", "part", null);
+
+      Assertions.assertEquals(Set.of(51), validParts,
+                               "a bucket the most recent period hasn't chronologically " +
+                               "reached yet must stay orphaned even though older periods " +
+                               "have real data for it");
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilValidPartsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilValidPartsTest.java
@@ -19,7 +19,12 @@ package inetsoft.uql.viewsheet.internal;
 
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.report.filter.DCMergeDatePartFilter;
+import inetsoft.report.lens.DataSetTable;
 import inetsoft.test.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.XDimensionRef;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,6 +33,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static inetsoft.test.XTableUtil.date;
@@ -109,5 +117,69 @@ class DateComparisonUtilValidPartsTest {
                                "a bucket the most recent period hasn't chronologically " +
                                "reached yet must stay orphaned even though older periods " +
                                "have real data for it");
+   }
+
+   /**
+    * Reproduces the residual gap in Bug #76391's original fix, found live against the actual
+    * reported Year_MonthToDate Chart4 fixture: WeekOfMonth "12-2" (2019: 18) still didn't
+    * render even after that fix, because the real "12-2"/"12-1" values are not plain
+    * month*10+week integers -- they are DCMergeDatePartFilter.MergePartCell instances whose
+    * compareTo() does a two-element tuple compare (month component, then week-of-month
+    * component; see MergePartCell.getMergedRefs()/compareTo()). The most recent period (2020)
+    * reaches month 12 (has a "12-1" row) but its calendar never produces a "12-2" split week,
+    * so maxPart is "12-1" and the plain "sorts at or before maxPart" rule from the first fix
+    * excludes "12-2" (its own tuple sorts after "12-1") even though 2020 plainly did reach
+    * month 12 -- the missing sub-bucket is calendar variation, not an unreached future month.
+    *
+    * The fix compares only the leading (non-tie-breaking) components against maxPart's own
+    * leading components: sharing "12" is enough to rescue "12-2", regardless of its trailing
+    * week-of-month value.
+    */
+   @Test
+   void mergePartCellSharingMaxPartsLeadingComponentsIsNotOrphaned() {
+      VSDimensionRef monthRef = new VSDimensionRef();
+      monthRef.setDataRef(new AttributeRef("MonthOfWeekN(date)"));
+      VSDimensionRef weekOfMonthRef = new VSDimensionRef();
+      weekOfMonthRef.setDataRef(new AttributeRef("WeekOfMonth(date)"));
+      VSDimensionRef dateGroupRef = new VSDimensionRef();
+      dateGroupRef.setDataRef(new AttributeRef("date"));
+
+      DataSet rawDataSet = new DefaultDataSet(new Object[][] {
+         { "MonthOfWeekN(date)", "WeekOfMonth(date)", "date" },
+         { 12, 1, date("2019-12-02") },   // 2019: 12-1
+         { 12, 2, date("2019-12-09") },   // 2019: 12-2 -- must not be orphaned
+         { 12, 1, date("2020-12-07") },   // 2020 (most recent): reaches month 12 via 12-1 only
+         });
+      DataSetTable base = new DataSetTable(rawDataSet);
+      List<XDimensionRef> extraRefs = Collections.singletonList(monthRef);
+      DCMergeDatePartFilter filter =
+         new DCMergeDatePartFilter(base, extraRefs, weekOfMonthRef, dateGroupRef, null);
+
+      // Column order matches the rawDataSet header above: MonthOfWeekN=0, WeekOfMonth=1, date=2.
+      int weekColIndex = 1;
+      int firstDataRow = base.getHeaderRowCount();
+
+      Object part2019_12_1 = filter.getObject(firstDataRow, weekColIndex);
+      Object part2019_12_2 = filter.getObject(firstDataRow + 1, weekColIndex);
+      Object part2020_12_1 = filter.getObject(firstDataRow + 2, weekColIndex);
+
+      Assertions.assertInstanceOf(DCMergeDatePartFilter.MergePartCell.class, part2019_12_2,
+                                  "test must exercise the real MergePartCell type, not a plain Integer");
+      Assertions.assertEquals("12-1", part2019_12_1.toString());
+      Assertions.assertEquals("12-2", part2019_12_2.toString());
+      Assertions.assertEquals("12-1", part2020_12_1.toString());
+
+      DataSet data = new DefaultDataSet(new Object[][] {
+         { "period", "part" },
+         { date("2019-01-01"), part2019_12_1 },
+         { date("2019-01-01"), part2019_12_2 },
+         { date("2020-01-01"), part2020_12_1 },
+         });
+
+      Set<Object> validParts = DateComparisonUtil.computeValidParts(data, "period", "part", null);
+
+      Assertions.assertTrue(validParts.contains(part2019_12_2),
+         "12-2 shares the most recent period's own reached month (12) and must not be " +
+         "orphaned merely because 2020's calendar never produces a 12-2 split week");
    }
 }


### PR DESCRIPTION
## Summary

Both bugs trace to the same root heuristic in `DateComparisonUtil.computeValidParts()` and are consolidated into one PR since #76390's fix builds directly on #76391's.

### Bug #76391 — Year_MonthToDate Chart4: WeekOfMonth rows missing

`computeValidParts()` used "does the most-recent comparison period's own data have a row for this part" as a proxy for "has the most-recent period chronologically reached this part yet." Those conditions only coincide when the most recent period's data is dense. When it's merely sparse — a real bucket with zero matching rows — the old algorithm dropped that bucket's data for *every* period, including older periods with real, legitimate rows for it.

**Fix:** keep a part valid whenever it sorts at or before the last part the most recent period's own rows actually reach, instead of requiring an exact row match. A part that sorts strictly beyond that point is still treated as an unreached "future" bucket and stays excluded, preserving the behavior Bug #75152/#76389 rely on.

### Bug #76390 — Shared dc1 Chart4: per-bar date labels blank after the first facet group

`DateComparisonFormat.initPartDate()` independently re-ran the same orphaned-cell heuristic (via `computeValidParts()`) purely to decide which facet groups' date labels to blank — but any row that reaches `DateComparisonFormat` has already passed the legitimate future-bucket filter upstream in `applyDateRange()`'s `ValidPartsSelector`. Re-filtering at the label stage was pure redundant/harmful duplication specific to facet mode, blanking real labels for every facet group after the first.

**Fix:** remove the redundant `orphanedCells` label-blanking logic from `DateComparisonFormat` entirely.

## Test plan

- [x] New tests: `DateComparisonUtilValidPartsTest` (reproduces #76391's exact drop pattern; guards the legitimate future-bucket-hiding case), `DateComparisonFormatOrphanedFacetTest` (reproduces #76390's exact label-blanking pattern)
- [x] Existing `DateComparisonIntervalConditionTest`, `DcFormatTableLensTest`, `VSChartShowDataServiceTest`, `DCMergeDateFilterTest` still pass
- [x] #76391 independently re-verified by a second reviewer pass (re-ran diff + all tests, probed edge cases)
- [x] #76390 verified live against the actual imported `Shared dc1.vso` on a running server (confirmed the reported bug reproduces pre-fix; test-verified post-fix)

Fixes Redmine #76391. Fixes Redmine #76390.