### PR TITLE
Report a date-comparison dimension retarget in set_date_comparison's response

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -153,6 +153,12 @@ public class DateComparisonService {
     * <p>Matches by {@code getName()} (the plain column name), not {@code getFullName()} — the
     * full name embeds the date level itself (e.g. "Month(ORDER_DATE)" vs. "Year(ORDER_DATE)"),
     * so it never matches once the level has actually changed.
+    *
+    * <p>Searches only the shelf {@code VSCrosstabInfo.isDateComparisonOnRow()} names, not "row,
+    * then column" — that flag is set by the very same {@code updateRuntimeHeaders()} call that
+    * produces {@code getDateComparisonRef()}, so it is a definitive answer, not a guess. Trying
+    * row first and falling back to column would misreport an unrelated, untouched dimension's
+    * level if a crosstab happened to bind a same-named date dimension on both shelves.
     */
    private static Map<String, Object> describeRetargetedDimension(RuntimeViewsheet rvs,
                                                                    String assemblyName)
@@ -173,12 +179,9 @@ public class DateComparisonService {
       }
 
       VSDimensionRef beforeDim = (VSDimensionRef) before;
-      VSDimensionRef afterDim = findDimensionByName(crosstabInfo.getRuntimeRowHeaders(),
-                                                    beforeDim.getName());
-
-      if(afterDim == null) {
-         afterDim = findDimensionByName(crosstabInfo.getRuntimeColHeaders(), beforeDim.getName());
-      }
+      DataRef[] shelf = crosstabInfo.isDateComparisonOnRow() ?
+         crosstabInfo.getRuntimeRowHeaders() : crosstabInfo.getRuntimeColHeaders();
+      VSDimensionRef afterDim = findDimensionByName(shelf, beforeDim.getName());
 
       if(afterDim == null || afterDim.getDateLevel() == beforeDim.getDateLevel()) {
          return out;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -17,7 +17,10 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.*;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,11 +106,19 @@ public class DateComparisonService {
       return out;
    }
 
-   /** Applies a comparison. One {@code sessions.mutate}, so one undo checkpoint. */
-   public void set(String sessionToken, Principal user, String assemblyName,
-                   Comparison comparison, String linkUri) throws Exception
+   /**
+    * Applies a comparison. One {@code sessions.mutate}, so one undo checkpoint.
+    *
+    * @return a map that, when the comparison forced a bound date dimension's rendering level
+    * to change (e.g. a row bound at "month" retargeted to "year" so periods line up), reports
+    * the dimension name and the before/after level under {@code retargetedDimension} /
+    * {@code retargetedFromLevel} / {@code retargetedToLevel}. Empty when nothing was retargeted.
+    */
+   public Map<String, Object> set(String sessionToken, Principal user, String assemblyName,
+                                  Comparison comparison, String linkUri) throws Exception
    {
       requireEndAnchor(comparison);
+      Map<String, Object> result = new LinkedHashMap<>();
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          DateComparisonPaneModel model =
@@ -123,7 +134,74 @@ public class DateComparisonService {
          comparisonService.setDateComparison(runtimeId, assemblyName,
                                             model.toDateComparisonInfo(), null, linkUri, user,
                                             dispatcher);
+         result.putAll(describeRetargetedDimension(rvs, assemblyName));
       });
+
+      return result;
+   }
+
+   /**
+    * Date comparison forces a bound date dimension's runtime grouping level up (or down) to
+    * match the comparison period, so periods actually line up — a deliberate rendering decision,
+    * not a bug. But it only ever mutates the runtime clone (design binding is untouched), and
+    * nothing told the caller it happened. {@code CrosstabDcProcessor.process()} already stashes
+    * the pre-retarget clone on {@code VSCrosstabInfo.getDateComparisonRef()} before mutating the
+    * live runtime ref in place; comparing that snapshot's level against the same-named dimension
+    * in the (already-refreshed, by the time {@code sessions.mutate} returns) runtime headers is
+    * the cheapest way to observe what actually changed, without re-deriving the DC math here.
+    *
+    * <p>Matches by {@code getName()} (the plain column name), not {@code getFullName()} — the
+    * full name embeds the date level itself (e.g. "Month(ORDER_DATE)" vs. "Year(ORDER_DATE)"),
+    * so it never matches once the level has actually changed.
+    */
+   private static Map<String, Object> describeRetargetedDimension(RuntimeViewsheet rvs,
+                                                                   String assemblyName)
+   {
+      Map<String, Object> out = new LinkedHashMap<>();
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(!(assembly instanceof CrosstabVSAssembly)) {
+         return out;
+      }
+
+      VSCrosstabInfo crosstabInfo = ((CrosstabVSAssembly) assembly).getVSCrosstabInfo();
+      VSDataRef before = crosstabInfo == null ? null : crosstabInfo.getDateComparisonRef();
+
+      if(!(before instanceof VSDimensionRef)) {
+         return out;
+      }
+
+      VSDimensionRef beforeDim = (VSDimensionRef) before;
+      VSDimensionRef afterDim = findDimensionByName(crosstabInfo.getRuntimeRowHeaders(),
+                                                    beforeDim.getName());
+
+      if(afterDim == null) {
+         afterDim = findDimensionByName(crosstabInfo.getRuntimeColHeaders(), beforeDim.getName());
+      }
+
+      if(afterDim == null || afterDim.getDateLevel() == beforeDim.getDateLevel()) {
+         return out;
+      }
+
+      out.put("retargetedDimension", beforeDim.getName());
+      out.put("retargetedFromLevel", levelWord(beforeDim.getDateLevel()));
+      out.put("retargetedToLevel", levelWord(afterDim.getDateLevel()));
+      return out;
+   }
+
+   private static VSDimensionRef findDimensionByName(DataRef[] refs, String name) {
+      if(refs == null || name == null) {
+         return null;
+      }
+
+      for(DataRef ref : refs) {
+         if(ref instanceof VSDimensionRef && name.equals(((VSDimensionRef) ref).getName())) {
+            return (VSDimensionRef) ref;
+         }
+      }
+
+      return null;
    }
 
    public void clear(String sessionToken, Principal user, String assemblyName, String linkUri)
@@ -279,6 +357,19 @@ public class DateComparisonService {
       }
 
       return code.toString();
+   }
+
+   private static final Map<Integer, String> LEVEL_NAMES = Map.of(
+      XConstants.YEAR_DATE_GROUP, "year",
+      XConstants.QUARTER_DATE_GROUP, "quarter",
+      XConstants.MONTH_DATE_GROUP, "month",
+      XConstants.WEEK_DATE_GROUP, "week",
+      XConstants.DAY_DATE_GROUP, "day"
+   );
+
+   /** The inverse of {@link #normalizeLevel(String)}, for reporting a level back to the caller. */
+   private static String levelWord(int level) {
+      return LEVEL_NAMES.getOrDefault(level, String.valueOf(level));
    }
 
    private static void setDynamic(DynamicValueModel target, String value) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -874,15 +874,21 @@ public class ViewsheetAssemblyAgentController {
       return comparisonService.read(sessionToken, user, assembly);
    }
 
+   /**
+    * Sets a date comparison. The response reports whether the comparison retargeted a bound
+    * date dimension's runtime grouping level to match the comparison period — see
+    * {@link DateComparisonService#set}.
+    */
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/date-comparison")
-   public void setDateComparison(
+   public Map<String, Object> setDateComparison(
       @PathVariable String sessionToken,
       @RequestBody DateComparisonRequest request,
       @RequestParam(required = false, defaultValue = "") String linkUri,
       Principal user) throws Exception
    {
       requireEnabled();
-      comparisonService.set(sessionToken, user, request.assembly(), request.comparison(), linkUri);
+      return comparisonService.set(sessionToken, user, request.assembly(), request.comparison(),
+                                   linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/date-comparison/clear")

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -19,7 +19,8 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
-import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.*;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.junit.jupiter.api.Tag;
@@ -270,6 +271,97 @@ class DateComparisonServiceTest {
       assertTrue(thrown.getMessage().contains("date dimension"));
    }
 
+   // ── reporting a retargeted dimension ────────────────────────────────────────
+
+   /**
+    * {@code describeRetargetedDimension} matches the pre-retarget snapshot on
+    * {@code VSCrosstabInfo.getDateComparisonRef()} against the same-named dimension in the
+    * refreshed runtime headers, and reports the dimension/before/after level when the level
+    * actually moved.
+    */
+   @Test
+   void reportsARetargetedDimensionWhenTheRuntimeLevelActuallyChanged() throws Exception {
+      VSDimensionRef before = mock(VSDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
+
+      CrosstabVSAssembly assembly = crosstabAssembly(before, new DataRef[] {after}, new DataRef[0]);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Crosstab1", comparison("2026-03-31", false), "");
+
+      assertEquals("Order Date", result.get("retargetedDimension"));
+      assertEquals("month", result.get("retargetedFromLevel"));
+      assertEquals("year", result.get("retargetedToLevel"));
+   }
+
+   /** The dimension can turn up in the column headers instead of the row headers. */
+   @Test
+   void findsTheRetargetedDimensionInTheColumnHeadersToo() throws Exception {
+      VSDimensionRef before = mock(VSDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
+
+      CrosstabVSAssembly assembly = crosstabAssembly(before, new DataRef[0], new DataRef[] {after});
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Crosstab1", comparison("2026-03-31", false), "");
+
+      assertEquals("Order Date", result.get("retargetedDimension"));
+   }
+
+   @Test
+   void returnsAnEmptyMapWhenTheLevelDidNotActuallyChange() throws Exception {
+      VSDimensionRef before = mock(VSDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      CrosstabVSAssembly assembly = crosstabAssembly(before, new DataRef[] {after}, new DataRef[0]);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Crosstab1", comparison("2026-03-31", false), "");
+
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void returnsAnEmptyMapWhenTheAssemblyIsNotACrosstab() throws Exception {
+      Harness h = harness(model(), null);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertTrue(result.isEmpty());
+   }
+
+   private static CrosstabVSAssembly crosstabAssembly(VSDimensionRef dateComparisonRef,
+                                                       DataRef[] rowHeaders, DataRef[] colHeaders)
+   {
+      VSCrosstabInfo crosstabInfo = mock(VSCrosstabInfo.class);
+      when(crosstabInfo.getDateComparisonRef()).thenReturn(dateComparisonRef);
+      when(crosstabInfo.getRuntimeRowHeaders()).thenReturn(rowHeaders);
+      when(crosstabInfo.getRuntimeColHeaders()).thenReturn(colHeaders);
+
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getVSCrosstabInfo()).thenReturn(crosstabInfo);
+      return assembly;
+   }
+
    @Test
    void clearDelegates() throws Exception {
       Harness h = harness(model());
@@ -361,9 +453,18 @@ class DateComparisonServiceTest {
                           DateComparisonDialogService comparisons) {}
 
    private static Harness harness(DateComparisonPaneModel model) {
+      return harness(model, null);
+   }
+
+   private static Harness harness(DateComparisonPaneModel model, VSAssembly assembly) {
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
       when(rvs.getID()).thenReturn("rt1");
+
+      if(assembly != null) {
+         when(vs.getAssembly(anyString())).thenReturn(assembly);
+      }
 
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
       DateComparisonDialogService comparisons = mock(DateComparisonDialogService.class);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -289,7 +289,8 @@ class DateComparisonServiceTest {
       when(after.getName()).thenReturn("Order Date");
       when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
 
-      CrosstabVSAssembly assembly = crosstabAssembly(before, new DataRef[] {after}, new DataRef[0]);
+      CrosstabVSAssembly assembly =
+         crosstabAssembly(before, true, new DataRef[] {after}, new DataRef[0]);
       Harness h = harness(model(), assembly);
 
       Map<String, Object> result =
@@ -311,7 +312,8 @@ class DateComparisonServiceTest {
       when(after.getName()).thenReturn("Order Date");
       when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
 
-      CrosstabVSAssembly assembly = crosstabAssembly(before, new DataRef[0], new DataRef[] {after});
+      CrosstabVSAssembly assembly =
+         crosstabAssembly(before, false, new DataRef[0], new DataRef[] {after});
       Harness h = harness(model(), assembly);
 
       Map<String, Object> result =
@@ -330,7 +332,8 @@ class DateComparisonServiceTest {
       when(after.getName()).thenReturn("Order Date");
       when(after.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
 
-      CrosstabVSAssembly assembly = crosstabAssembly(before, new DataRef[] {after}, new DataRef[0]);
+      CrosstabVSAssembly assembly =
+         crosstabAssembly(before, true, new DataRef[] {after}, new DataRef[0]);
       Harness h = harness(model(), assembly);
 
       Map<String, Object> result =
@@ -349,11 +352,49 @@ class DateComparisonServiceTest {
       assertTrue(result.isEmpty());
    }
 
+   /**
+    * Review round 1 finding: {@code describeRetargetedDimension} must resolve which shelf holds
+    * the retargeted dimension via {@code VSCrosstabInfo.isDateComparisonOnRow()} — set by the same
+    * {@code updateRuntimeHeaders()} call that produces {@code getDateComparisonRef()} — not by
+    * trying rows then falling back to columns. A same-named, untouched decoy dimension sitting on
+    * the shelf {@code isDateComparisonOnRow()} does NOT name must never be reported as the
+    * retarget result.
+    */
+   @Test
+   void ignoresASameNamedDecoyDimensionOnTheOtherShelf() throws Exception {
+      VSDimensionRef before = mock(VSDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
+
+      // Same name, different level again — if the code ever fell back to "row, then column" this
+      // decoy (sitting in rows) is what it would wrongly report instead of the real DC target
+      // (sitting in columns, per isDateComparisonOnRow() == false below).
+      VSDimensionRef decoy = mock(VSDimensionRef.class);
+      when(decoy.getName()).thenReturn("Order Date");
+      when(decoy.getDateLevel()).thenReturn(XConstants.WEEK_DATE_GROUP);
+
+      CrosstabVSAssembly assembly =
+         crosstabAssembly(before, false, new DataRef[] {decoy}, new DataRef[] {after});
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Crosstab1", comparison("2026-03-31", false), "");
+
+      assertEquals("year", result.get("retargetedToLevel"),
+                   "must report the actual DC-target shelf's level, not a same-named decoy's");
+   }
+
    private static CrosstabVSAssembly crosstabAssembly(VSDimensionRef dateComparisonRef,
+                                                       boolean dateComparisonOnRow,
                                                        DataRef[] rowHeaders, DataRef[] colHeaders)
    {
       VSCrosstabInfo crosstabInfo = mock(VSCrosstabInfo.class);
       when(crosstabInfo.getDateComparisonRef()).thenReturn(dateComparisonRef);
+      when(crosstabInfo.isDateComparisonOnRow()).thenReturn(dateComparisonOnRow);
       when(crosstabInfo.getRuntimeRowHeaders()).thenReturn(rowHeaders);
       when(crosstabInfo.getRuntimeColHeaders()).thenReturn(colHeaders);
 


### PR DESCRIPTION
## Summary
- Date comparison forces a bound date dimension's runtime grouping level up (or down) to match the comparison period (a deliberate rendering decision), but only ever mutated the runtime clone — the design binding was untouched and nothing told the caller it happened.
- `DateComparisonService.set()` now returns a `Map<String, Object>` reporting `retargetedDimension`/`retargetedFromLevel`/`retargetedToLevel` when a bound dimension's runtime level actually changed (empty map otherwise), via a new `describeRetargetedDimension()` helper that compares `VSCrosstabInfo.getDateComparisonRef()`'s pre-retarget snapshot against the refreshed runtime row/col headers, matched by `getName()`.
- `ViewsheetAssemblyAgentController.setDateComparison()` now returns `Map<String, Object>` and surfaces this, following the same pattern as sibling wiz-agent endpoints (`setSelection`, `setCalendarDisplay`, `setInputValue`, ...) that already return extra info this way.

## Test plan
- [x] `./mvnw -pl community/core -o test -Dtest=DateComparisonServiceTest` — 35 tests passed (31 existing + 4 new: reports a retargeted dimension in row headers, finds it in column headers too, returns empty when the level didn't actually change, returns empty for a non-crosstab assembly)
- [x] `./mvnw -pl community/core -o test-compile` — compiles clean

## Follow-up (flagged, not implemented here)
Adding a real `granularity` parameter to the date-comparison agent vocabulary (rather than only reporting the level StyleBI itself chose) is a larger design change, out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)