### PR TITLE
fix(item5): resolve date_in builtin range names case-insensitively

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/condition/ConditionUtil.java
+++ b/core/src/main/java/inetsoft/web/composer/model/condition/ConditionUtil.java
@@ -133,7 +133,7 @@ public class ConditionUtil {
 
                   // look for a built in condition with this name and clone it
                   for(DateCondition dateCondition : DateCondition.getBuiltinDateConditions()) {
-                     if(dateCondition.getName().equals(value)) {
+                     if(dateCondition.getName().equalsIgnoreCase(value)) {
                         condition = (XCondition) dateCondition.clone();
                         break;
                      }
@@ -143,10 +143,21 @@ public class ConditionUtil {
                   if(condition == null && rws != null) {
                      Worksheet ws = rws.getWorksheet();
 
-                     if(ws.getAssembly(value) instanceof DateRangeAssembly) {
-                        condition = ((DateRangeAssembly) ws.getAssembly(value))
-                           .getDateRange().clone();
+                     for(Assembly assembly : ws.getAssemblies()) {
+                        if(assembly instanceof DateRangeAssembly &&
+                           assembly.getName().equalsIgnoreCase(value))
+                        {
+                           condition = ((DateRangeAssembly) assembly).getDateRange().clone();
+                           break;
+                        }
                      }
+                  }
+
+                  if(condition == null) {
+                     throw new IllegalArgumentException(
+                        "'" + value + "' is not a known date range. Call list_condition_date_ranges " +
+                        "for the exact built-in names (e.g. \"Last month\"), or name a worksheet " +
+                        "date-range assembly.");
                   }
                }
                else if(conditionModel.getOperation() == AbstractCondition.TOP_N ||

--- a/core/src/main/java/inetsoft/web/composer/model/condition/ConditionUtil.java
+++ b/core/src/main/java/inetsoft/web/composer/model/condition/ConditionUtil.java
@@ -143,12 +143,21 @@ public class ConditionUtil {
                   if(condition == null && rws != null) {
                      Worksheet ws = rws.getWorksheet();
 
-                     for(Assembly assembly : ws.getAssemblies()) {
-                        if(assembly instanceof DateRangeAssembly &&
-                           assembly.getName().equalsIgnoreCase(value))
-                        {
-                           condition = ((DateRangeAssembly) assembly).getDateRange().clone();
-                           break;
+                     if(ws.getAssembly(value) instanceof DateRangeAssembly) {
+                        condition = ((DateRangeAssembly) ws.getAssembly(value))
+                           .getDateRange().clone();
+                     }
+                     else {
+                        // fall back to a case-insensitive scan only when no assembly is
+                        // named exactly value, so two assemblies differing only by case
+                        // never shadow the one the caller actually named
+                        for(Assembly assembly : ws.getAssemblies()) {
+                           if(assembly instanceof DateRangeAssembly &&
+                              assembly.getName().equalsIgnoreCase(value))
+                           {
+                              condition = ((DateRangeAssembly) assembly).getDateRange().clone();
+                              break;
+                           }
                         }
                      }
                   }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -2448,8 +2448,20 @@ public final class WorksheetMutationSupport {
          }
       }
 
-      if(ws != null && ws.getAssembly(value) instanceof DateRangeAssembly dra) {
-         return dra.getDateRange().clone();
+      if(ws != null) {
+         if(ws.getAssembly(value) instanceof DateRangeAssembly dra) {
+            return dra.getDateRange().clone();
+         }
+
+         // fall back to a case-insensitive scan only when no assembly is named exactly
+         // value, so two assemblies differing only by case never shadow the one the
+         // caller actually named -- mirrors ConditionUtil.fromModelToConditionList's
+         // DATE_IN branch
+         for(Assembly assembly : ws.getAssemblies()) {
+            if(assembly instanceof DateRangeAssembly dra && assembly.getName().equalsIgnoreCase(value)) {
+               return dra.getDateRange().clone();
+            }
+         }
       }
 
       throw new IllegalArgumentException(

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -2443,7 +2443,7 @@ public final class WorksheetMutationSupport {
       }
 
       for(DateCondition dc : DateCondition.getBuiltinDateConditions()) {
-         if(dc.getName().equals(value)) {
+         if(dc.getName().equalsIgnoreCase(value)) {
             return dc.clone();
          }
       }

--- a/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
+++ b/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
@@ -17,9 +17,12 @@
  */
 package inetsoft.web.composer.model.condition;
 
+import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.test.*;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.asset.DateCondition;
+import inetsoft.uql.asset.DefaultDateRangeAssembly;
+import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.wiz.viewsheet.ConditionVocabulary;
@@ -123,5 +126,85 @@ class ConditionUtilTest {
       assertThrows(IllegalArgumentException.class,
                    () -> ConditionUtil.fromModelToConditionList(model, null, null, principal),
                    "an unrecognized date range name must fail loud, not fall through silently");
+   }
+
+   /**
+    * A worksheet DateRangeAssembly's name match must not be case-sensitive -- an LLM might pass
+    * the range's name in the wrong case, and it must still resolve via the case-insensitive
+    * fallback scan (only reached once the exact-name lookup above it misses), not fall through
+    * to the "unrecognized" failure.
+    */
+   @Test
+   void aWorksheetDateRangeAssemblyNameInTheWrongCaseStillResolves() throws Exception {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn("OrderDate");
+      when(field.getDataType()).thenReturn(XSchema.DATE);
+
+      Worksheet ws = new Worksheet();
+      DateCondition.MonthCondition rangeCondition = new DateCondition.MonthCondition(2, 0);
+      DefaultDateRangeAssembly range = new DefaultDateRangeAssembly(ws, "MyRange");
+      range.setDateRange(rangeCondition);
+      ws.addAssembly(range);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      Object[] model = ConditionVocabulary.toConditionList(
+         List.of(new ConditionVocabulary.Clause(
+            "OrderDate", "date_in", List.of("myrange"), null, false)),
+         new DataRefModel[]{ field });
+
+      Principal principal = () -> "admin";
+      ConditionList conditions =
+         ConditionUtil.fromModelToConditionList(model, null, null, principal, rws);
+
+      assertInstanceOf(DateCondition.MonthCondition.class, conditions.getXCondition(0),
+                        "a wrong-case worksheet DateRangeAssembly name must still resolve to " +
+                        "the assembly's actual DateCondition, not fall through unresolved");
+      assertEquals(2, ((DateCondition.MonthCondition) conditions.getXCondition(0)).getMonthN());
+   }
+
+   /**
+    * When two worksheet DateRangeAssemblies differ only by case, an exact-name match must win
+    * over the case-insensitive fallback scan -- otherwise which one resolves depends on
+    * {@code Worksheet#getAssemblies()} iteration order, which callers cannot rely on. This is
+    * the determinism guarantee the exact-match-first ordering in the fix exists to provide.
+    */
+   @Test
+   void anExactCaseMatchIsPreferredOverACaseInsensitiveScanWhenBothExist() throws Exception {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn("OrderDate");
+      when(field.getDataType()).thenReturn(XSchema.DATE);
+
+      Worksheet ws = new Worksheet();
+
+      DateCondition.MonthCondition exactRange = new DateCondition.MonthCondition(2, 0);
+      DefaultDateRangeAssembly exact = new DefaultDateRangeAssembly(ws, "MyRange");
+      exact.setDateRange(exactRange);
+      ws.addAssembly(exact);
+
+      DateCondition.MonthCondition otherCaseRange = new DateCondition.MonthCondition(5, 1);
+      DefaultDateRangeAssembly otherCase = new DefaultDateRangeAssembly(ws, "MYRANGE");
+      otherCase.setDateRange(otherCaseRange);
+      ws.addAssembly(otherCase);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      Object[] model = ConditionVocabulary.toConditionList(
+         List.of(new ConditionVocabulary.Clause(
+            "OrderDate", "date_in", List.of("MyRange"), null, false)),
+         new DataRefModel[]{ field });
+
+      Principal principal = () -> "admin";
+      ConditionList conditions =
+         ConditionUtil.fromModelToConditionList(model, null, null, principal, rws);
+
+      DateCondition.MonthCondition resolved =
+         (DateCondition.MonthCondition) conditions.getXCondition(0);
+      assertEquals(0, resolved.getYearN());
+      assertEquals(2, resolved.getMonthN(),
+         "an exact-name match must be used, not whichever case-insensitive candidate the scan " +
+         "happens to hit first");
    }
 }

--- a/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
+++ b/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
@@ -68,4 +68,60 @@ class ConditionUtilTest {
                         "a date_in value naming a builtin range must resolve to a real " +
                         "DateCondition, not fall through to a plain value condition");
    }
+
+   /**
+    * The builtin lookup must not be case-sensitive -- a correctly-spelled name in the wrong
+    * case (e.g. an LLM normalizing "Last year" to "Last Year") must still resolve to the same
+    * builtin range, not silently fail to match and fall through.
+    */
+   @Test
+   void aBuiltinDateRangeNameInTheWrongCaseStillResolvesToTheSameDateCondition() throws Exception {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn("OrderDate");
+      when(field.getDataType()).thenReturn(XSchema.DATE);
+
+      String correctlyCasedName = "Last year";
+      String wrongCasedName = "Last Year";
+
+      Object[] correctModel = ConditionVocabulary.toConditionList(
+         List.of(new ConditionVocabulary.Clause(
+            "OrderDate", "date_in", List.of(correctlyCasedName), null, false)),
+         new DataRefModel[]{ field });
+      Object[] wrongCaseModel = ConditionVocabulary.toConditionList(
+         List.of(new ConditionVocabulary.Clause(
+            "OrderDate", "date_in", List.of(wrongCasedName), null, false)),
+         new DataRefModel[]{ field });
+
+      Principal principal = () -> "admin";
+      ConditionList correctConditions =
+         ConditionUtil.fromModelToConditionList(correctModel, null, null, principal);
+      ConditionList wrongCaseConditions =
+         ConditionUtil.fromModelToConditionList(wrongCaseModel, null, null, principal);
+
+      assertEquals(correctConditions.getXCondition(0), wrongCaseConditions.getXCondition(0),
+                   "a builtin name in the wrong case must resolve to the same DateCondition " +
+                   "as the correctly-cased name");
+   }
+
+   /**
+    * A value that names no builtin range and no worksheet date-range assembly must fail loud,
+    * not silently drop the condition or fall through to a plain value condition.
+    */
+   @Test
+   void anUnrecognizedDateRangeNameThrows() throws Exception {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn("OrderDate");
+      when(field.getDataType()).thenReturn(XSchema.DATE);
+
+      Object[] model = ConditionVocabulary.toConditionList(
+         List.of(new ConditionVocabulary.Clause(
+            "OrderDate", "date_in", List.of("Last Decade"), null, false)),
+         new DataRefModel[]{ field });
+
+      Principal principal = () -> "admin";
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> ConditionUtil.fromModelToConditionList(model, null, null, principal),
+                   "an unrecognized date range name must fail loud, not fall through silently");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -4687,6 +4687,29 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    /**
+    * A builtin name in the wrong case (e.g. an LLM normalizing "Last month" to "LAST MONTH")
+    * must still resolve, mirroring ConditionUtil.fromModelToConditionList's now-case-insensitive
+    * builtin lookup -- not fail to match and fall through to an unresolved condition.
+    */
+   @Test
+   void addFilterWithDateInResolvesANameInTheWrongCase() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addFilter("T", "a", "date_in", "LAST MONTH"));
+
+      XCondition xc = firstXCondition(t);
+      assertInstanceOf(DateCondition.MonthCondition.class, xc,
+         "a wrong-cased builtin name must still resolve to a real DateCondition");
+      DateCondition.MonthCondition mc = (DateCondition.MonthCondition) xc;
+      assertEquals(0, mc.getYearN());
+      assertEquals(1, mc.getMonthN());
+   }
+
+   /**
     * An unmatched/typo'd range name must fail loudly, naming the bad value -- not silently
     * substitute the shared rescue mechanism's hardcoded "one year ago" default (see
     * ConditionTest#toSqlConditionSilentlyDefaultsOnAnUnmatchedName for that default's own

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -4761,6 +4761,73 @@ class WorksheetEditServiceMutatorsTest {
          "must be a clone -- the assembly's own DateRange must not be aliased into the condition");
    }
 
+   /**
+    * The worksheet DateRangeAssembly name match must not be case-sensitive -- an LLM might pass
+    * the range's name in the wrong case, and it must still resolve via the case-insensitive
+    * fallback scan (only reached once the exact-name lookup above it misses), mirroring
+    * ConditionUtil.fromModelToConditionList's DATE_IN branch.
+    */
+   @Test
+   void addFilterWithDateInResolvesAWorksheetNamedDateRangeInTheWrongCase() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+
+      DateCondition.MonthCondition rangeCondition = new DateCondition.MonthCondition(2, 0);
+      DefaultDateRangeAssembly range = new DefaultDateRangeAssembly(ws, "MyRange");
+      range.setDateRange(rangeCondition);
+      ws.addAssembly(range);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addFilter("T", "a", "date_in", "myrange"));
+
+      XCondition xc = firstXCondition(t);
+      assertInstanceOf(DateCondition.MonthCondition.class, xc,
+         "a wrong-case worksheet DateRangeAssembly name must still resolve to a real " +
+         "DateCondition, not fall through unresolved");
+      DateCondition.MonthCondition mc = (DateCondition.MonthCondition) xc;
+      assertEquals(0, mc.getYearN());
+      assertEquals(2, mc.getMonthN());
+   }
+
+   /**
+    * When two worksheet DateRangeAssemblies differ only by case, an exact-name match must win
+    * over the case-insensitive fallback scan -- otherwise which one resolves depends on
+    * {@code Worksheet#getAssemblies()} iteration order, which callers cannot rely on. This is
+    * the determinism guarantee the exact-match-first ordering in the fix exists to provide.
+    */
+   @Test
+   void addFilterWithDateInPrefersExactNameMatchOverCaseInsensitiveScan() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+
+      DateCondition.MonthCondition exactRange = new DateCondition.MonthCondition(2, 0);
+      DefaultDateRangeAssembly exact = new DefaultDateRangeAssembly(ws, "MyRange");
+      exact.setDateRange(exactRange);
+      ws.addAssembly(exact);
+
+      DateCondition.MonthCondition otherCaseRange = new DateCondition.MonthCondition(5, 1);
+      DefaultDateRangeAssembly otherCase = new DefaultDateRangeAssembly(ws, "MYRANGE");
+      otherCase.setDateRange(otherCaseRange);
+      ws.addAssembly(otherCase);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addFilter("T", "a", "date_in", "MyRange"));
+
+      XCondition xc = firstXCondition(t);
+      assertInstanceOf(DateCondition.MonthCondition.class, xc);
+      DateCondition.MonthCondition mc = (DateCondition.MonthCondition) xc;
+      assertEquals(0, mc.getYearN());
+      assertEquals(2, mc.getMonthN(),
+         "an exact-name match must be used, not whichever case-insensitive candidate the scan " +
+         "happens to hit first");
+   }
+
    /** Mirrors addFilter's resolution through set_conditions's separate condition-building path. */
    @Test
    void setConditionsWithDateInResolvesNamedRangeToADateCondition() throws Exception {


### PR DESCRIPTION
## Summary
- `ConditionUtil.fromModelToConditionList`'s builtin `DateCondition` lookup (and the matching worksheet date-range-assembly lookup) used `equals()` against the exact builtin name, so a case variant an LLM might naturally produce (e.g. `"Last Year"` for the builtin `"Last year"`) silently failed to match and fell through instead of resolving to the real condition.
- `WorksheetMutationSupport`'s parallel builtin lookup had the same case-sensitivity bug.
- Both now match case-insensitively (`equalsIgnoreCase`), and `ConditionUtil` now throws a clear `IllegalArgumentException` naming the bad value when nothing matches (builtin or worksheet assembly), instead of silently dropping the condition.

## Test plan
- [x] Added `ConditionUtilTest#aBuiltinDateRangeNameInTheWrongCaseStillResolvesToTheSameDateCondition` — wrong-cased builtin name resolves to the same `DateCondition` as the correctly-cased name.
- [x] Added `ConditionUtilTest#anUnrecognizedDateRangeNameThrows` — an unrecognized date range name fails loud instead of falling through silently.
- [x] Added `WorksheetEditServiceMutatorsTest#addFilterWithDateInResolvesANameInTheWrongCase` — mirrors the fix in `WorksheetMutationSupport`'s builtin lookup.
- [x] `./mvnw -pl community/core -o clean test -Dtest=ConditionUtilTest,WorksheetEditServiceMutatorsTest` — 230 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)