### PR TITLE
76428, axis and plot lines overlapping

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-area.component.html
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.html
@@ -133,49 +133,11 @@
               [container]="container">
             </chart-facet-area>
           }
-          @for (axis of model.axes; track trackByFn($index, axis)) {
-            <chart-axis-area
-              [wTooltip]="tooltipString"
-              [tooltipCSS]="tooltipCSS"
-              [followCursor]="true"
-              [waitTime]="0"
-              [disableTooltipOnMousedown]="false"
-              [chartSelection]="model.chartSelection"
-              [model]="model"
-              [id]="axis.areaName"
-              [chartObject]="axis"
-              [maxMode]="model.maxMode"
-              [isDataTip]="isDataTip"
-              [genTime]="model.genTime"
-              [urlPrefix]="urlPrefix"
-              [scrollLeft]="scrollLeft"
-              [scrollTop]="scrollTop"
-              [scrollbarWidth]="scrollbarWidth"
-              [hideSortIcon]="hideSortIcon"
-              [dateComparisonDefined]="dateComparisonDefined"
-              [links]="links" [onTitle]="onTitle"
-              [flyover]="model.hasFlyovers"
-              [flyOnClick]="model.flyOnClick"
-              [dataTip]="vsChartModel.dataTip"
-              [dataTipOnClick]="model.dataTipOnClick"
-              (selectRegion)="selectRegion($event)"
-              (changeCursor)="changeCursor($event)"
-              (showTooltip)="showTooltip($event)"
-              (showHyperlink)="showHyperlink($event)"
-              (startAxisResize)="startAxisResize($event)"
-              (drill)="drill($event)"
-              (sortAxis)="sortAxis(axis)"
-              (brushChart)="onBrushChart.emit()"
-              (scrollAxis)="onScrollAxis($event, axis)"
-              (sendFlyover)="sendFlyover($event)"
-              (showDataTip)="showDataTip($event)"
-              (onLoad)="axisLoaded($event, axis.areaName)"
-              (onLoading)="axisLoading(axis.areaName)"
-              [supportHyperlink]="supportHyperlink"
-              [container]="container"
-              [resizeEnable]="!isResizeVisible || isResizeVisible('AxisResize')">
-            </chart-axis-area>
-          }
+          <!-- The plot is rendered before the axes: both regions are sized bounds + 1
+               (see VGraphPair.getSubGraphic) so they share one pixel at the plot boundary,
+               and DOM order decides which tile paints on top. Keeping the axes last leaves
+               the axis line above the plot grid lines, matching AXIS_Z_INDEX >
+               GRIDLINE_Z_INDEX in GDefaults. (Bug #76428) -->
           @if (model.plot) {
             <chart-plot-area
               #chartPlotArea
@@ -221,6 +183,49 @@
               (changeCursor)="changeCursor($event)"
               [container]="container">
             </chart-plot-area>
+          }
+          @for (axis of model.axes; track trackByFn($index, axis)) {
+            <chart-axis-area
+              [wTooltip]="tooltipString"
+              [tooltipCSS]="tooltipCSS"
+              [followCursor]="true"
+              [waitTime]="0"
+              [disableTooltipOnMousedown]="false"
+              [chartSelection]="model.chartSelection"
+              [model]="model"
+              [id]="axis.areaName"
+              [chartObject]="axis"
+              [maxMode]="model.maxMode"
+              [isDataTip]="isDataTip"
+              [genTime]="model.genTime"
+              [urlPrefix]="urlPrefix"
+              [scrollLeft]="scrollLeft"
+              [scrollTop]="scrollTop"
+              [scrollbarWidth]="scrollbarWidth"
+              [hideSortIcon]="hideSortIcon"
+              [dateComparisonDefined]="dateComparisonDefined"
+              [links]="links" [onTitle]="onTitle"
+              [flyover]="model.hasFlyovers"
+              [flyOnClick]="model.flyOnClick"
+              [dataTip]="vsChartModel.dataTip"
+              [dataTipOnClick]="model.dataTipOnClick"
+              (selectRegion)="selectRegion($event)"
+              (changeCursor)="changeCursor($event)"
+              (showTooltip)="showTooltip($event)"
+              (showHyperlink)="showHyperlink($event)"
+              (startAxisResize)="startAxisResize($event)"
+              (drill)="drill($event)"
+              (sortAxis)="sortAxis(axis)"
+              (brushChart)="onBrushChart.emit()"
+              (scrollAxis)="onScrollAxis($event, axis)"
+              (sendFlyover)="sendFlyover($event)"
+              (showDataTip)="showDataTip($event)"
+              (onLoad)="axisLoaded($event, axis.areaName)"
+              (onLoading)="axisLoading(axis.areaName)"
+              [supportHyperlink]="supportHyperlink"
+              [container]="container"
+              [resizeEnable]="!isResizeVisible || isResizeVisible('AxisResize')">
+            </chart-axis-area>
           }
           @for (title of model.titles; track trackByFn($index, title)) {
             <chart-title-area


### PR DESCRIPTION
  Root Cause:
  The chart is rendered server-side as separate image tiles per region — plot, axes,
  titles, facet corners. VGraphPair.getSubGraphic sizes each tile bounds+1 with a
  +0.5 translate (GDefaults.SVG_TILE_TRANSLATE) so edge strokes are not clipped, and
  the frontend sizes both .chart-axis-area and .chart-plot-area as layoutBounds + 1.
  As a result the axis tile's last pixel column and the plot tile's first pixel column
  land on the same screen column at the plot boundary. The plot tile is built with

  Draft comment for #76428, ready to post once you confirm (I won't post it without your go-ahead):

  Root Cause:
  The chart is rendered server-side as separate image tiles per region — plot, axes,
  +0.5 translate (GDefaults.SVG_TILE_TRANSLATE) so edge strokes are not clipped, and
  the frontend sizes both .chart-axis-area and .chart-plot-area as layoutBounds + 1.
  As a result the axis tile's last pixel column and the plot tile's first pixel column
  land on the same screen column at the plot boundary. The plot tile is built with
  paintAxes=false (grid lines, no axis line) and the axis tile with paintAxes=true /
  paintVOVisuals=false (axis line, no data).

  The graph engine paints strictly by z-index and intends the axis line on top:
  GRIDLINE_Z_INDEX=30 < VO_Z_INDEX=60 < AXIS_Z_INDEX=70. But in
  chart-area.component.html the <chart-axis-area> loop was rendered before
  <chart-plot-area>, and both are position:absolute with no z-index — so DOM order
  made the plot tile paint over the axis tiles, inverting the engine's z-order. Each
  grid line's antialiased end pixel then washed out the axis line, producing the
  notches in the screenshot (measured: the axis-line pixels lighten from 176 to 195
  at every grid row, and only at grid rows).

  Fix:
  Render the plot area before the axis areas in chart-area.component.html, giving
  facets -> plot -> axes -> titles -> legends. The axis tiles now paint above the plot
  tile at the shared boundary pixel, so the axis line sits on top of the grid lines
  while the grid lines still extend to the boundary, leaving no gap. This corrects all
  four axes. Legends and titles still render last, so they remain on top.