### PR TITLE
fix(wiz): restore selection/source endpoint dropped by a rebase conflict (PVA-016 regression)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -65,6 +65,7 @@ public class BindingAgentController {
                                  ChartAestheticAgentService aestheticService,
                                  TableBindingService tableService,
                                  CalcTableService calcService,
+                                 SelectionBindingService selectionService,
                                  SheetAgentBroadcastService broadcast)
    {
       this.feature = feature;
@@ -77,6 +78,7 @@ public class BindingAgentController {
       this.aestheticService = aestheticService;
       this.tableService = tableService;
       this.calcService = calcService;
+      this.selectionService = selectionService;
       this.broadcast = broadcast;
    }
 
@@ -408,6 +410,23 @@ public class BindingAgentController {
       requireBindableColumns(sessionToken, user, request.assembly(), request.fields());
       tableService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
                             request.fields());
+   }
+
+   public record SelectionSourceRequest(String assembly, String table, List<String> columns,
+                                        List<String> additionalTables, String measure,
+                                        Boolean force) {}
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/selection/source")
+   public Map<String, Object> setSelectionSource(
+      @PathVariable String sessionToken, @RequestBody SelectionSourceRequest request,
+      @RequestParam(required = false, defaultValue = "") String linkUri, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return selectionService.setSource(sessionToken, user, request.assembly(), request.table(),
+                                        request.columns(), request.additionalTables(),
+                                        request.measure(), Boolean.TRUE.equals(request.force()),
+                                        linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/source")
@@ -769,5 +788,6 @@ public class BindingAgentController {
    private final ChartAestheticAgentService aestheticService;
    private final TableBindingService tableService;
    private final CalcTableService calcService;
+   private final SelectionBindingService selectionService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -119,7 +119,8 @@ class BindingAgentControllerTest {
                                         mock(ChartBindingService.class),
                                         mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
-                                        mock(CalcTableService.class), mock(SelectionBindingService.class),
+                                        mock(CalcTableService.class),
+                                        mock(SelectionBindingService.class),
                                         mock(SheetAgentBroadcastService.class));
    }
 
@@ -134,7 +135,8 @@ class BindingAgentControllerTest {
                                         chartService,
                                         mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
-                                        mock(CalcTableService.class), mock(SelectionBindingService.class),
+                                        mock(CalcTableService.class),
+                                        mock(SelectionBindingService.class),
                                         mock(SheetAgentBroadcastService.class));
    }
 
@@ -271,8 +273,8 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
-         mock(TableBindingService.class), mock(CalcTableService.class), mock(SelectionBindingService.class),
-         mock(SheetAgentBroadcastService.class));
+         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.ShelfRequest request = new BindingAgentController.ShelfRequest(
          "Chart1", "x", List.of(new FieldRef("Region", "dimension", null, null, null)), "Sales");
@@ -299,8 +301,8 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
-         mock(TableBindingService.class), mock(CalcTableService.class), mock(SelectionBindingService.class),
-         mock(SheetAgentBroadcastService.class));
+         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.SingleShelfRequest request = new BindingAgentController.SingleShelfRequest(
          "Chart1", "close", new FieldRef("Price", "measure", "Sum", null, null), "Sales");
@@ -326,8 +328,8 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class), aestheticService,
-         mock(TableBindingService.class), mock(CalcTableService.class), mock(SelectionBindingService.class),
-         mock(SheetAgentBroadcastService.class));
+         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.AestheticFieldRequest request =
          new BindingAgentController.AestheticFieldRequest(
@@ -390,8 +392,8 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class),
-         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class), mock(SelectionBindingService.class),
-         mock(SheetAgentBroadcastService.class));
+         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.TableShelfRequest request =
          new BindingAgentController.TableShelfRequest(

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -119,7 +119,7 @@ class BindingAgentControllerTest {
                                         mock(ChartBindingService.class),
                                         mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
-                                        mock(CalcTableService.class),
+                                        mock(CalcTableService.class), mock(SelectionBindingService.class),
                                         mock(SheetAgentBroadcastService.class));
    }
 
@@ -134,7 +134,7 @@ class BindingAgentControllerTest {
                                         chartService,
                                         mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
-                                        mock(CalcTableService.class),
+                                        mock(CalcTableService.class), mock(SelectionBindingService.class),
                                         mock(SheetAgentBroadcastService.class));
    }
 
@@ -271,7 +271,7 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
-         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class), mock(SelectionBindingService.class),
          mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.ShelfRequest request = new BindingAgentController.ShelfRequest(
@@ -299,7 +299,7 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
-         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class), mock(SelectionBindingService.class),
          mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.SingleShelfRequest request = new BindingAgentController.SingleShelfRequest(
@@ -326,7 +326,7 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class), aestheticService,
-         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class), mock(SelectionBindingService.class),
          mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.AestheticFieldRequest request =
@@ -390,7 +390,7 @@ class BindingAgentControllerTest {
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class),
-         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
+         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class), mock(SelectionBindingService.class),
          mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.TableShelfRequest request =
@@ -421,7 +421,7 @@ class BindingAgentControllerTest {
          mock(ViewsheetSessionService.class), mock(BindableFieldsService.class),
          mock(BindingReadService.class), mock(ChartBindingService.class),
          mock(ChartAestheticAgentService.class), mock(TableBindingService.class),
-         mock(CalcTableService.class), broadcast);
+         mock(CalcTableService.class), mock(SelectionBindingService.class), broadcast);
 
       controller.detach("my-token", principal());
 
@@ -440,7 +440,7 @@ class BindingAgentControllerTest {
          mock(ViewsheetSessionService.class), mock(BindableFieldsService.class),
          mock(BindingReadService.class), mock(ChartBindingService.class),
          mock(ChartAestheticAgentService.class), mock(TableBindingService.class),
-         mock(CalcTableService.class), broadcast);
+         mock(CalcTableService.class), mock(SelectionBindingService.class), broadcast);
 
       controller.detach("someone-elses-token", principal());
 


### PR DESCRIPTION
## Summary
- #4927's rebase conflict resolution replaced the `SelectionBindingService` constructor param on `BindingAgentController` with the new `SheetAgentBroadcastService` one instead of adding it alongside — silently deleting the `POST .../selection/source` endpoint and `SelectionSourceRequest` record that #4917 added. `SelectionBindingService.java` itself was untouched and left orphaned (nothing called it).
- Confirmed live against a real locally-running server built from `stylebi-wiz-main-rebase`: the composer plugin's `set_selection_source` tool (already shipped, unaffected) got a 404 `NoResourceFoundException` — consistent with the route being entirely absent, not misconfigured.
- Restores the field/constructor param/endpoint method alongside `broadcast` (not instead of it), and updates the 8 `BindingAgentControllerTest` call sites that construct the controller directly.

## Test plan
- [x] `BindingAgentControllerTest` — 14/14 pass
- [x] `SelectionBindingServiceTest` — 12/12 pass (unaffected, confirms the service itself was always fine)
- [ ] Live re-verification of `set_selection_source` against a server rebuilt from this branch (blocked in this pass — the shared local dev server needs an operator to rebuild + restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)