### PR TITLE
Add Aerospike and OrientDB to the tabular catalog SPI, and let it carry sampled columns

### DIFF
--- a/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeCatalog.java
+++ b/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeCatalog.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * Assembles AerospikeRuntime's TabularCatalogProvider answers from standard java.sql.
@@ -40,8 +41,15 @@ import java.util.*;
  * tableNamePattern arguments to have been matched as literal equality: JDBC allows these to be
  * treated as LIKE patterns, and namespace/datasetId are not guaranteed free of underscore/percent.
  * getColumns goes further than a LIKE-pattern risk: the driver compiles tableNamePattern as a Java
- * regex (see describeColumns below), so a literal "%" is passed there rather than datasetId itself
- * and this exact-match filter is what actually narrows the result, not the pattern argument.
+ * regex, and -- more importantly for cost, not just correctness -- runs one live "SELECT ... LIMIT
+ * 1" against the cluster per regex-matched table (AerospikeDatabaseMetadata.getMetadata), unlike
+ * getTables/getPrimaryKeys, which only filter already-fetched, cached cluster metadata in memory.
+ * Passing "%" there unconditionally matches every set in the namespace and turns one
+ * describeDataset call into one live query per set in the namespace; see describeColumns below for
+ * how the pattern actually passed avoids that in the common case, and the one case (a literal '%'
+ * in datasetId) where it cannot and falls back to the expensive-but-correct "%". This exact-match
+ * filter is retained regardless, as the correctness backstop independent of which pattern was
+ * passed.
  */
 final class AerospikeCatalog {
    private AerospikeCatalog() {
@@ -120,12 +128,15 @@ final class AerospikeCatalog {
       // Confirmed against the driver: AerospikeDatabaseMetadata.getColumns compiles
       // tableNamePattern as a Java regex (only "%" is translated, to ".*"; every other regex
       // metacharacter passes through unescaped) and matches it with Matcher.matches() against each
-      // real table name -- not a SQL LIKE pattern. Passing datasetId itself here would silently
-      // drop the one real row for any set name containing an unescaped regex metacharacter (e.g.
-      // "orders(2024)"), even though the row exists and listDatasets would have reported it. Pass
-      // a literal "%" instead, matching every set in the namespace, and rely on the exact-match
-      // filter below (as listDatasets already does for getTables) to narrow it back down.
-      try(ResultSet rs = meta.getColumns(namespace, null, "%", "%")) {
+      // real table name -- not a SQL LIKE pattern -- and then runs one live query per match
+      // (getMetadata), so the pattern passed here also controls how many live queries this call
+      // makes, not just correctness. columnsTableNamePattern(datasetId) resolves that: it quotes
+      // datasetId so only the one real set matches (restoring a single live query), except for the
+      // one datasetId shape that cannot be quoted through the driver's own "%"->".*" substitution,
+      // where it falls back to the driver-matches-everything "%" from an earlier fix round. Either
+      // way, the exact-match filter below (as listDatasets already does for getTables) is what
+      // actually guarantees only this dataset's columns are returned.
+      try(ResultSet rs = meta.getColumns(namespace, null, columnsTableNamePattern(datasetId), "%")) {
          while(rs.next()) {
             if(!namespace.equalsIgnoreCase(rs.getString("TABLE_CAT")) ||
                !datasetId.equals(rs.getString("TABLE_NAME")))
@@ -140,6 +151,28 @@ final class AerospikeCatalog {
       }
 
       return new ArrayList<>(byPosition.values());
+   }
+
+   // Confirmed against the driver: AerospikeDatabaseMetadata.getColumns/getTables both apply
+   // tableNamePattern.replace("%", ".*") to the raw string *before* Pattern.compile ever sees it --
+   // so any "%" character in the resulting string becomes a wildcard, whatever put it there,
+   // including one Pattern.quote's own \Q...\E wrapper was relying on to be taken literally.
+   // Pattern.quote(datasetId) contains a "%" only when datasetId itself does (none of the
+   // characters \Q...\E adds is "%"), so for every datasetId without a literal "%" the quoted form
+   // survives that substitution unchanged and Matcher.matches() accepts only the exact set name --
+   // restoring the single-live-query cost getColumns had before an earlier fix round widened the
+   // pattern to "%" to fix a different (regex-metacharacter) bug. Verified with a standalone
+   // harness that a datasetId containing a literal "%" cannot be rescued the same way: quoting
+   // "orders%2024" produces "\Qorders%2024\E", and replacing "%" there turns it into
+   // "\Qorders.*2024\E" -- inside the now-corrupted \Q...\E wrapper, ".*" is required as two
+   // literal characters, not a wildcard, so the resulting pattern no longer matches the real set
+   // name "orders%2024" at all (and does not accidentally match some other real set instead; it
+   // matches nothing). There is no way to escape a literal "%" through this driver's own
+   // pre-substitution, so that one case falls back to "%", accepting the O(n)-live-queries-in-an-
+   // n-set-namespace cost this connector's caller (describeColumns) already documents, with the
+   // exact-match filter there as the correctness backstop.
+   private static String columnsTableNamePattern(String datasetId) {
+      return datasetId.contains("%") ? "%" : Pattern.quote(datasetId);
    }
 
    private static List<String> primaryKeyColumnNames(DatabaseMetaData meta, String namespace,

--- a/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeCatalog.java
+++ b/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeCatalog.java
@@ -30,16 +30,18 @@ import java.util.*;
  * DatabaseMetaData calls. Mirrors HiveCatalog's role: package-private, static methods, no state of
  * its own.
  *
- * ASSUMPTION, not independently confirmed against the driver (no jar available this round): the
- * Aerospike JDBC driver maps namespace to the JDBC catalog argument and set to table, the reverse
- * of Hive's database-as-schema pairing. Every getTables/getColumns/getPrimaryKeys call below passes
- * the configured Namespace as catalog and null as schema on that assumption. If it is wrong, these
- * calls need catalog and schema swapped.
+ * Confirmed against the driver (com.aerospike:aerospike-jdbc:1.10.1): AerospikeDatabaseMetadata.
+ * getCatalogTerm() returns "namespace", getSchemaTerm() returns "", and getTables/getColumns/
+ * getPrimaryKeys never reference their schema/schemaPattern argument. Every call below passes the
+ * configured Namespace as catalog and null as schema.
  *
  * Every DatabaseMetaData row is additionally filtered by an exact match on TABLE_CAT/TABLE_NAME
  * against what the caller asked for, rather than trusting the driver's catalog/schemaPattern/
  * tableNamePattern arguments to have been matched as literal equality: JDBC allows these to be
  * treated as LIKE patterns, and namespace/datasetId are not guaranteed free of underscore/percent.
+ * getColumns goes further than a LIKE-pattern risk: the driver compiles tableNamePattern as a Java
+ * regex (see describeColumns below), so a literal "%" is passed there rather than datasetId itself
+ * and this exact-match filter is what actually narrows the result, not the pattern argument.
  */
 final class AerospikeCatalog {
    private AerospikeCatalog() {
@@ -82,12 +84,20 @@ final class AerospikeCatalog {
       }
 
       List<String> keyColumns = primaryKeyColumnNames(meta, namespace, datasetId);
-      // ASSUMPTION, not independently confirmed against the driver: no quoting is applied to
-      // datasetId. Hive's backtick-wrap was justified by a specific, cited Hive configuration
-      // default; no equivalent citation is available for Aerospike's SQL layer, and set names are
-      // constrained enough by the platform itself that quoting is very unlikely to be load-bearing
-      // even if this guess turns out to be syntactically wrong.
-      String query = "SELECT * FROM " + datasetId;
+      // Confirmed against the driver (com.aerospike:aerospike-jdbc:1.10.1):
+      // AerospikeDatabaseMetadata.getIdentifierQuoteString() returns "\"" -- the driver declares
+      // double quote as its identifier-quoting character -- and the driver's own internal metadata
+      // query construction (AerospikeDatabaseMetadata.getMetadata) uses that exact quoted shape:
+      // format("SELECT * FROM \"%s.%s\" LIMIT 1", namespace, table). The query text is parsed with
+      // a full Calcite SQL grammar (AerospikeQuery.parse -> org.apache.calcite.sql.parser.
+      // SqlParser), which has reserved keywords and requires quoting for identifiers containing
+      // spaces or most special characters. Quoting unconditionally, doubling any embedded double
+      // quote, mirrors the driver's own convention rather than guessing around it.
+      //
+      // This does not solve a set name containing a literal '.': AerospikeQuery.setTable
+      // re-splits the already-parsed identifier text on a literal dot regardless of quoting -- a
+      // driver-level limitation this connector does not attempt to work around.
+      String query = "SELECT * FROM \"" + datasetId.replace("\"", "\"\"") + "\"";
 
       // Every column returned here came from the same bounded scan (AerospikeSchemaBuilder unions
       // bin names across at most 1000 records), never from declared, source-published metadata --
@@ -107,7 +117,15 @@ final class AerospikeCatalog {
       // choice (deterministic given a fixed ResultSet), but not confirmed meaningful.
       TreeMap<Integer, TabularColumn> byPosition = new TreeMap<>();
 
-      try(ResultSet rs = meta.getColumns(namespace, null, datasetId, "%")) {
+      // Confirmed against the driver: AerospikeDatabaseMetadata.getColumns compiles
+      // tableNamePattern as a Java regex (only "%" is translated, to ".*"; every other regex
+      // metacharacter passes through unescaped) and matches it with Matcher.matches() against each
+      // real table name -- not a SQL LIKE pattern. Passing datasetId itself here would silently
+      // drop the one real row for any set name containing an unescaped regex metacharacter (e.g.
+      // "orders(2024)"), even though the row exists and listDatasets would have reported it. Pass
+      // a literal "%" instead, matching every set in the namespace, and rely on the exact-match
+      // filter below (as listDatasets already does for getTables) to narrow it back down.
+      try(ResultSet rs = meta.getColumns(namespace, null, "%", "%")) {
          while(rs.next()) {
             if(!namespace.equalsIgnoreCase(rs.getString("TABLE_CAT")) ||
                !datasetId.equals(rs.getString("TABLE_NAME")))

--- a/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeCatalog.java
+++ b/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeCatalog.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.aerospike;
+
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.*;
+
+/**
+ * Assembles AerospikeRuntime's TabularCatalogProvider answers from standard java.sql.
+ * DatabaseMetaData calls. Mirrors HiveCatalog's role: package-private, static methods, no state of
+ * its own.
+ *
+ * ASSUMPTION, not independently confirmed against the driver (no jar available this round): the
+ * Aerospike JDBC driver maps namespace to the JDBC catalog argument and set to table, the reverse
+ * of Hive's database-as-schema pairing. Every getTables/getColumns/getPrimaryKeys call below passes
+ * the configured Namespace as catalog and null as schema on that assumption. If it is wrong, these
+ * calls need catalog and schema swapped.
+ *
+ * Every DatabaseMetaData row is additionally filtered by an exact match on TABLE_CAT/TABLE_NAME
+ * against what the caller asked for, rather than trusting the driver's catalog/schemaPattern/
+ * tableNamePattern arguments to have been matched as literal equality: JDBC allows these to be
+ * treated as LIKE patterns, and namespace/datasetId are not guaranteed free of underscore/percent.
+ */
+final class AerospikeCatalog {
+   private AerospikeCatalog() {
+   }
+
+   static TabularCatalog listDatasets(Connection conn, String namespace) throws Exception {
+      DatabaseMetaData meta = conn.getMetaData();
+      List<TabularDatasetRef> datasets = new ArrayList<>();
+
+      // null table types: Aerospike has no known equivalent of a view, and there is no way to
+      // confirm any driver-specific TABLE_TYPE string without the jar. A wrong guess would
+      // silently empty this list (the exact failure Hive's own TABLE_TYPES comment documents);
+      // null is the JDBC-spec-guaranteed "table type not used to narrow the search" choice.
+      try(ResultSet rs = meta.getTables(namespace, null, "%", null)) {
+         while(rs.next()) {
+            if(!namespace.equalsIgnoreCase(rs.getString("TABLE_CAT"))) {
+               continue;
+            }
+
+            datasets.add(new TabularDatasetRef(rs.getString("TABLE_NAME")));
+         }
+      }
+
+      // Aerospike exposes no driver-readable table-to-table reference/foreign-key construct --
+      // same "nothing to honestly report" position CassandraCatalog/HiveCatalog take.
+      return new TabularCatalog(datasets, List.of());
+   }
+
+   static TabularDatasetSchema describeDataset(Connection conn, String namespace, String datasetId)
+      throws Exception
+   {
+      DatabaseMetaData meta = conn.getMetaData();
+      List<TabularColumn> columns = describeColumns(meta, namespace, datasetId);
+
+      if(columns.isEmpty()) {
+         // getColumns() reports zero rows for an unknown set rather than throwing -- translate
+         // that into the explicit throw TabularCatalogProvider#describeDataset requires for an
+         // unknown dataset.
+         throw new Exception("Set '" + datasetId + "' not found in namespace '" + namespace + "'.");
+      }
+
+      List<String> keyColumns = primaryKeyColumnNames(meta, namespace, datasetId);
+      // ASSUMPTION, not independently confirmed against the driver: no quoting is applied to
+      // datasetId. Hive's backtick-wrap was justified by a specific, cited Hive configuration
+      // default; no equivalent citation is available for Aerospike's SQL layer, and set names are
+      // constrained enough by the platform itself that quoting is very unlikely to be load-bearing
+      // even if this guess turns out to be syntactically wrong.
+      String query = "SELECT * FROM " + datasetId;
+
+      // Every column returned here came from the same bounded scan (AerospikeSchemaBuilder unions
+      // bin names across at most 1000 records), never from declared, source-published metadata --
+      // this connector has no path that would make columnsMayBeIncomplete false.
+      return new TabularDatasetSchema(datasetId, columns, keyColumns,
+         Map.of("queryString", query), true);
+   }
+
+   private static List<TabularColumn> describeColumns(DatabaseMetaData meta, String namespace,
+                                                        String datasetId) throws Exception
+   {
+      AerospikeSQLTypes sqlTypes = new AerospikeSQLTypes();
+      // Explicitly sorted by ORDINAL_POSITION rather than trusted from the driver's own row order.
+      // ASSUMPTION: for a bin-unioned, Map-backed schema (per AerospikeSchemaBuilder), this
+      // ordinal is at best an artifact of the driver's internal iteration order, not a real,
+      // source-declared column order the way it is for Hive -- still the right implementation
+      // choice (deterministic given a fixed ResultSet), but not confirmed meaningful.
+      TreeMap<Integer, TabularColumn> byPosition = new TreeMap<>();
+
+      try(ResultSet rs = meta.getColumns(namespace, null, datasetId, "%")) {
+         while(rs.next()) {
+            if(!namespace.equalsIgnoreCase(rs.getString("TABLE_CAT")) ||
+               !datasetId.equals(rs.getString("TABLE_NAME")))
+            {
+               continue;
+            }
+
+            String type = sqlTypes.convertToXType(rs.getInt("DATA_TYPE"));
+            byPosition.put(rs.getInt("ORDINAL_POSITION"),
+               new TabularColumn(rs.getString("COLUMN_NAME"), type != null ? type : XSchema.STRING));
+         }
+      }
+
+      return new ArrayList<>(byPosition.values());
+   }
+
+   private static List<String> primaryKeyColumnNames(DatabaseMetaData meta, String namespace,
+                                                       String datasetId)
+   {
+      TreeMap<Short, String> byKeySeq = new TreeMap<>();
+
+      try(ResultSet rs = meta.getPrimaryKeys(namespace, null, datasetId)) {
+         while(rs.next()) {
+            if(!namespace.equalsIgnoreCase(rs.getString("TABLE_CAT")) ||
+               !datasetId.equals(rs.getString("TABLE_NAME")))
+            {
+               continue;
+            }
+
+            byKeySeq.put(rs.getShort("KEY_SEQ"), rs.getString("COLUMN_NAME"));
+         }
+      }
+      catch(Exception ex) {
+         // Whether an unsupported-method response surfaces as SQLFeatureNotSupportedException
+         // specifically or a generic SQLException is driver-dependent and unconfirmed here, so a
+         // broad catch is deliberate -- mirrors HiveCatalog.primaryKeyColumnNames. Treated as "this
+         // set declares no primary key" rather than propagated -- unlike getTables/getColumns,
+         // whose failures are almost always a real connection/permission problem and must
+         // propagate.
+         return List.of();
+      }
+
+      return new ArrayList<>(byKeySeq.values());
+   }
+}

--- a/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeRuntime.java
+++ b/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeRuntime.java
@@ -32,7 +32,7 @@ import java.util.Properties;
  * Class that provides Aerospike database connection and query execution utility
  */
 @SuppressWarnings("unused")
-public class AerospikeRuntime extends TabularRuntime {
+public class AerospikeRuntime extends TabularRuntime implements TabularCatalogProvider {
    /**
     * Execute a Aerospike query.
     *
@@ -137,6 +137,43 @@ public class AerospikeRuntime extends TabularRuntime {
       catch (Exception ex){
          LOG.warn("Failed to obtain Aerospike JDBC driver", ex);
          throw ex;
+      }
+   }
+
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      AerospikeDataSource ds = (AerospikeDataSource) dataSource;
+      requireNamespace(ds);
+
+      try(Connection conn = getConnection(ds)) {
+         return AerospikeCatalog.listDatasets(conn, ds.getNamespace());
+      }
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      AerospikeDataSource ds = (AerospikeDataSource) dataSource;
+      requireNamespace(ds);
+
+      try(Connection conn = getConnection(ds)) {
+         return AerospikeCatalog.describeDataset(conn, ds.getNamespace(), datasetId);
+      }
+   }
+
+   /**
+    * A4: a blank Namespace must throw, not silently enumerate nothing. Checked before
+    * {@link #getConnection} is ever called -- {@link #constructUrl} would otherwise happily build
+    * a "jdbc:aerospike:host:port/" URL from a blank namespace. AerospikeDataSource.namespace
+    * defaults to the non-null string "default", but that default does not close off every path a
+    * blank value could arrive by (an API caller, a deserialized doc, a future editor that allows
+    * clearing the field) -- same reasoning HiveRuntime.requireDbName already applies to dbName.
+    */
+   private static void requireNamespace(AerospikeDataSource ds) throws Exception {
+      if(ds.getNamespace() == null || ds.getNamespace().isBlank()) {
+         throw new Exception("Data source '" + ds.getName() +
+            "' has no namespace configured; cannot enumerate its sets.");
       }
    }
 

--- a/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeSQLTypes.java
+++ b/connectors/inetsoft-aerospike/src/main/java/inetsoft/uql/aerospike/AerospikeSQLTypes.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.aerospike;
+
+import inetsoft.uql.jdbc.util.SQLTypes;
+
+/**
+ * Exists only to reach {@link SQLTypes}'s protected no-arg constructor from this package — it
+ * overrides nothing. {@code AerospikeCatalog} calls {@link SQLTypes#convertToXType(int)}
+ * unmodified, exactly the way {@code HiveCatalog} calls it through {@code HiveSQLTypes}.
+ */
+final class AerospikeSQLTypes extends SQLTypes {
+   AerospikeSQLTypes() {
+   }
+}

--- a/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeCatalogTest.java
+++ b/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeCatalogTest.java
@@ -1,0 +1,393 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.aerospike;
+
+import inetsoft.sree.PropertiesEngine;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers charter assertions A1, A2, and A4 against {@link AerospikeCatalog}, driven entirely off
+ * mocked {@code Connection}/{@code DatabaseMetaData}/{@code ResultSet} — all three are
+ * {@code java.sql} JDK interfaces, so no aerospike-jdbc driver class is on the compile/test
+ * classpath for this file (D7: mock JDK interfaces, no test-scope driver dependency).
+ *
+ * <p>The {@code catalog}/{@code schema} arguments {@link AerospikeCatalog} passes to
+ * {@code getTables}/{@code getColumns}/{@code getPrimaryKeys} are asserted here as
+ * {@code catalog=namespace, schema=null} per the charter's own (unverified against the driver —
+ * no jar available) finding that this driver maps namespace to catalog and set to table, the
+ * reverse of Hive's database-as-schema pairing.
+ *
+ * <p>{@code SQLTypes} (the superclass {@link AerospikeSQLTypes} inherits {@code convertToXType}
+ * from) has a one-time static field initializer that reads {@code SreeEnv.getProperty} ->
+ * {@code PropertiesEngine.getInstance()}, so the first reference to either class anywhere in this
+ * JVM needs a Spring-free stand-in for that singleton (mirrors {@code HiveCatalogTest}'s own
+ * {@code mockStatic(PropertiesEngine.class)} pattern).
+ */
+class AerospikeCatalogTest {
+   private static MockedStatic<PropertiesEngine> propertiesEngineStatic;
+
+   @BeforeAll
+   static void mockPropertiesEngine() {
+      PropertiesEngine engine = mock(PropertiesEngine.class);
+      when(engine.getProperty(anyString(), anyBoolean())).thenReturn(null);
+      propertiesEngineStatic = mockStatic(PropertiesEngine.class);
+      propertiesEngineStatic.when(PropertiesEngine::getInstance).thenReturn(engine);
+   }
+
+   @AfterAll
+   static void resetPropertiesEngine() {
+      propertiesEngineStatic.close();
+   }
+
+   // ---- listDatasets --------------------------------------------------------------------------
+
+   @Test
+   void listDatasets_returnsSets_scopedToConfiguredNamespace() throws Exception {
+      ResultSet rs = mockResultSet(List.of(
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders"),
+         row("TABLE_CAT", "test", "TABLE_NAME", "customers")));
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getTables(eq("test"), isNull(), eq("%"), isNull())).thenReturn(rs);
+
+      TabularCatalog catalog = AerospikeCatalog.listDatasets(conn, "test");
+
+      assertEquals(List.of("orders", "customers"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+      assertEquals(List.of(), catalog.relationships());
+   }
+
+   @Test
+   void listDatasets_passesNullTableTypes_notAGuessedArray() throws Exception {
+      // Opposite of Hive's explicit three-string TABLE_TYPES array: Aerospike has no known
+      // equivalent of a view, and a wrong guess at a driver-specific TABLE_TYPE string would
+      // silently empty this list (the exact failure Hive's own comment warns about). null is the
+      // JDBC-spec-guaranteed "table type not used to narrow the search" choice.
+      ResultSet rs = mockResultSet(List.of());
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(rs);
+
+      AerospikeCatalog.listDatasets(conn, "test");
+
+      ArgumentCaptor<String[]> typesCaptor = ArgumentCaptor.forClass(String[].class);
+      verify(meta).getTables(any(), any(), any(), typesCaptor.capture());
+      assertNull(typesCaptor.getValue());
+   }
+
+   @Test
+   void listDatasets_filtersOutRowsFromDifferentNamespace_evenIfDriverReturnsThem()
+      throws Exception
+   {
+      // A defensive filter: JDBC allows the catalog argument to be treated as a LIKE pattern, so a
+      // driver that over-matches must not be trusted to have already scoped its rows to "test".
+      ResultSet rs = mockResultSet(List.of(
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders"),
+         row("TABLE_CAT", "test_archive", "TABLE_NAME", "old_orders")));
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(rs);
+
+      TabularCatalog catalog = AerospikeCatalog.listDatasets(conn, "test");
+
+      assertEquals(List.of("orders"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+   }
+
+   @Test
+   void listDatasets_emptyNamespace_returnsEmptyCatalog() throws Exception {
+      ResultSet rs = mockResultSet(List.of());
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(rs);
+
+      TabularCatalog catalog = AerospikeCatalog.listDatasets(conn, "test");
+
+      assertEquals(List.of(), catalog.datasets());
+   }
+
+   // ---- describeDataset: A1 (queryString param) -------------------------------------------------
+
+   @Test
+   void describeDataset_paramsHasLowercaseQueryStringKey_unqualifiedUnquotedSelect()
+      throws Exception
+   {
+      Connection conn = connectionWithColumns("test", "orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      // Reverse: not "QueryString", not "sql", not the @Property(label=) text "Enter SQL" -- must
+      // be exactly the AerospikeQuery bean property name TabularUtil.getPropertyMap derives.
+      assertEquals(Map.of("queryString", "SELECT * FROM orders"), schema.params());
+   }
+
+   // ---- describeDataset: column ordering ---------------------------------------------------------
+
+   @Test
+   void describeDataset_columnsOrderedByOrdinalPosition_evenIfResultSetRowsOutOfOrder()
+      throws Exception
+   {
+      Connection conn = connectionWithColumns("test", "orders", List.of(
+         row("COLUMN_NAME", "total", "DATA_TYPE", Types.DECIMAL, "ORDINAL_POSITION", 3),
+         row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1),
+         row("COLUMN_NAME", "customer_id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 2)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      assertEquals(List.of("id", "customer_id", "total"),
+         schema.columns().stream().map(TabularColumn::name).toList());
+   }
+
+   // ---- describeDataset: A2 (type mapping via SQLTypes.convertToXType) --------------------------
+
+   @Test
+   void convertToXType_booleanSqlType_mapsToXSchemaBoolean() {
+      // The Hive-round regression, repeated here as its own regression: the two-hop
+      // convertToJava -> CoreTool.getDataType chain has no Types.BOOLEAN branch and would land on
+      // XSchema.STRING. convertToXType merges BIT/BOOLEAN and returns XSchema.BOOLEAN directly.
+      assertEquals(XSchema.BOOLEAN, new AerospikeSQLTypes().convertToXType(Types.BOOLEAN));
+   }
+
+   @Test
+   void describeDataset_columnTypesComeFromConvertToXType_notANewSwitch() throws Exception {
+      Connection conn = connectionWithColumns("test", "orders", List.of(
+         row("COLUMN_NAME", "is_active", "DATA_TYPE", Types.BOOLEAN, "ORDINAL_POSITION", 1),
+         row("COLUMN_NAME", "is_flagged", "DATA_TYPE", Types.BIT, "ORDINAL_POSITION", 2),
+         row("COLUMN_NAME", "total", "DATA_TYPE", Types.DECIMAL, "ORDINAL_POSITION", 3),
+         row("COLUMN_NAME", "count", "DATA_TYPE", Types.NUMERIC, "ORDINAL_POSITION", 4),
+         row("COLUMN_NAME", "big_id", "DATA_TYPE", Types.BIGINT, "ORDINAL_POSITION", 5),
+         row("COLUMN_NAME", "created_at", "DATA_TYPE", Types.TIMESTAMP, "ORDINAL_POSITION", 6),
+         row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 7)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      Map<String, String> typesByName = schema.columns().stream()
+         .collect(Collectors.toMap(TabularColumn::name, TabularColumn::type));
+      assertEquals(XSchema.BOOLEAN, typesByName.get("is_active"));
+      assertEquals(XSchema.BOOLEAN, typesByName.get("is_flagged"));
+      assertEquals(XSchema.DOUBLE, typesByName.get("total"));
+      assertEquals(XSchema.DOUBLE, typesByName.get("count"));
+      assertEquals(XSchema.LONG, typesByName.get("big_id"));
+      assertEquals(XSchema.TIME_INSTANT, typesByName.get("created_at"));
+      assertEquals(XSchema.INTEGER, typesByName.get("id"));
+   }
+
+   @Test
+   void describeDataset_unmatchedColumnType_fallsBackToXSchemaString() throws Exception {
+      // Types.ARRAY is one of convertToXType's unmatched codes (falls to its default, returning
+      // null) -- AerospikeCatalog's own null -> XSchema.STRING bridge is what should produce this
+      // result, not a second, competing mapping.
+      Connection conn = connectionWithColumns("test", "orders",
+         List.of(row("COLUMN_NAME", "tags", "DATA_TYPE", Types.ARRAY, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      assertEquals(XSchema.STRING, schema.columns().get(0).type());
+   }
+
+   // ---- describeDataset: dataset-level incompleteness signal (A3, L1) ---------------------------
+
+   @Test
+   void describeDataset_columnsMayBeIncomplete_alwaysTrue() throws Exception {
+      // Every column here came from the same bounded scan (AerospikeSchemaBuilder unions bin
+      // names across at most 1000 records), never from declared, source-published metadata -- this
+      // connector has no path that would make it false.
+      Connection conn = connectionWithColumns("test", "orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      assertTrue(schema.columnsMayBeIncomplete());
+   }
+
+   // ---- describeDataset: getPrimaryKeys isolation -------------------------------------------------
+
+   @Test
+   void describeDataset_getPrimaryKeysThrows_keyColumnsEmpty_restOfSchemaStillReturned()
+      throws Exception
+   {
+      ResultSet columnsRs = mockResultSet(List.of(
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders", "COLUMN_NAME", "id",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getColumns(any(), any(), any(), any())).thenReturn(columnsRs);
+      // Not narrowed to SQLFeatureNotSupportedException: an unsupported-method response is not
+      // guaranteed to surface as that specific JDK subtype.
+      when(meta.getPrimaryKeys(any(), any(), any())).thenThrow(new SQLException("not supported"));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      assertEquals(List.of(), schema.keyColumns());
+      assertEquals(1, schema.columns().size());
+   }
+
+   @Test
+   void describeDataset_getColumnsThrows_propagates() throws Exception {
+      // Isolation must be two independent test cases, not one shared try/catch: a getColumns
+      // failure is almost always a real connection/permission problem and must not be swallowed
+      // the way a getPrimaryKeys failure is.
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getColumns(any(), any(), any(), any()))
+         .thenThrow(new SQLException("permission denied"));
+
+      Exception ex = assertThrows(Exception.class,
+         () -> AerospikeCatalog.describeDataset(conn, "test", "orders"));
+      assertTrue(ex.getMessage().contains("permission denied") ||
+         ex instanceof SQLException);
+   }
+
+   @Test
+   void describeDataset_keyColumnsOrderedByKeySeq() throws Exception {
+      ResultSet columnsRs = mockResultSet(List.of(
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders", "COLUMN_NAME", "tenant_id",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1),
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders", "COLUMN_NAME", "id",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 2)));
+      ResultSet pkRs = mockResultSet(List.of(
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders", "COLUMN_NAME", "id",
+            "KEY_SEQ", (short) 2),
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders", "COLUMN_NAME", "tenant_id",
+            "KEY_SEQ", (short) 1)));
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getColumns(any(), any(), any(), any())).thenReturn(columnsRs);
+      when(meta.getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      assertEquals(List.of("tenant_id", "id"), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_setNotFound_throws() throws Exception {
+      Connection conn = connectionWithColumns("test", "no_such_set", List.of());
+
+      Exception ex = assertThrows(Exception.class,
+         () -> AerospikeCatalog.describeDataset(conn, "test", "no_such_set"));
+      assertTrue(ex.getMessage().contains("no_such_set"));
+   }
+
+   // ---- catalog/schema argument semantics (stated assumption, see class javadoc) -----------------
+
+   @Test
+   void describeDataset_catalogAndSchemaArgs_namespaceAsCatalogSchemaNull() throws Exception {
+      ResultSet columnsRs = mockResultSet(List.of(
+         row("TABLE_CAT", "test", "TABLE_NAME", "orders", "COLUMN_NAME", "id",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+      ResultSet pkRs = mockResultSet(List.of());
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getColumns(any(), any(), any(), any())).thenReturn(columnsRs);
+      when(meta.getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      ArgumentCaptor<String> columnsCatalog = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> columnsSchema = ArgumentCaptor.forClass(String.class);
+      verify(meta).getColumns(columnsCatalog.capture(), columnsSchema.capture(), eq("orders"),
+         any());
+      assertEquals("test", columnsCatalog.getValue());
+      assertNull(columnsSchema.getValue());
+
+      ArgumentCaptor<String> pkCatalog = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> pkSchema = ArgumentCaptor.forClass(String.class);
+      verify(meta).getPrimaryKeys(pkCatalog.capture(), pkSchema.capture(), eq("orders"));
+      assertEquals("test", pkCatalog.getValue());
+      assertNull(pkSchema.getValue());
+   }
+
+   // ---- fixtures --------------------------------------------------------------------------------
+
+   private static Connection connectionWithColumns(String namespace, String setName,
+                                                    List<Map<String, Object>> columnRows)
+      throws Exception
+   {
+      List<Map<String, Object>> withCatalogAndTable = columnRows.stream()
+         .map(r -> {
+            Map<String, Object> withKeys = new LinkedHashMap<>(r);
+            withKeys.putIfAbsent("TABLE_CAT", namespace);
+            withKeys.putIfAbsent("TABLE_NAME", setName);
+            return withKeys;
+         })
+         .collect(Collectors.toList());
+      ResultSet columnsRs = mockResultSet(withCatalogAndTable);
+      ResultSet pkRs = mockResultSet(List.of());
+
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getColumns(any(), any(), any(), any())).thenReturn(columnsRs);
+      when(meta.getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      return conn;
+   }
+
+   private static ResultSet mockResultSet(List<Map<String, Object>> rows) throws SQLException {
+      ResultSet rs = mock(ResultSet.class);
+      int[] index = {-1};
+      when(rs.next()).thenAnswer(inv -> ++index[0] < rows.size());
+      when(rs.getString(anyString())).thenAnswer(inv ->
+         rows.get(index[0]).get((String) inv.getArgument(0)));
+      when(rs.getInt(anyString())).thenAnswer(inv -> {
+         Object v = rows.get(index[0]).get((String) inv.getArgument(0));
+         return v == null ? 0 : ((Number) v).intValue();
+      });
+      when(rs.getShort(anyString())).thenAnswer(inv -> {
+         Object v = rows.get(index[0]).get((String) inv.getArgument(0));
+         return v == null ? (short) 0 : ((Number) v).shortValue();
+      });
+      return rs;
+   }
+
+   private static Map<String, Object> row(Object... kv) {
+      Map<String, Object> m = new LinkedHashMap<>();
+
+      for(int i = 0; i < kv.length; i += 2) {
+         m.put((String) kv[i], kv[i + 1]);
+      }
+
+      return m;
+   }
+}

--- a/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeCatalogTest.java
+++ b/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeCatalogTest.java
@@ -144,7 +144,7 @@ class AerospikeCatalogTest {
    // ---- describeDataset: A1 (queryString param) -------------------------------------------------
 
    @Test
-   void describeDataset_paramsHasLowercaseQueryStringKey_unqualifiedUnquotedSelect()
+   void describeDataset_paramsHasLowercaseQueryStringKey_unqualifiedQuotedSelect()
       throws Exception
    {
       Connection conn = connectionWithColumns("test", "orders",
@@ -154,7 +154,68 @@ class AerospikeCatalogTest {
 
       // Reverse: not "QueryString", not "sql", not the @Property(label=) text "Enter SQL" -- must
       // be exactly the AerospikeQuery bean property name TabularUtil.getPropertyMap derives.
-      assertEquals(Map.of("queryString", "SELECT * FROM orders"), schema.params());
+      assertEquals(Map.of("queryString", "SELECT * FROM \"orders\""), schema.params());
+   }
+
+   @Test
+   void describeDataset_reservedWordSetName_unconditionalQuoteWrap() throws Exception {
+      // "order" parses as a reserved keyword under the Calcite SQL grammar AerospikeQuery.parse
+      // actually uses -- an unquoted "SELECT * FROM order" fails to parse. This is the
+      // discriminating case that tells an unconditional wrap apart from a "quote only when
+      // necessary" design, mirroring HiveCatalogTest's simple-lowercase-name case.
+      Connection conn = connectionWithColumns("test", "order",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", "order");
+
+      assertEquals("SELECT * FROM \"order\"", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_spaceInSetName_wrappedWithoutEscaping() throws Exception {
+      String setName = "my set";
+      Connection conn = connectionWithColumns("test", setName,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", setName);
+
+      assertEquals("SELECT * FROM \"my set\"", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_doubleQuoteInSetName_escapesByDoubling() throws Exception {
+      // AerospikeDatabaseMetadata.getIdentifierQuoteString() returns "\"" -- an unescaped wrap
+      // would break out of the identifier quoting after the embedded quote and produce malformed
+      // SQL, the same hazard HiveCatalogTest's embedded-backtick case guards against.
+      String setName = "weird\"set";
+      Connection conn = connectionWithColumns("test", setName,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = AerospikeCatalog.describeDataset(conn, "test", setName);
+
+      assertEquals("SELECT * FROM \"weird\"\"set\"", schema.params().get("queryString"));
+   }
+
+   // ---- describeDataset: getColumns tableNamePattern is a driver regex, not a literal -----------
+
+   @Test
+   void describeColumns_regexMetacharacterSetName_passesLiteralPercentNotDatasetId()
+      throws Exception
+   {
+      // The real driver (AerospikeDatabaseMetadata.getColumns) compiles tableNamePattern as a Java
+      // regex and matches it with Matcher.matches() -- a mock that only stubs the return value
+      // would happily return rows regardless of what pattern it was handed and could not catch a
+      // regression here, so this test asserts on the argument actually passed instead.
+      String setName = "orders(2024)";
+      Connection conn = connectionWithColumns("test", setName,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      AerospikeCatalog.describeDataset(conn, "test", setName);
+
+      DatabaseMetaData meta = conn.getMetaData();
+      ArgumentCaptor<String> tableNamePattern = ArgumentCaptor.forClass(String.class);
+      verify(meta).getColumns(any(), any(), tableNamePattern.capture(), any());
+      assertEquals("%", tableNamePattern.getValue());
    }
 
    // ---- describeDataset: column ordering ---------------------------------------------------------
@@ -326,7 +387,9 @@ class AerospikeCatalogTest {
 
       ArgumentCaptor<String> columnsCatalog = ArgumentCaptor.forClass(String.class);
       ArgumentCaptor<String> columnsSchema = ArgumentCaptor.forClass(String.class);
-      verify(meta).getColumns(columnsCatalog.capture(), columnsSchema.capture(), eq("orders"),
+      // tableNamePattern is "%", not "orders" -- see describeColumns_regexMetacharacterSetName_
+      // passesLiteralPercentNotDatasetId above for why. This test only cares about catalog/schema.
+      verify(meta).getColumns(columnsCatalog.capture(), columnsSchema.capture(), eq("%"),
          any());
       assertEquals("test", columnsCatalog.getValue());
       assertNull(columnsSchema.getValue());

--- a/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeCatalogTest.java
+++ b/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeCatalogTest.java
@@ -30,6 +30,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -196,17 +197,64 @@ class AerospikeCatalogTest {
       assertEquals("SELECT * FROM \"weird\"\"set\"", schema.params().get("queryString"));
    }
 
-   // ---- describeDataset: getColumns tableNamePattern is a driver regex, not a literal -----------
+   // ---- describeDataset: getColumns tableNamePattern balances correctness against live-query cost -
 
    @Test
-   void describeColumns_regexMetacharacterSetName_passesLiteralPercentNotDatasetId()
+   void describeColumns_regexMetacharacterSetName_passesQuotedPatternNotLiteralPercent()
       throws Exception
    {
       // The real driver (AerospikeDatabaseMetadata.getColumns) compiles tableNamePattern as a Java
-      // regex and matches it with Matcher.matches() -- a mock that only stubs the return value
-      // would happily return rows regardless of what pattern it was handed and could not catch a
-      // regression here, so this test asserts on the argument actually passed instead.
+      // regex and matches it with Matcher.matches(), then runs one live query per match
+      // (getMetadata) -- a mock that only stubs the return value would happily return rows
+      // regardless of what pattern it was handed and could not catch either a correctness
+      // regression (dropping this row) or a cost regression (matching every set in the namespace),
+      // so this test asserts on the argument actually passed instead. Would fail against fix
+      // round 1's unconditional "%": Pattern.quote(setName) != "%".
       String setName = "orders(2024)";
+      Connection conn = connectionWithColumns("test", setName,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      AerospikeCatalog.describeDataset(conn, "test", setName);
+
+      DatabaseMetaData meta = conn.getMetaData();
+      ArgumentCaptor<String> tableNamePattern = ArgumentCaptor.forClass(String.class);
+      verify(meta).getColumns(any(), any(), tableNamePattern.capture(), any());
+      assertEquals(Pattern.quote(setName), tableNamePattern.getValue());
+   }
+
+   @Test
+   void describeColumns_plainSetName_passesQuotedPatternNotLiteralPercent() throws Exception {
+      // A plain identifier has no regex-metacharacter correctness hazard, but the cost hazard
+      // (getColumns running one live "SELECT ... LIMIT 1" per regex match) still applies to it --
+      // this is the "common case" the round 2 fix restores a single live query for. Would fail
+      // against fix round 1's unconditional "%": Pattern.quote("orders") != "%".
+      Connection conn = connectionWithColumns("test", "orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      AerospikeCatalog.describeDataset(conn, "test", "orders");
+
+      DatabaseMetaData meta = conn.getMetaData();
+      ArgumentCaptor<String> tableNamePattern = ArgumentCaptor.forClass(String.class);
+      verify(meta).getColumns(any(), any(), tableNamePattern.capture(), any());
+      assertEquals(Pattern.quote("orders"), tableNamePattern.getValue());
+   }
+
+   @Test
+   void describeColumns_setNameContainingLiteralPercent_fallsBackToLiteralPercent()
+      throws Exception
+   {
+      // The driver applies tableNamePattern.replace("%", ".*") to the raw string before
+      // Pattern.compile ever sees it, so a "%" character in the resulting string always becomes a
+      // wildcard -- including one Pattern.quote's own \Q...\E wrapper was relying on to be taken
+      // literally (confirmed with a standalone harness against the real driver's exact
+      // replace-then-compile sequence: quoting "orders%2024" and then applying that replace turns
+      // the wrapper itself into "\Qorders.*2024\E", which no longer matches "orders%2024" -- or
+      // any other real set name -- at all). There is no way to escape a literal "%" through this
+      // pre-substitution, so this one datasetId shape deliberately keeps paying fix round 1's
+      // O(n)-live-queries-in-an-n-set-namespace cost, with the exact-match post-filter as the
+      // correctness backstop; that is a documented choice, not an oversight, and this test locks
+      // it down as behavior rather than leaving it to be rediscovered as a "regression" later.
+      String setName = "orders%2024";
       Connection conn = connectionWithColumns("test", setName,
          List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
 
@@ -387,10 +435,11 @@ class AerospikeCatalogTest {
 
       ArgumentCaptor<String> columnsCatalog = ArgumentCaptor.forClass(String.class);
       ArgumentCaptor<String> columnsSchema = ArgumentCaptor.forClass(String.class);
-      // tableNamePattern is "%", not "orders" -- see describeColumns_regexMetacharacterSetName_
-      // passesLiteralPercentNotDatasetId above for why. This test only cares about catalog/schema.
-      verify(meta).getColumns(columnsCatalog.capture(), columnsSchema.capture(), eq("%"),
-         any());
+      // tableNamePattern is Pattern.quote("orders"), not the bare literal "orders" -- see
+      // describeColumns_plainSetName_passesQuotedPatternNotLiteralPercent above for why. This test
+      // only cares about catalog/schema.
+      verify(meta).getColumns(columnsCatalog.capture(), columnsSchema.capture(),
+         eq(Pattern.quote("orders")), any());
       assertEquals("test", columnsCatalog.getValue());
       assertNull(columnsSchema.getValue());
 

--- a/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeRuntimeCatalogTest.java
+++ b/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeRuntimeCatalogTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.aerospike;
+
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.credential.*;
+import org.junit.jupiter.api.*;
+import org.springframework.context.ApplicationContext;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers charter assertion A4's "blank Namespace" path through {@link AerospikeRuntime}'s new SPI
+ * methods -- the one part of A4 that is provably testable without a real cluster or the
+ * aerospike-jdbc driver actually connecting, since {@code requireNamespace} runs before
+ * {@link AerospikeRuntime}'s private {@code getConnection} is ever called. Both data sources here
+ * point at a reserved, documentation-only address (RFC 5737 TEST-NET-2, 198.51.100.1) that is
+ * guaranteed never to be dialed: if the guard did not run first, connecting would attempt a real
+ * (doomed) TCP handshake and fail with a driver connection exception instead of this method's own
+ * message -- {@link Assertions#assertTimeout} additionally bounds the wait for that reason.
+ */
+class AerospikeRuntimeCatalogTest {
+   private static final String UNROUTABLE_HOST = "198.51.100.1";
+
+   @BeforeAll
+   static void mockService() {
+      CredentialService credentialService = mock(CredentialService.class);
+      when(credentialService.createCredential(CredentialType.PASSWORD))
+         .thenReturn(mock(LocalPasswordCredential.class));
+      when(credentialService.createCredential(CredentialType.PASSWORD, false))
+         .thenReturn(mock(LocalPasswordCredential.class));
+      ApplicationContext context = mock(ApplicationContext.class);
+      when(context.getBean(CredentialService.class)).thenReturn(credentialService);
+      ConfigurationContext.getContext().setApplicationContext(context);
+   }
+
+   @AfterAll
+   static void resetContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+   }
+
+   @Test
+   void listDatasets_blankNamespace_throwsBeforeConnecting() {
+      AerospikeDataSource ds = new AerospikeDataSource();
+      ds.setHost(UNROUTABLE_HOST);
+      ds.setNamespace("");
+      AerospikeRuntime runtime = new AerospikeRuntime();
+
+      Exception ex = assertTimeout(Duration.ofSeconds(2),
+         () -> assertThrows(Exception.class, () -> runtime.listDatasets(ds)));
+
+      assertTrue(ex.getMessage().contains("no namespace configured"));
+   }
+
+   @Test
+   void describeDataset_nullNamespace_throwsBeforeConnecting() {
+      AerospikeDataSource ds = new AerospikeDataSource();
+      ds.setHost(UNROUTABLE_HOST);
+      ds.setNamespace(null);
+      AerospikeRuntime runtime = new AerospikeRuntime();
+
+      Exception ex = assertTimeout(Duration.ofSeconds(2),
+         () -> assertThrows(Exception.class, () -> runtime.describeDataset(ds, "any_set")));
+
+      assertTrue(ex.getMessage().contains("no namespace configured"));
+   }
+}

--- a/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeRuntimeCatalogTest.java
+++ b/connectors/inetsoft-aerospike/src/test/java/inetsoft/uql/aerospike/AerospikeRuntimeCatalogTest.java
@@ -83,4 +83,19 @@ class AerospikeRuntimeCatalogTest {
 
       assertTrue(ex.getMessage().contains("no namespace configured"));
    }
+
+   @Test
+   void listDatasets_whitespaceOnlyNamespace_throwsBeforeConnecting() {
+      // requireNamespace calls String.isBlank(), not just a null/empty check -- "" and null are
+      // both covered above, but neither exercises the .isBlank() branch specifically.
+      AerospikeDataSource ds = new AerospikeDataSource();
+      ds.setHost(UNROUTABLE_HOST);
+      ds.setNamespace("   ");
+      AerospikeRuntime runtime = new AerospikeRuntime();
+
+      Exception ex = assertTimeout(Duration.ofSeconds(2),
+         () -> assertThrows(Exception.class, () -> runtime.listDatasets(ds)));
+
+      assertTrue(ex.getMessage().contains("no namespace configured"));
+   }
 }

--- a/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBCatalog.java
+++ b/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBCatalog.java
@@ -1,0 +1,242 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.orientdb;
+
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.*;
+
+/**
+ * Assembles OrientDBRuntime's TabularCatalogProvider answers from standard java.sql.
+ * DatabaseMetaData calls. Mirrors AerospikeCatalog's role: package-private, static methods, no
+ * state of its own.
+ *
+ * Confirmed against the driver (com.orientechnologies:orientdb-jdbc:3.2.29): {@code
+ * OrientJdbcConnection.getCatalog()} returns the connected database's own name and {@code
+ * getSchema()} always returns {@code null} -- there is exactly one database per connection, no
+ * separate schema concept. {@code getTables}/{@code getColumns}/{@code getPrimaryKeys} never read
+ * their {@code catalog}/{@code schemaPattern} arguments (the driver's own {@code TABLE_CAT}/{@code
+ * TABLE_SCHEM} output columns are always {@code database.getName()}, independent of what was
+ * passed in), so every call below passes {@code conn.getCatalog()} as catalog and {@code null} as
+ * schema purely as a self-documenting, forward-compatible convention -- not because today's driver
+ * needs it to filter correctly.
+ *
+ * A class name (the "table" in JDBC terms) is matched two different ways by this driver, and both
+ * matter here: {@code getTables} does a literal, case-insensitive {@code equals}/{@code
+ * equalsIgnoreCase} comparison against {@code tableNamePattern}, with no pattern semantics at all,
+ * while {@code getColumns} runs {@code tableNamePattern} through {@code OrientJdbcUtils.like},
+ * which is a real (if partial) SQL LIKE emulation: it escapes regex metacharacters first, then
+ * rewrites {@code _} to {@code .} (any single character) and {@code %} to {@code .*?}, and matches
+ * case-insensitively. Passing a literal class name to {@code getColumns} is therefore
+ * over-matching, not exact -- a class named {@code my_class} will also match {@code myXclass}, and
+ * {@code Orders} will also match {@code orders}. Every row this class reads back from either
+ * method is additionally filtered by an exact, case-sensitive {@code TABLE_NAME.equals(datasetId)}
+ * check before being trusted, rather than relying on the driver's own matching to have been exact.
+ */
+final class OrientDBCatalog {
+   private OrientDBCatalog() {
+   }
+
+   static TabularCatalog listDatasets(Connection conn) throws Exception {
+      DatabaseMetaData meta = conn.getMetaData();
+      String database = conn.getCatalog();
+      List<TabularDatasetRef> datasets = new ArrayList<>();
+
+      // types is passed explicitly as {"TABLE"}, never null: OrientJdbcDatabaseMetaData's own
+      // TABLE_TYPES default (used whenever types == null) is {"TABLE", "SYSTEM TABLE"} -- passing
+      // null would therefore ask for MORE, not fewer, rows than passing nothing. "SYSTEM TABLE" is
+      // how this driver classifies its own built-in security/bookkeeping classes (OUser, ORole,
+      // OIdentity, ORestricted, OFunction, plus the literal cluster name "internal"), which do not
+      // belong in a data-annotation catalog next to actual user classes.
+      try(ResultSet rs = meta.getTables(database, null, "%", new String[]{"TABLE"})) {
+         while(rs.next()) {
+            // Defensive re-check, not required by the types filter above: if a caller (or a test
+            // double) ever hands back a row this driver itself would have classified as "SYSTEM
+            // TABLE", this loop must not depend solely on the types argument having been honored
+            // upstream to keep it out of the catalog.
+            if(!"TABLE".equals(rs.getString("TABLE_TYPE"))) {
+               continue;
+            }
+
+            datasets.add(new TabularDatasetRef(rs.getString("TABLE_NAME")));
+         }
+      }
+
+      // OrientDB exposes no driver-readable class-to-class reference/foreign-key construct --
+      // same "nothing to honestly report" position AerospikeCatalog/HiveCatalog take.
+      return new TabularCatalog(datasets, List.of());
+   }
+
+   static TabularDatasetSchema describeDataset(Connection conn, String datasetId) throws Exception {
+      DatabaseMetaData meta = conn.getMetaData();
+      String database = conn.getCatalog();
+
+      if(!classExists(meta, database, datasetId)) {
+         throw new Exception("Class '" + datasetId + "' not found in database '" + database + "'.");
+      }
+
+      List<TabularColumn> columns = describeColumns(meta, database, datasetId);
+      String queryTarget = backtickQuote(datasetId);
+
+      // A class with zero reported columns is schema-less: getColumns walks clazz.properties(),
+      // OrientDB's declared-schema API, so zero rows means zero declared properties (inherited
+      // ones included -- see below), not "the driver failed to answer". A schema-less class's
+      // instances can still carry any runtime field, none of which any driver call can enumerate,
+      // so the only column this connector can honestly promise is the real pseudo-property @rid
+      // (verified against OrientJdbcResultSet's own read paths for it -- see describeColumns'
+      // javadoc note), with columnsMayBeIncomplete signaling that the true field set is unknown.
+      if(columns.isEmpty()) {
+         return new TabularDatasetSchema(datasetId, List.of(new TabularColumn("@rid", XSchema.STRING)),
+            List.of(), Map.of("queryString", "SELECT @rid FROM " + queryTarget), true);
+      }
+
+      // keyColumns comes from getPrimaryKeys, which only makes sense once a class is known to have
+      // a declared schema; see primaryKeyColumnNames' javadoc for why a schema-less class must
+      // skip this call entirely rather than just discard its result.
+      List<String> keyColumns = primaryKeyColumnNames(meta, database, datasetId);
+      return new TabularDatasetSchema(datasetId, columns, keyColumns,
+         Map.of("queryString", "SELECT * FROM " + queryTarget), false);
+   }
+
+   private static boolean classExists(DatabaseMetaData meta, String database, String datasetId)
+      throws Exception
+   {
+      try(ResultSet rs = meta.getTables(database, null, datasetId, new String[]{"TABLE"})) {
+         while(rs.next()) {
+            if(datasetId.equals(rs.getString("TABLE_NAME"))) {
+               return true;
+            }
+         }
+      }
+
+      return false;
+   }
+
+   /**
+    * {@code clazz.properties()} (what {@code getColumns} walks internally) recurses into
+    * superclasses -- {@code OClassImpl.properties(Collection)} explicitly adds the superclass's
+    * properties on top of its own, unlike {@code declaredProperties()}, which does not recurse.
+    * That is not a problem this method needs to work around: an inherited property really is a
+    * field every instance of this class carries, so reporting it here is correct, not a
+    * schema-less false negative. This connector therefore never calls an {@code OClass} API
+    * directly -- {@code getColumns}'s own result already reflects the right answer.
+    */
+   private static List<TabularColumn> describeColumns(DatabaseMetaData meta, String database,
+                                                        String datasetId) throws Exception
+   {
+      OrientDBSQLTypes sqlTypes = new OrientDBSQLTypes();
+      // ORDINAL_POSITION here is prop.getId(), which traces back to
+      // OSchemaShared.findOrCreateGlobalProperty's database-wide, monotonically increasing
+      // counter: the position at which a (property name, OType) pair was first registered
+      // ANYWHERE in the database's schema, not the position at which this particular class
+      // declared it. Two classes that happen to declare a same-named, same-typed property share
+      // one id; a property declared later on this class can therefore sort before one declared
+      // earlier on this same class, if some other class registered that (name, type) pair first.
+      // Still the right sort key: it is the only ordering signal this driver exposes, and it is
+      // deterministic and reproducible across calls against the same schema.
+      TreeMap<Integer, TabularColumn> byPosition = new TreeMap<>();
+
+      // columnNamePattern is null, not "%": getColumns has a dedicated null fast path that adds
+      // every column without running it through the LIKE-emulating OrientJdbcUtils.like at all --
+      // there is no reason to pay for (or risk a metacharacter surprise from) a pattern match
+      // against column names when every column of this class is wanted.
+      try(ResultSet rs = meta.getColumns(database, null, datasetId, null)) {
+         while(rs.next()) {
+            // tableNamePattern above matched via OrientJdbcUtils.like's "_"->"." and case-
+            // insensitive rewrite, which over-matches (see class javadoc) -- this exact,
+            // case-sensitive check is what actually restricts the result to this one class.
+            if(!datasetId.equals(rs.getString("TABLE_NAME"))) {
+               continue;
+            }
+
+            String type = sqlTypes.convertToXType(rs.getInt("DATA_TYPE"));
+            byPosition.put(rs.getInt("ORDINAL_POSITION"),
+               new TabularColumn(rs.getString("COLUMN_NAME"), type != null ? type : XSchema.STRING));
+         }
+      }
+
+      return new ArrayList<>(byPosition.values());
+   }
+
+   /**
+    * {@code getPrimaryKeys} reports every unique index on a class, not a single "primary key" --
+    * OrientDB has no such concept; records are identified by the system {@code @rid}. {@code
+    * KEY_SEQ} restarts at 1 within EACH index, so collecting rows into one sequence-keyed map
+    * (the way a real single-primary-key source would) would silently merge two unrelated unique
+    * indexes' fields into one bogus key when a class happens to declare more than one. Rows are
+    * therefore grouped by {@code PK_NAME} first; only when exactly one group exists does its
+    * KEY_SEQ-ordered column list become {@code keyColumns} -- zero groups (no unique index) and
+    * two-or-more groups (no single index this connector could call "the" key without guessing)
+    * both report an empty list, which is honest rather than a silent pick of the first, largest,
+    * or otherwise most plausible-looking index.
+    *
+    * Only called for a class already known to have a non-empty {@code getColumns} result: a
+    * schema-less class can still hold a unique index on an undeclared runtime field, and {@link
+    * inetsoft.web.wiz.service.TabularCatalogService}'s keyColumns validation requires every
+    * reported key column to also appear in {@code columns} -- for a schema-less class {@code
+    * columns} is only ever {@code @rid}, so any index-derived key name would fail that check and
+    * abort the whole describeDataset call. Skipping the call entirely (not just discarding a
+    * result that might contain such a name) avoids depending on this index happening not to exist.
+    */
+   private static List<String> primaryKeyColumnNames(DatabaseMetaData meta, String database,
+                                                       String datasetId)
+   {
+      Map<String, TreeMap<Short, String>> byIndexName = new LinkedHashMap<>();
+
+      try(ResultSet rs = meta.getPrimaryKeys(database, null, datasetId)) {
+         while(rs.next()) {
+            byIndexName.computeIfAbsent(rs.getString("PK_NAME"), k -> new TreeMap<>())
+               .put(rs.getShort("KEY_SEQ"), rs.getString("COLUMN_NAME"));
+         }
+      }
+      catch(Exception ex) {
+         // Whether an unsupported-method response surfaces as SQLFeatureNotSupportedException
+         // specifically or a generic SQLException is driver-dependent and unconfirmed here, so a
+         // broad catch is deliberate -- mirrors AerospikeCatalog.primaryKeyColumnNames. Treated as
+         // "this class declares no primary key" rather than propagated -- unlike getTables/
+         // getColumns, whose failures are almost always a real connection/permission problem and
+         // must propagate.
+         return List.of();
+      }
+
+      if(byIndexName.size() != 1) {
+         return List.of();
+      }
+
+      return new ArrayList<>(byIndexName.values().iterator().next().values());
+   }
+
+   /**
+    * Wraps {@code identifier} in backticks, the quoting OrientDB's SQL grammar actually supports
+    * for an identifier -- confirmed from {@code orientdb-core}'s parser grammar ({@code
+    * OrientSqlConstants}'s {@code QUOTED_IDENTIFIER} token) and {@code OIdentifier}'s own
+    * quoted-value handling, NOT from {@code DatabaseMetaData.getIdentifierQuoteString()} (which
+    * returns a single space here -- the JDBC-spec convention for "this driver does not support
+    * identifier quoting" -- describing this hand-written driver's own metadata self-report, not
+    * what the SQL engine it fronts actually parses) and NOT by analogy to Hive (doubles
+    * backticks) or Aerospike (doubles double quotes): OrientDB's escape for an embedded backtick
+    * is a single backslash, per {@code OIdentifier}'s value round-trip.
+    */
+   private static String backtickQuote(String identifier) {
+      return "`" + identifier.replace("`", "\\`") + "`";
+   }
+}

--- a/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBCatalog.java
+++ b/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBCatalog.java
@@ -36,11 +36,11 @@ import java.util.*;
  * separate schema concept. {@code getTables}/{@code getColumns}/{@code getPrimaryKeys} never read
  * their {@code catalog}/{@code schemaPattern} arguments to filter matches, but the three methods
  * don't treat their own {@code TABLE_CAT}/{@code TABLE_SCHEM} output columns the same way.
- * {@code getTables} ({@code OrientJdbcDatabaseMetaData.java} lines 733-734) and {@code getColumns}
- * (via {@code getPropertyAsDocument}, lines 1445-1446) always report both as {@code
- * database.getName()}, independent of what was passed in. {@code getPrimaryKeys} (lines 886-887)
- * instead echoes the passed-in {@code catalog} argument verbatim into both columns rather than
- * substituting {@code database.getName()} -- a difference this class never depends on, since
+ * {@code OrientJdbcDatabaseMetaData.getTables} and {@code getColumns} (the latter via {@code
+ * getPropertyAsDocument}) always report both as {@code database.getName()}, independent of what was
+ * passed in. {@code getPrimaryKeys} instead echoes the passed-in {@code catalog} argument verbatim
+ * into both columns rather than substituting {@code database.getName()} -- a difference this class
+ * never depends on, since
  * {@code primaryKeyColumnNames} below only reads {@code PK_NAME}/{@code COLUMN_NAME}/{@code
  * KEY_SEQ} from that result set. Either way, every call below passes {@code conn.getCatalog()} as
  * catalog and {@code null} as schema purely as a self-documenting, forward-compatible convention --

--- a/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBCatalog.java
+++ b/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBCatalog.java
@@ -34,11 +34,17 @@ import java.util.*;
  * OrientJdbcConnection.getCatalog()} returns the connected database's own name and {@code
  * getSchema()} always returns {@code null} -- there is exactly one database per connection, no
  * separate schema concept. {@code getTables}/{@code getColumns}/{@code getPrimaryKeys} never read
- * their {@code catalog}/{@code schemaPattern} arguments (the driver's own {@code TABLE_CAT}/{@code
- * TABLE_SCHEM} output columns are always {@code database.getName()}, independent of what was
- * passed in), so every call below passes {@code conn.getCatalog()} as catalog and {@code null} as
- * schema purely as a self-documenting, forward-compatible convention -- not because today's driver
- * needs it to filter correctly.
+ * their {@code catalog}/{@code schemaPattern} arguments to filter matches, but the three methods
+ * don't treat their own {@code TABLE_CAT}/{@code TABLE_SCHEM} output columns the same way.
+ * {@code getTables} ({@code OrientJdbcDatabaseMetaData.java} lines 733-734) and {@code getColumns}
+ * (via {@code getPropertyAsDocument}, lines 1445-1446) always report both as {@code
+ * database.getName()}, independent of what was passed in. {@code getPrimaryKeys} (lines 886-887)
+ * instead echoes the passed-in {@code catalog} argument verbatim into both columns rather than
+ * substituting {@code database.getName()} -- a difference this class never depends on, since
+ * {@code primaryKeyColumnNames} below only reads {@code PK_NAME}/{@code COLUMN_NAME}/{@code
+ * KEY_SEQ} from that result set. Either way, every call below passes {@code conn.getCatalog()} as
+ * catalog and {@code null} as schema purely as a self-documenting, forward-compatible convention --
+ * not because today's driver needs it to filter correctly.
  *
  * A class name (the "table" in JDBC terms) is matched two different ways by this driver, and both
  * matter here: {@code getTables} does a literal, case-insensitive {@code equals}/{@code
@@ -65,8 +71,12 @@ final class OrientDBCatalog {
       // TABLE_TYPES default (used whenever types == null) is {"TABLE", "SYSTEM TABLE"} -- passing
       // null would therefore ask for MORE, not fewer, rows than passing nothing. "SYSTEM TABLE" is
       // how this driver classifies its own built-in security/bookkeeping classes (OUser, ORole,
-      // OIdentity, ORestricted, OFunction, plus the literal cluster name "internal"), which do not
-      // belong in a data-annotation catalog next to actual user classes.
+      // OIdentity, ORestricted, OFunction) plus one bare literal, "internal" (OMetadataInternal.
+      // SYSTEM_CLUSTER), none of which belong in a data-annotation catalog next to actual user
+      // classes. Because "internal" is matched as a literal string rather than tied to an actual
+      // reserved class, a user-created class literally named "internal" (any case) would also be
+      // classified "SYSTEM TABLE" and silently excluded here -- a driver quirk, not something this
+      // connector introduces or works around.
       try(ResultSet rs = meta.getTables(database, null, "%", new String[]{"TABLE"})) {
          while(rs.next()) {
             // Defensive re-check, not required by the types filter above: if a caller (or a test

--- a/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBRuntime.java
+++ b/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBRuntime.java
@@ -32,7 +32,7 @@ import java.util.Properties;
  * Class that provides OrientDB database connection and query execution utility
  */
 @SuppressWarnings("unused")
-public class OrientDBRuntime extends TabularRuntime {
+public class OrientDBRuntime extends TabularRuntime implements TabularCatalogProvider {
    /**
     * Execute a OrientDB query.
     *
@@ -128,6 +128,26 @@ public class OrientDBRuntime extends TabularRuntime {
       catch (Exception ex){
          LOG.warn("Failed to obtain OrientDB JDBC driver", ex);
          throw ex;
+      }
+   }
+
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      OrientDBDataSource ds = (OrientDBDataSource) dataSource;
+
+      try(Connection conn = getConnection(ds)) {
+         return OrientDBCatalog.listDatasets(conn);
+      }
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      OrientDBDataSource ds = (OrientDBDataSource) dataSource;
+
+      try(Connection conn = getConnection(ds)) {
+         return OrientDBCatalog.describeDataset(conn, datasetId);
       }
    }
 

--- a/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBSQLTypes.java
+++ b/connectors/inetsoft-orientdb/src/main/java/inetsoft/uql/orientdb/OrientDBSQLTypes.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.orientdb;
+
+import inetsoft.uql.jdbc.util.SQLTypes;
+
+/**
+ * Exists only to reach {@link SQLTypes}'s protected no-arg constructor from this package — it
+ * overrides nothing. {@code OrientDBCatalog} calls {@link SQLTypes#convertToXType(int)} unmodified,
+ * exactly the way {@code AerospikeCatalog} calls it through {@code AerospikeSQLTypes}.
+ */
+final class OrientDBSQLTypes extends SQLTypes {
+   OrientDBSQLTypes() {
+   }
+}

--- a/connectors/inetsoft-orientdb/src/test/java/inetsoft/uql/orientdb/OrientDBCatalogTest.java
+++ b/connectors/inetsoft-orientdb/src/test/java/inetsoft/uql/orientdb/OrientDBCatalogTest.java
@@ -1,0 +1,564 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.orientdb;
+
+import inetsoft.sree.PropertiesEngine;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers charter assertions A1, A2, A3, A5, A8 against {@link OrientDBCatalog}, driven entirely off
+ * mocked {@code Connection}/{@code DatabaseMetaData}/{@code ResultSet} -- all three are {@code
+ * java.sql} JDK interfaces, so no orientdb-jdbc driver class is on the compile/test classpath for
+ * this file (D2: mock JDK interfaces, no test-scope driver dependency).
+ *
+ * <p>The {@code catalog}/{@code schema} arguments {@link OrientDBCatalog} passes to {@code
+ * getTables}/{@code getColumns}/{@code getPrimaryKeys} are {@code catalog=database, schema=null}
+ * (see {@code OrientDBCatalog}'s class javadoc) -- confirmed from the driver that neither method
+ * actually reads either argument, so those two are stubbed with {@code any()} throughout rather
+ * than asserted; the arguments this driver's behavior actually depends on ({@code types} and
+ * {@code tableNamePattern}) are asserted with {@link ArgumentCaptor} instead of inferred from
+ * return values, per this round's design note that a stub returns whatever it was told to
+ * regardless of what argument it was called with.
+ *
+ * <p>{@code SQLTypes} (the superclass {@link OrientDBSQLTypes} inherits {@code convertToXType}
+ * from) has a one-time static field initializer that reads {@code SreeEnv.getProperty} ->
+ * {@code PropertiesEngine.getInstance()}, so the first reference to either class anywhere in this
+ * JVM needs a Spring-free stand-in for that singleton (mirrors {@code AerospikeCatalogTest}'s own
+ * {@code mockStatic(PropertiesEngine.class)} pattern).
+ */
+class OrientDBCatalogTest {
+   private static final String DATABASE = "test";
+
+   private static MockedStatic<PropertiesEngine> propertiesEngineStatic;
+
+   @BeforeAll
+   static void mockPropertiesEngine() {
+      PropertiesEngine engine = mock(PropertiesEngine.class);
+      when(engine.getProperty(anyString(), anyBoolean())).thenReturn(null);
+      propertiesEngineStatic = mockStatic(PropertiesEngine.class);
+      propertiesEngineStatic.when(PropertiesEngine::getInstance).thenReturn(engine);
+   }
+
+   @AfterAll
+   static void resetPropertiesEngine() {
+      propertiesEngineStatic.close();
+   }
+
+   // ---- listDatasets --------------------------------------------------------------------------
+
+   @Test
+   void listDatasets_returnsClasses_inDriverOrder() throws Exception {
+      ResultSet rs = mockResultSet(List.of(
+         row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Orders"),
+         row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Customers")));
+      Connection conn = connectionReturningTables(rs);
+
+      TabularCatalog catalog = OrientDBCatalog.listDatasets(conn);
+
+      assertEquals(List.of("Orders", "Customers"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+      assertEquals(List.of(), catalog.relationships());
+   }
+
+   @Test
+   void listDatasets_passesExplicitTableTypesArray_notNull() throws Exception {
+      // A8: OrientJdbcDatabaseMetaData's own TABLE_TYPES default (used when types == null) is
+      // {"TABLE", "SYSTEM TABLE"} -- passing null hands OUser/ORole/OFunction and friends to the
+      // annotator as business tables. Asserted on the argument actually passed: a mock returns its
+      // stubbed rows regardless of what it was called with, so a return-value assertion could not
+      // falsify this.
+      Connection conn = connectionReturningTables(mockResultSet(List.of()));
+
+      OrientDBCatalog.listDatasets(conn);
+
+      DatabaseMetaData meta = conn.getMetaData();
+      ArgumentCaptor<String[]> typesCaptor = ArgumentCaptor.forClass(String[].class);
+      verify(meta).getTables(any(), any(), any(), typesCaptor.capture());
+      assertArrayEquals(new String[]{"TABLE"}, typesCaptor.getValue());
+   }
+
+   @Test
+   void listDatasets_excludesSystemTableRows_evenIfDriverReturnsThem() throws Exception {
+      // Defensive re-check on TABLE_TYPE, independent of the types argument above: if a row this
+      // driver itself classifies as "SYSTEM TABLE" is ever returned anyway, this connector's own
+      // loop must not fold it into the catalog.
+      ResultSet rs = mockResultSet(List.of(
+         row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Orders"),
+         row("TABLE_TYPE", "SYSTEM TABLE", "TABLE_NAME", "OUser")));
+      Connection conn = connectionReturningTables(rs);
+
+      TabularCatalog catalog = OrientDBCatalog.listDatasets(conn);
+
+      assertEquals(List.of("Orders"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+   }
+
+   @Test
+   void listDatasets_emptyDatabase_returnsEmptyCatalog() throws Exception {
+      Connection conn = connectionReturningTables(mockResultSet(List.of()));
+
+      TabularCatalog catalog = OrientDBCatalog.listDatasets(conn);
+
+      assertEquals(List.of(), catalog.datasets());
+   }
+
+   // ---- describeDataset: existence -----------------------------------------------------------
+
+   @Test
+   void describeDataset_classNotFound_throwsWithDatasetId() throws Exception {
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      ResultSet tablesRs = mockResultSet(List.of());
+      when(conn.getMetaData()).thenReturn(meta);
+      when(conn.getCatalog()).thenReturn(DATABASE);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(tablesRs);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> OrientDBCatalog.describeDataset(conn, "NoSuchClass"));
+      assertTrue(ex.getMessage().contains("NoSuchClass"));
+   }
+
+   @Test
+   void describeDataset_caseMismatch_treatedAsNotFound() throws Exception {
+      // getTables itself matches case-insensitively (equalsIgnoreCase), but datasetId must be
+      // exactly what listDatasets returned -- a caller passing the wrong case gets "not found",
+      // not a silent match.
+      ResultSet rs = mockResultSet(List.of(row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Orders")));
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(conn.getCatalog()).thenReturn(DATABASE);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(rs);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> OrientDBCatalog.describeDataset(conn, "orders"));
+      assertTrue(ex.getMessage().contains("orders"));
+   }
+
+   @Test
+   void describeDataset_getTables_passesLiteralDatasetIdAndTableTypesArray() throws Exception {
+      Connection conn = connectionWithClass("Orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      OrientDBCatalog.describeDataset(conn, "Orders");
+
+      DatabaseMetaData meta = conn.getMetaData();
+      ArgumentCaptor<String> pattern = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String[]> types = ArgumentCaptor.forClass(String[].class);
+      verify(meta).getTables(any(), any(), pattern.capture(), types.capture());
+      assertEquals("Orders", pattern.getValue());
+      assertArrayEquals(new String[]{"TABLE"}, types.getValue());
+   }
+
+   // ---- describeDataset: schema-full branch --------------------------------------------------
+
+   @Test
+   void describeDataset_schemaFull_columnsNotIncomplete_selectStarQuery() throws Exception {
+      Connection conn = connectionWithClass("Orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertFalse(schema.columnsMayBeIncomplete());
+      assertEquals(Map.of("queryString", "SELECT * FROM `Orders`"), schema.params());
+   }
+
+   @Test
+   void describeDataset_backtickInClassName_escapedWithBackslash() throws Exception {
+      // A3: OrientDB's escape for an embedded backtick is a single backslash (OIdentifier's own
+      // value round-trip), not doubling -- unlike Hive's doubled backticks or Aerospike's doubled
+      // double quotes.
+      String className = "Weird`Class";
+      Connection conn = connectionWithClass(className,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, className);
+
+      assertEquals("SELECT * FROM `Weird\\`Class`", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_spaceInClassName_wrappedWithoutEscaping() throws Exception {
+      String className = "My Class";
+      Connection conn = connectionWithClass(className,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, className);
+
+      assertEquals("SELECT * FROM `My Class`", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_reservedWordClassName_unconditionalBacktickWrap() throws Exception {
+      String className = "Order";
+      Connection conn = connectionWithClass(className,
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, className);
+
+      assertEquals("SELECT * FROM `Order`", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_columnsOrderedByOrdinalPosition_evenIfResultSetRowsOutOfOrder()
+      throws Exception
+   {
+      Connection conn = connectionWithClass("Orders", List.of(
+         row("COLUMN_NAME", "total", "DATA_TYPE", Types.DECIMAL, "ORDINAL_POSITION", 3),
+         row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1),
+         row("COLUMN_NAME", "customer_id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 2)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(List.of("id", "customer_id", "total"),
+         schema.columns().stream().map(TabularColumn::name).toList());
+   }
+
+   @Test
+   void describeDataset_getColumns_passesLiteralDatasetIdAndNullColumnNamePattern()
+      throws Exception
+   {
+      Connection conn = connectionWithClass("Orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+
+      OrientDBCatalog.describeDataset(conn, "Orders");
+
+      DatabaseMetaData meta = conn.getMetaData();
+      ArgumentCaptor<String> tableNamePattern = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> columnNamePattern = ArgumentCaptor.forClass(String.class);
+      verify(meta).getColumns(any(), any(), tableNamePattern.capture(), columnNamePattern.capture());
+      assertEquals("Orders", tableNamePattern.getValue());
+      assertNull(columnNamePattern.getValue());
+   }
+
+   @Test
+   void describeDataset_getColumnsOverMatchedRow_discardedByExactMatchFilter() throws Exception {
+      // OrientJdbcUtils.like rewrites "_" to "." and matches case-insensitively, so a
+      // tableNamePattern of "my_class" over-matches "myXclass", and "Orders" over-matches
+      // "orders". A mock stub returns whatever it is told to regardless of the pattern actually
+      // passed, so this must be exercised by feeding an over-matched row through the mock and
+      // asserting the exact-match post-filter discards it -- nothing else in this file would catch
+      // a regression that dropped that filter.
+      ResultSet columnsRs = mockResultSet(List.of(
+         row("TABLE_NAME", "Orders", "COLUMN_NAME", "id",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1),
+         row("TABLE_NAME", "orders", "COLUMN_NAME", "bogus",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 2)));
+      Connection conn = connectionWithClassExists("Orders");
+      DatabaseMetaData meta = conn.getMetaData();
+      ResultSet pkRs = mockResultSet(List.of());
+      when(meta.getColumns(any(), any(), any(), any())).thenReturn(columnsRs);
+      when(meta.getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(List.of("id"), schema.columns().stream().map(TabularColumn::name).toList());
+   }
+
+   // ---- describeDataset: A2 (type mapping via SQLTypes.convertToXType) ------------------------
+
+   @Test
+   void convertToXType_booleanSqlType_mapsToXSchemaBoolean() {
+      // The Hive-round regression, repeated here as its own regression: the two-hop
+      // convertToJava -> CoreTool.getDataType chain has no Types.BOOLEAN branch and would land on
+      // XSchema.STRING. convertToXType merges BIT/BOOLEAN and returns XSchema.BOOLEAN directly.
+      assertEquals(XSchema.BOOLEAN, new OrientDBSQLTypes().convertToXType(Types.BOOLEAN));
+   }
+
+   @Test
+   void describeDataset_columnTypesComeFromConvertToXType_notANewSwitch() throws Exception {
+      Connection conn = connectionWithClass("Orders", List.of(
+         row("COLUMN_NAME", "is_active", "DATA_TYPE", Types.BOOLEAN, "ORDINAL_POSITION", 1),
+         row("COLUMN_NAME", "total", "DATA_TYPE", Types.DECIMAL, "ORDINAL_POSITION", 2),
+         row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 3)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      Map<String, String> typesByName = schema.columns().stream()
+         .collect(Collectors.toMap(TabularColumn::name, TabularColumn::type));
+      assertEquals(XSchema.BOOLEAN, typesByName.get("is_active"));
+      assertEquals(XSchema.DOUBLE, typesByName.get("total"));
+      assertEquals(XSchema.INTEGER, typesByName.get("id"));
+   }
+
+   @Test
+   void describeDataset_unmatchedColumnType_fallsBackToXSchemaString() throws Exception {
+      // Types.ARRAY is one of convertToXType's unmatched codes (falls to its default, returning
+      // null) -- OrientDBCatalog's own null -> XSchema.STRING bridge is what should produce this
+      // result, not a second, competing mapping. Also stands in for OrientDB's own OType.LINKBAG,
+      // which OrientJdbcResultSetMetaData's DATA_TYPE map does not cover either (see design §8).
+      Connection conn = connectionWithClass("Orders",
+         List.of(row("COLUMN_NAME", "tags", "DATA_TYPE", Types.ARRAY, "ORDINAL_POSITION", 1)));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(XSchema.STRING, schema.columns().get(0).type());
+   }
+
+   // ---- describeDataset: getPrimaryKeys ------------------------------------------------------
+
+   @Test
+   void describeDataset_zeroUniqueIndexes_keyColumnsEmpty() throws Exception {
+      Connection conn = connectionWithClass("Orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+      ResultSet pkRs = mockResultSet(List.of());
+      when(conn.getMetaData().getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(List.of(), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_oneUniqueIndex_keyColumnsOrderedByKeySeq() throws Exception {
+      Connection conn = connectionWithClass("Orders", List.of(
+         row("COLUMN_NAME", "tenant_id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1),
+         row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 2)));
+      ResultSet pkRs = mockResultSet(List.of(
+         row("PK_NAME", "Orders_unique", "COLUMN_NAME", "id", "KEY_SEQ", (short) 2),
+         row("PK_NAME", "Orders_unique", "COLUMN_NAME", "tenant_id", "KEY_SEQ", (short) 1)));
+      when(conn.getMetaData().getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(List.of("tenant_id", "id"), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_twoUniqueIndexes_keyColumnsEmpty_doesNotMergeKeySeqAcrossIndexes()
+      throws Exception
+   {
+      // Both indexes restart KEY_SEQ at 1 -- a TreeMap<KEY_SEQ, name> collection (the Aerospike
+      // shape) would let the second index's KEY_SEQ=1 row silently overwrite the first's, and the
+      // one-and-only pk field would look mangled instead of the whole call recognizing there is no
+      // single declared key. Not present in AerospikeCatalogTest -- unique to this driver's
+      // multi-unique-index-per-class behavior.
+      Connection conn = connectionWithClass("Orders", List.of(
+         row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1),
+         row("COLUMN_NAME", "email", "DATA_TYPE", Types.VARCHAR, "ORDINAL_POSITION", 2)));
+      ResultSet pkRs = mockResultSet(List.of(
+         row("PK_NAME", "Orders_id_unique", "COLUMN_NAME", "id", "KEY_SEQ", (short) 1),
+         row("PK_NAME", "Orders_email_unique", "COLUMN_NAME", "email", "KEY_SEQ", (short) 1)));
+      when(conn.getMetaData().getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(List.of(), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_getPrimaryKeysThrows_keyColumnsEmpty_restOfSchemaStillReturned()
+      throws Exception
+   {
+      Connection conn = connectionWithClass("Orders",
+         List.of(row("COLUMN_NAME", "id", "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+      // Not narrowed to SQLFeatureNotSupportedException: an unsupported-method response is not
+      // guaranteed to surface as that specific JDK subtype.
+      when(conn.getMetaData().getPrimaryKeys(any(), any(), any()))
+         .thenThrow(new SQLException("not supported"));
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Orders");
+
+      assertEquals(List.of(), schema.keyColumns());
+      assertEquals(1, schema.columns().size());
+   }
+
+   @Test
+   void describeDataset_getColumnsThrows_propagates() throws Exception {
+      // Isolation must be two independent test cases, not one shared try/catch: a getColumns
+      // failure is almost always a real connection/permission problem and must not be swallowed
+      // the way a getPrimaryKeys failure is.
+      Connection conn = connectionWithClassExists("Orders");
+      when(conn.getMetaData().getColumns(any(), any(), any(), any()))
+         .thenThrow(new SQLException("permission denied"));
+
+      Exception ex = assertThrows(Exception.class,
+         () -> OrientDBCatalog.describeDataset(conn, "Orders"));
+      assertTrue(ex.getMessage().contains("permission denied") || ex instanceof SQLException);
+   }
+
+   // ---- describeDataset: schema-less branch --------------------------------------------------
+
+   @Test
+   void describeDataset_schemaLess_ridColumn_columnsMayBeIncomplete() throws Exception {
+      Connection conn = connectionWithClass("Event", List.of());
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Event");
+
+      assertEquals(List.of("@rid"), schema.columns().stream().map(TabularColumn::name).toList());
+      assertEquals(XSchema.STRING, schema.columns().get(0).type());
+      assertTrue(schema.columnsMayBeIncomplete());
+      assertEquals(List.of(), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_schemaLess_selectsRidNotStar() throws Exception {
+      Connection conn = connectionWithClass("Event", List.of());
+
+      TabularDatasetSchema schema = OrientDBCatalog.describeDataset(conn, "Event");
+
+      assertEquals("SELECT @rid FROM `Event`", schema.params().get("queryString"));
+   }
+
+   @Test
+   void describeDataset_schemaLess_neverCallsGetPrimaryKeys() throws Exception {
+      Connection conn = connectionWithClass("Event", List.of());
+
+      OrientDBCatalog.describeDataset(conn, "Event");
+
+      verify(conn.getMetaData(), never()).getPrimaryKeys(any(), any(), any());
+   }
+
+   // ---- describeDataset: mixed schema-full / schema-less database (A5) ------------------------
+
+   @Test
+   void listDatasets_thenDescribeDataset_mixedSchemaFullAndSchemaLessClasses_bothCorrect()
+      throws Exception
+   {
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(conn.getCatalog()).thenReturn(DATABASE);
+
+      ResultSet allTablesRs = mockResultSet(List.of(
+         row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Orders"),
+         row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Event")));
+      ResultSet ordersTableRs = mockResultSet(
+         List.of(row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Orders")));
+      ResultSet eventTableRs = mockResultSet(
+         List.of(row("TABLE_TYPE", "TABLE", "TABLE_NAME", "Event")));
+      ResultSet ordersColumnsRs = mockResultSet(List.of(
+         row("TABLE_NAME", "Orders", "COLUMN_NAME", "id",
+            "DATA_TYPE", Types.INTEGER, "ORDINAL_POSITION", 1)));
+      ResultSet eventColumnsRs = mockResultSet(List.of());
+      ResultSet pkRs = mockResultSet(List.of());
+
+      when(meta.getTables(any(), any(), eq("%"), any())).thenReturn(allTablesRs);
+      when(meta.getTables(any(), any(), eq("Orders"), any())).thenReturn(ordersTableRs);
+      when(meta.getTables(any(), any(), eq("Event"), any())).thenReturn(eventTableRs);
+      when(meta.getColumns(any(), any(), eq("Orders"), any())).thenReturn(ordersColumnsRs);
+      when(meta.getColumns(any(), any(), eq("Event"), any())).thenReturn(eventColumnsRs);
+      when(meta.getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      TabularCatalog catalog = OrientDBCatalog.listDatasets(conn);
+      assertEquals(List.of("Orders", "Event"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+
+      TabularDatasetSchema ordersSchema = OrientDBCatalog.describeDataset(conn, "Orders");
+      assertFalse(ordersSchema.columnsMayBeIncomplete());
+      assertEquals(List.of("id"),
+         ordersSchema.columns().stream().map(TabularColumn::name).toList());
+
+      TabularDatasetSchema eventSchema = OrientDBCatalog.describeDataset(conn, "Event");
+      assertTrue(eventSchema.columnsMayBeIncomplete());
+      assertEquals(List.of("@rid"),
+         eventSchema.columns().stream().map(TabularColumn::name).toList());
+   }
+
+   // ---- fixtures ------------------------------------------------------------------------------
+
+   private static Connection connectionReturningTables(ResultSet rs) throws Exception {
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(conn.getCatalog()).thenReturn(DATABASE);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(rs);
+      return conn;
+   }
+
+   /**
+    * A connection where {@code getTables} confirms {@code className} exists (for both the exact
+    * pattern and any other pattern this class might be asked with) and {@code getColumns}/
+    * {@code getPrimaryKeys} return the given column rows / no primary keys -- the common case for
+    * a {@code describeDataset} test that only cares about the columns/keys/query string outcome.
+    */
+   private static Connection connectionWithClass(String className,
+                                                   List<Map<String, Object>> columnRows)
+      throws Exception
+   {
+      Connection conn = connectionWithClassExists(className);
+      DatabaseMetaData meta = conn.getMetaData();
+
+      List<Map<String, Object>> withTableName = columnRows.stream()
+         .map(r -> {
+            Map<String, Object> withKey = new LinkedHashMap<>(r);
+            withKey.putIfAbsent("TABLE_NAME", className);
+            return withKey;
+         })
+         .collect(Collectors.toList());
+      ResultSet columnsRs = mockResultSet(withTableName);
+      ResultSet pkRs = mockResultSet(List.of());
+      when(meta.getColumns(any(), any(), any(), any())).thenReturn(columnsRs);
+      when(meta.getPrimaryKeys(any(), any(), any())).thenReturn(pkRs);
+
+      return conn;
+   }
+
+   private static Connection connectionWithClassExists(String className) throws Exception {
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      Connection conn = mock(Connection.class);
+      ResultSet tablesRs = mockResultSet(List.of(row("TABLE_TYPE", "TABLE", "TABLE_NAME", className)));
+      when(conn.getMetaData()).thenReturn(meta);
+      when(conn.getCatalog()).thenReturn(DATABASE);
+      when(meta.getTables(any(), any(), any(), any())).thenReturn(tablesRs);
+      return conn;
+   }
+
+   private static ResultSet mockResultSet(List<Map<String, Object>> rows) throws SQLException {
+      ResultSet rs = mock(ResultSet.class);
+      int[] index = {-1};
+      when(rs.next()).thenAnswer(inv -> ++index[0] < rows.size());
+      when(rs.getString(anyString())).thenAnswer(inv ->
+         rows.get(index[0]).get((String) inv.getArgument(0)));
+      when(rs.getInt(anyString())).thenAnswer(inv -> {
+         Object v = rows.get(index[0]).get((String) inv.getArgument(0));
+         return v == null ? 0 : ((Number) v).intValue();
+      });
+      when(rs.getShort(anyString())).thenAnswer(inv -> {
+         Object v = rows.get(index[0]).get((String) inv.getArgument(0));
+         return v == null ? (short) 0 : ((Number) v).shortValue();
+      });
+      return rs;
+   }
+
+   private static Map<String, Object> row(Object... kv) {
+      Map<String, Object> m = new LinkedHashMap<>();
+
+      for(int i = 0; i < kv.length; i += 2) {
+         m.put((String) kv[i], kv[i + 1]);
+      }
+
+      return m;
+   }
+}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
@@ -75,11 +75,12 @@ public interface TabularCatalogProvider {
     * level, so a per-column marker would just repeat one dataset-wide fact on every row. Record it
     * once, on the dataset.
     *
-    * That dataset-level "this list may be incomplete" signal is NOT implemented yet as of this
-    * writing — nothing currently produces sampled columns through this SPI, so the field would
-    * have no writer. It is meant to land in the same change that ships the first connector whose
-    * columns are actually sampled (a bounded scan over a schema-less or driver-inferred source),
-    * not before.
+    * That dataset-level "this list may be incomplete" signal is {@link TabularDatasetSchema#columnsMayBeIncomplete()}.
+    * Set it true when this method could only infer columns from a bounded scan rather than read
+    * them from the source's own declared metadata — {@code AerospikeCatalog} is the first
+    * implementer to do so. wiz surfaces a true value as one caveat sentence composed into the
+    * annotation prompt, the same way a truncated-sample-rows caveat is already surfaced today, so
+    * an LLM reading this data does not describe an inferred column list as a complete enumeration.
     *
     * Before reaching for sampling, check whether the source already publishes declared metadata —
     * if it does, read that instead of inferring from samples. This is not hypothetical: a

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
@@ -63,7 +63,31 @@ public interface TabularCatalogProvider {
    TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception;
 
    /**
-    * The columns of one dataset.
+    * The columns this connector can report for one dataset.
+    *
+    * A connector that can only infer columns from a bounded scan or a single response — rather
+    * than reading them from declared, source-published metadata — is a legitimate implementer of
+    * this method. Sampled or inferred columns satisfy this contract.
+    *
+    * What such a connector must NOT do is present that list as if it were authoritative. The
+    * imprecision belongs at the DATASET level, not the column level: every column returned by one
+    * {@code describeDataset} call comes from the same scan and therefore shares the same trust
+    * level, so a per-column marker would just repeat one dataset-wide fact on every row. Record it
+    * once, on the dataset.
+    *
+    * That dataset-level "this list may be incomplete" signal is NOT implemented yet as of this
+    * writing — nothing currently produces sampled columns through this SPI, so the field would
+    * have no writer. It is meant to land in the same change that ships the first connector whose
+    * columns are actually sampled (a bounded scan over a schema-less or driver-inferred source),
+    * not before.
+    *
+    * Before reaching for sampling, check whether the source already publishes declared metadata —
+    * if it does, read that instead of inferring from samples. This is not hypothetical: a
+    * REST source can carry its column list in the very same response body as the data (e.g. a
+    * `meta.view.columns` field alongside a `data` array); a spreadsheet can declare columns via
+    * its header row and per-column cell-format metadata; a document store can expose a mapping
+    * API describing its fields (e.g. Elasticsearch's `_mapping`). Falling back to sampling when a
+    * declaration exists manufactures uncertainty the source did not actually have.
     *
     * @param datasetId a {@link TabularDatasetRef#id()} previously returned by
     *                  {@link #listDatasets} for this same data source.

--- a/core/src/main/java/inetsoft/uql/tabular/TabularDatasetSchema.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularDatasetSchema.java
@@ -36,9 +36,31 @@ import java.util.Map;
  *                  parameters (e.g. the dataset id is itself the one property value a query needs)
  *                  or the connector has not implemented this yet. Never null — use the 3-arg
  *                  constructor below, which defaults to {@link Map#of()}, rather than passing null.
+ * @param columnsMayBeIncomplete true when {@code columns} was only inferred from a bounded scan of
+ *                  the source rather than read from the source's own declared metadata, so the
+ *                  list above may be missing columns the source actually holds. False for every
+ *                  connector that reads a declared schema (a JDBC catalog, an EDMX document, a list
+ *                  endpoint) — see {@link TabularCatalogProvider#describeDataset}. Deliberately a
+ *                  dataset-level fact, not a per-column one: every column returned by one
+ *                  {@code describeDataset} call comes from the same scan and shares the same trust
+ *                  level.
  */
 public record TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
-                                   List<String> keyColumns, Map<String, String> params) {
+                                   List<String> keyColumns, Map<String, String> params,
+                                   boolean columnsMayBeIncomplete) {
+   /**
+    * Compatibility constructor for callers written before {@code columnsMayBeIncomplete} existed —
+    * every existing connector's construction site. Defaults to {@code false}: Cassandra, Hive,
+    * OData, and SharePoint Online all read declared, source-published metadata rather than
+    * inferring columns from a bounded scan, so "this list is authoritative" is the true fact about
+    * them, not just a compatibility default.
+    */
+   public TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
+                               List<String> keyColumns, Map<String, String> params)
+   {
+      this(datasetId, columns, keyColumns, params, false);
+   }
+
    /**
     * Compatibility constructor for callers written before {@code params} existed — every existing
     * connector-test construction site and any connector that has not opted into target binding

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -364,7 +364,8 @@ public class TabularCatalogService {
          null : schema.keyColumns());
       dataset.setFields(fields);
       dataset.setCustomExtensions(
-         List.of(buildDatasetExtension(dsName, datasourceSubtype, schema.params(), objectMapper)));
+         List.of(buildDatasetExtension(dsName, datasourceSubtype, schema.params(),
+            schema.columnsMayBeIncomplete(), objectMapper)));
       return dataset;
    }
 
@@ -396,9 +397,17 @@ public class TabularCatalogService {
     * {@code "params"} key entirely rather than writing it out empty or null, so wiz's reader can't
     * tell "no params" apart from "not implemented yet" — which is exactly the point: both mean the
     * same thing to a consumer that only wants to know whether it has something to bind with.
+    *
+    * {@code columnsMayBeIncomplete} is written only when true, unlike {@code params}' "empty means
+    * absent" convention but for the opposite reason: every dataset that predates this key, and
+    * every dataset from a connector that reads declared metadata, has no way to ever produce it,
+    * and for those ABSENT must mean "complete" — writing it out as {@code false} unconditionally
+    * would say the same thing, so omitting it keeps this method's convention (present only when it
+    * says something) uniform across both keys — see {@link TabularDatasetSchema#columnsMayBeIncomplete()}.
     */
    private static OsiCustomExtension buildDatasetExtension(String dsName, String datasourceSubtype,
                                                             Map<String, String> params,
+                                                            boolean columnsMayBeIncomplete,
                                                             ObjectMapper objectMapper)
    {
       try {
@@ -410,6 +419,10 @@ public class TabularCatalogService {
 
          if(params != null && !params.isEmpty()) {
             extData.put("params", params);
+         }
+
+         if(columnsMayBeIncomplete) {
+            extData.put("columnsMayBeIncomplete", true);
          }
 
          OsiCustomExtension ext = new OsiCustomExtension();

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogDatasetExtensionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogDatasetExtensionTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Charter assertion B7, isolated from the rest of {@link TabularCatalogServiceTest}: a METADATA
@@ -94,5 +95,39 @@ class TabularCatalogDatasetExtensionTest {
       OsiCustomExtension ext = dataset.getCustomExtensions().get(0);
       JsonNode data = new ObjectMapper().readTree(ext.getData());
       assertEquals("Products", data.get("params").get("entity").asText());
+   }
+
+   /**
+    * This round's direct analogue of the params presence/absence tests above, for the new
+    * {@code columnsMayBeIncomplete} key: the 4-arg constructor defaults it to false, and false is
+    * omitted entirely rather than written out — same "present only when it says something"
+    * convention as {@code params}, applied to this key too.
+    */
+   @Test
+   void datasetCommonExtensionOmitsColumnsMayBeIncompleteKeyWhenFalse() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"));
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Rest/Northwind", "OData", schema, new ObjectMapper());
+
+      OsiCustomExtension ext = dataset.getCustomExtensions().get(0);
+      JsonNode data = new ObjectMapper().readTree(ext.getData());
+      assertFalse(data.has("columnsMayBeIncomplete"),
+         "columnsMayBeIncomplete key must be absent, not written as false");
+   }
+
+   @Test
+   void datasetCommonExtensionCarriesColumnsMayBeIncompleteWhenTrue() throws Exception {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"), Map.of(), true);
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Test/Aerospike", "Aerospike", schema, new ObjectMapper());
+
+      OsiCustomExtension ext = dataset.getCustomExtensions().get(0);
+      JsonNode data = new ObjectMapper().readTree(ext.getData());
+      assertTrue(data.get("columnsMayBeIncomplete").asBoolean(),
+         "columnsMayBeIncomplete must be written as a JSON boolean, not a string");
    }
 }


### PR DESCRIPTION
Three related changes that only make sense together: a contract decision, and the two connectors that are the first to need it.

## The contract question

`TabularCatalogProvider.describeDataset` promised "the columns of this dataset". Six connectors cannot honour that literally — they report the fields a bounded sample happened to contain. The javadoc now says a sampled column list satisfies the contract, provided the imprecision is declared **at dataset level** rather than per column, and that a source publishing declared metadata must be read rather than sampled.

Per-column marking was rejected: every column from one `describeDataset` call shares one trust level, so the marker would carry the same value on each, and nothing downstream reads it. The dataset-level signal reuses the mechanism that already delivers a truncated-sample caveat into the annotation prompt, which has live readers.

## Aerospike

Fifth implementer. Hive's shape — one `Enter SQL` property, a required `Namespace` scoping the dataset id to a bare set name — and the first connector to set the incompleteness signal, since its driver unions bin names across at most 1000 scanned records and lets the last record win a type conflict.

Two defects found in review and fixed:

- **The generated query emitted a bare identifier.** The driver declares the double quote as its identifier quote and builds this same query shape quoted, so a set named `order` or `my set` produced SQL that fails to parse, silently.
- **`describeDataset` denied a set that `listDatasets` had just returned.** The driver compiles `tableNamePattern` as a Java regex, translating only `%`, so `orders(2024)` does not match itself. Fifteen tests could not have caught this: they asserted on mocked return values, and a mock yields its stubbed rows whatever pattern it was handed. The fix asserts on the argument.

A follow-up round then found the first fix had traded correctness for cost — `getColumns` runs a live query per matched table, so a literal `%` turned one `describeDataset` into one query per set. Now `Pattern.quote`, falling back to `%` only for a name containing one, since the driver substitutes `%` before compiling.

## OrientDB

Sixth implementer. Its database scope comes from `Connection.getCatalog()` rather than a property, so the dataset id stays a bare class name.

Schema-less classes return no declared columns at all — `getColumns` walks `clazz.properties()` — which is a different situation from Aerospike, where something is always inferred. Those classes get `@rid`, a real pseudo-property the driver handles and `SELECT` accepts, plus the incompleteness signal, so they are annotated at table level and remain queryable through `SELECT @rid FROM`. No column is synthesised: a fabricated column would fail the moment anything selected it.

`listDatasets` passes `types = {"TABLE"}` explicitly, because the driver's default includes `SYSTEM TABLE` and would hand `OUser` and `ORole` to the annotator as business tables.

Worth knowing for anyone reading these three connectors together: they quote three different ways. Hive doubles backticks, Aerospike doubles double quotes, OrientDB escapes them with a backslash. Nothing here derives from anything else, and `getIdentifierQuoteString()` is not a reliable guide — OrientDB's returns a space, the JDBC convention for "unsupported", while its grammar has a real `QUOTED_IDENTIFIER` production.

## Tests and limits

Both connectors' modules had none; they now have 47 between them, and the four earlier implementers' suites re-run green. There is no Aerospike or OrientDB instance available and neither driver is a build dependency — both are loaded reflectively and expected from the user. Driver behaviour was established by reading the published sources, so claims about it are read-code-correct rather than executed; the backtick escaping in particular has never been through a live parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)