### PR TITLE
Per-visualization interactive filter controls: Java side (WizVsService, WizFilterLayout)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -69,6 +69,23 @@ public class WizViewsheetController {
       return run("apply highlight", () -> wizVsService.applyHighlight(model, user));
    }
 
+   @PostMapping(value = "/viewsheet/filters", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> addFilters(@Valid @RequestBody AddFiltersRequest request, Principal user) {
+      return run("add visualization filters", () -> wizVsService.addFilters(request, user));
+   }
+
+   @PostMapping(value = "/viewsheet/filters/remove", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> removeFilter(@Valid @RequestBody RemoveFilterRequest request, Principal user) {
+      return run("remove visualization filter", () -> wizVsService.removeFilter(request, user));
+   }
+
+   @PostMapping(value = "/viewsheet/image", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> getVisualizationImage(@Valid @RequestBody VisualizationImageRequest request,
+                                                  Principal user)
+   {
+      return run("render visualization image", () -> wizVsService.getVisualizationImage(request, user));
+   }
+
    @PostMapping("/viewsheet/validateBinding")
    public void validateBinding(@RequestBody CreateVisualizationModel model,
                                Principal user) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/model/AddFiltersRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AddFiltersRequest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/filters} — add-or-update (upsert by
+ * {@code field}) 1-3 interactive filter controls on the chart identified by
+ * {@code (runtimeId, assemblyName)}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AddFiltersRequest {
+   @NotBlank
+   private String runtimeId;
+   @NotBlank
+   private String assemblyName;
+   private String viewsheetIdentifier;
+   @NotEmpty
+   private List<FilterFieldSpec> fields;
+
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
+   public List<FilterFieldSpec> getFields() {
+      return fields;
+   }
+
+   public void setFields(List<FilterFieldSpec> fields) {
+      this.fields = fields;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/AddFiltersResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AddFiltersResponse.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/** Response body for {@code POST /api/wiz/viewsheet/filters}. */
+public class AddFiltersResponse {
+   public AddFiltersResponse() {
+   }
+
+   public AddFiltersResponse(String runtimeId, List<AppliedFilter> applied, List<SkippedFilter> skipped) {
+      this.runtimeId = runtimeId;
+      this.applied = applied;
+      this.skipped = skipped;
+   }
+
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public List<AppliedFilter> getApplied() {
+      return applied;
+   }
+
+   public void setApplied(List<AppliedFilter> applied) {
+      this.applied = applied;
+   }
+
+   public List<SkippedFilter> getSkipped() {
+      return skipped;
+   }
+
+   public void setSkipped(List<SkippedFilter> skipped) {
+      this.skipped = skipped;
+   }
+
+   private String runtimeId;
+   private List<AppliedFilter> applied;
+   private List<SkippedFilter> skipped;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/AppliedFilter.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AppliedFilter.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/** One field that was successfully attached as a filter control, in {@link AddFiltersResponse}. */
+public class AppliedFilter {
+   public AppliedFilter() {
+   }
+
+   public AppliedFilter(String field, String assemblyName, String controlType, String label) {
+      this.field = field;
+      this.assemblyName = assemblyName;
+      this.controlType = controlType;
+      this.label = label;
+   }
+
+   public String getField() {
+      return field;
+   }
+
+   public void setField(String field) {
+      this.field = field;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public String getControlType() {
+      return controlType;
+   }
+
+   public void setControlType(String controlType) {
+      this.controlType = controlType;
+   }
+
+   public String getLabel() {
+      return label;
+   }
+
+   public void setLabel(String label) {
+      this.label = label;
+   }
+
+   private String field;
+   private String assemblyName;
+   private String controlType;
+   private String label;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/FilterFieldSpec.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/FilterFieldSpec.java
@@ -33,6 +33,14 @@ public class FilterFieldSpec {
    @NotBlank
    private String controlType;
    private String label;
+   /**
+    * The assembly name wiz-services already tracks for this field (from an earlier
+    * add_visualization_filters call), if any. When present and still a live filter-control
+    * assembly on the viewsheet, {@code addFilters} UPDATES it in place (same assemblyName,
+    * re-titled/re-bound/re-positioned) instead of creating a duplicate — the upsert-by-field
+    * half of decision 1. Absent (or stale/no-longer-present) falls back to creating a new control.
+    */
+   private String existingAssemblyName;
 
    public String getField() {
       return field;
@@ -56,5 +64,13 @@ public class FilterFieldSpec {
 
    public void setLabel(String label) {
       this.label = label;
+   }
+
+   public String getExistingAssemblyName() {
+      return existingAssemblyName;
+   }
+
+   public void setExistingAssemblyName(String existingAssemblyName) {
+      this.existingAssemblyName = existingAssemblyName;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/FilterFieldSpec.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/FilterFieldSpec.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * One field to attach as an interactive filter control, as sent by
+ * {@code POST /api/wiz/viewsheet/filters}. {@code controlType} arrives already resolved by
+ * wiz-services (selection_list | time_slider | calendar) — this endpoint never infers a control
+ * type from a data type itself.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FilterFieldSpec {
+   @NotBlank
+   private String field;
+   @NotBlank
+   private String controlType;
+   private String label;
+
+   public String getField() {
+      return field;
+   }
+
+   public void setField(String field) {
+      this.field = field;
+   }
+
+   public String getControlType() {
+      return controlType;
+   }
+
+   public void setControlType(String controlType) {
+      this.controlType = controlType;
+   }
+
+   public String getLabel() {
+      return label;
+   }
+
+   public void setLabel(String label) {
+      this.label = label;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/RemoveFilterRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/RemoveFilterRequest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/filters/remove} — removes the single filter
+ * control assembly named by {@code assemblyName} (resolved by the caller from its own tracked
+ * field->assemblyName state). Idempotent: an already-absent assembly is not an error.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RemoveFilterRequest {
+   @NotBlank
+   private String runtimeId;
+   @NotBlank
+   private String assemblyName;
+   private String viewsheetIdentifier;
+
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/RemoveFilterResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/RemoveFilterResponse.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/** Response body for {@code POST /api/wiz/viewsheet/filters/remove}. */
+public class RemoveFilterResponse {
+   public RemoveFilterResponse() {
+   }
+
+   public RemoveFilterResponse(boolean removed) {
+      this.removed = removed;
+   }
+
+   public boolean isRemoved() {
+      return removed;
+   }
+
+   public void setRemoved(boolean removed) {
+      this.removed = removed;
+   }
+
+   private boolean removed;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/SkippedFilter.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/SkippedFilter.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/** One requested field that could not be resolved on the chart's bound table, in {@link AddFiltersResponse}. */
+public class SkippedFilter {
+   public SkippedFilter() {
+   }
+
+   public SkippedFilter(String field, String reason) {
+      this.field = field;
+      this.reason = reason;
+   }
+
+   public String getField() {
+      return field;
+   }
+
+   public void setField(String field) {
+      this.field = field;
+   }
+
+   public String getReason() {
+      return reason;
+   }
+
+   public void setReason(String reason) {
+      this.reason = reason;
+   }
+
+   private String field;
+   private String reason;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/VisualizationImageRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/VisualizationImageRequest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request body for {@code POST /api/wiz/viewsheet/image} — the {@code runtimeId}-keyed sibling of
+ * the paired-session {@code /api/wiz/v1/agent/viewsheet/{sessionToken}/image} endpoint. Omitting
+ * {@code target} renders the whole viewsheet (chart + any filter controls); naming an assembly
+ * renders just that assembly.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VisualizationImageRequest {
+   @NotBlank
+   private String runtimeId;
+   private String viewsheetIdentifier;
+   private String target;
+   private Integer width;
+   private Integer height;
+
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getViewsheetIdentifier() {
+      return viewsheetIdentifier;
+   }
+
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
+   public String getTarget() {
+      return target;
+   }
+
+   public void setTarget(String target) {
+      this.target = target;
+   }
+
+   public Integer getWidth() {
+      return width;
+   }
+
+   public void setWidth(Integer width) {
+      this.width = width;
+   }
+
+   public Integer getHeight() {
+      return height;
+   }
+
+   public void setHeight(Integer height) {
+      this.height = height;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/VisualizationImageResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/VisualizationImageResponse.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/** Response body for {@code POST /api/wiz/viewsheet/image}. Mirrors {@code ScriptImageService.ChartImage}. */
+public class VisualizationImageResponse {
+   public VisualizationImageResponse() {
+   }
+
+   public VisualizationImageResponse(String image, String format, int width, int height, String note) {
+      this.image = image;
+      this.format = format;
+      this.width = width;
+      this.height = height;
+      this.note = note;
+   }
+
+   public String getImage() {
+      return image;
+   }
+
+   public void setImage(String image) {
+      this.image = image;
+   }
+
+   public String getFormat() {
+      return format;
+   }
+
+   public void setFormat(String format) {
+      this.format = format;
+   }
+
+   public int getWidth() {
+      return width;
+   }
+
+   public void setWidth(int width) {
+      this.width = width;
+   }
+
+   public int getHeight() {
+      return height;
+   }
+
+   public void setHeight(int height) {
+      this.height = height;
+   }
+
+   public String getNote() {
+      return note;
+   }
+
+   public void setNote(String note) {
+      this.note = note;
+   }
+
+   private String image;
+   private String format;
+   private int width;
+   private int height;
+   private String note;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFilterLayout.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFilterLayout.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.asset.AbstractSheet;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.*;
+
+/**
+ * Packs 1-3 filter control assemblies into a shelf grid below a chart, per
+ * docs/superpowers/specs/2026-09-01-visualization-scoped-filters-design.md section 2.4. Pure and
+ * stateless: no RuntimeViewsheet/DB/network dependency, so it is independently unit-testable
+ * (WizFilterLayoutTest).
+ */
+public final class WizFilterLayout {
+   private WizFilterLayout() {
+   }
+
+   /** Fixed gap, in pixels, between packed controls and between the chart and the first shelf. */
+   private static final int GAP = 10;
+
+   /**
+    * Preferred (width, height) per control type. SelectionList (100x120) was measured live against
+    * a real StyleBI checkout (see the design doc's section 10.1); Calendar (200x220) and TimeSlider
+    * (280x50) are still estimates as of this build (design doc section 8).
+    */
+   private static final Map<Integer, Dimension> PREFERRED_SIZES = Map.of(
+      AbstractSheet.SELECTION_LIST_ASSET, new Dimension(100, 120),
+      AbstractSheet.CALENDAR_ASSET, new Dimension(200, 220),
+      AbstractSheet.TIME_SLIDER_ASSET, new Dimension(280, 50)
+   );
+
+   /**
+    * Computes packed placement rectangles for {@code orderedTypes}, one per input entry, in the
+    * SAME order as the input (callers zip the result back against their own field list by index)
+    * even though placement internally sorts by preferred height descending (shelf-packing: tallest
+    * items anchor each shelf).
+    *
+    * @param chartOffset  the chart assembly's own pixel offset (packed controls' x is relative to
+    *                     {@code chartOffset.x}, so the filter zone aligns under the chart).
+    * @param chartSize    the chart assembly's own pixel size (controls are packed starting at
+    *                     {@code chartOffset.y + chartSize.height + GAP}, width-limited to
+    *                     {@code chartSize.width}).
+    * @param orderedTypes one {@link AbstractSheet} asset-type code
+    *                     (SELECTION_LIST_ASSET/TIME_SLIDER_ASSET/CALENDAR_ASSET) per requested
+    *                     control, in the caller's original order.
+    * @return one {@link Rectangle} per input entry, same order as {@code orderedTypes}.
+    */
+   public static List<Rectangle> pack(Point chartOffset, Dimension chartSize, List<Integer> orderedTypes) {
+      int n = orderedTypes.size();
+      // A chart width of 0/negative (never expected in practice) would otherwise divide-by-zero
+      // below when clamping; 1px is not a meaningful "minimum layout width" the way the design's
+      // illustrative "e.g. 300px" floor was — that value exceeds every current preferred width
+      // (max 280, TimeSlider), which would make the clamp branch below unreachable and untestable.
+      int availableWidth = Math.max(chartSize.width, 1);
+
+      Dimension[] sizes = new Dimension[n];
+
+      for(int i = 0; i < n; i++) {
+         int type = orderedTypes.get(i);
+         Dimension preferred = PREFERRED_SIZES.get(type);
+
+         if(preferred == null) {
+            throw new IllegalArgumentException("Unsupported filter control type: " + type);
+         }
+
+         if(preferred.width > availableWidth) {
+            double ratio = (double) availableWidth / preferred.width;
+            sizes[i] = new Dimension(availableWidth, (int) Math.round(preferred.height * ratio));
+         }
+         else {
+            sizes[i] = new Dimension(preferred.width, preferred.height);
+         }
+      }
+
+      // Indices sorted by preferred height descending; Arrays.sort on a reference-type array with a
+      // Comparator is a stable sort, so ties keep the original input order.
+      Integer[] order = new Integer[n];
+
+      for(int i = 0; i < n; i++) {
+         order[i] = i;
+      }
+
+      Arrays.sort(order, Comparator.comparingInt((Integer i) -> sizes[i].height).reversed());
+
+      Rectangle[] result = new Rectangle[n];
+      int x = 0;
+      int y = chartOffset.y + chartSize.height + GAP;
+      int shelfHeight = 0;
+
+      for(int idx : order) {
+         Dimension size = sizes[idx];
+
+         if(x > 0 && x + size.width > availableWidth) {
+            y += shelfHeight + GAP;
+            x = 0;
+            shelfHeight = 0;
+         }
+
+         result[idx] = new Rectangle(chartOffset.x + x, y, size.width, size.height);
+         x += size.width + GAP;
+         shelfHeight = Math.max(shelfHeight, size.height);
+      }
+
+      return Arrays.asList(result);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFilterLayout.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFilterLayout.java
@@ -54,6 +54,9 @@ public final class WizFilterLayout {
     * even though placement internally sorts by preferred height descending (shelf-packing: tallest
     * items anchor each shelf).
     *
+    * <p>Equivalent to {@link #pack(Point, Dimension, List, List)} with an empty occupied list — no
+    * already-placed controls to pack around (a single-call sequence, or the first call ever).
+    *
     * @param chartOffset  the chart assembly's own pixel offset (packed controls' x is relative to
     *                     {@code chartOffset.x}, so the filter zone aligns under the chart).
     * @param chartSize    the chart assembly's own pixel size (controls are packed starting at
@@ -65,6 +68,25 @@ public final class WizFilterLayout {
     * @return one {@link Rectangle} per input entry, same order as {@code orderedTypes}.
     */
    public static List<Rectangle> pack(Point chartOffset, Dimension chartSize, List<Integer> orderedTypes) {
+      return pack(chartOffset, chartSize, orderedTypes, List.of());
+   }
+
+   /**
+    * Same as {@link #pack(Point, Dimension, List)}, but packs the new controls AROUND rectangles
+    * already occupied by controls a previous {@code add_visualization_filters} call placed (06-
+    * review-r1.md Important finding: without this, every call restarted at
+    * {@code chartOffset.y + chartSize.height + GAP} regardless of what was already there, so a
+    * second call with different fields landed directly on top of the first call's controls).
+    * Never repositions anything in {@code occupied} — those rectangles are read-only input, purely
+    * to avoid new placements overlapping them.
+    *
+    * @param occupied  pixel rectangles already occupied by live, still-present filter controls (in
+    *                  the SAME coordinate space as the returned rectangles — i.e. already offset by
+    *                  the chart's own pixel offset). Empty when there is nothing to pack around.
+    */
+   public static List<Rectangle> pack(
+      Point chartOffset, Dimension chartSize, List<Integer> orderedTypes, List<Rectangle> occupied)
+   {
       int n = orderedTypes.size();
       // A chart width of 0/negative (never expected in practice) would otherwise divide-by-zero
       // below when clamping; 1px is not a meaningful "minimum layout width" the way the design's
@@ -101,10 +123,44 @@ public final class WizFilterLayout {
 
       Arrays.sort(order, Comparator.comparingInt((Integer i) -> sizes[i].height).reversed());
 
-      Rectangle[] result = new Rectangle[n];
+      // Seed the shelf cursor from whatever is already occupied, instead of always starting fresh
+      // at the chart's own bottom edge. Rows are derived from `occupied` by grouping rectangles
+      // whose y-ranges overlap (this mirrors how this same method laid them out originally, one
+      // call at a time) -- the LAST such row (greatest y) is where a new item can still append, at
+      // its rightmost occupied edge; anything short of that starts a fresh row below it.
       int x = 0;
       int y = chartOffset.y + chartSize.height + GAP;
       int shelfHeight = 0;
+
+      if(!occupied.isEmpty()) {
+         List<Rectangle> sorted = new ArrayList<>(occupied);
+         sorted.sort(Comparator.comparingInt(r -> r.y));
+
+         int rowTop = sorted.get(0).y;
+         int rowBottom = sorted.get(0).y + sorted.get(0).height;
+         int rowRight = sorted.get(0).x + sorted.get(0).width;
+
+         for(int i = 1; i < sorted.size(); i++) {
+            Rectangle r = sorted.get(i);
+
+            if(r.y < rowBottom) {
+               // Same shelf row as the running group (y-ranges overlap).
+               rowBottom = Math.max(rowBottom, r.y + r.height);
+               rowRight = Math.max(rowRight, r.x + r.width);
+            }
+            else {
+               rowTop = r.y;
+               rowBottom = r.y + r.height;
+               rowRight = r.x + r.width;
+            }
+         }
+
+         x = rowRight - chartOffset.x + GAP;
+         y = rowTop;
+         shelfHeight = rowBottom - rowTop;
+      }
+
+      Rectangle[] result = new Rectangle[n];
 
       for(int idx : order) {
          Dimension size = sizes[idx];

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -108,7 +108,10 @@ public class WizVisualizationService {
     *   <li>Remove all worksheet tables NOT required by the target assembly.</li>
     *   <li>Persist the trimmed Worksheet under
     *       {@link GenerateWsService#WORKSHEET_COMPONENTS_FOLDER_PATH}.</li>
-    *   <li>Create a new single-assembly ViewSheet pointing to the new Worksheet.</li>
+    *   <li>Create a new ViewSheet pointing to the new Worksheet, containing the cloned target
+    *       assembly AND (when it is a chart) any sibling filter-control assemblies
+    *       {@code add_visualization_filters} placed below it on the source runtime
+    *       (07-fix-r3.md) -- a saved visualization is no longer necessarily single-assembly.</li>
     *   <li>Set {@code visualizationScope=SHARED}, {@code conversationId}, and
     *       {@code sourceAssemblyName} on the new AssetEntry.</li>
     *   <li>Persist the new ViewSheet under the user-selected folder.</li>
@@ -289,7 +292,7 @@ public class WizVisualizationService {
       AssetEntry newWsEntry = saveWorksheet(
          sourceVs, assembly, targetFolderPath, alias, updateTargetWsEntry, principal);
 
-      // ── Step 5: Build new single-assembly ViewSheet ───────────────────────────
+      // ── Step 5: Build new ViewSheet (target assembly + its filter controls) ──
       Viewsheet newVs = new Viewsheet();
 
       if(newWsEntry != null) {
@@ -302,9 +305,22 @@ public class WizVisualizationService {
 
       VSAssembly cloned = (VSAssembly) assembly.clone();
       cloned.setPrimary(true);
-      // Reset position so the assembly appears at the top-left of the new single-assembly viewsheet.
+      // Reset position so the assembly appears at the top-left of the new viewsheet.
       cloned.setPixelOffset(new Point(24, 24));
       newVs.addAssembly(cloned);
+
+      // Carry over sibling filter-control assemblies (add_visualization_filters places these below
+      // the chart on the SOURCE runtime -- 07-fix-r3.md) so a saved visualization keeps its
+      // interactive controls across save/reopen. Reuses fix round 1's occupancy-detection
+      // (WizVsService.findExistingFilterControls) rather than a second heuristic. Read from
+      // sourceVs (the ORIGINAL runtime), not newVs, which only has the chart clone so far. Unlike
+      // the chart clone above, a control's pixelOffset/pixelSize is preserved as-is: it must stay
+      // positioned relative to the chart it was packed under, not reset to the viewsheet's origin.
+      if(assembly instanceof ChartVSAssembly sourceChart) {
+         for(VSAssembly control : WizVsService.findExistingFilterControls(sourceVs, sourceChart)) {
+            newVs.addAssembly((VSAssembly) control.clone());
+         }
+      }
 
       // Carry over the source viewsheet's calc fields for this chart's source (e.g. a histogram's
       // materialized "Range@<measure>" range field) so the cloned chart's calc-field-backed bindings
@@ -671,8 +687,9 @@ public class WizVisualizationService {
 
    /**
     * Resolves the assembly to render for a saved wiz visualization: the first
-    * {@link ChartVSAssembly}, else the first {@link VSAssembly} — saved wiz visualizations are
-    * single-assembly, so this is unambiguous in practice.
+    * {@link ChartVSAssembly}, else the first {@link VSAssembly} — the chart is always the
+    * intended render target even when the visualization also carries sibling filter-control
+    * assemblies (07-fix-r3.md), so this stays unambiguous in practice.
     */
    private String resolvePrimaryAssemblyName(String runtimeId, Principal principal) {
       try {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -459,9 +459,9 @@ public class WizVsService {
     * Attaches 1-3 interactive filter controls (SelectionList/TimeSlider/Calendar) to the chart
     * identified by {@code (runtimeId, assemblyName)}, packed into a grid below it on the same
     * viewsheet ({@link WizFilterLayout}). Every control binds {@code setTableNames} to exactly the
-    * chart's own bound table (never a multi-table search — see the design doc section 2.5); a
-    * requested field not found on that table is reported in the response's {@code skipped} list
-    * rather than failing the whole call.
+    * chart's own bound table (never a multi-table search — see the design doc section 2.5) AND
+    * the resolved column itself ({@link #bindColumn}) — a requested field not found on that table
+    * is reported in the response's {@code skipped} list rather than failing the whole call.
     *
     * <p>Never touches {@code conditionModel}/{@code highlightModel} — this only adds sibling
     * assemblies to the viewsheet, independent of both.
@@ -594,6 +594,14 @@ public class WizVsService {
          }
 
          control.setTableNames(List.of(tableName));
+
+         // The actual filter binding -- without this the control has a table but no column, so it
+         // renders as an unbound widget with nothing to select (07-fix-r2.md; the design sketch,
+         // spec section 5, only carried `col` through to the title below, never to the binding
+         // itself). Always rebinds, even when `control` is a reused/existing assembly, since a
+         // reused-via-existingAssemblyName control can legitimately be repointed at a different
+         // field than it currently holds.
+         bindColumn(control, col);
 
          String title = !Tool.isEmptyString(spec.getLabel()) ? spec.getLabel() : col.getAttribute();
 
@@ -779,6 +787,43 @@ public class WizVsService {
          case "calendar" -> AbstractSheet.CALENDAR_ASSET;
          default -> throw new IllegalArgumentException("Unsupported controlType: " + controlType);
       };
+   }
+
+   /**
+    * Binds {@code col} as the control's actual filter column -- not just its display title (that
+    * is set separately, right after this call, in {@link #addFilters}). Mirrors
+    * {@code AddFilterService#createFilterAssembly}, the known-good binding path for these same
+    * three control types (also reused by {@link WizDashboardFilterBuilder}): SelectionList and
+    * Calendar bind directly via their own {@code setDataRef}; TimeSlider has no such direct
+    * setter and binds through a {@link SingleTimeInfo} instead, whose range type must match the
+    * column's own data type (numeric/time/date) the same way {@code createFilterAssembly}
+    * derives it -- getting this branch wrong (e.g. always defaulting to MONTH) would produce a
+    * control that LOOKS bound but silently mis-ranges a numeric or time-of-day column.
+    */
+   private static void bindColumn(AbstractSelectionVSAssembly control, DataRef col) {
+      if(control instanceof SelectionListVSAssembly list) {
+         list.setDataRef(col);
+      }
+      else if(control instanceof CalendarVSAssembly calendar) {
+         calendar.setDataRef(col);
+      }
+      else if(control instanceof TimeSliderVSAssembly slider) {
+         String dtype = col.getDataType();
+         SingleTimeInfo tinfo = new SingleTimeInfo();
+         tinfo.setDataRef(col);
+
+         if(XSchema.isNumericType(dtype)) {
+            tinfo.setRangeTypeValue(TimeInfo.NUMBER);
+         }
+         else if(XSchema.TIME.equals(dtype)) {
+            tinfo.setRangeTypeValue(TimeInfo.MINUTE_OF_DAY);
+         }
+         else {
+            tinfo.setRangeTypeValue(TimeInfo.MONTH);
+         }
+
+         slider.getTimeSliderInfo().setTimeInfo(tinfo);
+      }
    }
 
    /** Whether an existing assembly is still the right Java type to reuse for the given

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -509,9 +509,24 @@ public class WizVsService {
             continue;
          }
 
+         int type = resolveAddType(spec.getControlType());
+         String dtype = col.getDataType();
+
+         // TimeSlider's range type (bindColumn) only has a sensible value for numeric/date
+         // columns (mirrors AddFilterService.createFilterAssembly's own gate) -- an explicit
+         // time_slider override (assertion A2) on e.g. a boolean/string column has no sensible
+         // range and must be reported, not silently bound with a MONTH range (07-fix-r5.md).
+         if(type == AbstractSheet.TIME_SLIDER_ASSET &&
+            !(XSchema.isNumericType(dtype) || XSchema.isDateType(dtype)))
+         {
+            skipped.add(new SkippedFilter(spec.getField(),
+               "time_slider is not supported for " + dtype + " columns"));
+            continue;
+         }
+
          resolvable.add(spec);
          resolvedColumns.add(col);
-         resolvedTypes.add(resolveAddType(spec.getControlType()));
+         resolvedTypes.add(type);
       }
 
       // Every live filter-control assembly already sitting below the chart (06-review-r1.md
@@ -813,20 +828,27 @@ public class WizVsService {
       }
       else if(control instanceof TimeSliderVSAssembly slider) {
          String dtype = col.getDataType();
-         SingleTimeInfo tinfo = new SingleTimeInfo();
-         tinfo.setDataRef(col);
 
-         if(XSchema.isNumericType(dtype)) {
-            tinfo.setRangeTypeValue(TimeInfo.NUMBER);
-         }
-         else if(XSchema.TIME.equals(dtype)) {
-            tinfo.setRangeTypeValue(TimeInfo.MINUTE_OF_DAY);
-         }
-         else {
-            tinfo.setRangeTypeValue(TimeInfo.MONTH);
-         }
+         // Mirrors AddFilterService#createFilterAssembly's own outer gate -- addFilters already
+         // skips a time_slider override on a non-numeric/date column before reaching this call
+         // (07-fix-r5.md), but this gate is kept here too so this method can never mis-range a
+         // column its own doc comment above says it must not.
+         if(XSchema.isNumericType(dtype) || XSchema.isDateType(dtype)) {
+            SingleTimeInfo tinfo = new SingleTimeInfo();
+            tinfo.setDataRef(col);
 
-         slider.getTimeSliderInfo().setTimeInfo(tinfo);
+            if(XSchema.isNumericType(dtype)) {
+               tinfo.setRangeTypeValue(TimeInfo.NUMBER);
+            }
+            else if(XSchema.TIME.equals(dtype)) {
+               tinfo.setRangeTypeValue(TimeInfo.MINUTE_OF_DAY);
+            }
+            else {
+               tinfo.setRangeTypeValue(TimeInfo.MONTH);
+            }
+
+            slider.getTimeSliderInfo().setTimeInfo(tinfo);
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -72,12 +72,16 @@ import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import inetsoft.web.wiz.BindingFieldSettings;
 import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.script.ScriptImageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.security.Principal;
 import java.util.*;
 import java.util.function.BiFunction;
@@ -87,13 +91,15 @@ import java.util.stream.Collectors;
 public class WizVsService {
    public WizVsService(ViewsheetService viewsheetService, AssetRepository engine,
                        SecurityEngine securityEngine, SyncInfoHandler syncInfoHandler,
-                       VSWizardTemporaryInfoService temporaryInfoService)
+                       VSWizardTemporaryInfoService temporaryInfoService,
+                       ScriptImageService scriptImageService)
    {
       this.viewsheetService = viewsheetService;
       this.engine = engine;
       this.securityEngine = securityEngine;
       this.syncInfoHandler = syncInfoHandler;
       this.temporaryInfoService = temporaryInfoService;
+      this.scriptImageService = scriptImageService;
    }
 
    /**
@@ -447,6 +453,227 @@ public class WizVsService {
       }
 
       return result;
+   }
+
+   /**
+    * Attaches 1-3 interactive filter controls (SelectionList/TimeSlider/Calendar) to the chart
+    * identified by {@code (runtimeId, assemblyName)}, packed into a grid below it on the same
+    * viewsheet ({@link WizFilterLayout}). Every control binds {@code setTableNames} to exactly the
+    * chart's own bound table (never a multi-table search — see the design doc section 2.5); a
+    * requested field not found on that table is reported in the response's {@code skipped} list
+    * rather than failing the whole call.
+    *
+    * <p>Never touches {@code conditionModel}/{@code highlightModel} — this only adds sibling
+    * assemblies to the viewsheet, independent of both.
+    *
+    * <p>Upsert-in-place (reusing an existing field's control instead of creating a duplicate) is
+    * the caller's (wiz-services') responsibility, via its own tracked field-&gt;assemblyName state:
+    * a repeat call for an already-attached field removes the old control's assembly first via
+    * {@link #removeFilter}, so this method itself only ever creates.
+    */
+   public AddFiltersResponse addFilters(AddFiltersRequest request, Principal user) throws Exception {
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
+      RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+         viewsheetService, request.getRuntimeId(), request.getViewsheetIdentifier(), user);
+      Viewsheet vs = getValidatedViewsheet(rvs);
+
+      VSAssembly chartAssembly = vs.getAssembly(request.getAssemblyName());
+
+      if(!(chartAssembly instanceof ChartVSAssembly chart)) {
+         throw new IllegalArgumentException("No chart assembly named '" + request.getAssemblyName() + "'");
+      }
+
+      String tableName = chart.getTableName();
+      AbstractTableAssembly table = resolveBoundTable(vs, tableName, user);
+      ColumnSelection cols = table.getColumnSelection(false);
+
+      List<FilterFieldSpec> resolvable = new ArrayList<>();
+      List<DataRef> resolvedColumns = new ArrayList<>();
+      List<Integer> resolvedTypes = new ArrayList<>();
+      List<SkippedFilter> skipped = new ArrayList<>();
+
+      for(FilterFieldSpec spec : request.getFields()) {
+         DataRef col = cols.getAttribute(spec.getField());
+
+         if(col == null) {
+            skipped.add(new SkippedFilter(spec.getField(), "not found on bound table"));
+            continue;
+         }
+
+         resolvable.add(spec);
+         resolvedColumns.add(col);
+         resolvedTypes.add(resolveAddType(spec.getControlType()));
+      }
+
+      // Packed grid (design doc section 2.4), computed from the chart's own LIVE geometry -- free
+      // here, since `chart` is already in hand. Skipped fields do not consume a shelf slot.
+      List<Rectangle> rects = WizFilterLayout.pack(chart.getPixelOffset(), chart.getPixelSize(), resolvedTypes);
+
+      List<AppliedFilter> applied = new ArrayList<>();
+
+      for(int i = 0; i < resolvable.size(); i++) {
+         FilterFieldSpec spec = resolvable.get(i);
+         DataRef col = resolvedColumns.get(i);
+         VSAssembly created = VSEventUtil.createVSAssembly(rvs, resolvedTypes.get(i));
+
+         if(!(created instanceof AbstractSelectionVSAssembly control)) {
+            // Cannot happen: resolveAddType only returns the three SELECTION_LIST/TIME_SLIDER/
+            // CALENDAR codes, and createVSAssembly's switch creates an AbstractSelectionVSAssembly
+            // subclass for every one of them.
+            throw new IllegalStateException(
+               "Failed to create filter control for field '" + spec.getField() + "'");
+         }
+
+         control.setTableNames(List.of(tableName));
+
+         String title = !Tool.isEmptyString(spec.getLabel()) ? spec.getLabel() : col.getAttribute();
+
+         // SelectionListVSAssembly has its own setTitleValue but does not implement the
+         // TitledVSAssembly interface (unlike Calendar/TimeSlider) -- both branches are needed to
+         // cover all three control types.
+         if(control instanceof TitledVSAssembly titled) {
+            titled.setTitleValue(title);
+         }
+         else if(control instanceof SelectionListVSAssembly selectionList) {
+            selectionList.setTitleValue(title);
+         }
+
+         Rectangle r = rects.get(i);
+         control.setPixelOffset(new Point(r.x, r.y));
+         control.setPixelSize(new Dimension(r.width, r.height));
+         // Re-add for correct z-index AT THE FINAL, PACKED POSITION -- createVSAssembly already
+         // added the control once at its default (0,0) position; Viewsheet.addAssembly is
+         // idempotent (matches by name, replaces in place) but re-runs the z-index adjustment
+         // against whatever geometry the assembly holds at the moment of the call.
+         vs.addAssembly(control);
+
+         // Populates the control's own selectable values/range (box.executeView) -- never on the
+         // chart itself, since the chart's own binding/data is unchanged by adding a sibling filter.
+         executeAndExtract(rvs, control, 0);
+
+         applied.add(new AppliedFilter(spec.getField(), control.getName(), spec.getControlType(), title));
+      }
+
+      String viewsheetIdentifier = request.getViewsheetIdentifier();
+
+      if(!Tool.isEmptyString(viewsheetIdentifier)) {
+         persistViewsheet(vs, viewsheetIdentifier, user);
+      }
+
+      return new AddFiltersResponse(rvs.getID(), applied, skipped);
+   }
+
+   /**
+    * Removes a single filter control assembly (by name) from a live runtime viewsheet and persists
+    * the change back to the managed visualization asset. Idempotent — a missing/expired runtime or
+    * an already-absent assembly is treated as success ({@code removed:false}, not an error), mirroring
+    * {@link #removeVisualization}.
+    */
+   public RemoveFilterResponse removeFilter(RemoveFilterRequest request, Principal user) throws Exception {
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
+      RuntimeViewsheet rvs;
+
+      try {
+         rvs = WizUtil.getViewsheetOrRestore(
+            viewsheetService, request.getRuntimeId(), request.getViewsheetIdentifier(), user);
+      }
+      catch(Exception e) {
+         LOG.warn("Runtime viewsheet [{}] unavailable; treating filter removal as a no-op: {}",
+            request.getRuntimeId(), e.getMessage());
+         return new RemoveFilterResponse(false);
+      }
+
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs == null || vs.getAssembly(request.getAssemblyName()) == null) {
+         return new RemoveFilterResponse(false); // idempotent: nothing to remove
+      }
+
+      vs.removeAssembly(request.getAssemblyName());
+      rvs.getViewsheetSandbox().ifPresent(box -> {
+         box.resetDataMap(request.getAssemblyName());
+
+         try {
+            box.clearGraph(request.getAssemblyName());
+         }
+         catch(Exception ignore) {
+         }
+      });
+
+      if(!Tool.isEmptyString(request.getViewsheetIdentifier())) {
+         persistViewsheet(vs, request.getViewsheetIdentifier(), user);
+      }
+
+      return new RemoveFilterResponse(true);
+   }
+
+   /**
+    * Renders the whole viewsheet (chart + any filter controls, {@code target} omitted) or a single
+    * assembly, for a headless {@code runtimeId}-keyed runtime — the sibling of the paired-session
+    * {@code /api/wiz/v1/agent/viewsheet/{sessionToken}/image} endpoint
+    * ({@link inetsoft.web.wiz.viewsheet.ViewsheetAssemblyAgentController#image}), reusing the exact
+    * same underlying render mechanism ({@link ScriptImageService}) rather than a bespoke one.
+    */
+   public VisualizationImageResponse getVisualizationImage(VisualizationImageRequest request, Principal user)
+      throws Exception
+   {
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
+      RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+         viewsheetService, request.getRuntimeId(), request.getViewsheetIdentifier(), user);
+
+      String target = request.getTarget();
+      ScriptImageService.ChartImage image = Tool.isEmptyString(target)
+         ? scriptImageService.getViewsheetImage(rvs, request.getWidth(), request.getHeight(), user)
+         : scriptImageService.getAssemblyImage(rvs, target, request.getWidth(), request.getHeight(), user);
+
+      return new VisualizationImageResponse(
+         Base64.getEncoder().encodeToString(image.pngBytes()),
+         image.isPng() ? "png" : "svg",
+         image.width(), image.height(), image.note());
+   }
+
+   /** {@code controlType} -&gt; {@link AbstractSheet} asset-type code. Fails loud on an unrecognized
+    *  value rather than silently defaulting -- wiz-services' zod enum should already guarantee one
+    *  of the three, so reaching the default branch means the two sides have drifted. */
+   private static int resolveAddType(String controlType) {
+      return switch(controlType) {
+         case "selection_list" -> AbstractSheet.SELECTION_LIST_ASSET;
+         case "time_slider" -> AbstractSheet.TIME_SLIDER_ASSET;
+         case "calendar" -> AbstractSheet.CALENDAR_ASSET;
+         default -> throw new IllegalArgumentException("Unsupported controlType: " + controlType);
+      };
+   }
+
+   /**
+    * Resolves the worksheet table a chart's {@code tableName} refers to, the same pattern already
+    * live at {@code pushAggregationToWorksheet}'s call site: {@code engine.getSheet(vs.getBaseEntry(),
+    * ...)}, not {@code vs.getBaseWorksheet()}.
+    */
+   private AbstractTableAssembly resolveBoundTable(Viewsheet vs, String tableName, Principal user)
+      throws Exception
+   {
+      AssetEntry wsEntry = vs.getBaseEntry();
+      Worksheet ws = wsEntry != null
+         ? (Worksheet) engine.getSheet(wsEntry, user, false, AssetContent.ALL) : null;
+      Assembly wsAssembly = ws != null ? ws.getAssembly(VSUtil.stripOuter(tableName)) : null;
+
+      if(!(wsAssembly instanceof AbstractTableAssembly table)) {
+         throw new IllegalStateException("Cannot resolve worksheet table '" + tableName + "'");
+      }
+
+      return table;
    }
 
    /**
@@ -5815,6 +6042,7 @@ public class WizVsService {
    private final SecurityEngine securityEngine;
    private final SyncInfoHandler syncInfoHandler;
    private final VSWizardTemporaryInfoService temporaryInfoService;
+   private final ScriptImageService scriptImageService;
 
    private static final Logger LOG = LoggerFactory.getLogger(WizVsService.class);
    private static final Map<Class<?>, BiFunction<Viewsheet, String, VSAssembly>> ASSEMBLY_FACTORIES = Map.of(

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -466,10 +466,15 @@ public class WizVsService {
     * <p>Never touches {@code conditionModel}/{@code highlightModel} — this only adds sibling
     * assemblies to the viewsheet, independent of both.
     *
-    * <p>Upsert-in-place (reusing an existing field's control instead of creating a duplicate) is
-    * the caller's (wiz-services') responsibility, via its own tracked field-&gt;assemblyName state:
-    * a repeat call for an already-attached field removes the old control's assembly first via
-    * {@link #removeFilter}, so this method itself only ever creates.
+    * <p>Upsert-by-field (assertion A3/C2) does NOT depend on the caller's (wiz-services') own
+    * tracked field-&gt;assemblyName state being accurate — that state is only ever a mirror, and
+    * 06-review-r1.md's CRITICAL finding showed it can silently go stale (a sibling tool call, or a
+    * reopened saved visualization whose response shape carries no filter information at all). So:
+    * when {@code existingAssemblyName} IS supplied, it's used as a hint (fast path, and honors
+    * relabeling the exact control the caller means even before a repositioning pass); when it is
+    * ABSENT, this method searches the LIVE viewsheet itself for a filter-control assembly already
+    * bound to the same (table, field) and reuses that one instead of creating a duplicate. Session
+    * state is an optimization, never the correctness mechanism.
     */
    public AddFiltersResponse addFilters(AddFiltersRequest request, Principal user) throws Exception {
       if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
@@ -509,9 +514,62 @@ public class WizVsService {
          resolvedTypes.add(resolveAddType(spec.getControlType()));
       }
 
+      // Every live filter-control assembly already sitting below the chart (06-review-r1.md
+      // Important finding's chosen fix shape: derive occupancy from the viewsheet itself, not from
+      // a second session-tracked list). Used both to resolve a same-field reuse below (when the
+      // caller gave no existingAssemblyName hint) and to pack new controls around whatever isn't
+      // being reused/replaced this call.
+      List<VSAssembly> existingControls = findExistingFilterControls(vs, chart);
+
+      // Upsert-by-field resolution happens BEFORE packing, since packing needs to know which
+      // already-placed controls are staying put (and therefore must be packed around) versus being
+      // reused/replaced by THIS call (and therefore get a fresh position from pack() itself, same as
+      // a newly-created control would).
+      AbstractSelectionVSAssembly[] resolvedControls = new AbstractSelectionVSAssembly[resolvable.size()];
+      Set<String> claimed = new HashSet<>();
+
+      for(int i = 0; i < resolvable.size(); i++) {
+         FilterFieldSpec spec = resolvable.get(i);
+         DataRef col = resolvedColumns.get(i);
+         int type = resolvedTypes.get(i);
+         String existingName = spec.getExistingAssemblyName();
+         VSAssembly existing = null;
+
+         // Upsert-by-field (decision 1 / assertion A3/C2): reuse an existing control in place
+         // (same assemblyName) instead of creating a duplicate. A stale name (no longer on the
+         // viewsheet) or a type change (e.g. a repeat call with a different explicit controlType
+         // override) falls back to removing the old one and creating fresh.
+         if(!Tool.isEmptyString(existingName)) {
+            existing = vs.getAssembly(existingName);
+         }
+         else {
+            // No session hint -- fall back to the live viewsheet itself as the source of truth
+            // (see the method doc comment above). Only ever matches a control not already claimed
+            // by an earlier field in THIS SAME call, so two requested fields can never both resolve
+            // to the same pre-existing control.
+            existing = findControlForField(existingControls, tableName, col, claimed);
+         }
+
+         if(existing != null && matchesControlType(existing, type)) {
+            resolvedControls[i] = (AbstractSelectionVSAssembly) existing;
+            claimed.add(existing.getName());
+         }
+         else if(existing != null) {
+            vs.removeAssembly(existing.getName());
+            claimed.add(existing.getName());
+         }
+      }
+
       // Packed grid (design doc section 2.4), computed from the chart's own LIVE geometry -- free
-      // here, since `chart` is already in hand. Skipped fields do not consume a shelf slot.
-      List<Rectangle> rects = WizFilterLayout.pack(chart.getPixelOffset(), chart.getPixelSize(), resolvedTypes);
+      // here, since `chart` is already in hand. Skipped fields do not consume a shelf slot. Pack
+      // AROUND already-placed controls that are staying where they are (not claimed above, not
+      // this call's own chart) -- never repositions them (06-review-r1.md Important finding).
+      List<Rectangle> occupied = existingControls.stream()
+         .filter(a -> !claimed.contains(a.getName()))
+         .map(a -> new Rectangle(a.getPixelOffset(), a.getPixelSize()))
+         .collect(Collectors.toList());
+      List<Rectangle> rects = WizFilterLayout.pack(
+         chart.getPixelOffset(), chart.getPixelSize(), resolvedTypes, occupied);
 
       List<AppliedFilter> applied = new ArrayList<>();
 
@@ -519,25 +577,7 @@ public class WizVsService {
          FilterFieldSpec spec = resolvable.get(i);
          DataRef col = resolvedColumns.get(i);
          int type = resolvedTypes.get(i);
-
-         // Upsert-by-field (decision 1 / assertion A3): when wiz-services already tracks an
-         // assembly for this field AND it is still present AND still the same control type,
-         // reuse it in place (same assemblyName) instead of creating a duplicate. A stale name (no
-         // longer on the viewsheet) or a type change (e.g. a repeat call with a different explicit
-         // controlType override) falls back to removing the old one and creating fresh.
-         AbstractSelectionVSAssembly control = null;
-         String existingName = spec.getExistingAssemblyName();
-
-         if(!Tool.isEmptyString(existingName)) {
-            VSAssembly existing = vs.getAssembly(existingName);
-
-            if(existing != null && matchesControlType(existing, type)) {
-               control = (AbstractSelectionVSAssembly) existing;
-            }
-            else if(existing != null) {
-               vs.removeAssembly(existingName);
-            }
-         }
+         AbstractSelectionVSAssembly control = resolvedControls[i];
 
          if(control == null) {
             VSAssembly created = VSEventUtil.createVSAssembly(rvs, type);
@@ -590,6 +630,66 @@ public class WizVsService {
       }
 
       return new AddFiltersResponse(rvs.getID(), applied, skipped);
+   }
+
+   /**
+    * Every live selection/slider/calendar-type assembly positioned below the chart's bottom edge
+    * (06-review-r1.md Important finding's occupancy rule) -- this feature's own previously-placed
+    * controls AND any selection assembly a human placed in Composer alike, since there is no tag
+    * distinguishing the two (see the P6 fix-round builder log for why that's the deliberately
+    * conservative choice: pack around and refuse to blindly reuse anything not positively known to
+    * be this feature's own would need a tagging convention nothing here invents unilaterally).
+    */
+   private static List<VSAssembly> findExistingFilterControls(Viewsheet vs, ChartVSAssembly chart) {
+      Assembly[] all = vs.getAssemblies();
+
+      if(all == null) {
+         return List.of();
+      }
+
+      Point chartOffset = chart.getPixelOffset();
+      Dimension chartSize = chart.getPixelSize();
+      int chartBottom = chartOffset.y + chartSize.height;
+      List<VSAssembly> result = new ArrayList<>();
+
+      for(Assembly a : all) {
+         if(a instanceof AbstractSelectionVSAssembly sel) {
+            Point offset = sel.getPixelOffset();
+
+            if(offset != null && offset.y >= chartBottom) {
+               result.add(sel);
+            }
+         }
+      }
+
+      return result;
+   }
+
+   /**
+    * The first not-yet-{@code claimed} control among {@code candidates} already bound to
+    * {@code tableName} and {@code col} -- the live-viewsheet fallback for upsert-by-field when the
+    * caller supplied no {@code existingAssemblyName} hint (06-review-r1.md CRITICAL finding).
+    */
+   private static VSAssembly findControlForField(
+      List<VSAssembly> candidates, String tableName, DataRef col, Set<String> claimed)
+   {
+      for(VSAssembly a : candidates) {
+         if(claimed.contains(a.getName()) || !(a instanceof AbstractSelectionVSAssembly sel)) {
+            continue;
+         }
+
+         if(!sel.getTableNames().contains(tableName)) {
+            continue;
+         }
+
+         for(DataRef ref : sel.getDataRefs()) {
+            if(ref != null && Tool.equals(ref.getAttribute(), col.getAttribute())) {
+               return a;
+            }
+         }
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -518,14 +518,39 @@ public class WizVsService {
       for(int i = 0; i < resolvable.size(); i++) {
          FilterFieldSpec spec = resolvable.get(i);
          DataRef col = resolvedColumns.get(i);
-         VSAssembly created = VSEventUtil.createVSAssembly(rvs, resolvedTypes.get(i));
+         int type = resolvedTypes.get(i);
 
-         if(!(created instanceof AbstractSelectionVSAssembly control)) {
-            // Cannot happen: resolveAddType only returns the three SELECTION_LIST/TIME_SLIDER/
-            // CALENDAR codes, and createVSAssembly's switch creates an AbstractSelectionVSAssembly
-            // subclass for every one of them.
-            throw new IllegalStateException(
-               "Failed to create filter control for field '" + spec.getField() + "'");
+         // Upsert-by-field (decision 1 / assertion A3): when wiz-services already tracks an
+         // assembly for this field AND it is still present AND still the same control type,
+         // reuse it in place (same assemblyName) instead of creating a duplicate. A stale name (no
+         // longer on the viewsheet) or a type change (e.g. a repeat call with a different explicit
+         // controlType override) falls back to removing the old one and creating fresh.
+         AbstractSelectionVSAssembly control = null;
+         String existingName = spec.getExistingAssemblyName();
+
+         if(!Tool.isEmptyString(existingName)) {
+            VSAssembly existing = vs.getAssembly(existingName);
+
+            if(existing != null && matchesControlType(existing, type)) {
+               control = (AbstractSelectionVSAssembly) existing;
+            }
+            else if(existing != null) {
+               vs.removeAssembly(existingName);
+            }
+         }
+
+         if(control == null) {
+            VSAssembly created = VSEventUtil.createVSAssembly(rvs, type);
+
+            if(!(created instanceof AbstractSelectionVSAssembly newControl)) {
+               // Cannot happen: resolveAddType only returns the three SELECTION_LIST/TIME_SLIDER/
+               // CALENDAR codes, and createVSAssembly's switch creates an AbstractSelectionVSAssembly
+               // subclass for every one of them.
+               throw new IllegalStateException(
+                  "Failed to create filter control for field '" + spec.getField() + "'");
+            }
+
+            control = newControl;
          }
 
          control.setTableNames(List.of(tableName));
@@ -653,6 +678,19 @@ public class WizVsService {
          case "time_slider" -> AbstractSheet.TIME_SLIDER_ASSET;
          case "calendar" -> AbstractSheet.CALENDAR_ASSET;
          default -> throw new IllegalArgumentException("Unsupported controlType: " + controlType);
+      };
+   }
+
+   /** Whether an existing assembly is still the right Java type to reuse for the given
+    *  {@link AbstractSheet} asset-type code -- an assembly's concrete class can't change in
+    *  place, so a type change (e.g. a repeat call with a different controlType override) must
+    *  remove the old assembly and create a fresh one rather than "reuse" a mismatched type. */
+   private static boolean matchesControlType(VSAssembly assembly, int type) {
+      return switch(type) {
+         case AbstractSheet.SELECTION_LIST_ASSET -> assembly instanceof SelectionListVSAssembly;
+         case AbstractSheet.TIME_SLIDER_ASSET -> assembly instanceof TimeSliderVSAssembly;
+         case AbstractSheet.CALENDAR_ASSET -> assembly instanceof CalendarVSAssembly;
+         default -> false;
       };
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -647,8 +647,12 @@ public class WizVsService {
     * distinguishing the two (see the P6 fix-round builder log for why that's the deliberately
     * conservative choice: pack around and refuse to blindly reuse anything not positively known to
     * be this feature's own would need a tagging convention nothing here invents unilaterally).
+    *
+    * <p>Package-private (not private) so {@link WizVisualizationService#saveVisualization} can
+    * reuse this same occupancy detection to carry a chart's filter controls into a saved
+    * visualization (07-fix-r3.md), instead of a second, independently-maintained heuristic.
     */
-   private static List<VSAssembly> findExistingFilterControls(Viewsheet vs, ChartVSAssembly chart) {
+   static List<VSAssembly> findExistingFilterControls(Viewsheet vs, ChartVSAssembly chart) {
       Assembly[] all = vs.getAssemblies();
 
       if(all == null) {

--- a/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/BindingSlotsTest.java
@@ -144,7 +144,7 @@ class BindingSlotsTest {
       CrosstabVSAssembly assembly = new CrosstabVSAssembly();
       assembly.setVSCrosstabInfo(cinfo);
 
-      WizVsService service = new WizVsService(null, null, null, null, null);
+      WizVsService service = new WizVsService(null, null, null, null, null, null);
       CreateViewsheetResult.FlatBinding binding = service.collectFlatBinding(assembly);
 
       assertEquals(1, binding.getDimensions().size());

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFilterLayoutTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFilterLayoutTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.asset.AbstractSheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * WizFilterLayout.pack is pure and static — no RuntimeViewsheet/server/DB needed, per the design
+ * doc's own test plan (section 9).
+ */
+@Tag("core")
+class WizFilterLayoutTest {
+
+   @Test
+   void oneControlPlacedDirectlyBelowTheChartAtItsPreferredSize() {
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET));
+
+      assertEquals(1, rects.size());
+      assertEquals(new Rectangle(0, 250, 100, 120), rects.get(0));
+   }
+
+   @Test
+   void oneControlIsOffsetByTheChartsOwnPixelOffset() {
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(50, 30), new Dimension(400, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET));
+
+      assertEquals(1, rects.size());
+      // x is chartOffset.x + 0 (local); y is chartOffset.y + chartSize.height + GAP.
+      assertEquals(new Rectangle(50, 280, 100, 120), rects.get(0));
+   }
+
+   @Test
+   void threeControlsOfDifferentShapesPackIntoTwoShelvesSortedByHeightDescending() {
+      // Input order deliberately NOT height-sorted, to prove the algorithm sorts internally but
+      // still returns results zipped back to the ORIGINAL input order (see the last test below).
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET, AbstractSheet.TIME_SLIDER_ASSET, AbstractSheet.CALENDAR_ASSET));
+
+      assertEquals(3, rects.size());
+      // Shelf 1 (y=250): Calendar (220 tall, placed first) then SelectionList (120 tall) fits beside it
+      // (0+200+10=210, 210+100=310 <= 400). Shelf 2 (y=250+220+10=480): TimeSlider, which does not fit
+      // beside Calendar+SelectionList (210+100+10=320, 320+280=600 > 400).
+      assertEquals(new Rectangle(210, 250, 100, 120), rects.get(0), "SelectionList");
+      assertEquals(new Rectangle(0, 480, 280, 50), rects.get(1), "TimeSlider");
+      assertEquals(new Rectangle(0, 250, 200, 220), rects.get(2), "Calendar");
+   }
+
+   @Test
+   void aControlWiderThanTheChartIsClampedAndItsHeightScaledByTheSameRatio() {
+      // Chart narrower than SelectionList's 100px preferred width.
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(50, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET));
+
+      assertEquals(1, rects.size());
+      // ratio = 50/100 = 0.5; height = round(120 * 0.5) = 60.
+      assertEquals(new Rectangle(0, 250, 50, 60), rects.get(0));
+   }
+
+   @Test
+   void packIsDeterministicAcrossRepeatedCalls() {
+      Point offset = new Point(0, 0);
+      Dimension chartSize = new Dimension(400, 240);
+      List<Integer> types = List.of(
+         AbstractSheet.SELECTION_LIST_ASSET, AbstractSheet.TIME_SLIDER_ASSET, AbstractSheet.CALENDAR_ASSET);
+
+      List<Rectangle> first = WizFilterLayout.pack(offset, chartSize, types);
+      List<Rectangle> second = WizFilterLayout.pack(offset, chartSize, types);
+
+      assertEquals(first, second);
+   }
+
+   @Test
+   void outputOrderMatchesInputOrderRegardlessOfInternalHeightSort() {
+      // Already-height-descending input (Calendar, SelectionList, TimeSlider) should still come
+      // back in that exact order, not the algorithm's internal sort order.
+      List<Integer> types = List.of(
+         AbstractSheet.CALENDAR_ASSET, AbstractSheet.SELECTION_LIST_ASSET, AbstractSheet.TIME_SLIDER_ASSET);
+      List<Rectangle> rects = WizFilterLayout.pack(new Point(0, 0), new Dimension(400, 240), types);
+
+      assertEquals(200, rects.get(0).width, "Calendar first, matching input order");
+      assertEquals(100, rects.get(1).width, "SelectionList second, matching input order");
+      assertEquals(280, rects.get(2).width, "TimeSlider third, matching input order");
+   }
+
+   @Test
+   void unsupportedControlTypeFailsLoud() {
+      assertThrows(IllegalArgumentException.class, () -> WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240), List.of(AbstractSheet.SELECTION_TREE_ASSET)));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFilterLayoutTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFilterLayoutTest.java
@@ -116,4 +116,80 @@ class WizFilterLayoutTest {
       assertThrows(IllegalArgumentException.class, () -> WizFilterLayout.pack(
          new Point(0, 0), new Dimension(400, 240), List.of(AbstractSheet.SELECTION_TREE_ASSET)));
    }
+
+   // ── packing around already-placed controls (06-review-r1.md Important finding) ─────────────
+
+   @Test
+   void withNoOccupiedRectanglesMatchesTheThreeArgOverloadExactly() {
+      Point offset = new Point(0, 0);
+      Dimension chartSize = new Dimension(400, 240);
+      List<Integer> types = List.of(AbstractSheet.SELECTION_LIST_ASSET, AbstractSheet.CALENDAR_ASSET);
+
+      List<Rectangle> viaThreeArg = WizFilterLayout.pack(offset, chartSize, types);
+      List<Rectangle> viaFourArg = WizFilterLayout.pack(offset, chartSize, types, List.of());
+
+      assertEquals(viaThreeArg, viaFourArg);
+   }
+
+   @Test
+   void aSecondCallWithDifferentFieldsPacksBesideTheFirstCallsControlNotOnTopOfIt() {
+      // Call 1: one SelectionList, placed at its usual spot.
+      List<Rectangle> first = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240), List.of(AbstractSheet.SELECTION_LIST_ASSET));
+      Rectangle regionControl = first.get(0);
+      assertEquals(new Rectangle(0, 250, 100, 120), regionControl);
+
+      // Call 2 (separate, later call): two NEW fields, REGION's control still live and occupying
+      // its rectangle. Must not overlap it.
+      List<Rectangle> second = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240),
+         List.of(AbstractSheet.TIME_SLIDER_ASSET, AbstractSheet.SELECTION_LIST_ASSET),
+         List.of(regionControl));
+
+      for(Rectangle r : second) {
+         assertFalse(r.intersects(regionControl), "new control " + r + " must not overlap " + regionControl);
+      }
+   }
+
+   @Test
+   void newControlsAppendToTheSameShelfRowWhenThereIsRoom() {
+      // A 100-wide SelectionList already sits at the start of shelf 1 in a 400-wide chart -- plenty
+      // of room left on that row (400 - 100 - GAP = 290) for another SelectionList (100 wide).
+      Rectangle existing = new Rectangle(0, 250, 100, 120);
+
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET), List.of(existing));
+
+      assertEquals(new Rectangle(110, 250, 100, 120), rects.get(0), "appends beside, same shelf row");
+   }
+
+   @Test
+   void newControlsWrapToANewShelfWhenTheExistingRowHasNoRoomLeft() {
+      // Existing control already occupies the row almost edge-to-edge for a 400-wide chart -- not
+      // enough room left for another 100-wide SelectionList (400 - 350 - GAP = 40 < 100).
+      Rectangle existing = new Rectangle(0, 250, 350, 120);
+
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET), List.of(existing));
+
+      assertEquals(new Rectangle(0, 380, 100, 120), rects.get(0), "wraps to a new shelf row below");
+   }
+
+   @Test
+   void neverRepositionsAnythingInOccupied() {
+      // pack() only returns rectangles for orderedTypes -- occupied is read-only input. Assert this
+      // by confirming the returned rectangles are disjoint from occupied across a few shapes/sizes,
+      // i.e. nothing in the return value silently echoes back a moved copy of `existing`.
+      Rectangle existing = new Rectangle(50, 260, 200, 220);
+      List<Rectangle> rects = WizFilterLayout.pack(
+         new Point(0, 0), new Dimension(400, 240),
+         List.of(AbstractSheet.SELECTION_LIST_ASSET, AbstractSheet.TIME_SLIDER_ASSET), List.of(existing));
+
+      for(Rectangle r : rects) {
+         assertNotEquals(existing, r);
+         assertFalse(r.intersects(existing));
+      }
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
@@ -28,7 +28,12 @@ import inetsoft.test.SreeHome;
 import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.CalendarVSAssembly;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.SelectionListVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.TimeSliderVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.MessageException;
 import inetsoft.web.service.BinaryTransferService;
@@ -44,11 +49,15 @@ import inetsoft.web.wiz.request.WizVisualizationRenameRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.awt.Dimension;
+import java.awt.Point;
 import java.security.Principal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -164,6 +173,171 @@ class WizVisualizationServiceTest {
          any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class));
       verify(viewsheetService).setViewsheet(
          any(Viewsheet.class), any(AssetEntry.class), eq(principal), eq(true), eq(true));
+   }
+
+   // ── saveVisualization carries forward filter-control assemblies (07-fix-r3.md) ───────────────
+   //
+   // WizVisualizationService.saveVisualization historically cloned ONLY the one named chart
+   // assembly into the new single-assembly ViewSheet, so any sibling SelectionList/TimeSlider/
+   // Calendar controls add_visualization_filters had placed below it on the source runtime were
+   // silently dropped -- a saved visualization reopened with none of its controls. These three
+   // tests pin: (a) the pre-existing single-chart save path is unchanged when there are no
+   // controls; (b) 1-3 controls all survive, each at its original (unreset) position; (c) a
+   // control's table binding survives clone().
+
+   @Test
+   void savingAChartWithNoFilterControlsCarriesOnlyTheChart() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(viewsheetService, assetRepository);
+
+      AssetEntry insideEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      Viewsheet sourceVs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(sourceVs, "Chart1");
+      chart.setPixelOffset(new Point(0, 0));
+      chart.setPixelSize(new Dimension(400, 240));
+      sourceVs.addAssembly(chart);
+
+      WizVisualizationSaveEvent event = new WizVisualizationSaveEvent();
+      event.setSourceViewsheetIdentifier(insideEntry.toIdentifier());
+      event.setAssemblyName("Chart1");
+
+      Principal principal = mock(Principal.class);
+      when(principal.getName()).thenReturn("admin" + IdentityID.KEY_DELIMITER + "host-org");
+      when(assetRepository.getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(sourceVs);
+
+      service.saveVisualization(event, principal);
+
+      var captor = ArgumentCaptor.forClass(Viewsheet.class);
+      verify(viewsheetService).setViewsheet(
+         captor.capture(), any(AssetEntry.class), eq(principal), eq(true), eq(true));
+      Viewsheet newVs = captor.getValue();
+
+      assertEquals(1, newVs.getAssemblies().length, "no filter controls on the source -> only the chart clone");
+   }
+
+   @Test
+   void savingAChartWithThreeFilterControlsCarriesAllOfThemAtTheirOriginalPositions() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(viewsheetService, assetRepository);
+
+      AssetEntry insideEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      Viewsheet sourceVs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(sourceVs, "Chart1");
+      chart.setPixelOffset(new Point(0, 0));
+      chart.setPixelSize(new Dimension(400, 240));
+      sourceVs.addAssembly(chart);
+
+      SelectionListVSAssembly selectionList = new SelectionListVSAssembly(sourceVs, "SelectionList1");
+      selectionList.setPixelOffset(new Point(0, 250));
+      selectionList.setPixelSize(new Dimension(100, 120));
+      selectionList.setTableNames(List.of("SALES_FULL"));
+      sourceVs.addAssembly(selectionList);
+
+      TimeSliderVSAssembly timeSlider = new TimeSliderVSAssembly(sourceVs, "RangeSlider1");
+      timeSlider.setPixelOffset(new Point(100, 250));
+      timeSlider.setPixelSize(new Dimension(100, 120));
+      timeSlider.setTableNames(List.of("SALES_FULL"));
+      sourceVs.addAssembly(timeSlider);
+
+      CalendarVSAssembly calendar = new CalendarVSAssembly(sourceVs, "Calendar1");
+      calendar.setPixelOffset(new Point(200, 250));
+      calendar.setPixelSize(new Dimension(100, 120));
+      calendar.setTableNames(List.of("SALES_FULL"));
+      sourceVs.addAssembly(calendar);
+
+      WizVisualizationSaveEvent event = new WizVisualizationSaveEvent();
+      event.setSourceViewsheetIdentifier(insideEntry.toIdentifier());
+      event.setAssemblyName("Chart1");
+
+      Principal principal = mock(Principal.class);
+      when(principal.getName()).thenReturn("admin" + IdentityID.KEY_DELIMITER + "host-org");
+      when(assetRepository.getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(sourceVs);
+
+      service.saveVisualization(event, principal);
+
+      var captor = ArgumentCaptor.forClass(Viewsheet.class);
+      verify(viewsheetService).setViewsheet(
+         captor.capture(), any(AssetEntry.class), eq(principal), eq(true), eq(true));
+      Viewsheet newVs = captor.getValue();
+
+      assertEquals(4, newVs.getAssemblies().length,
+                   "chart + all 3 controls must be carried into the saved viewsheet");
+
+      VSAssembly clonedSelectionList = (VSAssembly) newVs.getAssembly("SelectionList1");
+      VSAssembly clonedTimeSlider = (VSAssembly) newVs.getAssembly("RangeSlider1");
+      VSAssembly clonedCalendar = (VSAssembly) newVs.getAssembly("Calendar1");
+      assertNotNull(clonedSelectionList, "SelectionList control must be present on the saved viewsheet");
+      assertNotNull(clonedTimeSlider, "TimeSlider control must be present on the saved viewsheet");
+      assertNotNull(clonedCalendar, "Calendar control must be present on the saved viewsheet");
+
+      // Unlike the primary chart's clone (reset to (24,24)), a control's pixelOffset/pixelSize must
+      // be preserved exactly -- it stays packed relative to the chart, never repositioned by save.
+      assertEquals(new Point(0, 250), clonedSelectionList.getPixelOffset());
+      assertEquals(new Dimension(100, 120), clonedSelectionList.getPixelSize());
+      assertEquals(new Point(100, 250), clonedTimeSlider.getPixelOffset());
+      assertEquals(new Point(200, 250), clonedCalendar.getPixelOffset());
+
+      VSAssembly clonedChart = (VSAssembly) newVs.getAssembly("Chart1");
+      assertEquals(new Point(24, 24), clonedChart.getPixelOffset(),
+                   "the primary chart clone is still reset to the viewsheet's top-left, unlike its controls");
+   }
+
+   @Test
+   void aCarriedOverFilterControlsTableBindingSurvivesClone() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(viewsheetService, assetRepository);
+
+      AssetEntry insideEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      Viewsheet sourceVs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(sourceVs, "Chart1");
+      chart.setPixelOffset(new Point(0, 0));
+      chart.setPixelSize(new Dimension(400, 240));
+      sourceVs.addAssembly(chart);
+
+      SelectionListVSAssembly selectionList = new SelectionListVSAssembly(sourceVs, "SelectionList1");
+      selectionList.setPixelOffset(new Point(0, 250));
+      selectionList.setPixelSize(new Dimension(100, 120));
+      selectionList.setTableNames(List.of("SALES_FULL"));
+      sourceVs.addAssembly(selectionList);
+
+      WizVisualizationSaveEvent event = new WizVisualizationSaveEvent();
+      event.setSourceViewsheetIdentifier(insideEntry.toIdentifier());
+      event.setAssemblyName("Chart1");
+
+      Principal principal = mock(Principal.class);
+      when(principal.getName()).thenReturn("admin" + IdentityID.KEY_DELIMITER + "host-org");
+      when(assetRepository.getSheet(
+         any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class)))
+         .thenReturn(sourceVs);
+
+      service.saveVisualization(event, principal);
+
+      var captor = ArgumentCaptor.forClass(Viewsheet.class);
+      verify(viewsheetService).setViewsheet(
+         captor.capture(), any(AssetEntry.class), eq(principal), eq(true), eq(true));
+      Viewsheet newVs = captor.getValue();
+
+      SelectionListVSAssembly clonedSelectionList =
+         (SelectionListVSAssembly) newVs.getAssembly("SelectionList1");
+      assertNotNull(clonedSelectionList);
+      assertEquals(List.of("SALES_FULL"), clonedSelectionList.getTableNames(),
+                   "the control's table binding must survive clone(), not just its geometry");
    }
 
    // ── createVisualizationFolder ─────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
@@ -388,4 +388,20 @@ class WizVsServiceAddFiltersTest {
       assertEquals("AMOUNT", amountInfo.getDataRef().getAttribute());
       assertEquals(TimeInfo.NUMBER, amountInfo.getRangeType());
    }
+
+   // ── 07-fix-r5.md: an explicit time_slider override on a column outside the reference gate
+   // (XSchema.isNumericType || XSchema.isDateType) must be reported as a named skip, not silently
+   // bound with a nonsensical MONTH range or substituted with a different control type. ──────────
+
+   @Test
+   void timeSliderOverrideOnAStringColumnIsSkippedNotMisRanged() throws Exception {
+      AddFiltersResponse resp = service.addFilters(requestOne("REGION", "time_slider"), user);
+
+      assertEquals(0, resp.getApplied().size());
+      assertEquals(1, resp.getSkipped().size());
+      assertEquals("REGION", resp.getSkipped().get(0).getField());
+      assertEquals("time_slider is not supported for " + XSchema.STRING + " columns",
+                   resp.getSkipped().get(0).getReason());
+      verify(vs, never()).addAssembly(any(TimeSliderVSAssembly.class));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
@@ -33,8 +33,13 @@ import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.CalendarVSAssembly;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.SelectionListVSAssembly;
+import inetsoft.uql.viewsheet.SingleTimeInfo;
+import inetsoft.uql.viewsheet.TimeInfo;
+import inetsoft.uql.viewsheet.TimeSliderVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.model.AddFiltersRequest;
@@ -59,6 +64,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -127,6 +134,12 @@ class WizVsServiceAddFiltersTest {
 
       ColumnSelection cols = new ColumnSelection();
       cols.addAttribute(new ColumnRef(new AttributeRef(null, "REGION")));
+      ColumnRef amountRef = new ColumnRef(new AttributeRef(null, "AMOUNT"));
+      amountRef.setDataType(XSchema.DOUBLE);
+      cols.addAttribute(amountRef);
+      ColumnRef orderDateRef = new ColumnRef(new AttributeRef(null, "ORDER_DATE"));
+      orderDateRef.setDataType(XSchema.DATE);
+      cols.addAttribute(orderDateRef);
       when(table.getColumnSelection(false)).thenReturn(cols);
 
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
@@ -149,6 +162,17 @@ class WizVsServiceAddFiltersTest {
       }
 
       req.setFields(specs);
+      return req;
+   }
+
+   private static AddFiltersRequest requestOne(String field, String controlType) {
+      AddFiltersRequest req = new AddFiltersRequest();
+      req.setRuntimeId("rt-1");
+      req.setAssemblyName("Chart1");
+      FilterFieldSpec spec = new FilterFieldSpec();
+      spec.setField(field);
+      spec.setControlType(controlType);
+      req.setFields(List.of(spec));
       return req;
    }
 
@@ -311,5 +335,57 @@ class WizVsServiceAddFiltersTest {
       // outside `resolvable` for this call.
       assertEquals(new Point(0, 250), regionControl.getPixelOffset());
       assertEquals(new Dimension(100, 120), regionControl.getPixelSize());
+   }
+
+   // ── column binding (07-fix-r2.md CRITICAL finding: a created control had a table but no
+   // column, so it rendered as an unbound widget with nothing to select) ─────────────────────────
+   // One case per control type, since the binding mechanism genuinely differs by type (direct
+   // setDataRef for SelectionList/Calendar; a SingleTimeInfo with a data-type-dependent range type
+   // for TimeSlider) -- exactly the gap the fix-round-2 brief called out in the existing suite.
+
+   @Test
+   void createsASelectionListControlBoundToTheResolvedColumn() throws Exception {
+      service.addFilters(requestOne("REGION", "selection_list"), user);
+
+      var captor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(captor.capture());
+      SelectionListVSAssembly control = (SelectionListVSAssembly) captor.getValue();
+      assertNotNull(control.getDataRef(), "SelectionList must be bound to a column, not left unbound");
+      assertEquals("REGION", control.getDataRef().getAttribute());
+   }
+
+   @Test
+   void createsACalendarControlBoundToTheResolvedColumn() throws Exception {
+      service.addFilters(requestOne("ORDER_DATE", "calendar"), user);
+
+      var captor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(captor.capture());
+      CalendarVSAssembly control = (CalendarVSAssembly) captor.getValue();
+      assertNotNull(control.getDataRef(), "Calendar must be bound to a column, not left unbound");
+      assertEquals("ORDER_DATE", control.getDataRef().getAttribute());
+   }
+
+   @Test
+   void createsATimeSliderControlBoundToTheResolvedColumnWithMatchingRangeType() throws Exception {
+      service.addFilters(requestOne("ORDER_DATE", "time_slider"), user);
+
+      var dateCaptor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(dateCaptor.capture());
+      TimeSliderVSAssembly dateControl = (TimeSliderVSAssembly) dateCaptor.getValue();
+      SingleTimeInfo dateInfo = (SingleTimeInfo) dateControl.getTimeInfo();
+      assertNotNull(dateInfo.getDataRef(), "TimeSlider must be bound to a column, not left unbound");
+      assertEquals("ORDER_DATE", dateInfo.getDataRef().getAttribute());
+      assertEquals(TimeInfo.MONTH, dateInfo.getRangeType());
+
+      clearInvocations(vs);
+      service.addFilters(requestOne("AMOUNT", "time_slider"), user);
+
+      var amountCaptor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(amountCaptor.capture());
+      TimeSliderVSAssembly amountControl = (TimeSliderVSAssembly) amountCaptor.getValue();
+      SingleTimeInfo amountInfo = (SingleTimeInfo) amountControl.getTimeInfo();
+      assertNotNull(amountInfo.getDataRef(), "TimeSlider must be bound to a column, not left unbound");
+      assertEquals("AMOUNT", amountInfo.getDataRef().getAttribute());
+      assertEquals(TimeInfo.NUMBER, amountInfo.getRangeType());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
@@ -25,12 +25,14 @@ import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.AbstractTableAssembly;
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.SelectionListVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
@@ -49,17 +51,21 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -85,6 +91,7 @@ class WizVsServiceAddFiltersTest {
    private WizVsService service;
    private Viewsheet vs;
    private ChartVSAssembly chart;
+   private AbstractTableAssembly table;
    private Principal user;
 
    @BeforeEach
@@ -113,7 +120,7 @@ class WizVsServiceAddFiltersTest {
       AssetEntry wsEntry = mock(AssetEntry.class);
       when(vs.getBaseEntry()).thenReturn(wsEntry);
 
-      AbstractTableAssembly table = mock(AbstractTableAssembly.class);
+      table = mock(AbstractTableAssembly.class);
       Worksheet ws = mock(Worksheet.class);
       when(ws.getAssembly(anyString())).thenReturn(table);
       when(engine.getSheet(eq(wsEntry), eq(user), eq(false), any(AssetContent.class))).thenReturn(ws);
@@ -213,5 +220,96 @@ class WizVsServiceAddFiltersTest {
 
       assertEquals(1, resp.getApplied().size());
       verify(vs, never()).removeAssembly("SelectionListGone");
+   }
+
+   // ── server-side dedupe when the caller gives no existingAssemblyName hint (06-review-r1.md
+   // CRITICAL finding, item 2 of the fix -- the guarantee must not depend on wiz-services' own
+   // tracked field->assemblyName state being accurate) ──────────────────────────────────────────
+
+   @Test
+   void noSessionHintButAMatchingLiveControlReusesItInsteadOfDuplicating() throws Exception {
+      SelectionListVSAssembly liveControl = mock(SelectionListVSAssembly.class);
+      when(liveControl.getName()).thenReturn("SelectionList1");
+      when(liveControl.getTableNames()).thenReturn(List.of("SALES_FULL"));
+      when(liveControl.getDataRefs()).thenReturn(new DataRef[] { new ColumnRef(new AttributeRef(null, "REGION")) });
+      when(liveControl.getPixelOffset()).thenReturn(new Point(0, 250));
+      when(liveControl.getPixelSize()).thenReturn(new Dimension(100, 120));
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { liveControl });
+
+      AddFiltersResponse resp = service.addFilters(request("REGION"), user); // no existingAssemblyName
+
+      assertEquals(1, resp.getApplied().size());
+      assertEquals("SelectionList1", resp.getApplied().get(0).getAssemblyName());
+      verify(vs, never()).removeAssembly(anyString());
+      // The reused mock is reconfigured in place (title/table/position) -- not replaced.
+      verify(liveControl).setTableNames(List.of("SALES_FULL"));
+   }
+
+   @Test
+   void noSessionHintAndNoMatchingLiveControlStillCreatesAFreshOne() throws Exception {
+      // A live control exists, but bound to a DIFFERENT field (CITY, not requested) -- must not be
+      // mistaken for a match, and must not be disturbed.
+      SelectionListVSAssembly unrelated = mock(SelectionListVSAssembly.class);
+      when(unrelated.getName()).thenReturn("SelectionList0");
+      when(unrelated.getTableNames()).thenReturn(List.of("SALES_FULL"));
+      when(unrelated.getDataRefs()).thenReturn(new DataRef[] { new ColumnRef(new AttributeRef(null, "CITY")) });
+      when(unrelated.getPixelOffset()).thenReturn(new Point(0, 250));
+      when(unrelated.getPixelSize()).thenReturn(new Dimension(100, 120));
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { unrelated });
+
+      AddFiltersResponse resp = service.addFilters(request("REGION"), user);
+
+      assertEquals(1, resp.getApplied().size());
+      assertNotEquals("SelectionList0", resp.getApplied().get(0).getAssemblyName());
+      verify(vs, never()).removeAssembly(anyString());
+      verify(vs, atLeastOnce()).addAssembly(any(SelectionListVSAssembly.class));
+      verify(unrelated, never()).setTableNames(any());
+   }
+
+   // ── packing around already-placed controls across separate calls (06-review-r1.md Important
+   // finding, item 3 of the fix) ────────────────────────────────────────────────────────────────
+
+   @Test
+   void aSecondSeparateCallWithDifferentFieldsDoesNotOverlapAnEarlierCallsControl() throws Exception {
+      AddFiltersResponse first = service.addFilters(request("REGION"), user);
+      assertEquals(1, first.getApplied().size());
+
+      var firstCaptor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(firstCaptor.capture());
+      VSAssembly regionControl = firstCaptor.getValue();
+      assertEquals(new Point(0, 250), regionControl.getPixelOffset());
+      assertEquals(new Dimension(100, 120), regionControl.getPixelSize());
+
+      // Call 2 is a SEPARATE, later call for a different field -- REGION's control is still live
+      // (present in vs.getAssemblies()) but the session tracks no existingAssemblyName for either
+      // field (simulating the exact staleness 06-review-r1.md's Critical finding described).
+      ColumnSelection extendedCols = new ColumnSelection();
+      extendedCols.addAttribute(new ColumnRef(new AttributeRef(null, "REGION")));
+      extendedCols.addAttribute(new ColumnRef(new AttributeRef(null, "CITY")));
+      when(table.getColumnSelection(false)).thenReturn(extendedCols);
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { regionControl });
+      // A real Viewsheet's own by-name lookup would already reflect REGION's control (it's really
+      // there) -- stub that explicitly too, so AssetUtil.getNextName's own by-name probe (a separate
+      // path from getAssemblies()) doesn't hand out the same name again for CITY's control.
+      when(vs.getAssembly(regionControl.getName())).thenReturn(regionControl);
+      clearInvocations(vs); // keep stubbing, drop call-1's recorded invocations
+
+      AddFiltersResponse second = service.addFilters(request("CITY"), user);
+      assertEquals(1, second.getApplied().size());
+
+      var secondCaptor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(secondCaptor.capture());
+      VSAssembly cityControl = secondCaptor.getValue();
+
+      assertNotEquals(regionControl.getName(), cityControl.getName(), "a NEW control, not the reused REGION one");
+      assertFalse(
+         new Rectangle(cityControl.getPixelOffset(), cityControl.getPixelSize())
+            .intersects(new Rectangle(regionControl.getPixelOffset(), regionControl.getPixelSize())),
+         "call 2's control must not land on top of call 1's still-live control");
+      // REGION's control was never moved -- pack() only ever returns rectangles for THIS call's
+      // requested fields, and nothing in addFilters calls setPixelOffset/setPixelSize on anything
+      // outside `resolvable` for this call.
+      assertEquals(new Point(0, 250), regionControl.getPixelOffset());
+      assertEquals(new Dimension(100, 120), regionControl.getPixelSize());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
@@ -1,0 +1,217 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.AbstractTableAssembly;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.SelectionListVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.AddFiltersRequest;
+import inetsoft.web.wiz.model.AddFiltersResponse;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.FilterFieldSpec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * WizVsService.addFilters — the one piece of section 4's Java sketch flagged (01-design.md
+ * section 6's risk list) as worth a dedicated unit test beyond WizFilterLayoutTest: column
+ * resolution (a genuinely-missing field lands in skipped, a genuinely-present one resolves) and
+ * the upsert-by-field reuse path (assertion A3 — same assemblyName across a repeat call, not a
+ * duplicate). executeAndExtract/persistViewsheet are stubbed via a Mockito spy, same pattern as
+ * {@link WizVsServiceFilterCopyTest} — this isolates addFilters' own wiring from the pre-existing,
+ * separately-tested sandbox-execution machinery.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceAddFiltersTest {
+   private WizVsService service;
+   private Viewsheet vs;
+   private ChartVSAssembly chart;
+   private Principal user;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      user = mock(Principal.class);
+
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
+      service = spy(real);
+      doReturn(new CreateViewsheetResult()).when(service).executeAndExtract(any(), any(), anyInt());
+      doReturn("vs-identifier").when(service).persistViewsheet(any(), any(), any());
+
+      chart = mock(ChartVSAssembly.class);
+      when(chart.getName()).thenReturn("Chart1");
+      when(chart.getTableName()).thenReturn("SALES_FULL");
+      when(chart.getPixelOffset()).thenReturn(new Point(0, 0));
+      when(chart.getPixelSize()).thenReturn(new Dimension(400, 240));
+
+      vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Chart1")).thenReturn(chart);
+      when(vs.getWizInfo()).thenReturn(new Viewsheet.WizInfo(true, null, null));
+
+      AssetEntry wsEntry = mock(AssetEntry.class);
+      when(vs.getBaseEntry()).thenReturn(wsEntry);
+
+      AbstractTableAssembly table = mock(AbstractTableAssembly.class);
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssembly(anyString())).thenReturn(table);
+      when(engine.getSheet(eq(wsEntry), eq(user), eq(false), any(AssetContent.class))).thenReturn(ws);
+
+      ColumnSelection cols = new ColumnSelection();
+      cols.addAttribute(new ColumnRef(new AttributeRef(null, "REGION")));
+      when(table.getColumnSelection(false)).thenReturn(cols);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+   }
+
+   private static AddFiltersRequest request(String... fields) {
+      AddFiltersRequest req = new AddFiltersRequest();
+      req.setRuntimeId("rt-1");
+      req.setAssemblyName("Chart1");
+      List<FilterFieldSpec> specs = new ArrayList<>();
+
+      for(String f : fields) {
+         FilterFieldSpec spec = new FilterFieldSpec();
+         spec.setField(f);
+         spec.setControlType("selection_list");
+         specs.add(spec);
+      }
+
+      req.setFields(specs);
+      return req;
+   }
+
+   @Test
+   void createsANewControlBoundToTheChartsTable() throws Exception {
+      AddFiltersResponse resp = service.addFilters(request("REGION"), user);
+
+      assertEquals(1, resp.getApplied().size());
+      assertEquals("REGION", resp.getApplied().get(0).getField());
+      // VSEventUtil.createVSAssembly already adds the assembly once internally, then addFilters
+      // re-adds it for z-index-at-final-position (01-design.md section 2.1) -- atLeastOnce, not an
+      // exact count, since that internal call count is VSEventUtil's own implementation detail.
+      verify(vs, atLeastOnce()).addAssembly(any(SelectionListVSAssembly.class));
+   }
+
+   @Test
+   void aFieldNotOnTheBoundTableIsSkippedNotFailed() throws Exception {
+      AddFiltersResponse resp = service.addFilters(request("NOPE"), user);
+
+      assertEquals(0, resp.getApplied().size());
+      assertEquals(1, resp.getSkipped().size());
+      assertEquals("NOPE", resp.getSkipped().get(0).getField());
+      assertEquals("not found on bound table", resp.getSkipped().get(0).getReason());
+   }
+
+   @Test
+   void aPartialFailureStillAppliesTheResolvableFields() throws Exception {
+      AddFiltersResponse resp = service.addFilters(request("REGION", "NOPE"), user);
+
+      assertEquals(1, resp.getApplied().size());
+      assertEquals("REGION", resp.getApplied().get(0).getField());
+      assertEquals(1, resp.getSkipped().size());
+      assertEquals("NOPE", resp.getSkipped().get(0).getField());
+   }
+
+   @Test
+   void repeatCallForAnAlreadyTrackedFieldReusesTheSameAssemblyInsteadOfCreatingADuplicate() throws Exception {
+      AddFiltersResponse first = service.addFilters(request("REGION"), user);
+      String assemblyName = first.getApplied().get(0).getAssemblyName();
+
+      var captor = forClass(VSAssembly.class);
+      verify(vs, atLeastOnce()).addAssembly(captor.capture());
+      VSAssembly created = captor.getValue();
+      when(vs.getAssembly(assemblyName)).thenReturn(created);
+
+      AddFiltersRequest req = request("REGION");
+      req.getFields().get(0).setLabel("Region (relabeled)");
+      req.getFields().get(0).setExistingAssemblyName(assemblyName);
+
+      AddFiltersResponse second = service.addFilters(req, user);
+
+      // Same assemblyName reused -- not a duplicate control (assertion A3).
+      assertEquals(assemblyName, second.getApplied().get(0).getAssemblyName());
+      assertEquals("Region (relabeled)", second.getApplied().get(0).getLabel());
+      // The SAME real assembly object was mutated in place, not a fresh one created alongside it --
+      // the strongest possible proof of reuse (an object identity check), independent of however
+      // many times VSEventUtil.createVSAssembly's own internals happen to call addAssembly.
+      assertEquals("Region (relabeled)", ((SelectionListVSAssembly) created).getTitleValue());
+      verify(vs, never()).removeAssembly(anyString());
+   }
+
+   @Test
+   void anExistingAssemblyNameThatNoLongerExistsFallsBackToCreatingFresh() throws Exception {
+      AddFiltersRequest req = request("REGION");
+      req.getFields().get(0).setExistingAssemblyName("SelectionListGone");
+      // vs.getAssembly("SelectionListGone") defaults to null (stale name, already removed).
+
+      AddFiltersResponse resp = service.addFilters(req, user);
+
+      assertEquals(1, resp.getApplied().size());
+      verify(vs, never()).removeAssembly("SelectionListGone");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceApplyHighlightCopyTest.java
@@ -87,7 +87,7 @@ class WizVsServiceApplyHighlightCopyTest {
       AssetRepository engine = mock(AssetRepository.class);
       SecurityEngine securityEngine = mock(SecurityEngine.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
       service = spy(real);
 
       // A simple TEXT output assembly — the highlight branch with the fewest collaborators to satisfy,

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceClassifyChartRefSecondaryYTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceClassifyChartRefSecondaryYTest.java
@@ -66,7 +66,7 @@ class WizVsServiceClassifyChartRefSecondaryYTest {
    @Test
    void collectFlatBindingEchoesSecondaryYTrueForAChartMeasureOnTheSecondaryAxis() {
       WizVsService service = new WizVsService(
-         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null);
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null, null);
 
       VSChartAggregateRef agg = new VSChartAggregateRef();
       agg.setColumnValue("Sales");

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCollectChartFlatBindingMultiStyleTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCollectChartFlatBindingMultiStyleTest.java
@@ -63,7 +63,7 @@ class WizVsServiceCollectChartFlatBindingMultiStyleTest {
    @Test
    void collectFlatBindingReadsTheDimensionFromAPerMeasureColorAestheticRef() {
       WizVsService service = new WizVsService(
-         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null);
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null, null);
 
       VSChartDimensionRef productName = new VSChartDimensionRef();
       productName.setGroupColumnValue("PRODUCT_NAME");
@@ -102,7 +102,7 @@ class WizVsServiceCollectChartFlatBindingMultiStyleTest {
    @Test
    void collectFlatBindingIgnoresAStaleAggregateColorFieldWhenNotMultiStyles() {
       WizVsService service = new WizVsService(
-         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null);
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null, null);
 
       VSChartDimensionRef productName = new VSChartDimensionRef();
       productName.setGroupColumnValue("PRODUCT_NAME");

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCorrectsWrongGeoMapTypeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCorrectsWrongGeoMapTypeTest.java
@@ -122,7 +122,7 @@ class WizVsServiceCorrectsWrongGeoMapTypeTest {
    }
 
    private static WizVsService newService() {
-      return new WizVsService(null, null, null, null, null);
+      return new WizVsService(null, null, null, null, null, null);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateViewsheetSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateViewsheetSecurityTest.java
@@ -60,7 +60,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null, null);
       CreateVisualizationModel model = new CreateVisualizationModel();
 
       SecurityException ex = assertThrows(SecurityException.class,
@@ -92,7 +92,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
       when(vsService.openTemporaryViewsheet(any(), any(), eq(principal), any()))
          .thenThrow(marker);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null, null);
       CreateVisualizationModel model = new CreateVisualizationModel();
 
       RuntimeException thrown = assertThrows(RuntimeException.class,
@@ -123,7 +123,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null, null);
 
       assertThrows(SecurityException.class,
          () -> service.persistViewsheet(vs, "1^128^__NULL__^visualizations/abc^host-org", principal));
@@ -144,7 +144,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null, null);
 
       assertThrows(SecurityException.class,
          () -> service.validateBinding(new CreateVisualizationModel(), principal));
@@ -163,7 +163,7 @@ class WizVsServiceCreateViewsheetSecurityTest {
          eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
          .thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null);
+      WizVsService service = new WizVsService(vsService, engine, securityEngine, null, null, null);
 
       assertThrows(SecurityException.class,
          () -> service.deleteViewsheet("1^128^__NULL__^visualizations/abc^host-org", principal));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicateAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicateAssemblyTest.java
@@ -64,7 +64,7 @@ class WizVsServiceDuplicateAssemblyTest {
       AssetRepository engine = mock(AssetRepository.class);
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizVsService(vsService, engine, sec, null, null);
+      return new WizVsService(vsService, engine, sec, null, null, null);
    }
 
    private static RuntimeViewsheet rvsOf(Viewsheet vs) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceDuplicatePrimaryAssemblyTest.java
@@ -64,7 +64,7 @@ class WizVsServiceDuplicatePrimaryAssemblyTest {
       AssetRepository engine = mock(AssetRepository.class);
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
-      return new WizVsService(vsService, engine, sec, null, null);
+      return new WizVsService(vsService, engine, sec, null, null, null);
    }
 
    private static RuntimeViewsheet rvsOf(Viewsheet vs) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFetchAssemblyDataTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFetchAssemblyDataTest.java
@@ -53,7 +53,7 @@ class WizVsServiceFetchAssemblyDataTest {
    }
 
    private static WizVsService service(ViewsheetService vsService, SecurityEngine sec) {
-      return new WizVsService(vsService, mock(AssetRepository.class), sec, null, null);
+      return new WizVsService(vsService, mock(AssetRepository.class), sec, null, null, null);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
@@ -94,7 +94,7 @@ class WizVsServiceFilterCopyTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
       service = spy(real);
 
       // The current primary assembly (isPrimary()=true) that findPrimaryAssembly resolves in the

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterOutputAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterOutputAssemblyTest.java
@@ -91,7 +91,7 @@ class WizVsServiceFilterOutputAssemblyTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
       service = spy(real);
 
       gauge = mock(GaugeVSAssembly.class);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
@@ -65,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SreeHome
 @Tag("core")
 class WizVsServiceHighlightRebindTest {
-   private final WizVsService service = new WizVsService(null, null, null, null, null);
+   private final WizVsService service = new WizVsService(null, null, null, null, null, null);
 
    private static ColumnSelection viewColumns(String... names) {
       ColumnSelection cols = new ColumnSelection();

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRebindClearsStaleRuntimeChartRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRebindClearsStaleRuntimeChartRefsTest.java
@@ -104,7 +104,7 @@ class WizVsServiceRebindClearsStaleRuntimeChartRefsTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       Principal user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
       WizVsService service = spy(real);
 
       // Source worksheet resolveSourceContext must find, with a primary table assembly.

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRecordFieldSettingsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRecordFieldSettingsTest.java
@@ -71,7 +71,7 @@ class WizVsServiceRecordFieldSettingsTest {
       tempInfo = mock(VSTemporaryInfo.class);
       when(tempInfoService.getVSTemporaryInfo(rvs)).thenReturn(tempInfo);
 
-      service = new WizVsService(viewsheetService, null, null, null, tempInfoService);
+      service = new WizVsService(viewsheetService, null, null, null, tempInfoService, null);
    }
 
    /** Puts a temp chart bound to {@code columns} behind the recommendation runtime, and returns its refs. */

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveFilterTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveFilterTest.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.RemoveFilterRequest;
+import inetsoft.web.wiz.model.RemoveFilterResponse;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * WizVsService.removeFilter mirrors {@link WizVsServiceRemoveVisualizationTest}'s
+ * removeVisualization coverage almost exactly (see that class's doc comment) — idempotent on a
+ * missing/expired runtime or an already-absent assembly, persists only when a
+ * viewsheetIdentifier is supplied.
+ */
+@Tag("core")
+class WizVsServiceRemoveFilterTest {
+   private static SecurityEngine grantedSecurity() throws Exception {
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return sec;
+   }
+
+   private static RemoveFilterRequest request(String runtimeId, String assemblyName, String viewsheetIdentifier) {
+      RemoveFilterRequest req = new RemoveFilterRequest();
+      req.setRuntimeId(runtimeId);
+      req.setAssemblyName(assemblyName);
+      req.setViewsheetIdentifier(viewsheetIdentifier);
+      return req;
+   }
+
+   @Test
+   void removesTheNamedControlAndResetsTheSandbox() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      VSAssembly control = mock(VSAssembly.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("SelectionList1")).thenReturn(control);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
+      RemoveFilterResponse resp = service.removeFilter(request("rt-1", "SelectionList1", null), null);
+
+      assertTrue(resp.isRemoved());
+      verify(vs).removeAssembly("SelectionList1");
+      verify(box).resetDataMap("SelectionList1");
+   }
+
+   @Test
+   void persistsWhenAViewsheetIdentifierIsSupplied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly control = mock(VSAssembly.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("SelectionList1")).thenReturn(control);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.empty());
+
+      WizVsService real = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
+      WizVsService service = spy(real);
+      doReturn("vi-1").when(service).persistViewsheet(any(), any(), any());
+
+      RemoveFilterResponse resp = service.removeFilter(request("rt-1", "SelectionList1", "vi-1"), null);
+
+      assertTrue(resp.isRemoved());
+      verify(service).persistViewsheet(vs, "vi-1", null);
+   }
+
+   @Test
+   void doesNotPersistWhenNoViewsheetIdentifierIsSupplied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly control = mock(VSAssembly.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("SelectionList1")).thenReturn(control);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.empty());
+
+      WizVsService real = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
+      WizVsService service = spy(real);
+
+      service.removeFilter(request("rt-1", "SelectionList1", null), null);
+
+      verify(service, never()).persistViewsheet(any(), any(), any());
+   }
+
+   @Test
+   void idempotentWhenTheControlIsAlreadyAbsent() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("SelectionList1")).thenReturn(null);
+
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
+      RemoveFilterResponse resp = service.removeFilter(request("rt-1", "SelectionList1", null), null);
+
+      assertFalse(resp.isRemoved());
+      verify(vs, never()).removeAssembly(anyString());
+   }
+
+   @Test
+   void idempotentWhenTheRuntimeIsUnavailable() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenThrow(new RuntimeException("expired"));
+
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
+      RemoveFilterResponse resp = service.removeFilter(request("rt-1", "SelectionList1", null), null);
+
+      assertFalse(resp.isRemoved());
+   }
+
+   @Test
+   void throwsSecurityExceptionWhenViewsheetAccessDenied() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
+
+      WizVsService service = new WizVsService(vsService, engine, sec, null, null, null);
+
+      assertThrows(SecurityException.class,
+                   () -> service.removeFilter(request("rt-1", "SelectionList1", null), null));
+
+      verifyNoInteractions(vsService);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRemoveVisualizationTest.java
@@ -45,7 +45,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(entry.getPath()).thenReturn(
          WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc");
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
@@ -71,7 +71,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(rvs.getEntry()).thenReturn(entry);
       when(entry.getPath()).thenReturn("some/other/folder/abc");
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs).removeAssembly("Chart1");
@@ -89,7 +89,7 @@ class WizVsServiceRemoveVisualizationTest {
       when(rvs.getViewsheet()).thenReturn(vs);
       when(vs.getAssembly("Chart1")).thenReturn(null);
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
       service.removeVisualization("rt-1", "Chart1", null);
 
       verify(vs, never()).removeAssembly(anyString());
@@ -102,7 +102,7 @@ class WizVsServiceRemoveVisualizationTest {
 
       when(vsService.getViewsheet("rt-1", null)).thenThrow(new RuntimeException("expired"));
 
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
       assertDoesNotThrow(() -> service.removeVisualization("rt-1", "Chart1", null));
    }
 
@@ -110,7 +110,7 @@ class WizVsServiceRemoveVisualizationTest {
    void throwsWhenArgsBlank() throws Exception {
       ViewsheetService vsService = mock(ViewsheetService.class);
       AssetRepository engine = mock(AssetRepository.class);
-      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null);
+      WizVsService service = new WizVsService(vsService, engine, grantedSecurity(), null, null, null);
 
       assertThrows(IllegalArgumentException.class,
                    () -> service.removeVisualization("", "Chart1", null));
@@ -129,7 +129,7 @@ class WizVsServiceRemoveVisualizationTest {
       SecurityEngine sec = mock(SecurityEngine.class);
       when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
 
-      WizVsService service = new WizVsService(vsService, engine, sec, null, null);
+      WizVsService service = new WizVsService(vsService, engine, sec, null, null, null);
 
       assertThrows(SecurityException.class,
                    () -> service.removeVisualization("rt-1", "Chart1", null));

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
@@ -79,7 +79,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
    @BeforeEach
    void setUp() {
       service = new WizVsService(
-         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null);
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null, null, null);
 
       // The exact shape bug #75889 reproduced on: one dimension on X, one measure on Y — a plain bar
       // chart, where the dimension carries the axis highlight and the measure the plot highlight.

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceSecondaryYAxisRenderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceSecondaryYAxisRenderTest.java
@@ -112,7 +112,7 @@ class WizVsServiceSecondaryYAxisRenderTest {
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       Principal user = mock(Principal.class);
 
-      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null);
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
       WizVsService service = spy(real);
 
       // Source worksheet resolveSourceContext must find, with a primary table assembly.


### PR DESCRIPTION
## Summary
Java-side support for viz-chat's new per-visualization interactive filter controls (see companion PR in `stylebi-wiz`):
- `WizVsService.addFilters`/`removeFilter` — create/remove SelectionList/TimeSlider/Calendar assemblies on a headless viz-chat runtime, server-side deduped by (table, field) so the guarantee doesn't depend on caller-side session state.
- `WizFilterLayout.pack` — deterministic shelf-packing layout, aware of already-placed controls across multiple calls (not just within one).
- `WizVisualizationService.saveVisualization` — now carries a chart's sibling filter-control assemblies into the saved asset (previously a single-assembly-only save path, from before this feature existed, silently discarded them).
- A runtime-keyed `getVisualizationImage` (mirrors composer-chat's `get_viewsheet_image`, since viz-chat had no image-render capability at all).

## ⚠️ Known gap before merge
This branch is based on `stylebi-wiz-main-rebase` at `aa1b2a762`, now ~170 commits behind current tip — it does **not** include unrelated work landed on `main` since (e.g. `178c143f40`/`EditRequest.crosstab`, `5767c7331`/PVA-004). Deliberately not rebased mid-run to avoid destabilizing a long-running feature branch; **needs a rebase onto current `stylebi-wiz-main-rebase` before merge**, coordinated with whoever owns that.

## Process
Five review-driven fix rounds on top of the original build — see `docs/teams/2026-09-01-stylebi-wiz-viz-scoped-filters/` in `stylebi-wiz` for the full archive (design, verify-plan, build, live verification, all five rounds' findings and fixes). Two defects were found only through live MCP verification, not caught by any unit test.

## Test plan
- [x] Full `WizVsService*`/`WizFilterLayout*`/`WizVisualizationService*` JUnit sweep — 168/168, independently re-run by the run's lead (not just taken on the builder's word)
- [x] Live-verified against a real StyleBI deployment: control-type inference, save→reload persistence (the fix round 3 defect), the `boundTableName` precondition
- [ ] The known pre-existing gap above needs resolving before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)