### PR TITLE
Harden IntervalPaneModel default and fix CrosstabDcProcessor typo (date comparison)

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/CrosstabDcProcessor.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/CrosstabDcProcessor.java
@@ -168,8 +168,9 @@ public class CrosstabDcProcessor {
       if(periodDim == null && dcInfo.getPeriods() instanceof StandardPeriods &&
          (!dcInfo.isCompareAll() || !dcInfo.periodLevelSameAsGranularityLevel()))
       {
-         XDimensionRef peroidDim = (XDimensionRef) dateDim.clone();
-         peroidDim.setDateLevel(dcInfo.getPeriodDateLevel());
+         periodDim = (XDimensionRef) dateDim.clone();
+         periodDim.setDateLevel(dcInfo.getPeriodDateLevel());
+         ((VSDimensionRef) periodDim).setDcRange(!dcInfo.isCompareAll());
       }
 
       return periodDim;

--- a/core/src/main/java/inetsoft/web/composer/model/vs/IntervalPaneModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/IntervalPaneModel.java
@@ -114,12 +114,12 @@ public class IntervalPaneModel implements Serializable {
 
    private boolean endDayAsToDate = true;
    private boolean inclusive = true;
-   private DynamicValueModel level = new DynamicValueModel(DateComparisonInfo.YEAR,
+   private DynamicValueModel level = new DynamicValueModel(DateComparisonInfo.ALL,
       DynamicValueModel.VALUE);
    private DynamicValueModel granularity = new DynamicValueModel(DateComparisonInfo.YEAR,
                                                                  DynamicValueModel.VALUE);
    private DynamicValueModel intervalEndDate = new DynamicValueModel(null, DynamicValueModel.VALUE);
-   private DynamicValueModel contextLevel = new DynamicValueModel(DateComparisonInfo.YEAR,
+   private DynamicValueModel contextLevel = new DynamicValueModel(DateComparisonInfo.ALL,
       DynamicValueModel.VALUE);
 
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/CrosstabDcProcessorTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/CrosstabDcProcessorTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import inetsoft.test.*;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
+import inetsoft.uql.viewsheet.internal.DateComparisonInterval;
+import inetsoft.uql.viewsheet.internal.StandardPeriods;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Method;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CrosstabDcProcessorTest {
+   /**
+    * updatePeriodDim()'s guard is only reachable when the outer updateRuntimeHeaders() guard
+    * did NOT already build a periodDim -- i.e. periods are StandardPeriods and the period
+    * level matches the interval's granularity level -- while the interval itself is not
+    * "compare all" (a real, non-ALL level). Before the fix, a typo'd local ("peroidDim") meant
+    * the computed clone was thrown away and null was always returned here.
+    */
+   @Test
+   void buildsPeriodDimWhenIntervalIsNotCompareAllButLevelMatchesGranularity() throws Exception {
+      StandardPeriods periods = new StandardPeriods();
+      periods.setPreCountValue("1");
+      periods.setDateLevelValue(String.valueOf(XConstants.YEAR_DATE_GROUP));
+
+      DateComparisonInterval interval = new DateComparisonInterval();
+      interval.setGranularityValue(String.valueOf(DateComparisonInfo.YEAR));
+      interval.setLevelValue(String.valueOf(DateComparisonInfo.YEAR_TO_DATE));
+
+      DateComparisonInfo dcInfo = new DateComparisonInfo();
+      dcInfo.setDateComparisonPeriods(periods);
+      dcInfo.setDateComparisonInterval(interval);
+
+      Assertions.assertFalse(dcInfo.isCompareAll());
+      Assertions.assertTrue(dcInfo.periodLevelSameAsGranularityLevel());
+
+      CrosstabDcProcessor processor =
+         new CrosstabDcProcessor(null, dcInfo, null, null, null);
+
+      VSDimensionRef dateDim = new VSDimensionRef();
+      dateDim.setDataRef(new inetsoft.uql.erm.AttributeRef(null, "Order Date"));
+      dateDim.setDateLevelValue(String.valueOf(XConstants.MONTH_DATE_GROUP));
+
+      Method updatePeriodDim =
+         CrosstabDcProcessor.class.getDeclaredMethod(
+            "updatePeriodDim", XDimensionRef.class, DataRef.class);
+      updatePeriodDim.setAccessible(true);
+
+      XDimensionRef result =
+         (XDimensionRef) updatePeriodDim.invoke(processor, (XDimensionRef) null, dateDim);
+
+      Assertions.assertNotNull(result);
+      Assertions.assertEquals(dcInfo.getPeriodDateLevel(), result.getDateLevel());
+      Assertions.assertTrue(((VSDimensionRef) result).isDcRange());
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/model/vs/IntervalPaneModelTest.java
+++ b/core/src/test/java/inetsoft/web/composer/model/vs/IntervalPaneModelTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.model.vs;
+
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class IntervalPaneModelTest {
+   /**
+    * A fresh IntervalPaneModel's "level" default (DateComparisonInfo.YEAR = 16) is not a
+    * member of the level domain (only ALL/YEAR_TO_DATE/.../SAME_MONTH etc. are valid), so it
+    * was always silently coerced to ALL by DynamicValue.findValue()'s restriction-list
+    * fallback. Pin that outcome explicitly so the default can't drift to another
+    * invalid-for-level value without this test catching it.
+    */
+   @Test
+   void defaultLevelResolvesToAll() {
+      IntervalPaneModel model = new IntervalPaneModel();
+
+      Assertions.assertEquals(
+         DateComparisonInfo.ALL, model.toDateComparisonInterval().getLevel());
+   }
+}


### PR DESCRIPTION
## Summary

This is **not** a fix for the originally-suspected symptom on this branch (a same-level year-over-year crosstab date comparison never rendering two periods). That symptom was investigated across two debugger passes and closed as **not a code defect** — the crosstab's guards that these two bugs live in are never reached by the original repro, and the repro's "always one row" outcome is fully, statically explained by the test dataset (`orders.sql`) having no `ORDER_DATE` rows in the current year. See `docs/teams/2026-09-01-bugs-composer-b5c6-followon/item3/01-diagnosis.md` and `02-refute.md` in the `stylebi-wiz` repo for the full trail.

This PR is general hardening for two smaller, independently-demonstrated defects found along the way:

- **`IntervalPaneModel`'s `level`/`contextLevel` defaults were invalid for their own domain.** They defaulted to `DateComparisonInfo.YEAR` (16), which is a valid *granularity* bit-flag but not a member of the *level* domain (`ALL`, `YEAR_TO_DATE`, `QUARTER_TO_DATE`, ...). `DynamicValue.findValue()` silently falls back to `restriction[0]` (`ALL`) whenever a value doesn't match its domain, so every read of the untouched default was already silently landing on `ALL`, with no error or log. This change makes that default explicit (`DateComparisonInfo.ALL`) instead of accidental. `granularity`'s default (16/`YEAR`) is untouched — it's a legitimate member of its own domain. Confirmed via the Angular UI (`date-comparison-interval-pane.component.ts`) that it has its own independent fallback-to-first-item behavior landing on the same `ALL` value, so this change is a no-op for UI behavior.

- **`CrosstabDcProcessor.updatePeriodDim()` discarded its computed result due to a typo.** It cloned `dateDim` into a misspelled local (`peroidDim`), configured it, and then returned the original, still-null `periodDim` parameter — the clone was always thrown away. Fixed by assigning back to `periodDim`. Also added `periodDim.setDcRange(!dcInfo.isCompareAll())` for parity with the sibling branch (`CrosstabDcProcessor.java` ~line 125) that already does this after cloning a period dimension — `ValueOfColumn.getDCRangePeriodDim()` locates the period dimension in the returned `comparisonDateDims` list by filtering on `isDcRange()`, so without this the fixed period dimension would silently be invisible to that lookup. In the only reachable branch of `updatePeriodDim()`'s guard, `isCompareAll()` is provably always `false`, so this addition is unconditionally `setDcRange(true)` there.

Note: fixing this typo does **not** change the originally-reported symptom — a same-level YoY crosstab comparison never reaches this guard at all (confirmed by two independent tests during diagnosis).

## Test plan

- [x] Added `IntervalPaneModelTest.defaultLevelResolvesToAll` pinning `new IntervalPaneModel().toDateComparisonInterval().getLevel() == DateComparisonInfo.ALL` explicitly (a future edit to either class can no longer silently reintroduce an invalid cross-domain default without breaking this test — note the assertion holds both before and after this change, since the point of the fix is to make an already-happening silent coercion explicit, not to change its outcome).
- [x] Added `CrosstabDcProcessorTest.buildsPeriodDimWhenIntervalIsNotCompareAllButLevelMatchesGranularity`, exercising the one reachable case of `updatePeriodDim()`'s guard (`StandardPeriods` with the period level matching the interval's granularity, but the interval is not "compare all"). Verified this test fails without the fix (`AssertionFailedError: expected not <null>`) and passes with it.
- [x] `./mvnw -pl community/core -o test -Dtest=IntervalPaneModelTest,CrosstabDcProcessorTest,DateComparisonIntervalConditionTest,*DateComparison*` — 36 tests, 0 failures (includes `DateComparisonServiceTest`'s 31 tests, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)