### PR TITLE
fix: surface actual JS error + fix-it hint before Assembly label in calc-table formula errors

### DIFF
--- a/core/src/main/java/inetsoft/report/lens/CalcTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/CalcTableLens.java
@@ -1130,9 +1130,11 @@ public class CalcTableLens extends DefaultTableLens {
       }
       catch(Exception ex) {
          String rname = getContextName();
+         String suggestion = senv.getSuggestion(ex, "field", tableScope);
          String str = Catalog.getCatalog().getString("JavaScript error") +
-            ": " + ex.getMessage();
-         throw new ScriptException(rname == null ? str : rname + str, ex);
+            ": " + ex.getMessage() +
+            (suggestion != null ? "\nTo fix: " + suggestion : "");
+         throw new ScriptException(rname == null ? str : str + "\n" + rname, ex);
       }
       finally {
          FormulaContext.popTable();

--- a/core/src/test/java/inetsoft/report/lens/CalcTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/CalcTableLensTest.java
@@ -21,6 +21,8 @@ package inetsoft.report.lens;
 import inetsoft.report.script.formula.CalcRef;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
+import inetsoft.uql.viewsheet.CalcTableVSAssembly;
+import inetsoft.util.script.graal.GraalJavaScriptEnv;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,5 +105,40 @@ public class CalcTableLensTest {
 
       Object[] arr = { 1, "a", null };
       Assertions.assertArrayEquals(new Object[]{ 1, "a", null }, (Object[]) CalcTableLens.unwrapCalcRefs(arr));
+   }
+
+   /**
+    * A hand-typed formula cell (content:"formula") referencing a bare, unqualified
+    * column name (e.g. Sum(PAID) instead of Sum(field['PAID'])) is invalid syntax in
+    * the calc-table script scope and always throws a ReferenceError, regardless of
+    * grouping. The rendered cell must lead with that ReferenceError and the
+    * GraalJavaScriptEnv.getSuggestion() fix-it hint, not the generic "Assembly: <name>"
+    * context label, since a cell only has room to render one line.
+    */
+   @Test
+   public void testFormulaErrorSurfacesReferenceErrorAndHintFirst() {
+      DefaultTableLens data = new DefaultTableLens(new Object[][] {
+         { "id" },
+         { 1 }
+      });
+
+      CalcTableVSAssembly assembly = new CalcTableVSAssembly();
+      assembly.setScriptTable(data);
+      assembly.setScriptEnv(new GraalJavaScriptEnv());
+
+      CalcTableLens calc = new CalcTableLens(data);
+      calc.setElement(assembly);
+      calc.setFormula(1, 0, "Sum(PAID)");
+
+      Object value = calc.getValue(1, 0);
+
+      Assertions.assertTrue(value instanceof String, "expected an ERROR string, got: " + value);
+      String message = (String) value;
+      String firstLine = message.split("\n", 2)[0];
+      Assertions.assertTrue(
+         firstLine.contains("ReferenceError") && firstLine.contains("is not defined"),
+         "first line should be the actual JS error, not the Assembly label: " + message);
+      Assertions.assertTrue(message.contains("field['columnName']"),
+         "message should include the getSuggestion() fix-it hint: " + message);
    }
 }


### PR DESCRIPTION
## Summary

A hand-typed calc-table formula cell containing a bare, unqualified identifier
(e.g. `Sum(PAID)` instead of `Sum(field['PAID'])`) is genuinely invalid syntax
in the GraalJS calc-table scope (`CalcTableScope` never registers bare column
names — only `field`). That syntax gate is correct, deliberate behavior and is
not changed by this PR.

The defect is message quality: `CalcTableLens.evaluate()`'s runtime
`catch(Exception ex)` block built the thrown `ScriptException` message as
`"Assembly: <name>\n" + "JavaScript error: " + ex.getMessage()`. Since a
calc-table cell can only render its first line, the useless `"Assembly: <name>"`
label ate the only visible line, hiding the actual `ReferenceError` and its
message. Separately, `GraalJavaScriptEnv.getSuggestion()` already computes a
ready-made fix-it hint ("...Field/row values are referenced using
`field['columnName']`.") for exactly this exception shape — the sibling
log-only handler a few lines above the runtime catch block already calls it,
but the runtime catch block that builds the user-visible message never did.

### Fix

`community/core/src/main/java/inetsoft/report/lens/CalcTableLens.java`,
`evaluate(int, int, Formula)`'s runtime `catch(Exception ex)` block:
- Call `senv.getSuggestion(ex, "field", tableScope)` (mirrors the existing
  log-only handler) and append `"\nTo fix: " + suggestion` to the message when
  non-null.
- Put the actual JS error (+ hint) first, and the `"Assembly: <name>"` context
  label last, so a space-constrained renderer shows the useful fragment.

No change to when/whether the exception is thrown, and no change to
`CalcTableScope`'s bare-identifier gate — this only changes what the message
says.

### Known gap (not blocking)

Both the diagnosis and an independent refutation pass ran this against an
isolated `CalcTableLens` (no live viewsheet wired up). The live-viewsheet
parent-scope-chain branch (`CalcTableLens.java` ~1039-1049) was traced by
reading `TableDataVSAScriptable`/`VSAScriptable`/`ViewsheetScope`/
`AssetQueryScope` and confirmed to have no dynamic bare-column-name
registration anywhere in it, so the fix should hold under the live path too —
but this is source-inference, not a live-Composer run.

### Out of scope (flagged, not touched)

`FormulaTableLens.java` has a similar-shaped message-ordering issue in its own
formula-error catch blocks (report `FormulaTableLens`, a different assembly
type), plus a second, simpler catch block with no context label to reorder at
all. Different class/assembly type from this item — left for a follow-up.

## Test plan

- Added `CalcTableLensTest.testFormulaErrorSurfacesReferenceErrorAndHintFirst`:
  builds a `CalcTableLens` + `CalcTableVSAssembly` + `GraalJavaScriptEnv`, sets
  a formula cell to `Sum(PAID)` (PAID not a column of the grid), asserts the
  returned `"ERROR: ..."` string's first line contains
  `ReferenceError`/`is not defined`, and that the full message contains the
  `field['columnName']` hint.
- Confirmed the new test fails against pre-fix code (reproduces
  `"ERROR: Assembly: null\nJavaScript error: ..."` with no hint) and passes
  with the fix.
- `./mvnw -pl community/core -o test -Dtest=CalcTableLensTest` — all 6 tests
  pass (`BUILD SUCCESS`).
- Grepped `core/src/test` for `"JavaScript error"` / `"Assembly: "` — no other
  test depends on the old message field order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)