### PR TITLE
fix(wiz): align the agent hyperlink service with the dialog's model

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -22,6 +22,7 @@ import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
 import inetsoft.web.composer.model.vs.InputParameterDialogModel;
@@ -484,7 +485,17 @@ public class AssemblyHyperlinkService {
          param.setName(name);
          param.setValueSource(source);
          param.setValue(value);
-         param.setType("constant".equals(source) ? str(paramMap, "type") : null);
+
+         // A constant entry always needs a type -- Hyperlink.getParameterType(name) returning
+         // null is how HyperlinkDialogService.getHyperlinkDialogModel's read path infers
+         // valueSource "field" (type == null ? "field" : "constant"). Leaving type null here for
+         // an agent that (naturally) omitted it would round-trip a constant param back as a
+         // "field" one on the very next read, and this class's own field-name validation above
+         // would then refuse it on resubmission -- rejecting a param that worked. XSchema.STRING
+         // matches what the real dialog itself defaults to (InputParameterDialog: every
+         // newly-created or "constant"-switched-to param starts as XSchema.STRING).
+         String type = str(paramMap, "type");
+         param.setType("constant".equals(source) ? (type == null ? XSchema.STRING : type) : null);
          params.add(param);
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -22,13 +22,16 @@ import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
+import inetsoft.web.composer.model.vs.InputParameterDialogModel;
 import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * An assembly's hyperlink.
@@ -349,6 +352,7 @@ public class AssemblyHyperlinkService {
          model.setBookmark(null);
          model.setTargetFrame(null);
          model.setTooltip(null);
+         model.setParamList(null);
          return;
       }
 
@@ -393,6 +397,98 @@ public class AssemblyHyperlinkService {
       if(link.get("disableParameterPrompt") instanceof Boolean disable) {
          model.setDisableParameterPrompt(disable);
       }
+
+      if(link.containsKey("paramList")) {
+         model.setParamList(parseParamList(link.get("paramList"), model));
+      }
+
+      // HyperlinkDialog.submit() (the Angular dialog) treats "self" as pure UI sugar: checking
+      // it rewrites targetFrame to "SELF" right before the model is sent, and
+      // HyperlinkDialogService.setHyperlinkDialogModel only ever reads targetFrame -- it never
+      // reads getSelf(). Without this, a caller sending self:true (and nothing else) gets ok:true
+      // and a link that does nothing when clicked, since the boolean this method stores above is
+      // discarded at persist time. Applying the same rewrite here, unconditionally and after every
+      // other field, is what makes self:true behave the way the checkbox does -- including
+      // overriding an explicit targetFrame in the same call, exactly like the checkbox overrides
+      // the dialog's own free-text field.
+      if(Boolean.TRUE.equals(link.get("self"))) {
+         model.setTargetFrame("SELF");
+      }
+   }
+
+   /**
+    * Maps the agent's {@code paramList} entries -- {@code {name, value, valueSource, type}} --
+    * onto {@link InputParameterDialogModel}, the same shape {@code HyperlinkDialogService} reads
+    * when building the persisted {@link Hyperlink}'s custom parameters.
+    *
+    * <p>Only two {@code valueSource} values exist on the real dialog
+    * ({@code InputParameterDialog.changeValueSource}): {@code constant} (a literal value, typed
+    * by {@code type}) and {@code field} (an existing bindable field's name, matching one of
+    * {@code model.getFields()} by {@link DataRefModel#getName()} -- the same identifier
+    * {@code InputParameterDialog.ok()} matches against). A {@code field} entry naming a column
+    * this assembly cannot actually bind is refused here rather than accepted and silently
+    * producing a parameter with no data behind it.
+    */
+   private static List<InputParameterDialogModel> parseParamList(Object raw,
+                                                                  HyperlinkDialogModel model)
+   {
+      if(!(raw instanceof List<?> rawList)) {
+         throw new IllegalArgumentException(
+            "'paramList' must be an array of {name, value, valueSource, type} objects, got '" +
+            raw + "'.");
+      }
+
+      Set<String> fieldNames = model.getFields().stream()
+         .map(DataRefModel::getName)
+         .collect(Collectors.toSet());
+      List<InputParameterDialogModel> params = new ArrayList<>();
+
+      for(Object entry : rawList) {
+         if(!(entry instanceof Map<?, ?> rawEntry)) {
+            throw new IllegalArgumentException(
+               "Each 'paramList' entry must be an object with 'name' and 'value', got '" + entry +
+               "'.");
+         }
+
+         @SuppressWarnings("unchecked")
+         Map<String, Object> paramMap = (Map<String, Object>) rawEntry;
+         String name = str(paramMap, "name");
+
+         if(name == null) {
+            throw new IllegalArgumentException("Each 'paramList' entry needs a 'name'.");
+         }
+
+         String source = str(paramMap, "valueSource");
+         source = source == null ? "constant" : source.trim().toLowerCase();
+
+         if(!"constant".equals(source) && !"field".equals(source)) {
+            throw new IllegalArgumentException(
+               "paramList entry '" + name + "': 'valueSource' must be 'constant' or 'field', " +
+               "got '" + source + "'.");
+         }
+
+         String value = str(paramMap, "value");
+
+         if(value == null) {
+            throw new IllegalArgumentException("paramList entry '" + name + "' needs a 'value'.");
+         }
+
+         if("field".equals(source) && !fieldNames.contains(value)) {
+            throw new IllegalArgumentException(
+               "paramList entry '" + name + "': 'value' must name a field this assembly can " +
+               "bind (see list_bindable_fields), got '" + value + "'. Known fields: " +
+               new TreeSet<>(fieldNames));
+         }
+
+         InputParameterDialogModel param = new InputParameterDialogModel();
+         param.setName(name);
+         param.setValueSource(source);
+         param.setValue(value);
+         param.setType("constant".equals(source) ? str(paramMap, "type") : null);
+         params.add(param);
+      }
+
+      return params;
    }
 
    private static Map<String, Object> describe(String assemblyName, HyperlinkDialogModel model,
@@ -409,12 +505,19 @@ public class AssemblyHyperlinkService {
       out.put("linkType", tokenOf(model.getLinkType()));
       out.put("webLink", model.getWebLink());
       out.put("assetLinkPath", model.getAssetLinkPath());
+      // The model carries this correctly (HyperlinkDialogService.getHyperlinkDialogModel sets it
+      // on every read), but it was never copied into this response -- a caller could set an
+      // explicit assetLinkId and then never see it come back, unable to confirm which of two
+      // same-named assets across scopes a link actually resolved to.
+      out.put("assetLinkId", model.getAssetLinkId());
       out.put("bookmark", model.getBookmark());
       out.put("targetFrame", model.getTargetFrame());
       out.put("tooltip", model.getTooltip());
       out.put("self", model.isSelf());
+      out.put("disableParameterPrompt", model.isDisableParameterPrompt());
       out.put("sendViewsheetParameters", model.isSendViewsheetParameters());
       out.put("sendSelectionsAsParameters", model.isSendSelectionsAsParameters());
+      out.put("paramList", describeParamList(model.getParamList()));
       out.put("row", model.getRow());
       out.put("col", model.getCol());
       // The dialog service does not echo colName back into the model, so reporting only the model's
@@ -423,6 +526,23 @@ public class AssemblyHyperlinkService {
       // it is the name this read was scoped to, whether or not the model repeats it.
       out.put("colName", model.getColName() != null ? model.getColName()
                  : asked == null ? null : asked.colName());
+      return out;
+   }
+
+   private static List<Map<String, Object>> describeParamList(
+      List<InputParameterDialogModel> paramList)
+   {
+      List<Map<String, Object>> out = new ArrayList<>();
+
+      for(InputParameterDialogModel param : paramList) {
+         Map<String, Object> entry = new LinkedHashMap<>();
+         entry.put("name", param.getName());
+         entry.put("valueSource", param.getValueSource());
+         entry.put("value", param.getValue());
+         entry.put("type", param.getType());
+         out.add(entry);
+      }
+
       return out;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -318,6 +318,31 @@ class AssemblyHyperlinkServiceTest {
       assertEquals("constant", capture(h.links).getParamList().get(0).getValueSource());
    }
 
+   /**
+    * A constant entry with no explicit type must still round-trip as constant.
+    * {@code Hyperlink.getParameterType} returns whatever was stored -- including {@code null} --
+    * and {@code HyperlinkDialogService.getHyperlinkDialogModel}'s read path infers
+    * {@code valueSource} purely from whether that comes back null ({@code "field"}) or not
+    * ({@code "constant"}). Leaving {@code type} null for an omitted-type constant entry would
+    * make it read back as {@code "field"}, and this class's own field-name validation would then
+    * refuse it on the very next {@code set_hyperlink} resubmission of that read-back state.
+    */
+   @Test
+   void paramListEntryWithNoExplicitTypeDefaultsToStringSoItRoundTripsAsConstant()
+      throws Exception
+   {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com",
+                         "paramList", List.of(Map.of("name", "region", "value", "West"))),
+                    "");
+
+      InputParameterDialogModel param = capture(h.links).getParamList().get(0);
+      assertEquals("string", param.getType(),
+                  "a null type is indistinguishable from a never-set one on read");
+   }
+
    @Test
    void paramListWithAFieldValueMustNameARealBindableField() throws Exception {
       HyperlinkDialogModel model = new HyperlinkDialogModel();

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -24,13 +24,16 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
+import inetsoft.web.composer.model.vs.InputParameterDialogModel;
 import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -223,6 +226,184 @@ class AssemblyHyperlinkServiceTest {
       verify(h.links).getHyperlinkDialogModel(anyString(), anyString(), eq(0), eq(0),
                                               isNull(), eq(false), eq(false), eq(true),
                                               eq(false), any(Principal.class));
+   }
+
+   // ── alignment with the real hyperlink-dialog UI ─────────────────────────────
+
+   /**
+    * The dialog's "self" checkbox is UI sugar -- {@code HyperlinkDialog.submit()} rewrites
+    * {@code targetFrame} to {@code "SELF"} right before sending, and
+    * {@code HyperlinkDialogService.setHyperlinkDialogModel} only ever reads {@code targetFrame}.
+    * Without the same rewrite here, {@code self:true} alone would be accepted and change nothing.
+    */
+   @Test
+   void selfNormalizesToTargetFrameSelf() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com", "self", true), "");
+
+      assertEquals("SELF", capture(h.links).getTargetFrame());
+   }
+
+   /**
+    * Mirrors the dialog exactly: checking "self" overrides whatever the free-text target-frame
+    * field held, rather than losing to it. An agent sending both in one call gets the same result
+    * a human checking the box after typing a custom frame would.
+    */
+   @Test
+   void selfOverridesAnExplicitTargetFrameInTheSameCall() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com",
+                         "targetFrame", "_blank", "self", true), "");
+
+      assertEquals("SELF", capture(h.links).getTargetFrame());
+   }
+
+   @Test
+   void disableParameterPromptIsApplied() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "viewsheet", "assetLinkPath", "Reports/Detail",
+                         "disableParameterPrompt", true), "");
+
+      assertTrue(capture(h.links).isDisableParameterPrompt());
+   }
+
+   @Test
+   void readBackIncludesAssetLinkIdAndDisableParameterPrompt() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(Hyperlink.VIEWSHEET_LINK);
+      model.setAssetLinkId("1^128^__NULL__^Reports/Detail");
+      model.setDisableParameterPrompt(true);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      assertEquals("1^128^__NULL__^Reports/Detail", read.get("assetLinkId"));
+      assertEquals(true, read.get("disableParameterPrompt"));
+   }
+
+   @Test
+   void paramListWithAConstantValueIsApplied() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com",
+                         "paramList", List.of(Map.of(
+                            "name", "region", "value", "West",
+                            "valueSource", "constant", "type", "string"))),
+                    "");
+
+      List<InputParameterDialogModel> params = capture(h.links).getParamList();
+      assertEquals(1, params.size());
+      assertEquals("region", params.get(0).getName());
+      assertEquals("West", params.get(0).getValue());
+      assertEquals("constant", params.get(0).getValueSource());
+      assertEquals("string", params.get(0).getType());
+   }
+
+   /** Omitting 'valueSource' means constant -- the common case shouldn't need it spelled out. */
+   @Test
+   void paramListEntryDefaultsToConstantValueSource() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com",
+                         "paramList", List.of(Map.of("name", "region", "value", "West"))),
+                    "");
+
+      assertEquals("constant", capture(h.links).getParamList().get(0).getValueSource());
+   }
+
+   @Test
+   void paramListWithAFieldValueMustNameARealBindableField() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      DataRefModel state = mock(DataRefModel.class);
+      when(state.getName()).thenReturn("STATE");
+      model.setFields(List.of(state));
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com",
+                         "paramList", List.of(Map.of(
+                            "name", "region", "value", "STATE", "valueSource", "field"))),
+                    "");
+
+      assertEquals("STATE", capture(h.links).getParamList().get(0).getValue());
+   }
+
+   @Test
+   void paramListRefusesAFieldValueThatIsNotABindableField() {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      DataRefModel state = mock(DataRefModel.class);
+      when(state.getName()).thenReturn("STATE");
+      model.setFields(List.of(state));
+      Harness h = harness(model);
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.set(
+         "tok", principal(), "Chart1", null,
+         link("linkType", "web", "webLink", "https://example.com",
+              "paramList", List.of(Map.of(
+                 "name", "region", "value", "NOT_A_FIELD", "valueSource", "field"))),
+         ""));
+
+      assertTrue(thrown.getMessage().contains("NOT_A_FIELD"));
+   }
+
+   @Test
+   void paramListEntryNeedsAName() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      assertThrows(Exception.class, () -> h.service.set(
+         "tok", principal(), "Chart1", null,
+         link("linkType", "web", "webLink", "https://example.com",
+              "paramList", List.of(Map.of("value", "West"))),
+         ""));
+   }
+
+   @Test
+   void paramListRefusesAnUnknownValueSource() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      assertThrows(Exception.class, () -> h.service.set(
+         "tok", principal(), "Chart1", null,
+         link("linkType", "web", "webLink", "https://example.com",
+              "paramList", List.of(Map.of(
+                 "name", "region", "value", "West", "valueSource", "expression"))),
+         ""));
+   }
+
+   @Test
+   void clearingALinkAlsoClearsTheParamList() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setParamList(new ArrayList<>(List.of(new InputParameterDialogModel())));
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", null, link("linkType", "none"), "");
+
+      assertTrue(capture(h.links).getParamList().isEmpty());
+   }
+
+   @Test
+   void readBackIncludesTheParamList() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      InputParameterDialogModel param = new InputParameterDialogModel();
+      param.setName("region");
+      param.setValueSource("constant");
+      param.setValue("West");
+      param.setType("string");
+      model.setParamList(List.of(param));
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> paramList = (List<Map<String, Object>>) read.get("paramList");
+      assertEquals(1, paramList.size());
+      assertEquals("region", paramList.get(0).get("name"));
+      assertEquals("West", paramList.get(0).get("value"));
    }
 
    // ── the read direction ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `AssemblyHyperlinkService` (the wiz-agent's thin wrapper around `HyperlinkDialogService`) had three gaps relative to the real hyperlink-dialog UI it's meant to expose:
  - `link.self` was read into the model but had no effect — the Angular dialog's "open in current window" checkbox is UI sugar that rewrites `targetFrame` to `"SELF"` before submit, and `HyperlinkDialogService.setHyperlinkDialogModel` only ever reads `targetFrame`, never `getSelf()`. `apply()` now applies the same rewrite, unconditionally and after every other field, so it overrides an explicit `targetFrame` in the same call exactly like the checkbox does.
  - `paramList` (the dialog's custom constant/field parameters, beyond the `sendViewsheetParameters`/`sendSelectionsAsParameters` bulk toggles) had no wiring at all on this path. `apply()` now maps it onto `InputParameterDialogModel`, validating a field-sourced value against the assembly's own bindable fields; `describe()` reads it back.
  - `describe()` never copied `assetLinkId` or `disableParameterPrompt` into its response even though the model carried both correctly — the same "write works, read never surfaces it" pattern already on record in the wiz plugin's own known-pitfalls notes.
- Follow-up commit fixes a round-trip bug found in review: a `constant`-valued `paramList` entry with no explicit `type` would read back as `valueSource:"field"` (since `Hyperlink.getParameterType` returns the stored `null` verbatim, and the read path infers `valueSource` from whether that's null) — a read-then-resubmit agent would then have its own working param rejected by the new field-name validation. Fixed by defaulting a type-less constant entry to `XSchema.STRING`, matching what the real Angular dialog itself defaults to.
- Companion PR in `stylebi-wiz`: inetsoft-technology/stylebi-wiz#2105 — exposes all of this through the `set_hyperlink`/`get_hyperlink` MCP tool.

## Test plan
- [x] `AssemblyHyperlinkServiceTest`: 49/49 passing, 13 new tests covering `self` normalization (including overriding an explicit `targetFrame`), `paramList` validation/clearing/round-trip, and the `describe()` read-back fix
- [x] `mvn -pl core compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)