### PR TITLE
Add regression tests for recent SSO fixes

### DIFF
--- a/core/src/test/java/inetsoft/web/security/AbstractSecurityFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/AbstractSecurityFilterTest.java
@@ -59,12 +59,16 @@ import inetsoft.sree.security.*;
 import inetsoft.sree.web.SessionLicenseServiceProvider;
 import inetsoft.uql.util.XSessionService;
 import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -103,6 +107,47 @@ class AbstractSecurityFilterTest {
       {
          chain.doFilter(request, response);
       }
+   }
+
+   /**
+    * Mimics StyleBIGoogleSSOFilter.getSSODefaultRole()'s override: no isMultiTenant() guard, just
+    * a fixed configured list of role names. Used to exercise createSSOSession()'s integration with
+    * getSSODefaultRoleID() (P1 scenarios 2/3 of the SSO test plan) without depending on
+    * StyleBIGoogleSSOFilter's own package (inetsoft.enterprise.sso) or its JWT/JOSE machinery --
+    * createSSOSession() is declared protected on AbstractSecurityFilter (inetsoft.web.security), so
+    * a real StyleBIGoogleSSOFilter instance could not call it from a test in the enterprise package
+    * anyway; the base-class integration point is what matters here, not the Google subclass itself.
+    */
+   private static final class GoogleLikeFilter extends AbstractSecurityFilter {
+      private final String[] defaultRoles;
+
+      GoogleLikeFilter(SessionLicenseServiceProvider provider, AuthenticationService service,
+                        String[] defaultRoles)
+      {
+         super(provider, service);
+         this.defaultRoles = defaultRoles;
+      }
+
+      @Override
+      protected String[] getSSODefaultRole() {
+         return defaultRoles;
+      }
+
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+         throws IOException, ServletException
+      {
+         chain.doFilter(request, response);
+      }
+   }
+
+   private static HttpServletRequest requestWithSession(HttpSession session) {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      lenient().when(request.getSession(true)).thenReturn(session);
+      lenient().when(request.getHeader(anyString())).thenReturn(null);
+      lenient().when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+      lenient().when(request.getLocale()).thenReturn(Locale.US);
+      return request;
    }
 
    @BeforeEach
@@ -312,5 +357,65 @@ class AbstractSecurityFilterTest {
       // the admin check is skipped when there is no provider, but the org scoping must not be
       assertEquals(new IdentityID(ROLE, TENANT_ORG),
                    filter.getSSODefaultRoleID(ROLE, principal(TENANT_ORG)));
+   }
+
+   // ── cross-filter integration matrix (SSO test plan P1): createSSOSession() end to end ──────
+   //
+   // getSSODefaultRoleID() above is proven correct in isolation. These two tests prove that
+   // createSSOSession() -- the method that actually merges its result onto the login principal --
+   // wires it up correctly for a filter whose getSSODefaultRole() override has NO isMultiTenant()
+   // guard, which is exactly StyleBIGoogleSSOFilter's shape (see its javadoc for why that absence
+   // is deliberate). This is Bug #76161's original end-to-end scenario, not just the unit-level
+   // guard tested above.
+
+   @Test
+   void multiTenant_googleStyleFilter_administratorPropertyValue_isRejected() throws Exception {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+      GoogleLikeFilter googleFilter = new GoogleLikeFilter(
+         mock(SessionLicenseServiceProvider.class), mock(AuthenticationService.class),
+         new String[] { "Administrator" });
+      HttpSession session = mock(HttpSession.class);
+      HttpServletRequest request = requestWithSession(session);
+
+      SRPrincipal result = googleFilter.createSSOSession(request, principal(TENANT_ORG));
+
+      assertFalse(Arrays.asList(result.getRoles()).contains(new IdentityID("Administrator", null)),
+         "a Google-style filter without the isMultiTenant() guard must still have the " +
+            "\"Administrator\" property value rejected by getSSODefaultRoleID() end to end -- this " +
+            "is Bug #76161's original self-registration-to-server-admin scenario");
+   }
+
+   @Test
+   void multiTenant_googleStyleFilter_selfOrgSignup_getsOrgScopedOrganizationAdministrator()
+      throws Exception
+   {
+      stubMultiTenant(true);
+      // NOTE (found while writing this test, not assumed up front): the built-in
+      // "Organization Administrator" role is seeded GLOBALLY (org-less, IdentityID(name, null)) --
+      // see isAssignableSSODefaultRole()'s first guard -- so it is refused by name for EVERY org,
+      // including the user's own new SELF org; there is no special case for self-signup there.
+      // What the class javadoc's "org-scoped ... is deliberately still allowed" comment (and the
+      // existing multiTenant_orgScopedOrgAdminRole_isAllowed test above) actually describes is an
+      // ORG-SCOPED role -- e.g. one an operator created specifically inside that org, or (as here)
+      // one the security provider resolves as existing only within the org being signed into, not
+      // the global built-in role sharing its name. So the role store below flags the org-admin bit
+      // on the SELF-org-scoped identity, not the null-org one.
+      stubRoleStore(Set.of(),
+         Set.of(new IdentityID("Organization Administrator", Organization.getSelfOrganizationID())));
+      GoogleLikeFilter googleFilter = new GoogleLikeFilter(
+         mock(SessionLicenseServiceProvider.class), mock(AuthenticationService.class),
+         new String[] { "Organization Administrator" });
+      HttpSession session = mock(HttpSession.class);
+      HttpServletRequest request = requestWithSession(session);
+
+      SRPrincipal result = googleFilter.createSSOSession(
+         request, principal(Organization.getSelfOrganizationID()));
+
+      assertTrue(Arrays.asList(result.getRoles()).contains(new IdentityID(
+            "Organization Administrator", Organization.getSelfOrganizationID())),
+         "an org-scoped Organization Administrator role resolved within the user's own SELF org " +
+            "must still be granted end to end -- this must not be collateral damage from the " +
+            "Administrator-name rejection fix");
    }
 }

--- a/core/src/test/java/inetsoft/web/security/JWTFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/JWTFilterTest.java
@@ -210,6 +210,22 @@ class JWTFilterTest {
          "ThreadContext must be restored to null after filter completes");
    }
 
+   // ---- valid token → principal.setIgnoreLogin(true) so isLogin() is not consulted (Bug #73926) ----
+
+   @Test
+   void doFilter_validToken_marksPrincipalIgnoreLogin() throws Exception {
+      MockHttpServletRequest request = apiRequest("GET", "/api/public/data");
+      request.addHeader("X-Inetsoft-Api-Token", "valid.token");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      SRPrincipal principal = mock(SRPrincipal.class);
+      when(principal.getLocale()).thenReturn(Locale.ENGLISH);
+      when(jwtService.getPrincipal(anyString(), eq("valid.token"))).thenReturn(principal);
+
+      filter.doFilter(request, response, chain);
+
+      verify(principal).setIgnoreLogin(true);
+   }
+
    // ---- team websocket endpoint without token → 401 ----
 
    @Test

--- a/core/src/test/java/inetsoft/web/security/SecuredAspectTest.java
+++ b/core/src/test/java/inetsoft/web/security/SecuredAspectTest.java
@@ -26,8 +26,7 @@ package inetsoft.web.security;
  * became a 500. The fix switched the thrown type to the unchecked java.lang.SecurityException and
  * added it to ControllerErrorHandler's handler alongside the original checked type (kept for any
  * other code path that still throws it directly). This class had zero test coverage of either half
- * of that fix before this file -- see docs/superpowers/plans/2026-09-01-sso-recent-fixes-test-plan.md
- * section 0 (historical commit 04dfb3074) for how that gap was found.
+ * of that fix before this file.
  */
 
 import inetsoft.sree.AnalyticRepository;

--- a/core/src/test/java/inetsoft/web/security/SecuredAspectTest.java
+++ b/core/src/test/java/inetsoft/web/security/SecuredAspectTest.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.security;
+
+/*
+ * Regression coverage for the community half of Bug #73926 (commit 04dfb3074): SecuredAspect used
+ * to throw the CHECKED inetsoft.sree.security.SecurityException when a @Secured check failed.
+ * Spring AOP proxies wrap a checked exception thrown from a method that does not declare it in
+ * an UndeclaredThrowableException, which is not a SecurityException at all, so
+ * ControllerErrorHandler's @ExceptionHandler(SecurityException.class) never matched and a 403
+ * became a 500. The fix switched the thrown type to the unchecked java.lang.SecurityException and
+ * added it to ControllerErrorHandler's handler alongside the original checked type (kept for any
+ * other code path that still throws it directly). This class had zero test coverage of either half
+ * of that fix before this file -- see docs/superpowers/plans/2026-09-01-sso-recent-fixes-test-plan.md
+ * section 0 (historical commit 04dfb3074) for how that gap was found.
+ */
+
+import inetsoft.sree.AnalyticRepository;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.util.log.LogManager;
+import inetsoft.web.admin.authz.ComponentAuthorizationService;
+import inetsoft.web.portal.controller.ControllerErrorHandler;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class SecuredAspectTest {
+   @Mock
+   private DataSourceRegistry dataSourceRegistry;
+   @Mock
+   private ComponentAuthorizationService componentAuthorizationService;
+   @Mock
+   private AnalyticRepository repletRepository;
+   @Mock
+   private HttpServletRequest request;
+
+   private SecuredAspect aspect;
+   private MockedStatic<SUtil> sUtilMock;
+
+   @BeforeEach
+   void setUp() {
+      aspect = new SecuredAspect(dataSourceRegistry, componentAuthorizationService);
+      sUtilMock = mockStatic(SUtil.class);
+      sUtilMock.when(SUtil::getRepletRepository).thenReturn(repletRepository);
+      lenient().when(request.getRequestURI()).thenReturn("/api/portal/secured-resource");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+   }
+
+   @AfterEach
+   void tearDown() {
+      RequestContextHolder.resetRequestAttributes();
+      sUtilMock.close();
+   }
+
+   private ProceedingJoinPoint joinPointFor(String methodName, Principal user) throws Exception {
+      Method method = SecuredFixture.class.getMethod(methodName, Principal.class);
+      MethodSignature signature = mock(MethodSignature.class);
+      when(signature.getMethod()).thenReturn(method);
+      ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+      when(joinPoint.getSignature()).thenReturn(signature);
+      when(joinPoint.getArgs()).thenReturn(new Object[] { user });
+      return joinPoint;
+   }
+
+   // ── scenario 1: denied access throws java.lang.SecurityException, not the checked type ──
+
+   @Test
+   void deniedAccess_throwsUncheckedSecurityException_notCheckedType() throws Throwable {
+      when(repletRepository.checkPermission(any(), eq(ResourceType.REPORT),
+         eq("secured-resource"), eq(ResourceAction.READ))).thenReturn(false);
+      Principal user = () -> "alice";
+      ProceedingJoinPoint joinPoint = joinPointFor("securedMethod", user);
+
+      java.lang.SecurityException thrown = assertThrows(java.lang.SecurityException.class,
+         () -> aspect.authorize(joinPoint),
+         "denied @Secured access must throw java.lang.SecurityException (a RuntimeException), " +
+            "not the checked inetsoft.sree.security.SecurityException -- otherwise Spring AOP " +
+            "wraps it in UndeclaredThrowableException and ControllerErrorHandler never matches it");
+
+      assertEquals(java.lang.SecurityException.class, thrown.getClass());
+      verify(joinPoint, never()).proceed();
+   }
+
+   // ── scenario: allowed access proceeds normally (regression guard for the main path) ──
+
+   @Test
+   void allowedAccess_proceeds() throws Throwable {
+      when(repletRepository.checkPermission(any(), eq(ResourceType.REPORT),
+         eq("secured-resource"), eq(ResourceAction.READ))).thenReturn(true);
+      Principal user = () -> "alice";
+      ProceedingJoinPoint joinPoint = joinPointFor("securedMethod", user);
+
+      assertDoesNotThrow(() -> aspect.authorize(joinPoint));
+      verify(joinPoint).proceed();
+   }
+
+   // ── scenario 2: ControllerErrorHandler maps BOTH exception types to 403, not 500 ──
+
+   @Test
+   void controllerErrorHandler_mapsUncheckedSecurityExceptionTo403() {
+      ControllerErrorHandler handler = new ControllerErrorHandler(mock(LogManager.class));
+
+      ResponseEntity<Map<String, String>> response =
+         handler.handleSecurityException(new java.lang.SecurityException("denied"));
+
+      assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+   }
+
+   @Test
+   void controllerErrorHandler_mapsCheckedSecurityExceptionTo403() {
+      ControllerErrorHandler handler = new ControllerErrorHandler(mock(LogManager.class));
+
+      ResponseEntity<Map<String, String>> response =
+         handler.handleSecurityException(new inetsoft.sree.security.SecurityException("denied"));
+
+      assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+         "the checked type stays handled too, in case any other code path still throws it directly");
+   }
+
+   // ── fixture ──────────────────────────────────────────────────────────────
+
+   private static final class SecuredFixture {
+      @Secured({
+         @RequiredPermission(resourceType = ResourceType.REPORT, resource = "secured-resource",
+            actions = ResourceAction.READ)
+      })
+      public void securedMethod(@PermissionUser Principal user) {
+      }
+   }
+}


### PR DESCRIPTION
Covers setIgnoreLogin/SecuredAspect exception handling (Bug #73926) and the SSO default-role tenant-isolation matrix (Bug #76161) with new SecuredAspectTest, a JWTFilterTest case, and additions to AbstractSecurityFilterTest.