### PR TITLE
fix(wiz): finish trimming the dropped date-comparison frame field from tests

### DIFF
--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -217,8 +217,7 @@ class DateComparisonServiceTest {
    {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison =
-         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
-                                              null);
+         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null);
 
       harness(model).service.set("tok", principal(), "Chart1", comparison, "");
 
@@ -232,8 +231,7 @@ class DateComparisonServiceTest {
    void refusesAnUnrecognizedPeriodLevel(String word) {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison =
-         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
-                                              null);
+         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null);
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,


### PR DESCRIPTION
## Summary
- Commit 729755296 (#4818) dropped one field from `DateComparisonService.Comparison` (8 params -> 7 — the disabled colour-frame field) and updated three of the five test constructor call sites, but missed two: `translatesThePeriodLevelWordToTheNumericGroupCode` and `refusesAnUnrecognizedPeriodLevel`.
- Both still passed a stray trailing `null`, which no longer matches the record's shape and fails core module test compilation entirely (blocking every test in `core`, not just this file).
- This trims the extra argument from both call sites to match the current 7-field record.

## Test plan
- [x] `./mvnw.cmd -pl core test -Dtest=DateComparisonServiceTest -Dsurefire.failIfNoSpecifiedTests=false` — 31/31 passing, module compiles again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)