### PR TITLE
L4 chart sub-elements & layout parity: close 12 agent-path gaps

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -29,6 +29,8 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.*;
 import inetsoft.report.composition.region.ChartArea;
+import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.viewsheet.controller.chart.*;
@@ -99,7 +101,8 @@ public class ChartElementService {
     *                chart title. Null, or blank, means all of that element.
     */
    public void setVisibility(String sessionToken, Principal user, String assemblyName,
-                             String element, String target, boolean visible, String linkUri)
+                             String element, String target, boolean visible, boolean secondary,
+                             String linkUri)
       throws Exception
    {
       String kind = requireElement(element);
@@ -159,8 +162,8 @@ public class ChartElementService {
          switch(kind) {
             case "axis" -> axesService.eventHandler(
                runtimeId,
-               event(Map.of("chartName", assemblyName, "hide", !visible), "columnName", target0,
-                     VSChartAxesVisibilityEvent.class),
+               event(Map.of("chartName", assemblyName, "hide", !visible, "secondary", secondary),
+                     "columnName", target0, VSChartAxesVisibilityEvent.class),
                linkUri, user, dispatcher);
             case "legend" -> legendsService.eventHandler(
                runtimeId, legendEvent, linkUri, user, dispatcher);
@@ -563,6 +566,35 @@ public class ChartElementService {
       out.put("axesMeasured", axes.measured());
       out.put("legends", describe(regions.legends()));
       out.put("legendsMeasured", regions.legends().measured());
+
+      // Which measure(s) are on the secondary axis -- the piece a caller needs to pass
+      // setVisibility's own 'secondary' correctly. Without this, "hide the axis for measure X"
+      // on a dual-Y-axis chart has no way to know whether X is the primary or secondary one; a
+      // wrong guess used to always resolve to the primary axis regardless (parity audit L4,
+      // finding G1-3).
+      List<String> secondaryFields = sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         VSChartInfo info = ChartRegionResolver.requireChart(rvs, assembly).getVSChartInfo();
+         List<String> found = new ArrayList<>();
+
+         for(ChartRef ref : info.getXFields()) {
+            if(ref instanceof ChartAggregateRef agg && agg.isSecondaryY()) {
+               found.add(ref.getFullName());
+            }
+         }
+
+         for(ChartRef ref : info.getYFields()) {
+            if(ref instanceof ChartAggregateRef agg && agg.isSecondaryY()) {
+               found.add(ref.getFullName());
+            }
+         }
+
+         return found;
+      });
+
+      if(!secondaryFields.isEmpty()) {
+         out.put("secondaryFields", secondaryFields);
+      }
+
       return out;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -120,6 +120,30 @@ public class ChartElementService {
             "hide the ones you do not want.");
       }
 
+      // Unlike legends (VSChartLegendsVisibilityService.showAllLegends genuinely iterates every
+      // legend descriptor), neither the axis nor the title event has a real "hide everything"
+      // mode: VSChartAxesVisibilityEvent#getColumnName's own javadoc documents null as meaning
+      // "show all axis", never hide-all, and hideAxis()/hideChartTitle() both fall through a null
+      // target to one arbitrary/narrow descriptor. A prior version of this method let that
+      // fallthrough run silently: it reported "Hid all axiss on <chart>" while only ever touching
+      // one unrelated descriptor (no axis label ever changed, confirmed live), and reported "Hid
+      // all titles" while only ever touching the chart's own title (axis titles were untouched,
+      // also confirmed live). Refusing here, rather than teaching the event a hide-all mode it was
+      // never designed to have, is the same choice the show-path above already made for "showing
+      // one is not supported" — tell the caller what actually works instead of a false success.
+      if(!visible && target0 == null && !"legend".equals(kind)) {
+         throw new IllegalArgumentException(
+            "Hiding every " + kind + " with no 'target' is not supported — there is no Composer " +
+            "action that hides every " + kind + " at once, so this call cannot honour it. Name " +
+            ("title".equals(kind)
+               ? "the title to hide: 'chart' for the chart's own title, or an axis type (x, x2, " +
+                 "y, y2) for that axis's title."
+               : "the " + kind + " to hide (its column name — call get_binding, but see " +
+                 "list_chart_elements's own axis note for a date/named-group dimension) one at " +
+                 "a time.") +
+            " Hide them one at a time if you need more than one gone.");
+      }
+
       // Resolved before the runtime is mutated, for the same reason as the guard above and by the
       // same route ChartRegionPropertyService takes for its own refusals: sessions.mutate
       // checkpoints and broadcasts in a finally, deliberately, because a composer service can

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.Principal;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * Properties of a chart's <b>sub-elements</b>: its axes, legends and titles.
@@ -119,7 +120,7 @@ public class ChartRegionPropertyService {
       }
 
       if("axis".equals(name)) {
-         requireLinearAxisForLinearOnlyKeys(sessionToken, user, assembly, key, properties);
+         requireLinearAxisForLinearOnlyKeys(sessionToken, user, assembly, key, field, properties);
       }
 
       Object model = readModel(sessionToken, user, assembly, name, key, field);
@@ -199,7 +200,7 @@ public class ChartRegionPropertyService {
     */
    private void requireLinearAxisForLinearOnlyKeys(String sessionToken, Principal user,
                                                     String assembly, String axisTarget,
-                                                    Map<String, Object> properties)
+                                                    String field, Map<String, Object> properties)
       throws Exception
    {
       Set<String> requested = new TreeSet<>(properties.keySet());
@@ -216,18 +217,35 @@ public class ChartRegionPropertyService {
          boolean secondary = "y2".equals(canonical) || "x2".equals(canonical);
          boolean onYShelf = "y".equals(canonical) || "y2".equals(canonical);
          ChartRef[] refs = (onYShelf != inverted) ? info.getYFields() : info.getXFields();
+         Stream<ChartRef> candidates = Arrays.stream(refs);
 
-         return Arrays.stream(refs).anyMatch(ref ->
-            ref instanceof ChartAggregateRef aggregate &&
-            (!secondary || aggregate.isSecondaryY()));
+         // A shelf can carry more than one field of the same axis type (the tool's own
+         // vocabulary() note: "to address one of several axes of the same type... pass the
+         // column name as 'field'") -- checking "does ANY field on the shelf happen to be a
+         // measure" instead of the ONE field this call actually addresses would let a write
+         // aimed at a dimension slip through on a mixed dimension+measure shelf. When 'field' is
+         // given, resolve to that specific ref; only fall back to "any measure on the shelf" when
+         // it is not, matching how the rest of this class already treats an absent field as "the
+         // shelf has just the one".
+         if(field != null && !field.isBlank()) {
+            candidates = candidates.filter(ref ->
+               field.equals(ref.getFullName()) || field.equals(ref.getName()));
+         }
+
+         // Exact match, not "secondary implies acceptable, primary accepts anything": a measure
+         // that lives on the OTHER axis of this type must not make this one look linear, in
+         // either direction.
+         return candidates.anyMatch(ref ->
+            ref instanceof ChartAggregateRef aggregate && aggregate.isSecondaryY() == secondary);
       });
 
       if(!linear) {
          throw new IllegalArgumentException(
             "'" + String.join("', '", requested) + "' only apply to a linear (measure) axis. " +
-            "'" + axisTarget + "' on this chart is bound to a dimension, not a measure, so " +
-            "these would be silently ignored — or, on some chart types, corrupt the render " +
-            "instead of being ignored. Omit them for a dimension axis.");
+            "'" + axisTarget + "'" + (field != null && !field.isBlank() ? " ('" + field + "')" : "")
+            + " on this chart is bound to a dimension, not a measure, so these would be " +
+            "silently ignored — or, on some chart types, corrupt the render instead of being " +
+            "ignored. Omit them for a dimension axis.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -17,6 +17,9 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.composer.vs.dialog.RegionPropertyDialogService;
 import inetsoft.web.graph.model.dialog.AxisPropertyDialogModel;
 import inetsoft.web.graph.model.dialog.LegendFormatDialogModel;
@@ -115,6 +118,10 @@ public class ChartRegionPropertyService {
             "list_chart_region_properties reports the names this region accepts.");
       }
 
+      if("axis".equals(name)) {
+         requireLinearAxisForLinearOnlyKeys(sessionToken, user, assembly, key, properties);
+      }
+
       Object model = readModel(sessionToken, user, assembly, name, key, field);
       Map<String, String> aliases = aliasesFor(name);
       Map<String, Object> resolved = new LinkedHashMap<>();
@@ -161,6 +168,67 @@ public class ChartRegionPropertyService {
             runtimeId, assembly, key, (TitleFormatDialogModel) written, linkUri, user, dispatcher);
          }
       });
+   }
+
+   /** Axis properties that only mean something on a linear (measure) axis. */
+   private static final Set<String> LINEAR_ONLY_AXIS_KEYS =
+      Set.of("reverse", "logarithmicScale", "shared", "minimum", "maximum", "minorIncrement");
+
+   /**
+    * Refuses a linear-only axis property (a numeric range, a log scale, a reversed direction...)
+    * on an axis that is not linear.
+    *
+    * <p>{@code AxisPropertyDialogModel.updateAxisPropertyDialogModel} only applies these under
+    * {@code if(this.linear)} — correct given its input. The bug is upstream: {@link #readModel}
+    * and {@link #set} ask {@code RegionPropertyDialogService.getAxisPropertyDialogModel} for area
+    * index {@code 0} unconditionally, and {@code ChartRegionHandler.createAxisPropertyDialogModel}
+    * uses that index to <em>infer</em> linearity from whichever leaf area happens to sort first on
+    * screen ({@code AxisLineArea} vs. {@code DimensionLabelArea}) — a proxy that is valid for the
+    * real Composer, which derives the index from the user's actual click, and meaningless here,
+    * where there was no click and the index is always {@code 0}. For an ordinary bottom x-axis the
+    * tick/line area sorts before the label area regardless of whether the bound field is a
+    * dimension or a measure, so a purely categorical axis (e.g. a year-grouped date dimension)
+    * silently comes back {@code isLinear: true}. Confirmed live: {@code minimum:"5"} on such an
+    * axis was persisted and rendered as a fabricated numeric range, corrupting the chart.
+    *
+    * <p>This checks linearity independently, the same way {@code ChartRegionHandler}'s own
+    * ref-driven branch does it ({@code ref instanceof ChartAggregateRef}), straight off the
+    * binding rather than off the area sort order — and refuses rather than trying to fix the
+    * shared area-index mechanism in place, which the real UI also depends on for its own,
+    * legitimate click-derived index.
+    */
+   private void requireLinearAxisForLinearOnlyKeys(String sessionToken, Principal user,
+                                                    String assembly, String axisTarget,
+                                                    Map<String, Object> properties)
+      throws Exception
+   {
+      Set<String> requested = new TreeSet<>(properties.keySet());
+      requested.retainAll(LINEAR_ONLY_AXIS_KEYS);
+
+      if(requested.isEmpty()) {
+         return;
+      }
+
+      boolean linear = sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         VSChartInfo info = ChartRegionResolver.requireChart(rvs, assembly).getVSChartInfo();
+         String canonical = ChartRegionResolver.canonical(axisTarget);
+         boolean inverted = info.isInvertedGraph();
+         boolean secondary = "y2".equals(canonical) || "x2".equals(canonical);
+         boolean onYShelf = "y".equals(canonical) || "y2".equals(canonical);
+         ChartRef[] refs = (onYShelf != inverted) ? info.getYFields() : info.getXFields();
+
+         return Arrays.stream(refs).anyMatch(ref ->
+            ref instanceof ChartAggregateRef aggregate &&
+            (!secondary || aggregate.isSecondaryY()));
+      });
+
+      if(!linear) {
+         throw new IllegalArgumentException(
+            "'" + String.join("', '", requested) + "' only apply to a linear (measure) axis. " +
+            "'" + axisTarget + "' on this chart is bound to a dimension, not a measure, so " +
+            "these would be silently ignored — or, on some chart types, corrupt the render " +
+            "instead of being ignored. Omit them for a dimension axis.");
+      }
    }
 
    /**
@@ -371,7 +439,13 @@ public class ChartRegionPropertyService {
 
    private static Map<String, String> legend() {
       Map<String, String> aliases = new LinkedHashMap<>();
-      aliases.put("title", "legendFormatGeneralPaneModel.title");
+      // "title" (not titleValue) is the read-only dvalue/default the combo box shows as a
+      // placeholder (legend-format-general-pane.component.html's origValue) -- the field a human
+      // actually edits, and the only one LegendFormatDialogModel.updateLegendFormatDialogModel
+      // ever persists, is titleValue. Aliasing "title" here used to point at the wrong sibling:
+      // set_chart_region_properties({region:"legend", properties:{title:"X"}}) returned ok:true
+      // and silently changed nothing, confirmed live 2026-09-02.
+      aliases.put("title", "legendFormatGeneralPaneModel.titleValue");
       aliases.put("visible", "legendFormatGeneralPaneModel.visible");
       aliases.put("position", "legendFormatGeneralPaneModel.position");
       aliases.put("fillColor", "legendFormatGeneralPaneModel.fillColor");

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -123,6 +123,11 @@ public class ChartRegionPropertyService {
          requireLinearAxisForLinearOnlyKeys(sessionToken, user, assembly, key, field, properties);
       }
 
+      if(properties.containsKey("rotation")) {
+         properties = new LinkedHashMap<>(properties);
+         properties.put("rotation", canonicalRotation(name, properties.get("rotation")));
+      }
+
       Object model = readModel(sessionToken, user, assembly, name, key, field);
       Map<String, String> aliases = aliasesFor(name);
       Map<String, Object> resolved = new LinkedHashMap<>();
@@ -247,6 +252,40 @@ public class ChartRegionPropertyService {
             "silently ignored — or, on some chart types, corrupt the render instead of being " +
             "ignored. Omit them for a dimension axis.");
       }
+   }
+
+   /** The axis label's rotation offers "auto"; the title's does not (it is never presented). */
+   private static final Set<String> AXIS_ROTATIONS = Set.of("auto", "-90", "-45", "0", "45", "90");
+   private static final Set<String> TITLE_ROTATIONS = Set.of("-90", "-45", "0", "45", "90");
+
+   /**
+    * Validates a {@code rotation} against the domain the target region's model actually accepts,
+    * and returns the canonical spelling PropertyPath should be given.
+    *
+    * <p>Both {@code AxisLabelPaneModel}'s and {@code TitleFormatPaneModel}'s rotation live at a
+    * path ending in {@code .rotation} (via their shared {@code RotationRadioGroupModel}), so a
+    * single {@code PropertyPath.CONSTRAINED_STRINGS} entry keyed by that leaf name cannot express
+    * that the two accept different domains: the axis label genuinely offers {@code "auto"} in the
+    * Composer (clears the rotation back to the default, matched case-sensitively —
+    * {@code AxisPropertyDialogModel.java:300}, {@code "auto".equals(rotation)}), while the
+    * title's own persist step ({@code TitleFormatDialogModel.updateTitleFormatPaneModel}) does not
+    * handle {@code "auto"} at all and calls {@code Float.parseFloat(rotation)} directly on
+    * whatever string arrives, which throws an unhelpful raw {@code NumberFormatException} for it.
+    * Checked here, region-aware, before either path is reached — and canonicalized the same way
+    * {@code PropertyPath}'s own {@code CONSTRAINED_STRINGS} check does, so {@code "AUTO"} reaches
+    * the axis model as the lowercase {@code "auto"} the exact-match check requires.
+    */
+   private static String canonicalRotation(String region, Object rotation) {
+      String text = rotation == null ? "" : String.valueOf(rotation).trim().toLowerCase();
+      Set<String> allowed = "axis".equals(region) ? AXIS_ROTATIONS : TITLE_ROTATIONS;
+
+      if(!allowed.contains(text)) {
+         throw new IllegalArgumentException(
+            "'rotation' on a chart " + region + " accepts only " + new TreeSet<>(allowed) +
+            "; '" + rotation + "' is not one of them.");
+      }
+
+      return text;
    }
 
    /**
@@ -452,6 +491,10 @@ public class ChartRegionPropertyService {
       aliases.put("minorIncrement", "axisLinePaneModel.minorIncrement");
       aliases.put("showAxisLabel", "axisLabelPaneModel.showAxisLabel");
       aliases.put("labelOnSecondaryAxis", "axisLabelPaneModel.labelOnSecondaryAxis");
+      // The Label tab's Rotation fieldset had no tool equivalent (parity audit L4, finding G3-6).
+      // Unlike the title's rotation, "auto" is a real, offered value here -- see
+      // requireValidRotation for why the two can't share one CONSTRAINED_STRINGS entry.
+      aliases.put("rotation", "axisLabelPaneModel.rotationRadioGroupModel.rotation");
       return aliases;
    }
 
@@ -470,12 +513,24 @@ public class ChartRegionPropertyService {
       aliases.put("style", "legendFormatGeneralPaneModel.style");
       aliases.put("notShowNull", "legendFormatGeneralPaneModel.notShowNull");
       aliases.put("symbolSize", "legendFormatGeneralPaneModel.symbolSize");
+      // Only meaningful on a measure-bound legend (LegendScalePaneModel.reverseVisible/
+      // includeZeroVisible say which of these two actually apply, per legend; logarithmic is
+      // always offered). Genuinely missing before this: the UI's Scale tab had no tool
+      // equivalent at all (parity audit L4, finding G3-3).
+      aliases.put("logarithmicScale", "legendScalePaneModel.logarithmic");
+      aliases.put("reverse", "legendScalePaneModel.reverse");
+      aliases.put("includeZero", "legendScalePaneModel.includeZero");
       return aliases;
    }
 
    private static Map<String, String> title() {
       Map<String, String> aliases = new LinkedHashMap<>();
       aliases.put("title", "titleFormatPaneModel.title");
+      // The Title Properties dialog's Rotation fieldset had no tool equivalent (parity audit L4,
+      // finding G3-5). "auto" is not offered here -- the UI's own title-rotation control never
+      // offers it either (contrast axis-label rotation, which does); the fixed angles are -90,
+      // -45, 0, 45, 90.
+      aliases.put("rotation", "titleFormatPaneModel.rotationRadioGroupModel.rotation");
       return aliases;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -126,17 +126,28 @@ public class ChartRegionPropertyService {
 
       if(properties.containsKey("rotation") || properties.containsKey("aliases")) {
          properties = new LinkedHashMap<>(properties);
-
-         if(properties.containsKey("rotation")) {
-            properties.put("rotation", canonicalRotation(name, properties.get("rotation")));
-         }
-
-         if(properties.containsKey("aliases")) {
-            properties.put("aliases", toModelAliases(properties.get("aliases")));
-         }
       }
 
+      if(properties.containsKey("rotation")) {
+         properties.put("rotation", canonicalRotation(name, properties.get("rotation")));
+      }
+
+      // Shape-validated here, before readModel, so a malformed 'aliases' value keeps failing
+      // fast the same way every other bad-shape property in this class does -- with no model
+      // fetch spent on a request that was always going to be refused. Resolving each entry's
+      // real value needs the model (see toModelAliases), which is fetched below regardless for
+      // the main property-write loop; the resolution itself waits until then.
+      List<Map<?, ?>> aliasEntries = properties.containsKey("aliases")
+                                     && ("axis".equals(name) || "legend".equals(name))
+         ? parseAliasEntries(properties.get("aliases")) : null;
+
       Object model = readModel(sessionToken, user, assembly, name, key, field);
+
+      if(aliasEntries != null) {
+         Object current = PropertyPath.get(model, "aliasPaneModel.aliasList");
+         properties.put("aliases", toModelAliases(aliasEntries, (ModelAlias[]) current));
+      }
+
       Map<String, String> aliases = aliasesFor(name);
       Map<String, Object> resolved = new LinkedHashMap<>();
 
@@ -310,20 +321,30 @@ public class ChartRegionPropertyService {
     * an already-correct {@code ModelAlias[]} and its own pass-through check
     * ({@code target.isInstance(value)}) hands it straight to the setter unchanged.
     *
-    * <p>Each entry needs {@code value} (the real data value the alias replaces) and {@code alias}
-    * (what to show instead); {@code label} is optional and, when omitted, mirrors {@code value} --
-    * on the read side, {@code label} is the value as StyleBI's own {@code GraphUtil.getLegendItems}
-    * / {@code getAxisItems} format it, which for a caller supplying a value fresh rather than
-    * echoing one just read back is not always knowable in advance.
+    * <p>Each entry needs {@code value} (the data value the alias replaces) and {@code alias}
+    * (what to show instead). {@code value} is matched against {@code current} — the region's own
+    * alias list, exactly as {@link #list} already reports it — first by real value, then, more
+    * forgivingly, by display {@code label}: a date-grouped axis's real value is not its display
+    * text (e.g. the label {@code "2022"}'s real value is {@code "2022-01-01 00:00:00"}), and
+    * both {@link AxisPropertyDialogModel#updateAxisPropertyDialogModel} and
+    * {@link LegendFormatDialogModel#updateLegendFormatDialogModel} call
+    * {@code XxxDescriptor.setLabelAlias(value, alias)} with whatever {@code value} this method
+    * hands them, <b>unconditionally, with no matching of their own</b> — so a caller-supplied
+    * value that does not match the real one is silently stored under a key nothing ever reads
+    * back. Live-confirmed 2026-09-02, found by this audit's own live verification pass: writing
+    * {@code {value:"2022", alias:"FY22"}} against a year-grouped axis returned {@code ok:true},
+    * left the chart showing "2022" unchanged, and read back the original, untouched alias list.
+    * A value matching neither the real value nor the label is refused by name, rather than
+    * repeating that silent-no-op shape for a typo or a stale value from an earlier read.
     */
-   private static ModelAlias[] toModelAliases(Object value) {
+   private static List<Map<?, ?>> parseAliasEntries(Object value) {
       if(!(value instanceof List<?> list)) {
          throw new IllegalArgumentException(
             "'aliases' expects a JSON array of {value, alias} objects; '" + value + "' is not " +
             "an array.");
       }
 
-      ModelAlias[] result = new ModelAlias[list.size()];
+      List<Map<?, ?>> parsed = new ArrayList<>(list.size());
 
       for(int i = 0; i < list.size(); i++) {
          Object entry = list.get(i);
@@ -334,22 +355,78 @@ public class ChartRegionPropertyService {
                "'.");
          }
 
-         Object rawValue = map.get("value");
-         Object rawAlias = map.get("alias");
-
-         if(rawValue == null || rawAlias == null) {
+         if(map.get("value") == null || map.get("alias") == null) {
             throw new IllegalArgumentException(
                "'aliases[" + i + "]' needs both 'value' (the data value to replace) and 'alias' " +
                "(what to show instead); got " + map + ".");
          }
 
-         String stringValue = String.valueOf(rawValue);
-         Object rawLabel = map.get("label");
-         String label = rawLabel == null ? stringValue : String.valueOf(rawLabel);
-         result[i] = new ModelAlias(label, stringValue, String.valueOf(rawAlias));
+         parsed.add(map);
+      }
+
+      return parsed;
+   }
+
+   private static ModelAlias[] toModelAliases(List<Map<?, ?>> entries, ModelAlias[] current) {
+      ModelAlias[] result = new ModelAlias[entries.size()];
+
+      for(int i = 0; i < entries.size(); i++) {
+         Map<?, ?> map = entries.get(i);
+         String suppliedValue = String.valueOf(map.get("value"));
+         Object rawAlias = map.get("alias");
+         ModelAlias resolved = resolveAliasItem(suppliedValue, current, i);
+         String realValue = resolved != null ? resolved.getValue() : suppliedValue;
+         String realLabel = resolved != null ? resolved.getLabel() : suppliedValue;
+         result[i] = new ModelAlias(realLabel, realValue, String.valueOf(rawAlias));
       }
 
       return result;
+   }
+
+   /**
+    * Finds the {@code current} entry a caller-supplied alias {@code value} means — an exact match
+    * on the real value first, then a match on the real display label — and refuses, naming the
+    * real value/label pairs, when {@code current} is non-empty and neither matches. {@code null}
+    * (not a refusal) means {@code current} is empty: this region has no items to check against
+    * yet (an unbound or not-yet-laid-out chart), so there is nothing to validate against and the
+    * caller-supplied value passes through rather than being refused for a reason unrelated to
+    * what they typed.
+    */
+   private static ModelAlias resolveAliasItem(String suppliedValue, ModelAlias[] current, int index) {
+      if(current == null || current.length == 0) {
+         return null;
+      }
+
+      for(ModelAlias item : current) {
+         if(suppliedValue.equals(item.getValue())) {
+            return item;
+         }
+      }
+
+      for(ModelAlias item : current) {
+         if(suppliedValue.equals(item.getLabel())) {
+            return item;
+         }
+      }
+
+      StringBuilder known = new StringBuilder();
+
+      for(ModelAlias item : current) {
+         if(known.length() > 0) {
+            known.append(", ");
+         }
+
+         known.append("'").append(item.getLabel()).append("'");
+
+         if(!Objects.equals(item.getLabel(), item.getValue())) {
+            known.append(" (real value '").append(item.getValue()).append("')");
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'aliases[" + index + "].value' ('" + suppliedValue + "') matches neither the real " +
+         "value nor the display label of anything list_chart_region_properties reports for " +
+         "this region. Known: " + known + ".");
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -273,9 +273,8 @@ public class ChartRegionPropertyService {
       }
    }
 
-   /** The axis label's rotation offers "auto"; the title's does not (it is never presented). */
-   private static final Set<String> AXIS_ROTATIONS = Set.of("auto", "-90", "-45", "0", "45", "90");
-   private static final Set<String> TITLE_ROTATIONS = Set.of("-90", "-45", "0", "45", "90");
+   /** The angles both the axis label and the title actually offer, degrees, "auto" aside. */
+   private static final Set<Integer> ROTATION_DEGREES = Set.of(-90, -45, 0, 45, 90);
 
    /**
     * Validates a {@code rotation} against the domain the target region's model actually accepts,
@@ -290,21 +289,41 @@ public class ChartRegionPropertyService {
     * title's own persist step ({@code TitleFormatDialogModel.updateTitleFormatPaneModel}) does not
     * handle {@code "auto"} at all and calls {@code Float.parseFloat(rotation)} directly on
     * whatever string arrives, which throws an unhelpful raw {@code NumberFormatException} for it.
-    * Checked here, region-aware, before either path is reached — and canonicalized the same way
-    * {@code PropertyPath}'s own {@code CONSTRAINED_STRINGS} check does, so {@code "AUTO"} reaches
-    * the axis model as the lowercase {@code "auto"} the exact-match check requires.
+    * Checked here, region-aware, before either path is reached.
+    *
+    * <p>The numeric side is compared as a float, not as an exact string: the model itself never
+    * stores a bare integer string. {@code AxisPropertyDialogModel.updateAxisPropertyDialogModel}
+    * populates {@code RotationRadioGroupModel} via {@code rotation + ""} and
+    * {@code TitleFormatDialogModel} via {@code Number.toString()} on a {@code Float} field, which
+    * yields {@code "90.0"}, not {@code "90"} — the same form the Composer UI's own radio group
+    * writes ({@code rotation-radio-group.component.ts}). A read-then-write round trip through
+    * {@code list_chart_region_properties} must not be rejected just because the stored form has a
+    * decimal point PropertyPath.CONSTRAINED_STRINGS-style exact matching would have missed.
     */
    private static String canonicalRotation(String region, Object rotation) {
-      String text = rotation == null ? "" : String.valueOf(rotation).trim().toLowerCase();
-      Set<String> allowed = "axis".equals(region) ? AXIS_ROTATIONS : TITLE_ROTATIONS;
+      String text = rotation == null ? "" : String.valueOf(rotation).trim();
 
-      if(!allowed.contains(text)) {
-         throw new IllegalArgumentException(
-            "'rotation' on a chart " + region + " accepts only " + new TreeSet<>(allowed) +
-            "; '" + rotation + "' is not one of them.");
+      if("axis".equals(region) && text.equalsIgnoreCase("auto")) {
+         return "auto";
       }
 
-      return text;
+      try {
+         float parsed = Float.parseFloat(text);
+         int degrees = (int) parsed;
+
+         if(degrees == parsed && ROTATION_DEGREES.contains(degrees)) {
+            return String.valueOf(degrees);
+         }
+      }
+      catch(NumberFormatException ignore) {
+         // falls through to the error below
+      }
+
+      String allowedDescription = "axis".equals(region)
+         ? "[-90, -45, 0, 45, 90, auto]" : "[-90, -45, 0, 45, 90]";
+      throw new IllegalArgumentException(
+         "'rotation' on a chart " + region + " accepts only " + allowedDescription +
+         "; '" + rotation + "' is not one of them.");
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -23,6 +23,7 @@ import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.composer.vs.dialog.RegionPropertyDialogService;
 import inetsoft.web.graph.model.dialog.AxisPropertyDialogModel;
 import inetsoft.web.graph.model.dialog.LegendFormatDialogModel;
+import inetsoft.web.graph.model.dialog.ModelAlias;
 import inetsoft.web.graph.model.dialog.TitleFormatDialogModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -123,9 +124,16 @@ public class ChartRegionPropertyService {
          requireLinearAxisForLinearOnlyKeys(sessionToken, user, assembly, key, field, properties);
       }
 
-      if(properties.containsKey("rotation")) {
+      if(properties.containsKey("rotation") || properties.containsKey("aliases")) {
          properties = new LinkedHashMap<>(properties);
-         properties.put("rotation", canonicalRotation(name, properties.get("rotation")));
+
+         if(properties.containsKey("rotation")) {
+            properties.put("rotation", canonicalRotation(name, properties.get("rotation")));
+         }
+
+         if(properties.containsKey("aliases")) {
+            properties.put("aliases", toModelAliases(properties.get("aliases")));
+         }
       }
 
       Object model = readModel(sessionToken, user, assembly, name, key, field);
@@ -286,6 +294,62 @@ public class ChartRegionPropertyService {
       }
 
       return text;
+   }
+
+   /**
+    * Converts the caller's per-value label overrides into the {@code ModelAlias[]} the Alias
+    * tab's own model expects.
+    *
+    * <p>Not handled by {@code PropertyPath}'s generic array coercion: that engine builds an array
+    * of a component type by recursively coercing each JSON element, but a {@code ModelAlias} is a
+    * plain bean with no scalar/enum/array shape {@code PropertyPath.coerce} knows how to
+    * construct from a JSON object, and extending that generic engine to build arbitrary beans
+    * from a {@code Map} would widen every other property this class and its siblings expose, not
+    * just this one. Converting here, before the value ever reaches {@code PropertyPath}, keeps
+    * the change scoped to the one property that needs it: {@code PropertyPath.set} then receives
+    * an already-correct {@code ModelAlias[]} and its own pass-through check
+    * ({@code target.isInstance(value)}) hands it straight to the setter unchanged.
+    *
+    * <p>Each entry needs {@code value} (the real data value the alias replaces) and {@code alias}
+    * (what to show instead); {@code label} is optional and, when omitted, mirrors {@code value} --
+    * on the read side, {@code label} is the value as StyleBI's own {@code GraphUtil.getLegendItems}
+    * / {@code getAxisItems} format it, which for a caller supplying a value fresh rather than
+    * echoing one just read back is not always knowable in advance.
+    */
+   private static ModelAlias[] toModelAliases(Object value) {
+      if(!(value instanceof List<?> list)) {
+         throw new IllegalArgumentException(
+            "'aliases' expects a JSON array of {value, alias} objects; '" + value + "' is not " +
+            "an array.");
+      }
+
+      ModelAlias[] result = new ModelAlias[list.size()];
+
+      for(int i = 0; i < list.size(); i++) {
+         Object entry = list.get(i);
+
+         if(!(entry instanceof Map<?, ?> map)) {
+            throw new IllegalArgumentException(
+               "'aliases[" + i + "]' must be an object with 'value' and 'alias', got '" + entry +
+               "'.");
+         }
+
+         Object rawValue = map.get("value");
+         Object rawAlias = map.get("alias");
+
+         if(rawValue == null || rawAlias == null) {
+            throw new IllegalArgumentException(
+               "'aliases[" + i + "]' needs both 'value' (the data value to replace) and 'alias' " +
+               "(what to show instead); got " + map + ".");
+         }
+
+         String stringValue = String.valueOf(rawValue);
+         Object rawLabel = map.get("label");
+         String label = rawLabel == null ? stringValue : String.valueOf(rawLabel);
+         result[i] = new ModelAlias(label, stringValue, String.valueOf(rawAlias));
+      }
+
+      return result;
    }
 
    /**
@@ -495,6 +559,9 @@ public class ChartRegionPropertyService {
       // Unlike the title's rotation, "auto" is a real, offered value here -- see
       // requireValidRotation for why the two can't share one CONSTRAINED_STRINGS entry.
       aliases.put("rotation", "axisLabelPaneModel.rotationRadioGroupModel.rotation");
+      // The Alias tab (per-value label overrides), shown only for a non-linear axis, had no tool
+      // equivalent (parity audit L4, finding G3-7). See toModelAliases for the payload shape.
+      aliases.put("aliases", "aliasPaneModel.aliasList");
       return aliases;
    }
 
@@ -520,6 +587,10 @@ public class ChartRegionPropertyService {
       aliases.put("logarithmicScale", "legendScalePaneModel.logarithmic");
       aliases.put("reverse", "legendScalePaneModel.reverse");
       aliases.put("includeZero", "legendScalePaneModel.includeZero");
+      // The Alias tab (per-value label overrides), shown only for a dimension-bound legend, had
+      // no tool equivalent (parity audit L4, finding G3-4). See toModelAliases for the payload
+      // shape.
+      aliases.put("aliases", "aliasPaneModel.aliasList");
       return aliases;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -394,9 +394,8 @@ public class ChartRegionPropertyService {
          String suppliedValue = String.valueOf(map.get("value"));
          Object rawAlias = map.get("alias");
          ModelAlias resolved = resolveAliasItem(suppliedValue, current, i);
-         String realValue = resolved != null ? resolved.getValue() : suppliedValue;
-         String realLabel = resolved != null ? resolved.getLabel() : suppliedValue;
-         result[i] = new ModelAlias(realLabel, realValue, String.valueOf(rawAlias));
+         result[i] = new ModelAlias(resolved.getLabel(), resolved.getValue(),
+                                    String.valueOf(rawAlias));
       }
 
       return result;
@@ -405,15 +404,30 @@ public class ChartRegionPropertyService {
    /**
     * Finds the {@code current} entry a caller-supplied alias {@code value} means — an exact match
     * on the real value first, then a match on the real display label — and refuses, naming the
-    * real value/label pairs, when {@code current} is non-empty and neither matches. {@code null}
-    * (not a refusal) means {@code current} is empty: this region has no items to check against
-    * yet (an unbound or not-yet-laid-out chart), so there is nothing to validate against and the
-    * caller-supplied value passes through rather than being refused for a reason unrelated to
-    * what they typed.
+    * real value/label pairs, when {@code current} is non-empty and neither matches.
+    *
+    * <p>An empty {@code current} is refused too, rather than passed through unresolved. An
+    * earlier version treated empty as "unbound or not-yet-laid-out, nothing to validate against"
+    * and let the value through as-is — but {@code current} comes from
+    * {@code GraphUtil.getAxisItems}, which reads the <em>executed</em> graph area, not the
+    * binding: a genuinely bound axis reports empty just as easily when the graph has not been
+    * (re-)executed since a binding/filter change, or the active filter currently excludes every
+    * row. Passing the caller's raw value through in that window reproduces the exact silent-no-op
+    * shape {@link #parseAliasEntries}'s javadoc records (a display-text value stored under a key
+    * nothing reads back) for the case that most needs the resolution — a date-grouped or
+    * named-group axis is the one most likely to have just changed. Refusing here costs a
+    * legitimately-unbound region a clear error instead of a silent no-op; the caller is guided to
+    * check {@code list_chart_region_properties} first, which reads the same {@code current}.
     */
    private static ModelAlias resolveAliasItem(String suppliedValue, ModelAlias[] current, int index) {
       if(current == null || current.length == 0) {
-         return null;
+         throw new IllegalArgumentException(
+            "'aliases[" + index + "]' cannot be resolved: this region currently reports no " +
+            "known values (list_chart_region_properties reports the same empty list). This " +
+            "can mean the field is unbound, or the chart has not been (re-)executed since a " +
+            "binding or filter change -- refresh the chart or re-check " +
+            "list_chart_region_properties before retrying, rather than setting an alias whose " +
+            "value cannot be matched against anything and may silently do nothing.");
       }
 
       for(ModelAlias item : current) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -237,10 +237,19 @@ public class ChartRegionPropertyService {
       boolean linear = sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          VSChartInfo info = ChartRegionResolver.requireChart(rvs, assembly).getVSChartInfo();
          String canonical = ChartRegionResolver.canonical(axisTarget);
-         boolean inverted = info.isInvertedGraph();
          boolean secondary = "y2".equals(canonical) || "x2".equals(canonical);
          boolean onYShelf = "y".equals(canonical) || "y2".equals(canonical);
-         ChartRef[] refs = (onYShelf != inverted) ? info.getYFields() : info.getXFields();
+         // Canonical x/x2 always reads getXFields(), canonical y/y2 always reads getYFields() --
+         // the same convention ChartRegionResolver.fromBinding uses one call earlier in this same
+         // class's requireExistingTarget (present.add("x") off getXFields() alone, with no
+         // isInvertedGraph() factor at all for the primary case; for the secondary case, the
+         // inverted-ness of the chart decides which canonical NAME -- x2 or y2 -- a secondary
+         // measure gets, not which shelf backs a given name). A repair-review catch confirmed live
+         // 2026-09-02: an earlier cut XOR'd this with isInvertedGraph(), which resolves every
+         // canonical target to the wrong shelf on any inverted chart (e.g. a Gantt chart, which is
+         // unconditionally inverted) -- reopening the exact corruption this method exists to close,
+         // or wrongly refusing a legitimate write on a real measure axis.
+         ChartRef[] refs = onYShelf ? info.getYFields() : info.getXFields();
          Stream<ChartRef> candidates = Arrays.stream(refs);
 
          // A shelf can carry more than one field of the same axis type (the tool's own

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -531,5 +531,10 @@ public final class PropertyPath {
       // ChartLinePaneModel.getIndexByName walks TRENDLINE_NAMES with equals() and starts its
       // index at 0, so anything it does not match exactly becomes "NONE" with no complaint.
       "trendLineType", Set.of("NONE", "Linear", "Quadratic", "Cubic", "Exponential",
-                              "Logarithmic", "Power"));
+                              "Logarithmic", "Power"),
+      // LegendFormatDialogModel.getIndexByName has the identical starts-at-0 bug against
+      // LEGEND_POSITIONS: set_chart_region_properties({region:"legend", properties:
+      // {position:"right"}}) -- literally this tool's own docstring example -- silently landed
+      // on "Top" instead, confirmed live 2026-09-02.
+      "position", Set.of("Top", "Right", "Bottom", "Left", "In Place"));
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -353,7 +353,7 @@ public class ViewsheetAssemblyAgentController {
    }
 
    public record ElementVisibilityRequest(String assembly, String element, String target,
-                                          Boolean visible) {}
+                                          Boolean visible, Boolean secondary) {}
    public record PlotResizeRequest(String assembly, Double ratio, Boolean vertical,
                                    Boolean reset) {}
 
@@ -563,7 +563,7 @@ public class ViewsheetAssemblyAgentController {
 
       chartElementService.setVisibility(sessionToken, user, request.assembly(),
                                         request.element(), request.target(), request.visible(),
-                                        linkUri);
+                                        Boolean.TRUE.equals(request.secondary()), linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/plot-size")

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -94,6 +94,25 @@ class ChartElementServiceTest {
       assertFalse(captor.getValue().isHide());
    }
 
+   /**
+    * Unlike legends, neither axis event has a real hide-everything mode:
+    * {@code VSChartAxesVisibilityEvent#getColumnName}'s own javadoc documents a null target as
+    * meaning "show all axis", never hide-all, and {@code hideAxis()} falls a null target through
+    * to one arbitrary descriptor. This used to run silently and report
+    * "Hid all axiss on Chart1" while touching no axis label at all — confirmed live 2026-09-02.
+    */
+   @Test
+   void refusesToHideEveryAxisWithNoTarget() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "axis", null, false, ""));
+
+      assertTrue(thrown.getMessage().contains("no 'target'"));
+      verifyNoInteractions(h.axes);
+   }
+
    @Test
    void hidesEveryLegendWhenNoneIsNamed() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
@@ -260,6 +279,24 @@ class ChartElementServiceTest {
       h.service.setVisibility("tok", principal(), "Chart1", "title", null, true, "");
 
       assertFalse(captureTitle(h).isHide(), "hide=false is the event's show-everything case");
+   }
+
+   /**
+    * {@code ChartElementService.titleFields()} maps a no-target hide specifically to
+    * {@code "chart-title"} — there is no branch that hides every title. This used to run silently
+    * and report "Hid all titles on Chart1" while only ever hiding the chart's own title; the x/y
+    * axis titles stayed fully visible — confirmed live 2026-09-02.
+    */
+   @Test
+   void refusesToHideEveryTitleWithNoTarget() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", null, false, ""));
+
+      assertTrue(thrown.getMessage().contains("no 'target'"));
+      verifyNoInteractions(h.titles);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -561,8 +561,16 @@ class ChartElementServiceTest {
       assertEquals(java.util.List.of("x", "y", "chart"), out.get("titleTargets"),
                    "no y2 on the chart means no y2 in the vocabulary - and the chart title, " +
                    "which is not an axis title, stays");
+      assertFalse(out.containsKey("secondaryFields"),
+                  "no secondary measure means the field is omitted entirely, not an empty list");
    }
 
+   /**
+    * Claude review (PR #2092/#4942): this test already built a chart with a secondary-axis
+    * measure but only asserted on 'axes', not on 'secondaryFields' -- the field this PR adds
+    * specifically for this scenario (G1-3: setVisibility's 'secondary' flag has no way to know
+    * which measure is on the secondary axis without this).
+    */
    @Test
    void vocabularyKeepsY2WhenAMeasureActuallyUsesTheSecondaryAxis() throws Exception {
       Harness h = harness(boundChart(true));
@@ -571,6 +579,7 @@ class ChartElementServiceTest {
 
       assertEquals(java.util.List.of("x", "y", "y2"), out.get("axes"),
                    "filtering must not amount to always hiding y2");
+      assertEquals(java.util.List.of("Sum(Revenue)"), out.get("secondaryFields"));
    }
 
    /**
@@ -736,6 +745,7 @@ class ChartElementServiceTest {
       if(secondaryAxis) {
          VSChartAggregateRef secondary = mock(VSChartAggregateRef.class);
          when(secondary.isSecondaryY()).thenReturn(true);
+         when(secondary.getFullName()).thenReturn("Sum(Revenue)");
          y = new ChartRef[] { primary, secondary };
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -70,7 +70,7 @@ class ChartElementServiceTest {
    void hidesOneAxisByColumnName() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, false, "");
 
       ArgumentCaptor<VSChartAxesVisibilityEvent> captor =
          ArgumentCaptor.forClass(VSChartAxesVisibilityEvent.class);
@@ -81,11 +81,46 @@ class ChartElementServiceTest {
       assertTrue(captor.getValue().isHide());
    }
 
+   /**
+    * L4 finding G1-3: on a dual-Y-axis (non-separated) chart, {@code VSChartAxesVisibilityEvent}
+    * resolves which descriptor to touch off {@code isSecondary()}, not off which axis the named
+    * column is actually bound to -- so hiding by a secondary-axis measure's column name always
+    * hit the primary axis, and there was no parameter to say which one was meant. Live-confirmed
+    * 2026-09-02: naming the secondary measure hid the primary axis's labels instead.
+    */
+   @Test
+   void hidesTheSecondaryAxisWhenAskedFor() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Revenue", false, true, "");
+
+      ArgumentCaptor<VSChartAxesVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartAxesVisibilityEvent.class);
+      verify(h.axes).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertEquals("Revenue", captor.getValue().getColumnName());
+      assertTrue(captor.getValue().isSecondary());
+   }
+
+   /** Omitting 'secondary' must still default to the primary axis, unchanged from before. */
+   @Test
+   void defaultsToThePrimaryAxisWhenSecondaryIsOmitted() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, false, "");
+
+      ArgumentCaptor<VSChartAxesVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartAxesVisibilityEvent.class);
+      verify(h.axes).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertFalse(captor.getValue().isSecondary());
+   }
+
    @Test
    void showsAllAxes() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "axis", null, true, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", null, true, false, "");
 
       ArgumentCaptor<VSChartAxesVisibilityEvent> captor =
          ArgumentCaptor.forClass(VSChartAxesVisibilityEvent.class);
@@ -107,7 +142,7 @@ class ChartElementServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "axis", null, false, ""));
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "axis", null, false, false, ""));
 
       assertTrue(thrown.getMessage().contains("no 'target'"));
       verifyNoInteractions(h.axes);
@@ -117,7 +152,7 @@ class ChartElementServiceTest {
    void hidesEveryLegendWhenNoneIsNamed() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "legend", null, false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "legend", null, false, false, "");
 
       ArgumentCaptor<VSChartLegendsVisibilityEvent> captor =
          ArgumentCaptor.forClass(VSChartLegendsVisibilityEvent.class);
@@ -141,7 +176,7 @@ class ChartElementServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false, false,
                                        ""));
 
       assertTrue(thrown.getMessage().contains("without 'target'"), "and say what to call instead");
@@ -157,7 +192,7 @@ class ChartElementServiceTest {
    void readsABlankTargetAsNoTarget() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "legend", "  ", false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "legend", "  ", false, false, "");
 
       ArgumentCaptor<VSChartLegendsVisibilityEvent> captor =
          ArgumentCaptor.forClass(VSChartLegendsVisibilityEvent.class);
@@ -165,7 +200,7 @@ class ChartElementServiceTest {
                                      any(Principal.class), any());
       assertNull(captor.getValue().getAestheticType(), "which is the event's hide-all");
       assertDoesNotThrow(
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "", true, ""),
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "", true, false, ""),
          "and showing with a blank target is showing them all, not a refused single show");
    }
 
@@ -181,7 +216,7 @@ class ChartElementServiceTest {
 
       assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false, false,
                                        ""));
 
       verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
@@ -239,7 +274,7 @@ class ChartElementServiceTest {
    void hidesAnAxisTitleWithTheDescriptorToken() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "title", "y", false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "title", "y", false, false, "");
 
       VSChartTitlesVisibilityEvent event = captureTitle(h);
       assertEquals("y_title", event.getTitleType());
@@ -255,7 +290,7 @@ class ChartElementServiceTest {
    void showsTheChartTitleThroughTheEventsOwnSpecialCase() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "title", "chart", true, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "title", "chart", true, false, "");
 
       VSChartTitlesVisibilityEvent event = captureTitle(h);
       assertTrue(event.isHide(), "hide=true is how this event says 'show the chart title'");
@@ -266,7 +301,7 @@ class ChartElementServiceTest {
    void hidesTheChartTitle() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "title", "chart", false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "title", "chart", false, false, "");
 
       VSChartTitlesVisibilityEvent event = captureTitle(h);
       assertEquals("chart-title", event.getTitleType());
@@ -276,7 +311,7 @@ class ChartElementServiceTest {
    void showsAllTitlesOnlyWhenNoTargetWasNamed() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "title", null, true, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "title", null, true, false, "");
 
       assertFalse(captureTitle(h).isHide(), "hide=false is the event's show-everything case");
    }
@@ -293,7 +328,7 @@ class ChartElementServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", null, false, ""));
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", null, false, false, ""));
 
       assertTrue(thrown.getMessage().contains("no 'target'"));
       verifyNoInteractions(h.titles);
@@ -309,7 +344,7 @@ class ChartElementServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", "y", true, ""));
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", "y", true, false, ""));
 
       assertTrue(thrown.getMessage().contains("all titles"));
    }
@@ -320,10 +355,10 @@ class ChartElementServiceTest {
 
       assertThrows(Exception.class,
                    () -> h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region",
-                                                 true, ""));
+                                                 true, false, ""));
       assertThrows(Exception.class,
                    () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Cat",
-                                                 true, ""));
+                                                 true, false, ""));
       verifyNoInteractions(h.sessions);
    }
 
@@ -333,7 +368,7 @@ class ChartElementServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", "z", false, ""));
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", "z", false, false, ""));
 
       assertTrue(thrown.getMessage().contains("z"));
    }
@@ -344,7 +379,7 @@ class ChartElementServiceTest {
 
       assertThrows(Exception.class,
                    () -> h.service.setVisibility("tok", principal(), "Chart1", "gridline", null,
-                                                 false, ""));
+                                                 false, false, ""));
    }
 
    @Test
@@ -353,7 +388,7 @@ class ChartElementServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> h.service.setVisibility("tok", principal(), "Text1", "axis", null, true, ""));
+         () -> h.service.setVisibility("tok", principal(), "Text1", "axis", null, true, false, ""));
 
       assertTrue(thrown.getMessage().contains("Text1"));
    }
@@ -497,7 +532,7 @@ class ChartElementServiceTest {
    void eachVisibilityChangeIsOneCheckpoint() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, false, "");
 
       verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -243,6 +243,67 @@ class ChartRegionPropertyServiceTest {
       verifyNoInteractions(h.regions);
    }
 
+   /**
+    * Claude review (stylebi PR #4942): an earlier cut of the shelf lookup XOR'd {@code onYShelf}
+    * with {@code isInvertedGraph()}, which resolves every canonical target to the wrong shelf on
+    * any inverted chart. On an inverted chart the dimension sits on the Y shelf (per
+    * {@code isInvertedGraph()}'s own definition -- a measure on the X shelf, not the Y one) --
+    * canonical 'y' must still refuse a linear-only property, the same as the non-inverted 'x' case
+    * above. Every existing test in this file stubs {@code isInvertedGraph()} false or leaves it
+    * unstubbed (same default), so this branch had zero coverage before.
+    */
+   @Test
+   void refusesLinearOnlyAxisPropertiesOnADimensionAxisWhenTheChartIsInverted() {
+      VSChartAggregateRef measure = mock(VSChartAggregateRef.class);
+      when(measure.isSecondaryY()).thenReturn(false);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(new ChartRef[] { measure });
+      when(info.getYFields()).thenReturn(new ChartRef[] { mock(VSChartDimensionRef.class) });
+      when(info.isInvertedGraph()).thenReturn(true);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(chart);
+
+      Harness h = harness(vs);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                             Map.of("minimum", "5"), ""));
+
+      assertTrue(thrown.getMessage().contains("minimum"));
+      verifyNoInteractions(h.regions);
+   }
+
+   /** The mirror case: canonical 'x' on that same inverted chart is the real measure axis. */
+   @Test
+   void stillAcceptsLinearOnlyAxisPropertiesOnAMeasureAxisWhenTheChartIsInverted()
+      throws Exception
+   {
+      VSChartAggregateRef measure = mock(VSChartAggregateRef.class);
+      when(measure.isSecondaryY()).thenReturn(false);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(new ChartRef[] { measure });
+      when(info.getYFields()).thenReturn(new ChartRef[] { mock(VSChartDimensionRef.class) });
+      when(info.isInvertedGraph()).thenReturn(true);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(chart);
+
+      Harness h = harness(vs);
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "x", null, Map.of("minimum", "5"), "");
+
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), any(), anyString(), any(Principal.class),
+                                                   any());
+   }
+
    /** L4 finding G3-3: the legend Scale tab (logarithmic/reverse/includeZero) had no tool alias. */
    @Test
    void writesLegendScaleProperties() throws Exception {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -358,6 +358,69 @@ class ChartRegionPropertyServiceTest {
       verifyNoInteractions(h.regions);
    }
 
+   /**
+    * Repair-review finding on G3-5/G3-6: neither model ever stores a bare integer string.
+    * {@code AxisPropertyDialogModel.updateAxisPropertyDialogModel} populates
+    * {@code RotationRadioGroupModel} via {@code rotation + ""} on a {@code Float} field, which
+    * yields {@code "90.0"} -- the exact form {@code list_chart_region_properties} would read back
+    * and the exact form the Composer UI's own radio group writes. A round trip through this tool
+    * must not be rejected just because the stored form has a decimal point.
+    */
+   @Test
+   void writesAxisLabelRotationSuppliedInTheModelsOwnDecimalForm() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y", null, Map.of("rotation", "-45.0"),
+                    "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertEquals("-45",
+                   captor.getValue().getAxisLabelPaneModel().getRotationRadioGroupModel()
+                      .getRotation());
+   }
+
+   /** Same round-trip form on the title side, which has no "auto" branch to fall back on. */
+   @Test
+   void writesTitleRotationSuppliedInTheModelsOwnDecimalForm() throws Exception {
+      Harness h = harness();
+      when(h.regions.getTitleFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                               any(Principal.class)))
+         .thenReturn(titleModel());
+
+      h.service.set("tok", principal(), "Chart1", "title", "y", null, Map.of("rotation", "90.0"),
+                    "");
+
+      ArgumentCaptor<TitleFormatDialogModel> captor =
+         ArgumentCaptor.forClass(TitleFormatDialogModel.class);
+      verify(h.regions).setTitleFormatDialogModel(anyString(), anyString(), anyString(),
+                                                  captor.capture(), anyString(),
+                                                  any(Principal.class), any());
+      assertEquals("90",
+                   captor.getValue().getTitleFormatPaneModel().getRotationRadioGroupModel()
+                      .getRotation());
+   }
+
+   /** A decimal value that isn't one of the five real angles is still refused. */
+   @Test
+   void refusesADecimalRotationOutsideEitherDomain() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                             Map.of("rotation", "90.5"), ""));
+
+      assertTrue(thrown.getMessage().contains("90.5"));
+      verifyNoInteractions(h.regions);
+   }
+
    /** L4 finding G3-4: the legend Alias tab (per-value label overrides) had no tool alias. */
    @Test
    void writesLegendAliases() throws Exception {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -425,9 +425,14 @@ class ChartRegionPropertyServiceTest {
    @Test
    void writesLegendAliases() throws Exception {
       Harness h = harness();
+      LegendFormatDialogModel model = legendModel();
+      model.getAliasPaneModel().setAliasList(new ModelAlias[] {
+         new ModelAlias("2022", "2022", "2022"),
+         new ModelAlias("2023", "2023", "2023"),
+      });
       when(h.regions.getLegendFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
                                                 any(Principal.class)))
-         .thenReturn(legendModel());
+         .thenReturn(model);
 
       h.service.set("tok", principal(), "Chart1", "legend", "0", null,
                     Map.of("aliases", List.of(
@@ -452,9 +457,13 @@ class ChartRegionPropertyServiceTest {
    @Test
    void writesAxisAliases() throws Exception {
       Harness h = harness();
+      AxisPropertyDialogModel model = axisModel();
+      model.getAliasPaneModel().setAliasList(new ModelAlias[] {
+         new ModelAlias("West", "West", "West"),
+      });
       when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
                                                 any(), anyString(), any(Principal.class)))
-         .thenReturn(axisModel());
+         .thenReturn(model);
 
       h.service.set("tok", principal(), "Chart1", "axis", "y", null,
                     Map.of("aliases", List.of(Map.of("value", "West", "alias", "Region West"))),
@@ -562,6 +571,36 @@ class ChartRegionPropertyServiceTest {
 
       assertTrue(thrown.getMessage().contains("9999"));
       assertTrue(thrown.getMessage().contains("2022"));
+      verify(h.regions, never()).setAxisPropertyDialogModel(anyString(), anyString(), anyString(),
+                                                            anyInt(), any(), any(), anyString(),
+                                                            any(Principal.class), any());
+   }
+
+   /**
+    * Repair-review finding on the G3-4/G3-7 fix: an empty {@code current} used to pass the
+    * caller's raw value through unresolved on the theory that empty means "unbound, nothing to
+    * validate against." But {@code current} comes from the executed graph area, not the binding
+    * -- a genuinely bound axis reports empty too when the graph has not been (re-)executed since
+    * a binding/filter change, or the active filter currently excludes every row. Passing the
+    * value through in that window reproduces the exact silent-no-op shape this whole feature
+    * exists to close, for the case most likely to have just changed. Refused instead.
+    */
+   @Test
+   void refusesAnAliasWhenTheRegionReportsNoCurrentValues() throws Exception {
+      Harness h = harness();
+      AxisPropertyDialogModel model = axisModel();
+      model.getAliasPaneModel().setAliasList(new ModelAlias[0]);
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "x", null,
+                             Map.of("aliases", List.of(Map.of("value", "2022", "alias", "FY22"))),
+                             ""));
+
+      assertTrue(thrown.getMessage().contains("no known values"), thrown.getMessage());
       verify(h.regions, never()).setAxisPropertyDialogModel(anyString(), anyString(), anyString(),
                                                             anyInt(), any(), any(), anyString(),
                                                             any(Principal.class), any());

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -409,6 +409,101 @@ class ChartRegionPropertyServiceTest {
       assertEquals("West", written[0].getLabel(), "label defaults to the value when omitted");
    }
 
+   /**
+    * The bug this test exists to pin, found live 2026-09-02 by this audit's own promotion pass
+    * on a real year-grouped axis: {@code AxisPropertyDialogModel.updateAxisPropertyDialogModel}
+    * calls {@code axisDesc.setLabelAlias(value, alias)} with WHATEVER value this service hands
+    * it, unconditionally -- it does not itself match against the real items. A caller supplying
+    * the display text ({@code "2022"}) rather than the real underlying value (a date-grouped
+    * axis's real value is a full timestamp, e.g. {@code "2022-01-01 00:00:00"}) used to have
+    * that alias silently stored under a key nothing ever reads back -- {@code ok:true}, chart
+    * unchanged. This asserts the value actually written is the REAL one, resolved from the
+    * axis's own current alias list (mirroring what list_chart_region_properties already reports),
+    * not the caller's display-text guess.
+    */
+   @Test
+   void resolvesAnAxisAliasValueSuppliedAsItsDisplayLabel() throws Exception {
+      Harness h = harness();
+      AxisPropertyDialogModel model = axisModel();
+      model.getAliasPaneModel().setAliasList(new ModelAlias[] {
+         new ModelAlias("2022", "2022-01-01 00:00:00", "2022"),
+         new ModelAlias("2023", "2023-01-01 00:00:00", "2023"),
+      });
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+
+      h.service.set("tok", principal(), "Chart1", "axis", "x", null,
+                    Map.of("aliases", List.of(Map.of("value", "2022", "alias", "FY22"))), "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      ModelAlias written = captor.getValue().getAliasPaneModel().getAliasList()[0];
+      assertEquals("2022-01-01 00:00:00", written.getValue(),
+                   "the REAL value must be written, not the caller's display-text guess -- " +
+                   "AxisPropertyDialogModel keys setLabelAlias on whatever value arrives here " +
+                   "with no matching of its own");
+      assertEquals("FY22", written.getAlias());
+   }
+
+   /** Supplying the real value directly (not the label) must also resolve, unchanged. */
+   @Test
+   void resolvesAnAxisAliasValueSuppliedAsTheRealValue() throws Exception {
+      Harness h = harness();
+      AxisPropertyDialogModel model = axisModel();
+      model.getAliasPaneModel().setAliasList(new ModelAlias[] {
+         new ModelAlias("2022", "2022-01-01 00:00:00", "2022"),
+      });
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+
+      h.service.set("tok", principal(), "Chart1", "axis", "x", null,
+                    Map.of("aliases",
+                           List.of(Map.of("value", "2022-01-01 00:00:00", "alias", "FY22"))),
+                    "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertEquals("2022-01-01 00:00:00",
+                   captor.getValue().getAliasPaneModel().getAliasList()[0].getValue());
+   }
+
+   /**
+    * A value matching neither the real value nor the label used to reach the same silent-no-op
+    * shape resolvesAnAxisAliasValueSuppliedAsItsDisplayLabel pins -- refused here instead, naming
+    * what the axis actually has, so the caller can retry with a value that will actually work.
+    */
+   @Test
+   void refusesAnAxisAliasValueMatchingNeitherRealValueNorLabel() throws Exception {
+      Harness h = harness();
+      AxisPropertyDialogModel model = axisModel();
+      model.getAliasPaneModel().setAliasList(new ModelAlias[] {
+         new ModelAlias("2022", "2022-01-01 00:00:00", "2022"),
+      });
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "x", null,
+                             Map.of("aliases", List.of(Map.of("value", "9999", "alias", "FY99"))),
+                             ""));
+
+      assertTrue(thrown.getMessage().contains("9999"));
+      assertTrue(thrown.getMessage().contains("2022"));
+      verify(h.regions, never()).setAxisPropertyDialogModel(anyString(), anyString(), anyString(),
+                                                            anyInt(), any(), any(), anyString(),
+                                                            any(Principal.class), any());
+   }
+
    @Test
    void refusesAnAliasEntryMissingAlias() {
       Harness h = harness();

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -357,6 +358,83 @@ class ChartRegionPropertyServiceTest {
       verifyNoInteractions(h.regions);
    }
 
+   /** L4 finding G3-4: the legend Alias tab (per-value label overrides) had no tool alias. */
+   @Test
+   void writesLegendAliases() throws Exception {
+      Harness h = harness();
+      when(h.regions.getLegendFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(Principal.class)))
+         .thenReturn(legendModel());
+
+      h.service.set("tok", principal(), "Chart1", "legend", "0", null,
+                    Map.of("aliases", List.of(
+                       Map.of("value", "2022", "alias", "FY22"),
+                       Map.of("value", "2023", "alias", "FY23"))),
+                    "");
+
+      ArgumentCaptor<LegendFormatDialogModel> captor =
+         ArgumentCaptor.forClass(LegendFormatDialogModel.class);
+      verify(h.regions).setLegendFormatDialogModel(anyString(), anyString(), anyInt(),
+                                                   captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      ModelAlias[] written = captor.getValue().getAliasPaneModel().getAliasList();
+      assertEquals(2, written.length);
+      assertEquals("2022", written[0].getValue());
+      assertEquals("FY22", written[0].getAlias());
+      assertEquals("2023", written[1].getValue());
+      assertEquals("FY23", written[1].getAlias());
+   }
+
+   /** L4 finding G3-7: the axis Alias tab (per-value label overrides) had no tool alias. */
+   @Test
+   void writesAxisAliases() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                    Map.of("aliases", List.of(Map.of("value", "West", "alias", "Region West"))),
+                    "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      ModelAlias[] written = captor.getValue().getAliasPaneModel().getAliasList();
+      assertEquals(1, written.length);
+      assertEquals("West", written[0].getValue());
+      assertEquals("Region West", written[0].getAlias());
+      assertEquals("West", written[0].getLabel(), "label defaults to the value when omitted");
+   }
+
+   @Test
+   void refusesAnAliasEntryMissingAlias() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "legend", "0", null,
+                             Map.of("aliases", List.of(Map.of("value", "2022"))), ""));
+
+      assertTrue(thrown.getMessage().contains("alias"));
+      verifyNoInteractions(h.regions);
+   }
+
+   @Test
+   void refusesANonArrayAliasesValue() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "legend", "0", null,
+                             Map.of("aliases", "not-an-array"), ""));
+
+      assertTrue(thrown.getMessage().contains("array"));
+      verifyNoInteractions(h.regions);
+   }
+
    private static Viewsheet mixedShelfViewsheet(ChartRef[] xFields) {
       VSChartAggregateRef y = mock(VSChartAggregateRef.class);
       when(y.isSecondaryY()).thenReturn(false);
@@ -667,6 +745,7 @@ class ChartRegionPropertyServiceTest {
       AxisLabelPaneModel labelPaneModel = new AxisLabelPaneModel();
       labelPaneModel.setRotationRadioGroupModel(new RotationRadioGroupModel());
       model.setAxisLabelPaneModel(labelPaneModel);
+      model.setAliasPaneModel(new AliasPaneModel());
       return model;
    }
 
@@ -674,6 +753,7 @@ class ChartRegionPropertyServiceTest {
       LegendFormatDialogModel model = new LegendFormatDialogModel();
       model.setLegendFormatGeneralPaneModel(new LegendFormatGeneralPaneModel());
       model.setLegendScalePaneModel(new LegendScalePaneModel());
+      model.setAliasPaneModel(new AliasPaneModel());
       return model;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -242,6 +242,121 @@ class ChartRegionPropertyServiceTest {
       verifyNoInteractions(h.regions);
    }
 
+   /** L4 finding G3-3: the legend Scale tab (logarithmic/reverse/includeZero) had no tool alias. */
+   @Test
+   void writesLegendScaleProperties() throws Exception {
+      Harness h = harness();
+      when(h.regions.getLegendFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(Principal.class)))
+         .thenReturn(legendModel());
+
+      h.service.set("tok", principal(), "Chart1", "legend", "0", null,
+                    Map.of("logarithmicScale", true, "reverse", true, "includeZero", true), "");
+
+      ArgumentCaptor<LegendFormatDialogModel> captor =
+         ArgumentCaptor.forClass(LegendFormatDialogModel.class);
+      verify(h.regions).setLegendFormatDialogModel(anyString(), anyString(), anyInt(),
+                                                   captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      LegendScalePaneModel scale = captor.getValue().getLegendScalePaneModel();
+      assertTrue(scale.isLogarithmic());
+      assertTrue(scale.isReverse());
+      assertTrue(scale.isIncludeZero());
+   }
+
+   /** L4 finding G3-5: the Title Properties dialog's Rotation fieldset had no tool alias. */
+   @Test
+   void writesTitleRotation() throws Exception {
+      Harness h = harness();
+      when(h.regions.getTitleFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                               any(Principal.class)))
+         .thenReturn(titleModel());
+
+      h.service.set("tok", principal(), "Chart1", "title", "y", null, Map.of("rotation", "-90"), "");
+
+      ArgumentCaptor<TitleFormatDialogModel> captor =
+         ArgumentCaptor.forClass(TitleFormatDialogModel.class);
+      verify(h.regions).setTitleFormatDialogModel(anyString(), anyString(), anyString(),
+                                                  captor.capture(), anyString(),
+                                                  any(Principal.class), any());
+      assertEquals("-90",
+                   captor.getValue().getTitleFormatPaneModel().getRotationRadioGroupModel()
+                      .getRotation());
+   }
+
+   /**
+    * The title's rotation does not accept "auto" -- unlike the axis label's, its own persist step
+    * calls {@code Float.parseFloat} on whatever arrives with no "auto" branch at all, which would
+    * otherwise surface as a raw {@code NumberFormatException} instead of a named refusal.
+    */
+   @Test
+   void refusesAutoRotationOnATitle() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "title", "y", null,
+                             Map.of("rotation", "auto"), ""));
+
+      assertTrue(thrown.getMessage().contains("rotation"));
+      verifyNoInteractions(h.regions);
+   }
+
+   /** L4 finding G3-6: the axis Label tab's Rotation fieldset had no tool alias. */
+   @Test
+   void writesAxisLabelRotation() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y", null, Map.of("rotation", "45"), "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertEquals("45",
+                   captor.getValue().getAxisLabelPaneModel().getRotationRadioGroupModel()
+                      .getRotation());
+   }
+
+   /** Unlike the title, the axis label genuinely offers "auto" -- and normalizes its case. */
+   @Test
+   void writesAutoRotationOnAnAxisCaseInsensitively() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y", null, Map.of("rotation", "AUTO"), "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertEquals("auto",
+                   captor.getValue().getAxisLabelPaneModel().getRotationRadioGroupModel()
+                      .getRotation(),
+                   "AxisPropertyDialogModel matches \"auto\" case-sensitively, so the canonical " +
+                   "lowercase form must reach it, not the caller's original casing");
+   }
+
+   @Test
+   void refusesARotationOutsideEitherDomain() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                             Map.of("rotation", "30"), ""));
+
+      assertTrue(thrown.getMessage().contains("30"));
+      verifyNoInteractions(h.regions);
+   }
+
    private static Viewsheet mixedShelfViewsheet(ChartRef[] xFields) {
       VSChartAggregateRef y = mock(VSChartAggregateRef.class);
       when(y.isSecondaryY()).thenReturn(false);
@@ -549,19 +664,24 @@ class ChartRegionPropertyServiceTest {
    private static AxisPropertyDialogModel axisModel() {
       AxisPropertyDialogModel model = new AxisPropertyDialogModel();
       model.setAxisLinePaneModel(new AxisLinePaneModel());
-      model.setAxisLabelPaneModel(new AxisLabelPaneModel());
+      AxisLabelPaneModel labelPaneModel = new AxisLabelPaneModel();
+      labelPaneModel.setRotationRadioGroupModel(new RotationRadioGroupModel());
+      model.setAxisLabelPaneModel(labelPaneModel);
       return model;
    }
 
    private static LegendFormatDialogModel legendModel() {
       LegendFormatDialogModel model = new LegendFormatDialogModel();
       model.setLegendFormatGeneralPaneModel(new LegendFormatGeneralPaneModel());
+      model.setLegendScalePaneModel(new LegendScalePaneModel());
       return model;
    }
 
    private static TitleFormatDialogModel titleModel() {
       TitleFormatDialogModel model = new TitleFormatDialogModel();
-      model.setTitleFormatPaneModel(new TitleFormatPaneModel());
+      TitleFormatPaneModel paneModel = new TitleFormatPaneModel();
+      paneModel.setRotationRadioGroupModel(new RotationRadioGroupModel());
+      model.setTitleFormatPaneModel(paneModel);
       return model;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -158,6 +158,104 @@ class ChartRegionPropertyServiceTest {
                                                    any());
    }
 
+   /**
+    * A repair-review catch, live 2026-09-02: the first cut of the linearity check asked "does
+    * ANY field on this shelf happen to be a measure" instead of resolving the specific field this
+    * call addresses. On a shelf carrying both a dimension and a measure of the same axis type —
+    * exactly the case {@code vocabulary()}'s own note describes ("to address one of several axes
+    * of the same type... pass the column name as 'field'") — that let a write aimed at the
+    * dimension slip through because a measure happened to sit on the same shelf, reopening the
+    * exact corruption this fix exists to close.
+    */
+   @Test
+   void refusesLinearOnlyKeysOnADimensionFieldEvenWhenTheShelfAlsoHasAMeasure() {
+      VSChartDimensionRef dimension = mock(VSChartDimensionRef.class);
+      when(dimension.getFullName()).thenReturn("Year(ORDER_DATE)");
+      when(dimension.getName()).thenReturn("ORDER_DATE");
+      VSChartAggregateRef measure = mock(VSChartAggregateRef.class);
+      when(measure.isSecondaryY()).thenReturn(false);
+      when(measure.getFullName()).thenReturn("Sum(Total)");
+
+      Harness h = harness(mixedShelfViewsheet(new ChartRef[] { dimension, measure }));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "x", "Year(ORDER_DATE)",
+                             Map.of("minimum", "5"), ""));
+
+      assertTrue(thrown.getMessage().contains("minimum"));
+      verifyNoInteractions(h.regions);
+   }
+
+   /** The measure on that same mixed shelf must still be reachable via its own 'field'. */
+   @Test
+   void stillAcceptsLinearOnlyKeysOnTheMeasureFieldOfAMixedShelf() throws Exception {
+      VSChartDimensionRef dimension = mock(VSChartDimensionRef.class);
+      when(dimension.getFullName()).thenReturn("Year(ORDER_DATE)");
+      VSChartAggregateRef measure = mock(VSChartAggregateRef.class);
+      when(measure.isSecondaryY()).thenReturn(false);
+      when(measure.getFullName()).thenReturn("Sum(Total)");
+      when(measure.getName()).thenReturn("Sum(Total)");
+
+      Harness h = harness(mixedShelfViewsheet(new ChartRef[] { dimension, measure }));
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "x", "Sum(Total)",
+                    Map.of("minimum", "5"), "");
+
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), any(), anyString(), any(Principal.class),
+                                                   any());
+   }
+
+   /**
+    * A repair-review catch, live 2026-09-02: the first cut only required
+    * {@code isSecondaryY()} on the SECONDARY side ({@code !secondary || isSecondaryY()}), which
+    * degrades to "any measure at all" on the PRIMARY side. A chart whose only y-shelf measure is
+    * itself flagged secondary must still refuse a write to the primary 'y' — that primary axis is
+    * a grid-line carrier mirroring the real (secondary) one, per
+    * {@code ChartRegionResolver}'s own documentation, not a genuine linear axis of its own.
+    */
+   @Test
+   void refusesLinearOnlyKeysOnAPrimaryAxisWhoseOnlyMeasureIsFlaggedSecondary() {
+      VSChartAggregateRef onlySecondary = mock(VSChartAggregateRef.class);
+      when(onlySecondary.isSecondaryY()).thenReturn(true);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(new ChartRef[] { mock(VSChartDimensionRef.class) });
+      when(info.getYFields()).thenReturn(new ChartRef[] { onlySecondary });
+      when(info.isInvertedGraph()).thenReturn(false);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(chart);
+
+      Harness h = harness(vs);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                             Map.of("minimum", "5"), ""));
+
+      assertTrue(thrown.getMessage().contains("minimum"));
+      verifyNoInteractions(h.regions);
+   }
+
+   private static Viewsheet mixedShelfViewsheet(ChartRef[] xFields) {
+      VSChartAggregateRef y = mock(VSChartAggregateRef.class);
+      when(y.isSecondaryY()).thenReturn(false);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(xFields);
+      when(info.getYFields()).thenReturn(new ChartRef[] { y });
+      when(info.isInvertedGraph()).thenReturn(false);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(chart);
+      return vs;
+   }
+
    @Test
    void writesALegendPropertyAddressedByIndex() throws Exception {
       Harness h = harness();
@@ -476,10 +574,12 @@ class ChartRegionPropertyServiceTest {
    }
 
    private static Harness harness(boolean secondaryAxis) {
+      return harness(viewsheet(secondaryAxis));
+   }
+
+   private static Harness harness(Viewsheet vs) {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      // Built first: calling viewsheet() inside the when(...) argument is nested stubbing.
-      Viewsheet vs = viewsheet(secondaryAxis);
       when(rvs.getViewsheet()).thenReturn(vs);
 
       try {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -100,6 +100,64 @@ class ChartRegionPropertyServiceTest {
                                                             any(Principal.class), any());
    }
 
+   /**
+    * A categorical (dimension) axis given a linear-only property used to be silently accepted:
+    * {@code getAxisPropertyDialogModel} always asked for area index 0, which
+    * {@code ChartRegionHandler.createAxisPropertyDialogModel} used to <em>infer</em> linearity
+    * from whichever leaf area happened to sort first on screen rather than from the bound field,
+    * so an ordinary bottom x-axis came back {@code isLinear: true} regardless of what was bound
+    * to it. Live evidence: {@code minimum:"5"} on a year-grouped date dimension was persisted and
+    * rendered as a fabricated numeric axis, corrupting the chart (2026-09-02). This checks
+    * linearity independently, off the actual bound ref, before the buggy area-index path is ever
+    * reached.
+    */
+   @Test
+   void refusesLinearOnlyAxisPropertiesOnADimensionAxis() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "x", null,
+                             Map.of("minimum", "5", "reverse", true), ""));
+
+      assertTrue(thrown.getMessage().contains("minimum"));
+      assertTrue(thrown.getMessage().contains("reverse"));
+      assertTrue(thrown.getMessage().contains("'x'"));
+      verifyNoInteractions(h.regions);
+   }
+
+   /** The same categorical axis must still accept properties that apply regardless of type. */
+   @Test
+   void stillAcceptsNonLinearAxisPropertiesOnADimensionAxis() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "x", null,
+                    Map.of("showAxisLine", false, "ignoreNull", true), "");
+
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), any(), anyString(), any(Principal.class),
+                                                   any());
+   }
+
+   /** The genuinely linear y-axis (a real measure, per the default harness) must be unaffected. */
+   @Test
+   void stillAcceptsLinearOnlyAxisPropertiesOnAMeasureAxis() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                    Map.of("minimum", "5", "reverse", true), "");
+
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), any(), anyString(), any(Principal.class),
+                                                   any());
+   }
+
    @Test
    void writesALegendPropertyAddressedByIndex() throws Exception {
       Harness h = harness();
@@ -116,6 +174,33 @@ class ChartRegionPropertyServiceTest {
                                                    captor.capture(), anyString(),
                                                    any(Principal.class), any());
       assertFalse(captor.getValue().getLegendFormatGeneralPaneModel().isVisible());
+   }
+
+   /**
+    * The legend's {@code title} property must land on {@code titleValue} — the field
+    * {@code legend-format-general-pane.component.html} actually binds
+    * ({@code [(value)]="model.titleValue"}; {@code title} is only the read-only {@code origValue}
+    * placeholder). Aliasing it onto {@code title} used to return {@code ok:true} and change
+    * nothing, since {@code LegendFormatDialogModel.updateLegendFormatDialogModel} only ever reads
+    * {@code getTitleValue()}. Found live 2026-09-02.
+    */
+   @Test
+   void writesLegendTitleOntoTheEditableTitleValueField() throws Exception {
+      Harness h = harness();
+      when(h.regions.getLegendFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(Principal.class)))
+         .thenReturn(legendModel());
+
+      h.service.set("tok", principal(), "Chart1", "legend", "0", null,
+                    Map.of("title", "Revenue by Year"), "");
+
+      ArgumentCaptor<LegendFormatDialogModel> captor =
+         ArgumentCaptor.forClass(LegendFormatDialogModel.class);
+      verify(h.regions).setLegendFormatDialogModel(anyString(), anyString(), anyInt(),
+                                                   captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertEquals("Revenue by Year",
+                   captor.getValue().getLegendFormatGeneralPaneModel().getTitleValue());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
@@ -543,6 +543,41 @@ class PropertyPathTest {
       assertTrue(thrown.getMessage().contains("Linear"), "list the tokens that do work");
    }
 
+   /** Mirrors {@code LegendFormatGeneralPaneModel.position}. */
+   public static class Position {
+      public String getPosition() { return position; }
+      public void setPosition(String position) { this.position = position; }
+
+      private String position = "Top";
+   }
+
+   /**
+    * {@code LegendFormatDialogModel.getIndexByName} has the identical starts-at-0-on-no-match bug
+    * as {@code trendLineType}'s: {@code set_chart_region_properties}'s own docstring example,
+    * {@code {position: "right"}} (lowercase), silently landed on {@code "Top"} instead of
+    * {@code "Right"}. Found live 2026-09-02.
+    */
+   @Test
+   void storesTheDomainsSpellingNotTheCallersForLegendPosition() {
+      Position target = new Position();
+
+      PropertyPath.set(target, "position", "right");
+
+      assertEquals("Right", target.getPosition(),
+                   "LegendFormatDialogModel.getIndexByName compares with equals() and starts at " +
+                   "0 ('Top'); 'right' would have silently meant 'Top'");
+   }
+
+   @Test
+   void refusesALegendPositionOutsideTheDomainListingTheValid() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Position(), "position", "sideways"));
+
+      assertTrue(thrown.getMessage().contains("position"), "name the property");
+      assertTrue(thrown.getMessage().contains("Right"), "list the tokens that do work");
+   }
+
    @Test
    void anUnconstrainedStringKeepsTheCallersSpelling() {
       Leaf leaf = new Leaf();


### PR DESCRIPTION
## Summary

StyleBI-side changes for parity audit lane L4 ("Chart Sub-Elements & Layout": chart element
visibility, plot sizing, chart region properties). Paired with the plugin-repo PR
[stylebi-wiz#2092](https://github.com/inetsoft-technology/stylebi-wiz/pull/2092), which has the full
findings report (`docs/parity/L4-chart-sub-elements-layout/L4-parity-report.md`).

16 findings across 3 groups: 12 fixed (5 real defects, 6 missing capabilities shipped as new tool
surface, 1 docs-only), 2 declined (confirmed real, confirmed harmless), 1 left open, 1 half-fixed.

**Real defects fixed**:
- `ChartRegionPropertyService` silently no-op'd `set_chart_region_properties` on a legend title
  (wrong model path) and silently defaulted an invalid legend `position` to `Top` instead of refusing
  it (its own docstring example, `{position:"right"}`, triggered the bug).
- `ChartElementService.setVisibility` let "hide all axes/titles" report success while doing something
  narrower than asked (no-target refusal added); a dual-Y-axis hide had no way to address the
  secondary axis at all (`secondary` param + `secondaryFields` discovery added).
- A categorical (non-linear) axis could receive a fabricated numeric range (`minimum`/`maximum`/
  `logarithmicScale`/...) that visibly corrupted the chart's render — `ChartRegionHandler`'s
  area-index-based linearity inference is only valid for a real click-derived index, meaningless for
  a tool call with no click. Checked independently off the binding instead; hardened twice more after
  repair review (dimension+measure mixed shelves, primary axis whose only measure is flagged
  secondary).

**New capability shipped** (5 real, persisted, non-visual dialog fields had no tool surface at all):
legend scale toggles (`logarithmicScale`/`reverse`/`includeZero`), per-value label aliases for both
legend and axis (with real-value/label resolution against the region's own current items — a caller
supplying the display label instead of the real underlying value, e.g. a date-grouped axis's `"2022"`
vs. real `"2022-01-01 00:00:00"`, used to silently store the alias under a key nothing reads back),
and title/axis-label rotation (with a region-aware domain check since axis allows `"auto"` and title
doesn't, sharing one model leaf name `PropertyPath.CONSTRAINED_STRINGS` can't distinguish), plus
`secondary` on `setVisibility`.

**Repair-review follow-up** (separate-context review of the above, before any row could be called
`fixed`): found `canonicalRotation` rejected the decimal form (`"90.0"`) both dialog models actually
store rotation as — a read-then-write round trip via `list_chart_region_properties` would be refused
for a value the tool itself just reported. Fixed to compare numerically. Also found
`resolveAliasItem`'s empty-`current` pass-through (originally meant for "unbound, nothing to validate
against") could reproduce the exact silent-no-op bug the alias feature exists to fix, since `current`
reflects the executed graph area, not the binding, and can be empty on a genuinely bound axis. Fixed
to refuse rather than pass through.

**Unrelated, fixed separately**: verifying the rotation fix required compiling `core`, which failed —
`DateComparisonServiceTest.java` had two call sites left at the old 8-argument
`DateComparisonService.Comparison` shape after commit 729755296 (#4818) trimmed the record to 7
fields. Traced, confirmed unrelated to this lane, and already merged via
[#4941](https://github.com/inetsoft-technology/stylebi/pull/4941) — this branch is based on top of it.

## Test plan

- [x] `./mvnw.cmd -pl core test -Dtest="inetsoft.web.wiz.viewsheet.**"` — 0 failures, 0 errors
      (re-verified after merging `origin/stylebi-wiz-main-rebase`)
- [x] Every live experiment (scratch assemblies, removed afterward) went through the plugin's own MCP
      tools only, on a real running StyleBI instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)