### PR TITLE
fix(viz-filters): gate Calendar binding on date-typed columns (VZF-017)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -524,6 +524,16 @@ public class WizVsService {
             continue;
          }
 
+         // Calendar has no numeric-range use case the way TimeSlider does (VZF-017) -- a
+         // "calendar" widget only makes sense over a date/time/timeInstant column, so an explicit
+         // calendar override on a string/numeric column has no sensible date to display and must
+         // be reported, not silently bound (case-vzf-017-calendar-gate/01-diagnosis.md).
+         if(type == AbstractSheet.CALENDAR_ASSET && !XSchema.isDateType(dtype)) {
+            skipped.add(new SkippedFilter(spec.getField(),
+               "calendar is not supported for " + dtype + " columns"));
+            continue;
+         }
+
          resolvable.add(spec);
          resolvedColumns.add(col);
          resolvedTypes.add(type);
@@ -817,14 +827,23 @@ public class WizVsService {
     * setter and binds through a {@link SingleTimeInfo} instead, whose range type must match the
     * column's own data type (numeric/time/date) the same way {@code createFilterAssembly}
     * derives it -- getting this branch wrong (e.g. always defaulting to MONTH) would produce a
-    * control that LOOKS bound but silently mis-ranges a numeric or time-of-day column.
+    * control that LOOKS bound but silently mis-ranges a numeric or time-of-day column. Only
+    * SelectionList is unconditionally safe for any type ("list all distinct values" is meaningful
+    * regardless of dtype); Calendar's {@code setDataRef} is also gated below, to a date type only
+    * (VZF-017) -- unlike TimeSlider, Calendar has no legitimate numeric-range use case.
     */
    private static void bindColumn(AbstractSelectionVSAssembly control, DataRef col) {
       if(control instanceof SelectionListVSAssembly list) {
          list.setDataRef(col);
       }
       else if(control instanceof CalendarVSAssembly calendar) {
-         calendar.setDataRef(col);
+         // Mirrors the TimeSlider branch's own defense-in-depth gate below -- addFilters already
+         // skips a calendar override on a non-date column before reaching this call
+         // (case-vzf-017-calendar-gate/01-diagnosis.md), but this gate is kept here too so this
+         // method can never mis-bind a column its own doc comment above says it must not.
+         if(XSchema.isDateType(col.getDataType())) {
+            calendar.setDataRef(col);
+         }
       }
       else if(control instanceof TimeSliderVSAssembly slider) {
          String dtype = col.getDataType();

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceAddFiltersTest.java
@@ -404,4 +404,32 @@ class WizVsServiceAddFiltersTest {
                    resp.getSkipped().get(0).getReason());
       verify(vs, never()).addAssembly(any(TimeSliderVSAssembly.class));
    }
+
+   // ── case-vzf-017-calendar-gate/01-diagnosis.md: an explicit calendar override on a
+   // non-date column must be reported as a named skip, not silently bound (Calendar has no
+   // legitimate numeric-range use case, unlike TimeSlider, so its gate is isDateType alone). ──────
+
+   @Test
+   void calendarOverrideOnAStringColumnIsSkippedNotMisBound() throws Exception {
+      AddFiltersResponse resp = service.addFilters(requestOne("REGION", "calendar"), user);
+
+      assertEquals(0, resp.getApplied().size());
+      assertEquals(1, resp.getSkipped().size());
+      assertEquals("REGION", resp.getSkipped().get(0).getField());
+      assertEquals("calendar is not supported for " + XSchema.STRING + " columns",
+                   resp.getSkipped().get(0).getReason());
+      verify(vs, never()).addAssembly(any(CalendarVSAssembly.class));
+   }
+
+   @Test
+   void calendarOverrideOnANumericColumnIsSkippedNotMisBound() throws Exception {
+      AddFiltersResponse resp = service.addFilters(requestOne("AMOUNT", "calendar"), user);
+
+      assertEquals(0, resp.getApplied().size());
+      assertEquals(1, resp.getSkipped().size());
+      assertEquals("AMOUNT", resp.getSkipped().get(0).getField());
+      assertEquals("calendar is not supported for " + XSchema.DOUBLE + " columns",
+                   resp.getSkipped().get(0).getReason());
+      verify(vs, never()).addAssembly(any(CalendarVSAssembly.class));
+   }
 }


### PR DESCRIPTION
## Summary
- `WizVsService.addFilters`'s Calendar branch had no type gate: an explicit `controlType:"calendar"` override on a string/numeric column was silently accepted and bound directly as the Calendar's `DataRef`, producing a control that renders as a fully normal, functional Calendar with zero relation to the underlying column's actual values.
- Same defect family as the TimeSlider gate added in PR #4944 (fix round 5) -- that round gated TimeSlider but missed the structurally identical gap for Calendar.
- Fix: add an outer skip gate in `addFilters` (`!XSchema.isDateType(dtype)`, unlike TimeSlider's `isNumericType||isDateType` -- Calendar has no legitimate numeric-range use case), plus a defense-in-depth re-check in `bindColumn`'s Calendar branch, plus a doc-comment update.

## Test plan
- [x] `WizVsServiceAddFiltersTest`, `WizVsServiceRemoveFilterTest`, `WizFilterLayoutTest` -- 32 passed, 0 failed (added 2 new cases: `calendarOverrideOnAStringColumnIsSkippedNotMisBound`, `calendarOverrideOnANumericColumnIsSkippedNotMisBound`)
- [x] Broader sweep `WizVsService*Test,WizFilterLayoutTest,WizFilterOperationTest,WizVisualizationServiceTest` -- 175 passed, 0 failed
- [ ] Live MCP re-verification against a redeployed container (pending, tracked separately)

Full diagnosis: `stylebi-wiz/docs/teams/2026-09-02-test-visualizations-boards/case-vzf-017-calendar-gate/01-diagnosis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)