### PR TITLE
fix(wiz): infer numeric type for pure-arithmetic expression columns (PWA-002)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1335,6 +1335,13 @@ public final class WorksheetMutationSupport {
       if(type != null) {
          colRef.setDataType(type);
       }
+      else {
+         String inferred = inferNumericExpressionType(t, expression);
+
+         if(inferred != null) {
+            colRef.setDataType(inferred);
+         }
+      }
 
       ColumnSelection cs = t.getColumnSelection(false);
       cs.addAttribute(colRef);
@@ -1370,6 +1377,16 @@ public final class WorksheetMutationSupport {
 
                if(type != null) {
                   cr.setDataType(type);
+               }
+               else if(XSchema.STRING.equals(cr.getDataType())) {
+                  // Only re-infer when the column is still sitting on the untyped
+                  // fallback -- a real, previously-set explicit type (e.g. "integer")
+                  // must be left alone per the "null = leave unchanged" contract above.
+                  String inferred = inferNumericExpressionType(t, expression);
+
+                  if(inferred != null) {
+                     cr.setDataType(inferred);
+                  }
                }
 
                t.setColumnSelection(cs, false);
@@ -1436,6 +1453,18 @@ public final class WorksheetMutationSupport {
    }
 
    private static boolean isDateColumn(ColumnSelection cs, String field) {
+      DataRef ref = resolveColumn(cs, field);
+
+      if(ref == null) {
+         return false;
+      }
+
+      String dtype = ref.getDataType();
+      return XSchema.DATE.equals(dtype) || XSchema.TIME_INSTANT.equals(dtype) ||
+         XSchema.TIME.equals(dtype);
+   }
+
+   private static DataRef resolveColumn(ColumnSelection cs, String field) {
       DataRef ref = cs.getAttribute(field);
 
       if(ref == null) {
@@ -1447,13 +1476,64 @@ public final class WorksheetMutationSupport {
          }
       }
 
-      if(ref == null) {
-         return false;
+      return ref;
+   }
+
+   /** Matches a single {@code field['x']} reference. */
+   private static final java.util.regex.Pattern FIELD_REF_PATTERN =
+      java.util.regex.Pattern.compile("field\\['([^']+)'\\]");
+
+   /**
+    * Infers a numeric data type for an expression column when the caller omits an
+    * explicit {@code type}, instead of leaving it to fall through to the untyped
+    * default of {@link XSchema#STRING} ({@link inetsoft.uql.erm.AbstractDataRef
+    * #getDataType()}).
+    *
+    * <p>Only infers when the intent is unambiguous: every {@code field['x']} reference
+    * in the expression must resolve to an existing numeric column, and everything
+    * outside those references must be pure arithmetic (digits, {@code + - * /},
+    * parentheses, whitespace). Any other shape (string concatenation, comparisons,
+    * unresolvable fields, non-numeric fields) is left alone -- returning {@code null}
+    * preserves the existing string default rather than guessing.</p>
+    *
+    * @return {@link XSchema#DOUBLE}, or {@code null} if the expression's type cannot be
+    *         unambiguously inferred as numeric
+    */
+   private static String inferNumericExpressionType(TableAssembly t, String expression) {
+      if(expression == null || expression.isBlank()) {
+         return null;
       }
 
-      String dtype = ref.getDataType();
-      return XSchema.DATE.equals(dtype) || XSchema.TIME_INSTANT.equals(dtype) ||
-         XSchema.TIME.equals(dtype);
+      ColumnSelection cs = t.getColumnSelection(false);
+
+      if(cs == null) {
+         return null;
+      }
+
+      java.util.regex.Matcher m = FIELD_REF_PATTERN.matcher(expression);
+      StringBuilder remainder = new StringBuilder();
+      int last = 0;
+      int fieldCount = 0;
+
+      while(m.find()) {
+         remainder.append(expression, last, m.start());
+         last = m.end();
+         fieldCount++;
+
+         DataRef ref = resolveColumn(cs, m.group(1));
+
+         if(ref == null || !XSchema.isNumericType(ref.getDataType())) {
+            return null;
+         }
+      }
+
+      remainder.append(expression.substring(last));
+
+      if(fieldCount == 0 || !remainder.toString().matches("[\\s+\\-*/().0-9eE]*")) {
+         return null;
+      }
+
+      return XSchema.DOUBLE;
    }
 
    // =========================================================================

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1378,10 +1378,10 @@ public final class WorksheetMutationSupport {
                if(type != null) {
                   cr.setDataType(type);
                }
-               else if(XSchema.STRING.equals(cr.getDataType())) {
-                  // Only re-infer when the column is still sitting on the untyped
-                  // fallback -- a real, previously-set explicit type (e.g. "integer")
-                  // must be left alone per the "null = leave unchanged" contract above.
+               else if(!cr.isDataTypeSet()) {
+                  // Only re-infer when the column has never had an explicit type set --
+                  // a real, previously-set explicit type (even "string") must be left
+                  // alone per the "null = leave unchanged" contract above.
                   String inferred = inferNumericExpressionType(t, expression);
 
                   if(inferred != null) {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2735,6 +2735,34 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void editExpressionPreservesExplicitStringPriorTypeWhenTypeOmitted() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ColumnSelection cs = t.getColumnSelection(false);
+      ((ColumnRef) cs.getAttribute("a")).setDataType(XSchema.INTEGER);
+      ((ColumnRef) cs.getAttribute("b")).setDataType(XSchema.INTEGER);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "calc", "field['a'] * 1", "string", false));
+
+      // An explicit "string" prior type happens to equal the untyped fallback's
+      // *derived* getDataType() value, so a guard that compares against that value
+      // (instead of checking whether a type was ever explicitly set) would wrongly
+      // re-infer here. Omitting "type" on edit_expression must still leave a real,
+      // previously-set explicit "string" type alone, even though the new expression
+      // would otherwise infer as numeric (double).
+      svc.apply("TOK", agent, ed ->
+         ed.editExpression("T", "calc", "field['a'] * field['b']", null, false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertNotNull(col);
+      assertEquals(XSchema.STRING, col.getDataType());
+   }
+
+   @Test
    void editJoinUpdatesKeyColumns() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id", "altId");

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2261,6 +2261,90 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("field['end_date'] - field['start_date']", expr3);
    }
 
+   @Test
+   void addExpressionColumnInfersNumericTypeForPureArithmeticExpression() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ColumnSelection cs = t.getColumnSelection(false);
+      ((ColumnRef) cs.getAttribute("a")).setDataType(XSchema.INTEGER);
+      ((ColumnRef) cs.getAttribute("b")).setDataType(XSchema.INTEGER);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // No "type" argument -- a purely-arithmetic expression over numeric columns must
+      // infer numeric instead of silently falling through to the untyped "string"
+      // default.
+      svc.apply("TOK", agent,
+         ed -> ed.addExpressionColumn("T", "computed", "field['a'] * field['b']", null, false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("computed");
+      assertNotNull(col);
+      assertEquals(XSchema.DOUBLE, col.getDataType());
+   }
+
+   @Test
+   void addExpressionColumnInfersNumericTypeForThreeFactorExpression() throws Exception {
+      // The three-factor, parenthesized-subtraction shape from the bug doc's G9 case --
+      // must infer the same as the two-factor case above.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b", "c");
+      ColumnSelection cs = t.getColumnSelection(false);
+      ((ColumnRef) cs.getAttribute("a")).setDataType(XSchema.DOUBLE);
+      ((ColumnRef) cs.getAttribute("b")).setDataType(XSchema.DOUBLE);
+      ((ColumnRef) cs.getAttribute("c")).setDataType(XSchema.DOUBLE);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addExpressionColumn(
+         "T", "computed", "field['a'] * field['b'] * (1 - field['c'])", null, false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("computed");
+      assertNotNull(col);
+      assertEquals(XSchema.DOUBLE, col.getDataType());
+   }
+
+   @Test
+   void addExpressionColumnLeavesStringDefaultForNonNumericExpression() throws Exception {
+      Worksheet ws = new Worksheet();
+      // "a" and "b" are left at their default (untyped -> string) type.
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Referenced fields are not numeric -- must not guess; the existing "string"
+      // default is preserved.
+      svc.apply("TOK", agent,
+         ed -> ed.addExpressionColumn("T", "computed", "field['a'] + field['b']", null, false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("computed");
+      assertNotNull(col);
+      assertEquals(XSchema.STRING, col.getDataType());
+   }
+
+   @Test
+   void addExpressionColumnHonorsExplicitTypeOverInference() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ColumnSelection cs = t.getColumnSelection(false);
+      ((ColumnRef) cs.getAttribute("a")).setDataType(XSchema.INTEGER);
+      ((ColumnRef) cs.getAttribute("b")).setDataType(XSchema.INTEGER);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Even though the expression would infer as numeric, an explicit "type" argument
+      // must still win over inference (no regression on the existing explicit-type path).
+      svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "computed", "field['a'] * field['b']", "integer", false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("computed");
+      assertNotNull(col);
+      assertEquals(XSchema.INTEGER, col.getDataType());
+   }
+
    // =========================================================================
    // Duplicate-name rejection tests — add_column / add_expression_column
    // =========================================================================
@@ -2596,6 +2680,58 @@ class WorksheetEditServiceMutatorsTest {
 
       assertNotNull(t.getColumnSelection(false).getAttribute("newcalc"),
                     "'newcalc' should be added as a new expression column");
+   }
+
+   @Test
+   void editExpressionInfersNumericTypeWhenTypeOmitted() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ColumnSelection cs = t.getColumnSelection(false);
+      ((ColumnRef) cs.getAttribute("a")).setDataType(XSchema.INTEGER);
+      ((ColumnRef) cs.getAttribute("b")).setDataType(XSchema.INTEGER);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Original add omits "type" against a non-numeric expression, landing on the
+      // untyped "string" default -- same gap as add_expression_column.
+      svc.apply("TOK", agent,
+         ed -> ed.addExpressionColumn("T", "calc", "'literal'", null, false));
+
+      // A later edit_expression, also omitting "type", switches to a purely-arithmetic
+      // numeric expression -- it must infer numeric instead of keeping the stale string
+      // default.
+      svc.apply("TOK", agent,
+         ed -> ed.editExpression("T", "calc", "field['a'] * field['b']", null, false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertNotNull(col);
+      assertEquals(XSchema.DOUBLE, col.getDataType());
+   }
+
+   @Test
+   void editExpressionPreservesExplicitPriorTypeWhenTypeOmitted() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ColumnSelection cs = t.getColumnSelection(false);
+      ((ColumnRef) cs.getAttribute("a")).setDataType(XSchema.INTEGER);
+      ((ColumnRef) cs.getAttribute("b")).setDataType(XSchema.INTEGER);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "calc", "field['a'] * 1", "integer", false));
+
+      // Omitting "type" on edit_expression must leave a real, previously-set explicit
+      // type alone -- per the "null = leave unchanged" contract -- even though the new
+      // expression would otherwise infer as numeric (double).
+      svc.apply("TOK", agent, ed ->
+         ed.editExpression("T", "calc", "field['a'] * field['b']", null, false));
+
+      ColumnRef col = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertNotNull(col);
+      assertEquals(XSchema.INTEGER, col.getDataType());
    }
 
    @Test


### PR DESCRIPTION
## Summary

`add_expression_column`/`edit_expression` silently defaulted an omitted `type`
to `"string"` -- no inference was attempted anywhere on the call path, so
`ExpressionRef.getDataType()` fell through to `AbstractDataRef`'s unconditional
`XSchema.STRING` default, even for a purely-arithmetic expression over numeric
columns (e.g. `field['QUANTITY'] * field['PRICE']`).

## Root cause

`WorksheetMutationSupport.addExpressionColumn`/`editExpression` both had
`if(type != null) { ...setDataType(type); }` with no `else` -- when the caller
(the plugin, when the LLM omits `type`) sends no type, nothing is ever set.

## Fix

Add `inferNumericExpressionType(TableAssembly, String)`: extracts every
`field['x']` reference from the expression, and if every referenced field
resolves to a numeric column *and* everything else in the expression is pure
arithmetic (digits, `+ - * /`, parens, whitespace), infers `XSchema.DOUBLE`.
Any other shape (string concatenation, comparisons, unresolvable/non-numeric
fields) is left alone, preserving the existing `"string"` default rather than
guessing -- matching the CLAUDE.md tool-misuse-is-a-plugin-gap principle
(forgiving on the unambiguous case, unchanged otherwise).

`editExpression`'s javadoc says `type == null` means "leave unchanged," so its
inference only fires when the column's *current* type is still the untyped
`"string"` fallback -- a real, previously-set explicit type (e.g. `"integer"`)
is never clobbered by re-inferring from a later expression edit.

## Test plan

- [x] Added 6 regression tests to `WorksheetEditServiceMutatorsTest`:
  - two-factor (`a * b`) and three-factor/parenthesized (the bug doc's "G9"
    shape) pure-numeric expressions infer `double` when `type` is omitted
  - a non-numeric/ambiguous expression (string concatenation over default
    string-typed columns) still defaults to `string`
  - an explicit `type` argument still wins over inference (no regression)
  - `edit_expression` infers numeric the same way when `type` is omitted
  - `edit_expression` leaves a real prior explicit type alone when `type` is
    omitted, even though the new expression would otherwise infer numeric
- [x] Verified the 3 inference-asserting tests fail without the production
  fix (temporarily stashed it) and pass with it restored
- [x] `mvnw -pl core test -Dtest=WorksheetEditServiceMutatorsTest` --
  231/231 passing

Ref: PWA-002 (debug-workflow batch, `docs/teams/2026-09-02-bugs-p0-p2-composer/bug-PWA-002/`)