### PR TITLE
feat(wiz): add CalcFieldAgentService for viewsheet-scoped calc field CRUD (PCB-006)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -66,6 +66,7 @@ public class BindingAgentController {
                                  TableBindingService tableService,
                                  CalcTableService calcService,
                                  SelectionBindingService selectionService,
+                                 CalcFieldAgentService calcFieldService,
                                  SheetAgentBroadcastService broadcast)
    {
       this.feature = feature;
@@ -79,6 +80,7 @@ public class BindingAgentController {
       this.tableService = tableService;
       this.calcService = calcService;
       this.selectionService = selectionService;
+      this.calcFieldService = calcFieldService;
       this.broadcast = broadcast;
    }
 
@@ -427,6 +429,17 @@ public class BindingAgentController {
                                         request.columns(), request.additionalTables(),
                                         request.measure(), Boolean.TRUE.equals(request.force()),
                                         linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc-field")
+   public void modifyCalcField(@PathVariable String sessionToken,
+                               @RequestBody CalcFieldAgentService.CalcFieldRequest request,
+                               @RequestParam(required = false, defaultValue = "") String linkUri,
+                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      calcFieldService.modify(sessionToken, user, request, linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/source")
@@ -789,5 +802,6 @@ public class BindingAgentController {
    private final TableBindingService tableService;
    private final CalcTableService calcService;
    private final SelectionBindingService selectionService;
+   private final CalcFieldAgentService calcFieldService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
@@ -17,6 +17,10 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.web.binding.controller.ModifyCalculateFieldServiceProxy;
 import inetsoft.web.binding.drm.CalculateRefModel;
@@ -50,11 +54,13 @@ public class CalcFieldAgentService {
    @Autowired
    public CalcFieldAgentService(ViewsheetSessionService sessions,
                                 BindableFieldsService fieldsService,
-                                ModifyCalculateFieldServiceProxy modifyCalculateFieldService)
+                                ModifyCalculateFieldServiceProxy modifyCalculateFieldService,
+                                SecurityEngine securityEngine)
    {
       this.sessions = sessions;
       this.fieldsService = fieldsService;
       this.modifyCalculateFieldService = modifyCalculateFieldService;
+      this.securityEngine = securityEngine;
    }
 
    /**
@@ -89,6 +95,16 @@ public class CalcFieldAgentService {
    public void modify(String sessionToken, Principal agent, CalcFieldRequest req, String linkUri)
       throws Exception
    {
+      // ModifyCalculateFieldService.modifyCalculateField itself performs no permission check --
+      // the native Formula Editor dialog's own controller (ModifyCalculateFieldController) is the
+      // sole enforcement point, gating on this exact resource/action. Calling the service directly,
+      // as this class does, bypasses that gate unless it is re-applied here.
+      if(!securityEngine.checkPermission(
+         agent, ResourceType.VIEWSHEET_CALCULATED_FIELD, "*", ResourceAction.ACCESS))
+      {
+         throw new SecurityException("You do not have permission to modify calculated fields.");
+      }
+
       if(req.table() == null || req.table().isBlank()) {
          throw new IllegalArgumentException(
             "A calc field requires 'table' -- the source table it belongs to, as reported by " +
@@ -200,4 +216,5 @@ public class CalcFieldAgentService {
    private final ViewsheetSessionService sessions;
    private final BindableFieldsService fieldsService;
    private final ModifyCalculateFieldServiceProxy modifyCalculateFieldService;
+   private final SecurityEngine securityEngine;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.web.binding.controller.ModifyCalculateFieldServiceProxy;
 import inetsoft.web.binding.drm.CalculateRefModel;
 import inetsoft.web.binding.event.ImmutableModifyCalculateFieldEvent;
@@ -67,12 +68,16 @@ public class CalcFieldAgentService {
     * @param newName     a new name, when renaming an existing calc field; {@code null} to keep
     *                    {@code name}. Ignored when {@code remove} is {@code true}.
     * @param expression  the formula text. Required unless {@code remove} is {@code true}.
-    * @param dataType    the calc field's data type (e.g. {@code "double"}, {@code "string"}), or
-    *                    {@code null} to leave it to the engine to infer.
-    * @param sql         {@code true} for a native-SQL expression, {@code false}/{@code null} for
-    *                    a JavaScript one.
-    * @param baseOnDetail {@code true} (the default when {@code null}) for a per-row (detail)
-    *                    calculation; {@code false} for one computed from an aggregate result.
+    * @param dataType    the calc field's data type (e.g. {@code "double"}, {@code "string"}). On
+    *                    create, {@code null} leaves it to the engine to infer; on edit, {@code
+    *                    null} keeps the existing calc field's current data type.
+    * @param sql         {@code true} for a native-SQL expression, {@code false} for a JavaScript
+    *                    one. On create, {@code null} defaults to {@code false}; on edit, {@code
+    *                    null} keeps the existing calc field's current setting.
+    * @param baseOnDetail {@code true} for a per-row (detail) calculation, {@code false} for one
+    *                    computed from an aggregate result. On create, {@code null} defaults to
+    *                    {@code true}; on edit, {@code null} keeps the existing calc field's
+    *                    current setting.
     * @param remove      {@code true} to remove the named calc field. Fields other than
     *                    {@code table}/{@code name} are ignored.
     * @param create      {@code true} to create a new calc field rather than edit an existing one.
@@ -104,30 +109,42 @@ public class CalcFieldAgentService {
       String newName = req.newName() != null && !req.newName().isBlank()
          ? req.newName() : req.name();
 
-      CalculateRefModel model = null;
-
-      if(!req.remove()) {
-         ExpressionRefModel exprModel = new ExpressionRefModel();
-         exprModel.setName(newName);
-         exprModel.setExp(req.expression());
-         exprModel.setDType(req.dataType());
-
-         model = new CalculateRefModel();
-         model.setDataRefModel(exprModel);
-         model.setBaseOnDetail(req.baseOnDetail() == null || req.baseOnDetail());
-         model.setSql(Boolean.TRUE.equals(req.sql()));
-         model.setDataType(req.dataType());
-      }
-
-      CalculateRefModel finalModel = model;
-
       sessions.mutate(sessionToken, agent, (rvs, runtimeId, dispatcher) -> {
          String tableName = requireBindableTable(runtimeId, req.table(), agent);
+
+         CalculateRefModel model = null;
+
+         if(!req.remove()) {
+            // On edit, an omitted sql/baseOnDetail/dataType means "leave it as it already is",
+            // not "reset to the create-time default" -- so a plain rename or expression-only
+            // tweak doesn't silently flip an existing field's SQL/detail mode.
+            boolean editing = !req.create();
+            CalculateRef existing = editing
+               ? rvs.getViewsheet().getCalcField(tableName, req.name()) : null;
+
+            String dataType = req.dataType() != null ? req.dataType()
+               : existing != null ? existing.getDataType() : null;
+            boolean baseOnDetail = req.baseOnDetail() != null ? req.baseOnDetail()
+               : existing != null ? existing.isBaseOnDetail() : true;
+            boolean sql = req.sql() != null ? req.sql()
+               : existing != null && existing.isSQL();
+
+            ExpressionRefModel exprModel = new ExpressionRefModel();
+            exprModel.setName(newName);
+            exprModel.setExp(req.expression());
+            exprModel.setDType(dataType);
+
+            model = new CalculateRefModel();
+            model.setDataRefModel(exprModel);
+            model.setBaseOnDetail(baseOnDetail);
+            model.setSql(sql);
+            model.setDataType(dataType);
+         }
 
          ImmutableModifyCalculateFieldEvent event = ImmutableModifyCalculateFieldEvent.builder()
             .name(req.assembly())
             .confirmed(true)
-            .calculateRef(finalModel)
+            .calculateRef(model)
             .tableName(tableName)
             .remove(req.remove())
             .create(req.create())

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
@@ -1,0 +1,186 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.controller.ModifyCalculateFieldServiceProxy;
+import inetsoft.web.binding.drm.CalculateRefModel;
+import inetsoft.web.binding.event.ImmutableModifyCalculateFieldEvent;
+import inetsoft.web.binding.model.ExpressionRefModel;
+import inetsoft.web.wiz.binding.model.BindableTable;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Create/edit/remove a VIEWSHEET-scoped calculated field ("calc field") -- the field the native
+ * Composer's Formula Editor dialog creates, stored in {@code Viewsheet.calcmap} and visible only
+ * to charts/crosstabs/calc-tables bound to the same source table in THIS viewsheet. Distinct
+ * from a worksheet expression column, which is shared by every viewsheet built on that worksheet
+ * -- this is the mechanism to reach for when a data need must NOT be visible to other dashboards
+ * sharing the same worksheet (see {@code list_worksheet_dependents} for checking that claim
+ * before assuming it).
+ *
+ * <p>Delegates the actual write to {@link ModifyCalculateFieldServiceProxy#modifyCalculateField},
+ * the same service the Formula Editor dialog's OK button drives -- this class only builds the
+ * event and validates the table name up front, rather than re-implementing the wizard/cube/
+ * aggregate-info side effects that method already handles.
+ */
+@Service
+public class CalcFieldAgentService {
+   @Autowired
+   public CalcFieldAgentService(ViewsheetSessionService sessions,
+                                BindableFieldsService fieldsService,
+                                ModifyCalculateFieldServiceProxy modifyCalculateFieldService)
+   {
+      this.sessions = sessions;
+      this.fieldsService = fieldsService;
+      this.modifyCalculateFieldService = modifyCalculateFieldService;
+   }
+
+   /**
+    * @param table       the source table the calc field belongs to (required)
+    * @param assembly    the chart/crosstab/calc-table this edit is being made from, or
+    *                    {@code null} for one not tied to a specific assembly yet -- only affects
+    *                    that assembly's own aggregate-info refresh, not where the field is stored
+    * @param name        the calc field's current name (required) -- the name to create it under
+    *                    when {@code create} is {@code true}, or the name to find when editing/
+    *                    removing an existing one
+    * @param newName     a new name, when renaming an existing calc field; {@code null} to keep
+    *                    {@code name}. Ignored when {@code remove} is {@code true}.
+    * @param expression  the formula text. Required unless {@code remove} is {@code true}.
+    * @param dataType    the calc field's data type (e.g. {@code "double"}, {@code "string"}), or
+    *                    {@code null} to leave it to the engine to infer.
+    * @param sql         {@code true} for a native-SQL expression, {@code false}/{@code null} for
+    *                    a JavaScript one.
+    * @param baseOnDetail {@code true} (the default when {@code null}) for a per-row (detail)
+    *                    calculation; {@code false} for one computed from an aggregate result.
+    * @param remove      {@code true} to remove the named calc field. Fields other than
+    *                    {@code table}/{@code name} are ignored.
+    * @param create      {@code true} to create a new calc field rather than edit an existing one.
+    */
+   public record CalcFieldRequest(String table, String assembly, String name, String newName,
+                                  String expression, String dataType, Boolean sql,
+                                  Boolean baseOnDetail, boolean remove, boolean create) {}
+
+   public void modify(String sessionToken, Principal agent, CalcFieldRequest req, String linkUri)
+      throws Exception
+   {
+      if(req.table() == null || req.table().isBlank()) {
+         throw new IllegalArgumentException(
+            "A calc field requires 'table' -- the source table it belongs to, as reported by " +
+            "list_bindable_fields.");
+      }
+
+      if(req.name() == null || req.name().isBlank()) {
+         throw new IllegalArgumentException(
+            "A calc field requires 'name' -- its current name when editing/removing, or the " +
+            "name to create it under.");
+      }
+
+      if(!req.remove() && (req.expression() == null || req.expression().isBlank())) {
+         throw new IllegalArgumentException(
+            "Creating or editing a calc field requires 'expression'.");
+      }
+
+      String newName = req.newName() != null && !req.newName().isBlank()
+         ? req.newName() : req.name();
+
+      CalculateRefModel model = null;
+
+      if(!req.remove()) {
+         ExpressionRefModel exprModel = new ExpressionRefModel();
+         exprModel.setName(newName);
+         exprModel.setExp(req.expression());
+         exprModel.setDType(req.dataType());
+
+         model = new CalculateRefModel();
+         model.setDataRefModel(exprModel);
+         model.setBaseOnDetail(req.baseOnDetail() == null || req.baseOnDetail());
+         model.setSql(Boolean.TRUE.equals(req.sql()));
+         model.setDataType(req.dataType());
+      }
+
+      CalculateRefModel finalModel = model;
+
+      sessions.mutate(sessionToken, agent, (rvs, runtimeId, dispatcher) -> {
+         String tableName = requireBindableTable(runtimeId, req.table(), agent);
+
+         ImmutableModifyCalculateFieldEvent event = ImmutableModifyCalculateFieldEvent.builder()
+            .name(req.assembly())
+            .confirmed(true)
+            .calculateRef(finalModel)
+            .tableName(tableName)
+            .remove(req.remove())
+            .create(req.create())
+            .refName(req.name())
+            .checkTrap(false)
+            .wizard(false)
+            .build();
+
+         modifyCalculateFieldService.modifyCalculateField(
+            runtimeId, event, agent, dispatcher, linkUri);
+      });
+   }
+
+   /**
+    * The write-after-write verification this class exists to enforce: {@code Viewsheet.addCalcField}
+    * stores a calc field under any table name handed to it, with no check the name refers to a
+    * table the viewsheet can actually bind to -- an orphaned calc field would otherwise be created
+    * silently, visible in no field listing, matching how {@code BindableColumns} guards a similar
+    * unchecked-name gap on the column side.
+    *
+    * <p>Matched case-insensitively, like {@code SelectionBindingService}/{@code TableBindingService}'s
+    * own {@code resolveTable} helpers -- and, like both of those, this returns the LISTING's own
+    * canonically-cased name rather than the caller's raw string. {@code Viewsheet.calcmap} is a
+    * plain, case-sensitive {@code Map<String, List<CalculateRef>>}: storing under the caller's
+    * casing instead of the canonical one would pass this check yet create a field under a key no
+    * chart bound to the real table ever looks up -- silently orphaned, not merely misspelled.
+    *
+    * <p>Unscoped ({@code assembly: null}) deliberately, exactly like
+    * {@code SelectionBindingService.resolveTable} -- passing {@code assembly} here would narrow
+    * the listing to THAT assembly's own currently-bound source (see
+    * {@code BindableFieldsService.list}/{@code VSTreeHandler.getChartTreeModel}), which would
+    * wrongly refuse a real worksheet table whenever the given assembly happens to be bound to a
+    * different one. {@code table} and {@code assembly} are independent by this class's own
+    * contract -- {@code assembly} only affects that one assembly's aggregate-info refresh, not
+    * where the field is stored or which tables are valid to store it under.
+    */
+   private String requireBindableTable(String runtimeId, String table, Principal agent)
+      throws Exception
+   {
+      List<BindableTable> tables = fieldsService.list(runtimeId, null, agent);
+
+      for(BindableTable candidate : tables) {
+         if(table.equalsIgnoreCase(candidate.name())) {
+            return candidate.name();
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + table + "' is not a bindable table in this viewsheet. Available: " +
+         tables.stream().map(BindableTable::name).collect(Collectors.joining(", ")) + ".");
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final BindableFieldsService fieldsService;
+   private final ModifyCalculateFieldServiceProxy modifyCalculateFieldService;
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -121,6 +121,7 @@ class BindingAgentControllerTest {
                                         mock(TableBindingService.class),
                                         mock(CalcTableService.class),
                                         mock(SelectionBindingService.class),
+                                        mock(CalcFieldAgentService.class),
                                         mock(SheetAgentBroadcastService.class));
    }
 
@@ -137,6 +138,7 @@ class BindingAgentControllerTest {
                                         mock(TableBindingService.class),
                                         mock(CalcTableService.class),
                                         mock(SelectionBindingService.class),
+                                        mock(CalcFieldAgentService.class),
                                         mock(SheetAgentBroadcastService.class));
    }
 
@@ -274,7 +276,8 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
          mock(TableBindingService.class), mock(CalcTableService.class),
-         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.ShelfRequest request = new BindingAgentController.ShelfRequest(
          "Chart1", "x", List.of(new FieldRef("Region", "dimension", null, null, null)), "Sales");
@@ -302,7 +305,8 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), chartService, mock(ChartAestheticAgentService.class),
          mock(TableBindingService.class), mock(CalcTableService.class),
-         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.SingleShelfRequest request = new BindingAgentController.SingleShelfRequest(
          "Chart1", "close", new FieldRef("Price", "measure", "Sum", null, null), "Sales");
@@ -329,7 +333,8 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class), aestheticService,
          mock(TableBindingService.class), mock(CalcTableService.class),
-         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.AestheticFieldRequest request =
          new BindingAgentController.AestheticFieldRequest(
@@ -393,7 +398,8 @@ class BindingAgentControllerTest {
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
          mock(BindingReadService.class), mock(ChartBindingService.class),
          mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
-         mock(SelectionBindingService.class), mock(SheetAgentBroadcastService.class));
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
 
       BindingAgentController.TableShelfRequest request =
          new BindingAgentController.TableShelfRequest(
@@ -423,7 +429,8 @@ class BindingAgentControllerTest {
          mock(ViewsheetSessionService.class), mock(BindableFieldsService.class),
          mock(BindingReadService.class), mock(ChartBindingService.class),
          mock(ChartAestheticAgentService.class), mock(TableBindingService.class),
-         mock(CalcTableService.class), mock(SelectionBindingService.class), broadcast);
+         mock(CalcTableService.class), mock(SelectionBindingService.class),
+         mock(CalcFieldAgentService.class), broadcast);
 
       controller.detach("my-token", principal());
 
@@ -442,7 +449,8 @@ class BindingAgentControllerTest {
          mock(ViewsheetSessionService.class), mock(BindableFieldsService.class),
          mock(BindingReadService.class), mock(ChartBindingService.class),
          mock(ChartAestheticAgentService.class), mock(TableBindingService.class),
-         mock(CalcTableService.class), mock(SelectionBindingService.class), broadcast);
+         mock(CalcTableService.class), mock(SelectionBindingService.class),
+         mock(CalcFieldAgentService.class), broadcast);
 
       controller.detach("someone-elses-token", principal());
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.binding;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.controller.ModifyCalculateFieldServiceProxy;
 import inetsoft.web.binding.drm.CalculateRefModel;
@@ -288,6 +289,54 @@ class CalcFieldAgentServiceTest {
       assertTrue(event.remove());
       assertEquals("NetTotal", event.refName());
       assertNull(event.calculateRef());
+   }
+
+   /**
+    * A caller editing a field previously created with {@code sql: true}/{@code baseOnDetail:
+    * false} that omits both (a plain rename or expression-only tweak) must NOT have them
+    * silently reset to the create-time defaults ({@code sql: false}/{@code baseOnDetail: true}) --
+    * the omitted fields mean "leave as-is" on edit, not "reset".
+    */
+   @Test
+   void editOmittingSqlAndBaseOnDetailPreservesTheExistingCalcFieldsSettings() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      CalculateRef existing = mock(CalculateRef.class);
+      when(existing.isSQL()).thenReturn(true);
+      when(existing.isBaseOnDetail()).thenReturn(false);
+      when(existing.getDataType()).thenReturn("double");
+      when(vs.getCalcField(eq("ORDERS"), eq("NetTotal"))).thenReturn(existing);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      doAnswer(invocation -> {
+         ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+         mutation.run(rvs, "rt1", null);
+         return null;
+      }).when(sessions).mutate(anyString(), any(Principal.class), any());
+
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessions, fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      // Edit: rename only, sql/baseOnDetail/dataType all omitted (null).
+      CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "NetTotal", "NetAfterDiscount",
+         "field['Total']*0.9", null, null, null, false, false);
+
+      service.modify("tok", agent, req, "");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq(""));
+
+      CalculateRefModel calc = captor.getValue().calculateRef();
+      assertNotNull(calc);
+      assertTrue(calc.isSql(), "sql:true must be preserved, not reset to the create default");
+      assertFalse(calc.isBaseOnDetail(),
+         "baseOnDetail:false must be preserved, not reset to the create default");
+      assertEquals("double", calc.getDataType(), "dataType must be preserved when omitted");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
@@ -18,6 +18,10 @@
 package inetsoft.web.wiz.binding;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.controller.ModifyCalculateFieldServiceProxy;
@@ -54,6 +58,15 @@ class CalcFieldAgentServiceTest {
       return fields;
    }
 
+   /** A SecurityEngine that grants every permission check -- the default for tests not exercising
+   * the VIEWSHEET_CALCULATED_FIELD gate itself. */
+   private static SecurityEngine allowingSecurityEngine() throws Exception {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+         any(ResourceAction.class))).thenReturn(true);
+      return securityEngine;
+   }
+
    /** A session service whose mutate() runs the mutation immediately against runtime "rt1". */
    private static ViewsheetSessionService sessionsRunningAgainstRt1() throws Exception {
       Viewsheet vs = mock(Viewsheet.class);
@@ -70,11 +83,42 @@ class CalcFieldAgentServiceTest {
       return sessions;
    }
 
+   /**
+    * {@code ModifyCalculateFieldService.modifyCalculateField} performs no permission check of its
+    * own -- {@code ModifyCalculateFieldController} is the sole enforcement point for the native
+    * Formula Editor dialog, gating on {@code VIEWSHEET_CALCULATED_FIELD}/{@code ACCESS}. Calling
+    * the service directly, as this class does, must re-apply that same gate up front, before the
+    * table/name validation, model building, or {@code sessions.mutate} -- an admin-restricted
+    * agent must be refused before any of that runs, not merely before the proxy call.
+    */
+   @Test
+   void refusesWhenCalculatedFieldPermissionIsDenied() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      BindableFieldsService fieldsService = mock(BindableFieldsService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+         any(ResourceAction.class))).thenReturn(false);
+
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessions, fieldsService, proxy, securityEngine);
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "ORDERS", null, "NetTotal", null, "field['Total']", "double", false, true, false, true);
+
+      assertThrows(SecurityException.class,
+         () -> service.modify("tok", principal(), req, ""));
+
+      verifyNoInteractions(proxy);
+      verifyNoInteractions(sessions);
+      verifyNoInteractions(fieldsService);
+   }
+
    @Test
    void requiresTable() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
 
       CalcFieldRequest req = new CalcFieldRequest(
          null, null, "NetTotal", null, "field['Total']", "double", false, true, false, true);
@@ -89,7 +133,7 @@ class CalcFieldAgentServiceTest {
    void requiresName() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
 
       CalcFieldRequest req = new CalcFieldRequest(
          "ORDERS", null, "", null, "field['Total']", "double", false, true, false, true);
@@ -104,7 +148,7 @@ class CalcFieldAgentServiceTest {
    void requiresExpressionUnlessRemoving() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
 
       CalcFieldRequest req = new CalcFieldRequest(
          "ORDERS", null, "NetTotal", null, null, null, null, null, false, true);
@@ -119,7 +163,7 @@ class CalcFieldAgentServiceTest {
    void refusesATableTheListingDoesNotHave() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
 
       CalcFieldRequest req = new CalcFieldRequest(
          "NO_SUCH_TABLE", null, "NetTotal", null, "field['Total']", "double", false, true, false,
@@ -143,7 +187,7 @@ class CalcFieldAgentServiceTest {
    void resolvesTableNameToTheListingsCanonicalCasing() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest(
@@ -178,7 +222,7 @@ class CalcFieldAgentServiceTest {
       when(fields.list(eq("rt1"), isNull(), any(Principal.class))).thenReturn(List.of(orders));
 
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fields, proxy);
+         sessionsRunningAgainstRt1(), fields, proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest("ORDERS", "Chart1", "NetTotal", null,
@@ -193,7 +237,7 @@ class CalcFieldAgentServiceTest {
    void createBuildsAnEventWithTheGivenNameAndSensibleDefaults() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest("ORDERS", "Chart1", "NetTotal", null,
@@ -226,7 +270,7 @@ class CalcFieldAgentServiceTest {
    void editWithoutNewNameKeepsTheSameName() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "NetTotal", null,
@@ -249,7 +293,7 @@ class CalcFieldAgentServiceTest {
    void editWithNewNameRenames() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "NetTotal", "NetAfterDiscount",
@@ -273,7 +317,7 @@ class CalcFieldAgentServiceTest {
    void removeSendsNoCalculateRefAndSkipsExpressionValidation() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest(
@@ -318,7 +362,7 @@ class CalcFieldAgentServiceTest {
       }).when(sessions).mutate(anyString(), any(Principal.class), any());
 
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessions, fieldsServiceWithOrdersTable(), proxy);
+         sessions, fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       // Edit: rename only, sql/baseOnDetail/dataType all omitted (null).
@@ -343,7 +387,7 @@ class CalcFieldAgentServiceTest {
    void baseOnDetailFalseIsPreserved() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
       CalcFieldAgentService service = new CalcFieldAgentService(
-         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
       Principal agent = principal();
 
       CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "AvgDiscountPct", null,

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
@@ -1,0 +1,311 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.controller.ModifyCalculateFieldServiceProxy;
+import inetsoft.web.binding.drm.CalculateRefModel;
+import inetsoft.web.binding.event.ModifyCalculateFieldEvent;
+import inetsoft.web.binding.model.ExpressionRefModel;
+import inetsoft.web.wiz.binding.CalcFieldAgentService.CalcFieldRequest;
+import inetsoft.web.wiz.binding.model.BindableField;
+import inetsoft.web.wiz.binding.model.BindableTable;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class CalcFieldAgentServiceTest {
+   private static Principal principal() {
+      return () -> "admin";
+   }
+
+   /** A table listing with exactly one bindable table, "ORDERS". */
+   private static BindableFieldsService fieldsServiceWithOrdersTable() throws Exception {
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      BindableTable orders = new BindableTable("ORDERS", null,
+         List.of(new BindableField("DISCOUNT", "double", null)));
+      when(fields.list(eq("rt1"), any(), any(Principal.class))).thenReturn(List.of(orders));
+      return fields;
+   }
+
+   /** A session service whose mutate() runs the mutation immediately against runtime "rt1". */
+   private static ViewsheetSessionService sessionsRunningAgainstRt1() throws Exception {
+      Viewsheet vs = mock(Viewsheet.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      doAnswer(invocation -> {
+         ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+         mutation.run(rvs, "rt1", null);
+         return null;
+      }).when(sessions).mutate(anyString(), any(Principal.class), any());
+
+      return sessions;
+   }
+
+   @Test
+   void requiresTable() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         null, null, "NetTotal", null, "field['Total']", "double", false, true, false, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.modify("tok", principal(), req, ""));
+      assertTrue(thrown.getMessage().contains("table"), thrown.getMessage());
+      verifyNoInteractions(proxy);
+   }
+
+   @Test
+   void requiresName() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "ORDERS", null, "", null, "field['Total']", "double", false, true, false, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.modify("tok", principal(), req, ""));
+      assertTrue(thrown.getMessage().contains("name"), thrown.getMessage());
+      verifyNoInteractions(proxy);
+   }
+
+   @Test
+   void requiresExpressionUnlessRemoving() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "ORDERS", null, "NetTotal", null, null, null, null, null, false, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.modify("tok", principal(), req, ""));
+      assertTrue(thrown.getMessage().contains("expression"), thrown.getMessage());
+      verifyNoInteractions(proxy);
+   }
+
+   @Test
+   void refusesATableTheListingDoesNotHave() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "NO_SUCH_TABLE", null, "NetTotal", null, "field['Total']", "double", false, true, false,
+         true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.modify("tok", principal(), req, ""));
+      assertTrue(thrown.getMessage().contains("NO_SUCH_TABLE"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("ORDERS"), thrown.getMessage());
+      verifyNoInteractions(proxy);
+   }
+
+   /**
+    * {@code Viewsheet.calcmap} is a plain, case-sensitive map keyed by table name. Matching
+    * "orders" against the listed "ORDERS" case-insensitively and then storing the calc field
+    * under the caller's own casing ("orders") would create it under a key no chart bound to the
+    * real "ORDERS" table ever looks up -- silently orphaned, not merely a cosmetic mismatch. The
+    * event sent downstream must always carry the LISTING's canonical casing.
+    */
+   @Test
+   void resolvesTableNameToTheListingsCanonicalCasing() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "orders", null, "NetTotal", null, "field['Total']", "double", false, true, false, true);
+
+      service.modify("tok", agent, req, "");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq(""));
+      assertEquals("ORDERS", captor.getValue().tableName(),
+         "must store under the listing's canonical casing, not the caller's raw 'orders'");
+   }
+
+   /**
+    * {@code table} and {@code assembly} are independent by this class's own contract -- passing
+    * an {@code assembly} must not narrow the bindable-table check to THAT assembly's own current
+    * source, which would wrongly refuse a real worksheet table whenever the assembly happens to
+    * be bound elsewhere. Mirrors the reasoning already applied in
+    * {@code SelectionBindingService.resolveTable}.
+    */
+   @Test
+   void tableValidationIsNotScopedToTheGivenAssembly() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      BindableTable orders = new BindableTable("ORDERS", null,
+         List.of(new BindableField("DISCOUNT", "double", null)));
+      // Scoped to "Chart1" (a different, already-bound assembly) the listing would be narrowed to
+      // whatever THAT chart is bound to -- stubbed empty here so a scoped call fails loudly.
+      when(fields.list(eq("rt1"), eq("Chart1"), any(Principal.class))).thenReturn(List.of());
+      // Unscoped (assembly: null), the listing is worksheet-wide and finds ORDERS.
+      when(fields.list(eq("rt1"), isNull(), any(Principal.class))).thenReturn(List.of(orders));
+
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fields, proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest("ORDERS", "Chart1", "NetTotal", null,
+         "field['Total']", "double", false, true, false, true);
+
+      service.modify("tok", agent, req, "");
+
+      verify(proxy).modifyCalculateField(eq("rt1"), any(), eq(agent), any(), eq(""));
+   }
+
+   @Test
+   void createBuildsAnEventWithTheGivenNameAndSensibleDefaults() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest("ORDERS", "Chart1", "NetTotal", null,
+         "field['Total']*(1-field['Discount'])", "double", false, null, false, true);
+
+      service.modify("tok", agent, req, "link");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq("link"));
+
+      ModifyCalculateFieldEvent event = captor.getValue();
+      assertTrue(event.create());
+      assertFalse(event.remove());
+      assertEquals("ORDERS", event.tableName());
+      assertEquals("Chart1", event.name());
+      assertEquals("NetTotal", event.refName());
+
+      CalculateRefModel calc = event.calculateRef();
+      assertNotNull(calc);
+      assertTrue(calc.isBaseOnDetail(), "baseOnDetail should default to true when omitted");
+      assertFalse(calc.isSql());
+      assertEquals("double", calc.getDataType());
+      ExpressionRefModel expr = (ExpressionRefModel) calc.getDataRefModel();
+      assertEquals("NetTotal", expr.getName());
+      assertEquals("field['Total']*(1-field['Discount'])", expr.getExp());
+   }
+
+   @Test
+   void editWithoutNewNameKeepsTheSameName() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "NetTotal", null,
+         "field['Total']*0.9", "double", false, true, false, false);
+
+      service.modify("tok", agent, req, "");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq(""));
+
+      ModifyCalculateFieldEvent event = captor.getValue();
+      assertFalse(event.create());
+      assertEquals("NetTotal", event.refName());
+      ExpressionRefModel expr = (ExpressionRefModel) event.calculateRef().getDataRefModel();
+      assertEquals("NetTotal", expr.getName());
+   }
+
+   @Test
+   void editWithNewNameRenames() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "NetTotal", "NetAfterDiscount",
+         "field['Total']*0.9", "double", false, true, false, false);
+
+      service.modify("tok", agent, req, "");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq(""));
+
+      ModifyCalculateFieldEvent event = captor.getValue();
+      // refName carries the OLD name, so the service can find the existing calc field...
+      assertEquals("NetTotal", event.refName());
+      // ...and the new CalculateRef carries the NEW name, so the rename is actually requested.
+      ExpressionRefModel expr = (ExpressionRefModel) event.calculateRef().getDataRefModel();
+      assertEquals("NetAfterDiscount", expr.getName());
+   }
+
+   @Test
+   void removeSendsNoCalculateRefAndSkipsExpressionValidation() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "ORDERS", null, "NetTotal", null, null, null, null, null, true, false);
+
+      service.modify("tok", agent, req, "");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq(""));
+
+      ModifyCalculateFieldEvent event = captor.getValue();
+      assertTrue(event.remove());
+      assertEquals("NetTotal", event.refName());
+      assertNull(event.calculateRef());
+   }
+
+   @Test
+   void baseOnDetailFalseIsPreserved() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessionsRunningAgainstRt1(), fieldsServiceWithOrdersTable(), proxy);
+      Principal agent = principal();
+
+      CalcFieldRequest req = new CalcFieldRequest("ORDERS", null, "AvgDiscountPct", null,
+         "sum(field['Discount'])/sum(field['Total'])", "double", false, false, false, true);
+
+      service.modify("tok", agent, req, "");
+
+      ArgumentCaptor<ModifyCalculateFieldEvent> captor =
+         ArgumentCaptor.forClass(ModifyCalculateFieldEvent.class);
+      verify(proxy).modifyCalculateField(eq("rt1"), captor.capture(), eq(agent), any(), eq(""));
+
+      assertFalse(captor.getValue().calculateRef().isBaseOnDetail());
+   }
+}


### PR DESCRIPTION
## Summary
- Part of PCB-006 (docs/bug-reports/plugin-composer-chart-binding.md, stylebi-wiz repo): the only correct path for a data need that must not touch a worksheet other dashboards share is a viewsheet-scoped calc field (`Viewsheet.calcmap` — the field the Formula Editor dialog creates), and no tool on the wiz-agent surface could create, edit, or remove one.
- Adds `POST /api/wiz/v1/agent/binding/{sessionToken}/calc-field`, delegating to the same `ModifyCalculateFieldServiceProxy` the Formula Editor's OK button drives (via `sessions.mutate` + a built `ModifyCalculateFieldEvent`) rather than reimplementing its wizard/cube/aggregate-info side effects.
- Table names are matched case-insensitively against `list_bindable_fields`'s own listing but **stored under the listing's canonical casing**, not the caller's raw string — `Viewsheet.calcmap` is a plain case-sensitive map, so storing under the wrong casing would silently create an orphaned field.
- The bindable-table listing used for validation is deliberately **unscoped** (`assembly: null`), matching `SelectionBindingService.resolveTable`'s own precedent — scoping it to a given `assembly` would narrow the check to that assembly's current bound source and wrongly refuse a real table when the assembly happens to be bound elsewhere.

**Stacked on #4947** (this branch is based on `fix/pva-016-selection-binding-controller-regression`, since both touch `BindingAgentController`'s constructor and stacking avoids repeating that PR's own root cause). Please merge/land #4947 first, or rebase this one, before merging.

## Review history
An independent code-reviewer pass (agent) initially found two real defects in the first version of `requireBindableTable` — case-mismatch would store under the wrong key, and passing `assembly` through would wrongly scope/narrow the validation listing. Both are fixed in this version, with regression tests (`resolvesTableNameToTheListingsCanonicalCasing`, `tableValidationIsNotScopedToTheGivenAssembly`) added alongside the fix.

## Test plan
- [x] `CalcFieldAgentServiceTest` — 11/11 pass (create/edit/rename/remove/defaults/validation, including the two regression cases above)
- [x] `BindingAgentControllerTest` — 14/14 pass (8 constructor call sites updated for the new arity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)