### PR TITLE
Bug #76412, stabilize Ignite cluster membership changes

### DIFF
--- a/core/src/main/java/inetsoft/sree/ClientInfo.java
+++ b/core/src/main/java/inetsoft/sree/ClientInfo.java
@@ -82,6 +82,30 @@ public class ClientInfo implements Cloneable, Serializable, XMLSerializable {
    }
 
    /**
+    * Gets a key identifying this user's login, for use as the key of the cluster-wide map of
+    * logged-in principals.
+    *
+    * <p>Unlike {@link #getCacheKey()} this omits the locale, and omits the client address when a
+    * session id is present. Both are part of {@link #equals(Object)} and {@link #hashCode()}, and
+    * both can differ between the node where the user logged in and a node that receives the same
+    * principal after it has been serialized across the cluster. A real login is already uniquely
+    * identified by the user identity plus the session id, so including the other two fields only
+    * makes the lookup miss and the user appear to be logged out.
+    *
+    * <p>The address is retained when the session id is empty. Several callers build a
+    * {@code ClientInfo} with no session at all (the two-argument constructor normalizes it to
+    * {@code ""}); for those the address is the only thing distinguishing two otherwise identical
+    * entries, and dropping it would collapse them into one — so one caller would receive another's
+    * principal, and a logout by either would deregister both.
+    *
+    * @return the login key.
+    */
+   public ClientInfo getLoginKey() {
+      return new ClientInfo(userID, session == null || session.isEmpty() ? addr : null,
+                            session, null);
+   }
+
+   /**
     * Returns the user name.
     *
     * @return the user name.

--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -518,16 +518,35 @@ public class PropertiesEngine {
    /**
     * Reads a property directly from the backing key-value storage, bypassing the in-memory
     * cache. Use this when a stale null from the cache would cause irreversible side effects.
+    *
+    * <p>A failure to read the store is propagated rather than reported as an absent value. Every
+    * caller uses this method to decide whether a key already exists before generating a new one,
+    * and "storage is unreadable" must not be mistaken for "storage is confirmed empty" — that
+    * mistake is what lets two nodes each generate a different key. Failing here is recoverable;
+    * silently minting a second signing or encryption key is not.
+    *
+    * @param name the name of the property.
+    *
+    * @return the stored value, or {@code null} if the store confirms there is no such property.
+    *
+    * @throws RuntimeException if the store could not be read.
     */
    public String getPropertyFromStorage(String name) {
       name = fixPropertyNameCase(name);
+      KeyValueStorage<String> storage = kvStorage;
+
+      if(storage == null) {
+         throw new IllegalStateException(
+            "Cannot read property " + name + " from storage: the property storage is not " +
+            "initialized yet.");
+      }
 
       try {
-         return kvStorage.get(name);
+         return storage.get(name);
       }
       catch(Exception e) {
-         LOG.debug("Failed to read property from storage: {}", name, e);
-         return null;
+         LOG.warn("Failed to read property from storage: {}", name, e);
+         throw new RuntimeException("Failed to read property from storage: " + name, e);
       }
    }
 

--- a/core/src/main/java/inetsoft/sree/SreeEnv.java
+++ b/core/src/main/java/inetsoft/sree/SreeEnv.java
@@ -24,6 +24,7 @@ import inetsoft.util.log.LogContext;
 import inetsoft.util.log.LogLevel;
 
 import java.awt.*;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,6 +73,31 @@ public class SreeEnv {
 
    public static String getPropertyFromStorage(String name) {
       return PropertiesEngine.getInstance().getPropertyFromStorage(name);
+   }
+
+   /**
+    * Adds a listener that is notified when the named property is changed in shared storage,
+    * including changes made by another cluster node. Use this to invalidate values that are
+    * cached in a field for the lifetime of the JVM.
+    *
+    * @param propertyName the name of the property to watch.
+    * @param listener     the listener to add.
+    */
+   public static void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+      PropertiesEngine.getInstance().addPropertyChangeListener(propertyName, listener);
+   }
+
+   /**
+    * Removes a property change listener added by
+    * {@link #addPropertyChangeListener(String, PropertyChangeListener)}.
+    *
+    * @param propertyName the name of the property being watched.
+    * @param listener     the listener to remove.
+    */
+   public static void removePropertyChangeListener(String propertyName,
+                                                   PropertyChangeListener listener)
+   {
+      PropertiesEngine.getInstance().removePropertyChangeListener(propertyName, listener);
    }
 
    public static boolean getBooleanProperty(String name, boolean earlyLoaded, boolean orgScope, String ... trueValues) {
@@ -212,8 +238,24 @@ public class SreeEnv {
     * @return the value of the property.
     */
    public static String getPassword(String name) {
-      String encryptedPassword = getProperty(name);
+      return decodePassword(name, getProperty(name));
+   }
 
+   /**
+    * Get the value of a password property, reading it directly from the backing store instead
+    * of the in-memory property cache. Use this when a stale null from the cache would cause
+    * irreversible side effects, such as regenerating a key that another cluster node has
+    * already generated and persisted.
+    *
+    * @param name the name of the property.
+    *
+    * @return the value of the property.
+    */
+   public static String getPasswordFromStorage(String name) {
+      return decodePassword(name, getPropertyFromStorage(name));
+   }
+
+   private static String decodePassword(String name, String encryptedPassword) {
       if(Tool.isEmptyString(encryptedPassword)) {
          return encryptedPassword;
       }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/AffinityCallException.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/AffinityCallException.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.internal.cluster;
+
+import inetsoft.util.MessageException;
+import inetsoft.util.log.LogLevel;
+
+/**
+ * {@code AffinityCallException} is thrown when a request could not be executed on the cluster node
+ * that owns the target resource. This is a transient, retriable condition: it means the call was
+ * never delivered or never answered, typically because the owning node left the cluster or the
+ * call timed out during a topology change. It does not indicate that the work itself failed.
+ *
+ * <p>It extends {@link MessageException} so the user is shown a message saying the operation can
+ * be retried, instead of the bare 500 that a plain runtime exception produces. It is logged at
+ * WARN without a stack trace: during a rolling update this is expected, and the stack of a
+ * timeout carries no useful information.
+ */
+public class AffinityCallException extends MessageException {
+   public AffinityCallException(String message) {
+      super(message, LogLevel.WARN, false);
+   }
+
+   public AffinityCallException(String message, Throwable cause) {
+      this(message);
+      initCause(cause);
+   }
+}

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxy.java
@@ -31,15 +31,35 @@ public class DistributedLockProxy implements Lock {
       this.realLock = realLock;
    }
 
+   /**
+    * {@inheritDoc}
+    *
+    * <p>Waits indefinitely while the lock is simply held elsewhere, as {@link Lock#lock()}
+    * requires — callers use the standard {@code lock(); try { … } finally { unlock(); }} idiom and
+    * are not written to handle a failure to acquire. Only repeated <em>errors</em> from the
+    * underlying distributed lock are bounded, at {@link #MAX_TRY_COUNT} attempts.
+    *
+    * <p>A long wait is logged rather than aborted, so a lock held far longer than expected is
+    * visible in the log instead of silent. {@code IgniteCluster} also runs a watchdog that warns
+    * about locks held beyond {@code MIN_LOCK_DURATION_MILLIS}.
+    */
    @Override
    public void lock() {
       Exception exception = null;
       int attempts = 0;
+      int timeouts = 0;
 
       while(true) {
          try {
             if(realLock.tryLock(LOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                return;
+            }
+
+            // Held by someone else. Keep waiting: aborting here would break the Lock contract.
+            // Log periodically so a lock that is never released is diagnosable.
+            if(++timeouts % TIMEOUT_LOG_INTERVAL == 0) {
+               LOG.warn("Still waiting for the {} lock after {} seconds", lockName,
+                        (long) timeouts * LOCK_TIMEOUT_SECONDS);
             }
          }
          catch(InterruptedException e) {
@@ -96,6 +116,8 @@ public class DistributedLockProxy implements Lock {
    private final Lock realLock;
    private final String lockName;
    private static final int MAX_TRY_COUNT = 10;
+   // warn roughly once a minute while waiting (20 x 3s)
+   private static final int TIMEOUT_LOG_INTERVAL = 20;
    private static final int LOCK_TIMEOUT_SECONDS = 3;
    private static final int RETRY_DELAY_MS = 3_000;
    private static final Logger LOG = LoggerFactory.getLogger(DistributedLockProxy.class);

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -19,6 +19,7 @@ package inetsoft.sree.internal.cluster.ignite;
 
 import inetsoft.report.composition.ExpiredSheetException;
 import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.cluster.*;
 import inetsoft.sree.security.AuthenticationService;
 import inetsoft.uql.asset.ConfirmException;
@@ -79,7 +80,8 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       ignite.message().localListen(MESSAGE_TOPIC, new MessageDispatcher());
       ignite.message().localListen(AFFINITY_TOPIC, new AffinityCallProcessor());
       ignite.message().localListen(ServiceTaskExecutorImpl.RESULT_TOPIC, new ServiceTaskResultListener());
-      ignite.events().localListen(new MembershipDispatcher(), EventType.EVT_NODE_JOINED, EventType.EVT_NODE_LEFT);
+      ignite.events().localListen(new MembershipDispatcher(), EventType.EVT_NODE_JOINED,
+                                  EventType.EVT_NODE_LEFT, EventType.EVT_NODE_FAILED);
       String localIp = ignite.cluster().localNode().attribute("local.ip.addr");
       InetAddress fileTransferAddress;
 
@@ -96,9 +98,20 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       messageExecutor = Executors.newFixedThreadPool(
          Runtime.getRuntime().availableProcessors(),
          r -> new GroupedThread(r, "IgniteMessages"));
-      affinityExecutor = Executors.newFixedThreadPool(
-         Runtime.getRuntime().availableProcessors(),
-         r -> new GroupedThread(r, "IgniteMessages"));
+      // Affinity requests run arbitrary service code (opening a viewsheet, loading table data,
+      // executing a chart), which is dominated by locks and I/O rather than CPU, and which can
+      // itself issue a nested affinity call. Sizing this pool to the CPU count meant a couple of
+      // concurrent remote sheet operations could consume every thread, so a nested call blocked
+      // on a response that only work queued behind it could produce. Allow the pool to grow well
+      // past the CPU count and let idle threads retire.
+      //
+      // This pool also gets its own thread name. It previously shared "IgniteMessages" with the
+      // message dispatch pool above, which made thread dumps ambiguous about which of the two
+      // was actually stuck.
+      affinityExecutor = new ThreadPoolExecutor(
+         Runtime.getRuntime().availableProcessors(), getAffinityPoolMaxSize(),
+         60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+         r -> new GroupedThread(r, "IgniteAffinity"));
       listenerExecutor = Executors.newSingleThreadExecutor(
          r -> new GroupedThread(r, "IgniteMapEvents"));
 
@@ -206,7 +219,11 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             EventType.EVT_CACHE_ENTRY_EVICTED,
             EventType.EVT_CACHE_REBALANCE_STOPPED,
             EventType.EVT_NODE_JOINED,
-            EventType.EVT_NODE_LEFT
+            EventType.EVT_NODE_LEFT,
+            // Ignite fires EVT_NODE_LEFT only for a graceful stop. A pod that is OOMKilled,
+            // killed with SIGKILL, segmented, or partitioned away fires EVT_NODE_FAILED instead,
+            // which is the common case during an AKS rolling update or a crash.
+            EventType.EVT_NODE_FAILED
          };
 
          config.setIncludeEventTypes(includedEvents);
@@ -1072,6 +1089,188 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       return localNode.isClient() || Boolean.TRUE.equals(localNode.attribute("scheduler"));
    }
 
+   /**
+    * A remote affinity call that has been sent but not yet answered. The recipient is tracked so
+    * that the call can be failed immediately if that node leaves the cluster, instead of blocking
+    * the caller until the affinity call timeout expires.
+    */
+   private record PendingAffinityCall(String recipient, CompletableFuture<?> future) {
+   }
+
+   /**
+    * Registers a pending remote affinity call so it can be completed by the response listener or
+    * failed if the target node leaves.
+    */
+   private void registerAffinityFuture(String id, String recipient, CompletableFuture<?> future) {
+      affinityFutures.put(id, new PendingAffinityCall(recipient, future));
+   }
+
+   /**
+    * Fails every affinity call still waiting on the given node. Called when a node leaves the
+    * cluster: without this, an in-flight call to a node that is shutting down (a rolling update,
+    * for example) blocks the calling request thread for the full affinity call timeout, since the
+    * response that would complete the future can never arrive.
+    */
+   private void failAffinityCallsTo(String nodeName) {
+      if(nodeName == null) {
+         return;
+      }
+
+      for(Map.Entry<String, PendingAffinityCall> entry : affinityFutures.entrySet()) {
+         PendingAffinityCall pending = entry.getValue();
+
+         if(pending != null && nodeName.equals(pending.recipient()) &&
+            affinityFutures.remove(entry.getKey(), pending))
+         {
+            LOG.warn("Failing affinity call {} because node {} left the cluster", entry.getKey(),
+                     nodeName);
+            pending.future().completeExceptionally(new AffinityCallException(
+               "The node handling this request (" + nodeName + ") left the cluster. " +
+               "Retry the operation."));
+         }
+      }
+   }
+
+   /**
+    * Hands an inbound affinity request to the affinity pool for execution.
+    *
+    * <p>If the Spring application context is not up yet (a race between the Ignite cluster join
+    * and Spring startup on a newly scaled pod), the request waits for it <i>without</i> occupying
+    * an affinity pool thread. Doing that wait inside the pooled task used to consume one of the
+    * few available threads for up to two minutes per request.
+    */
+   @SuppressWarnings({ "rawtypes", "unchecked" })
+   private void submitAffinityRequest(AffinityCallRequest request) {
+      CompletableFuture<Void> ready = ConfigurationContext.getContext().getSpringContextReady();
+
+      if(ready.isDone()) {
+         executeAffinityRequest(request);
+         return;
+      }
+
+      LOG.warn("Affinity request waiting for Spring context to initialize: {}", request);
+      // copy() first: orTimeout() completes the future it is called on, and springContextReady is
+      // shared, so applying the timeout to it directly would fail it for every other waiter.
+      ready.copy()
+         .orTimeout(SPRING_CONTEXT_WAIT_MILLIS, TimeUnit.MILLISECONDS)
+         .whenComplete((v, ex) -> {
+            if(ex != null) {
+               LOG.warn("Spring context did not initialize in time for affinity request: {}",
+                        request, ex);
+               sendAffinityFailure(request, new AffinityCallException(
+                  "Node " + getNodeName(ignite.cluster().localNode()) + " is still starting up " +
+                  "and could not handle the request. Retry the operation.", ex));
+            }
+            else {
+               executeAffinityRequest(request);
+            }
+         });
+   }
+
+   @SuppressWarnings({ "rawtypes", "unchecked" })
+   private void executeAffinityRequest(AffinityCallRequest request) {
+      try {
+         affinityExecutor.submit(new AffinityCallRequestTask(request));
+         LOG.debug("SUBMITTED AFFINITY REQUEST: {}", request);
+      }
+      catch(RejectedExecutionException e) {
+         // The pool is saturated. Tell the caller now so it can retry or report a real error,
+         // rather than leaving it to block until the affinity call timeout.
+         LOG.warn("Rejected affinity request, the affinity pool is saturated: {}", request);
+         sendAffinityFailure(request, new AffinityCallException(
+            "Node " + getNodeName(ignite.cluster().localNode()) + " is at capacity and could " +
+            "not accept the request. Retry the operation."));
+      }
+   }
+
+   @SuppressWarnings({ "rawtypes", "unchecked" })
+   private void sendAffinityFailure(AffinityCallRequest request, Throwable error) {
+      try {
+         AffinityCallResponse response = new AffinityCallResponse<>(
+            request.getId(), request.getSender(), null, error);
+         ignite.message().sendOrdered(AFFINITY_TOPIC, response, 0);
+      }
+      catch(Exception e) {
+         LOG.error("Failed to send affinity failure response: {}", request, e);
+      }
+   }
+
+   /**
+    * Gets the maximum number of affinity requests this node will execute concurrently.
+    *
+    * <p>Read from a system property rather than from {@code SreeEnv}: this runs in the
+    * {@code IgniteCluster} constructor, and the {@code SreeEnv} property store is itself backed by
+    * the cluster, so reading it here would be circular.
+    */
+   private static int getAffinityPoolMaxSize() {
+      String property = System.getProperty("inetsoft.cluster.affinity.pool.maxSize");
+      int size = DEFAULT_AFFINITY_POOL_MAX_SIZE;
+
+      if(property != null) {
+         try {
+            int configured = Integer.parseInt(property.trim());
+
+            if(configured > 0) {
+               size = configured;
+            }
+            else {
+               LOG.warn("Ignoring non-positive inetsoft.cluster.affinity.pool.maxSize: {}",
+                        property);
+            }
+         }
+         catch(NumberFormatException e) {
+            LOG.warn("Ignoring invalid inetsoft.cluster.affinity.pool.maxSize: {}", property);
+         }
+      }
+
+      return Math.max(size, Runtime.getRuntime().availableProcessors());
+   }
+
+   /**
+    * Translates the failure of a remote affinity call into the exception the caller should see.
+    *
+    * <p>The remote failure is rethrown with its own type so that a caller handling a specific
+    * exception still matches it. Wrapping every cause in a {@code RuntimeException} made a
+    * failure raised on another node look different from the identical failure raised locally,
+    * which is what let a remote {@code SecurityException} reach request handlers as an opaque
+    * {@code RuntimeException(ExecutionException(SecurityException))}.
+    *
+    * <p>Declared to return {@code RuntimeException} so callers can write {@code throw
+    * rethrowAffinityCause(ex)} and have the compiler see that control does not continue; this
+    * method always throws.
+    */
+   static RuntimeException rethrowAffinityCause(ExecutionException ex) {
+      Throwable cause = ex.getCause();
+
+      switch(cause) {
+      case null -> throw new RuntimeException(ex);
+      case ExpiredSheetException ese -> throw ese;
+      case MessageException me -> throw me;
+      case ConfirmException ce -> throw ce;
+      case RuntimeException re -> throw re;
+      case Error err -> throw err;
+      default -> throw new RuntimeException(cause);
+      }
+   }
+
+   /**
+    * Gets the maximum time to wait for a remote affinity call to respond.
+    */
+   private static long getAffinityCallTimeoutMillis() {
+      String property = SreeEnv.getProperty("cluster.affinity.call.timeout");
+
+      if(property != null) {
+         try {
+            return Long.parseLong(property.trim());
+         }
+         catch(NumberFormatException e) {
+            LOG.warn("Invalid value for cluster.affinity.call.timeout: {}", property);
+         }
+      }
+
+      return DEFAULT_AFFINITY_CALL_TIMEOUT_MILLIS;
+   }
+
    @Override
    public <T> T affinityCall(String cache, Object key, AffinityCallable<T> job) {
       String id = UUID.randomUUID().toString();
@@ -1092,21 +1291,30 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          }
       }
 
+      String recipient = getNodeName(node);
       AffinityCallRequest<T> request = new AffinityCallRequest<>(
-         id, getNodeName(ignite.cluster().localNode()), getNodeName(node), job);
+         id, getNodeName(ignite.cluster().localNode()), recipient, job);
       CompletableFuture<T> future = new CompletableFuture<>();
-      affinityFutures.put(id, future);
+      registerAffinityFuture(id, recipient, future);
 
       try {
          LOG.debug("AFFINITY CALL SENDING: cache={}, key={}, node={}, id={}, request={}", cache, key, node, id, request);
          ignite.message().sendOrdered(AFFINITY_TOPIC, request, 0);
       }
       catch(Exception e) {
-         LOG.error("Failed to send affinity call request: cache={}, key={}, node={}, id={}, exception={}", cache, key, node, id, e);
+         // The request never left this node, so no response can ever arrive. Fail now instead of
+         // waiting out the full affinity call timeout.
+         LOG.error("Failed to send affinity call request: cache={}, key={}, node={}, id={}", cache, key, node, id, e);
+         affinityFutures.remove(id);
+         throw new AffinityCallException(
+            "Failed to send the request to node " + recipient + " for key " + key +
+            " in cache " + cache + ". Retry the operation.", e);
       }
 
+      long timeout = getAffinityCallTimeoutMillis();
+
       try {
-         return future.get(5L, TimeUnit.MINUTES);
+         return future.get(timeout, TimeUnit.MILLISECONDS);
       }
       catch(RuntimeException ex) {
          affinityFutures.remove(id);
@@ -1114,13 +1322,14 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       }
       catch(ExecutionException ex) {
          affinityFutures.remove(id);
-
-         switch(ex.getCause()) {
-         case ExpiredSheetException ese -> throw ese;
-         case MessageException me -> throw me;
-         case ConfirmException ce -> throw ce;
-         default -> throw new RuntimeException(ex);
-         }
+         throw rethrowAffinityCause(ex);
+      }
+      catch(TimeoutException e) {
+         affinityFutures.remove(id);
+         throw new AffinityCallException(
+            "Timed out after " + timeout + "ms waiting for node " +
+            recipient + " to handle key " + key + " in cache " + cache +
+            ". Retry the operation.", e);
       }
       catch(Exception e) {
          affinityFutures.remove(id);
@@ -1140,30 +1349,49 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       if(Objects.equals(node, ignite.cluster().localNode())) {
          LOG.debug("AFFINITY CALL ASYNC DIRECT: cache={}, key={}, node={}, id={}", cache, key, node, id);
 
-         return CompletableFuture.supplyAsync(() -> {
-            try {
-               return job.call();
-            }
-            catch(RuntimeException ex) {
-               throw ex;
-            }
-            catch(Exception ex) {
-               throw new RuntimeException(ex);
-            }
-         }, affinityExecutor);
+         try {
+            return CompletableFuture.supplyAsync(() -> {
+               try {
+                  return job.call();
+               }
+               catch(RuntimeException ex) {
+                  throw ex;
+               }
+               catch(Exception ex) {
+                  throw new RuntimeException(ex);
+               }
+            }, affinityExecutor);
+         }
+         catch(RejectedExecutionException e) {
+            // The affinity pool grows to a bound and then rejects. supplyAsync submits inline, so
+            // without this the rejection escapes as a bare RejectedExecutionException instead of
+            // the retriable failure every other affinity path produces.
+            LOG.warn("Rejected local affinity call, the affinity pool is saturated: " +
+                     "cache={}, key={}", cache, key);
+            return CompletableFuture.failedFuture(new AffinityCallException(
+               "This node is at capacity and could not accept the request. " +
+               "Retry the operation.", e));
+         }
       }
 
+      String recipient = getNodeName(node);
       AffinityCallRequest<T> request = new AffinityCallRequest<>(
-         id, getNodeName(ignite.cluster().localNode()), getNodeName(node), job);
+         id, getNodeName(ignite.cluster().localNode()), recipient, job);
       CompletableFuture<T> future = new CompletableFuture<>();
-      affinityFutures.put(id, future);
+      registerAffinityFuture(id, recipient, future);
 
       try {
          LOG.debug("AFFINITY CALL ASYNC SENDING: cache={}, key={}, node={}, id={}, request={}", cache, key, node, id, request);
          ignite.message().sendOrdered(AFFINITY_TOPIC, request, 0);
       }
       catch(Exception e) {
-         LOG.error("Failed to send affinity call async request: cache={}, key={}, node={}, id={}, exception={}", cache, key, node, id, e);
+         // The request never left this node, so no response can ever arrive. Fail the returned
+         // future instead of handing back one that can only ever time out.
+         LOG.error("Failed to send affinity call async request: cache={}, key={}, node={}, id={}", cache, key, node, id, e);
+         affinityFutures.remove(id);
+         future.completeExceptionally(new AffinityCallException(
+            "Failed to send the request to node " + recipient + " for key " + key +
+            " in cache " + cache + ". Retry the operation.", e));
       }
 
       LOG.debug("AFFINITY CALL ASYNC COMPLETED: cache={}, key={}, node={}, id={}", cache, key, node, id);
@@ -1190,10 +1418,11 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
             }
             else if(!node.isClient()) {
                String id = UUID.randomUUID().toString();
+               String recipient = getNodeName(node);
                AffinityCallRequest<T> request = new AffinityCallRequest<>(
-                  id, getNodeName(ignite.cluster().localNode()), getNodeName(node), job);
+                  id, getNodeName(ignite.cluster().localNode()), recipient, job);
                CompletableFuture<T> future = new CompletableFuture<>();
-               affinityFutures.put(id, future);
+               registerAffinityFuture(id, recipient, future);
                futures.add(future);
                futureIds.add(id);
                ignite.message(ignite.cluster().forServers()).sendOrdered(AFFINITY_TOPIC, request, 0);
@@ -1206,10 +1435,10 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       }
 
       // Wait for all remote futures under a single shared timeout so that N failed
-      // nodes cost at most 5 minutes total rather than N × 5 minutes.
+      // nodes cost at most one timeout total rather than N × the timeout.
       try {
          CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-            .get(5L, TimeUnit.MINUTES);
+            .get(getAffinityCallTimeoutMillis(), TimeUnit.MILLISECONDS);
       }
       catch(RuntimeException ex) {
          futureIds.forEach(affinityFutures::remove);
@@ -1716,6 +1945,18 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       }
 
       pendingServiceTasks.clear();
+
+      // Ignite is already closed above, so no affinity response can still arrive. Fail anything
+      // waiting rather than leaving those callers blocked until the affinity call timeout, which
+      // matters when this node is being drained during a rolling update.
+      for(PendingAffinityCall pending : affinityFutures.values()) {
+         if(pending != null) {
+            pending.future().completeExceptionally(
+               new AffinityCallException("This node is shutting down. Retry the operation."));
+         }
+      }
+
+      affinityFutures.clear();
       messageExecutor.shutdownNow();
       affinityExecutor.shutdownNow();
       listenerExecutor.shutdownNow();
@@ -1927,7 +2168,7 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
    private final Set<ClusterLifecycleListener> lifecycleListeners =
       new CopyOnWriteArraySet<>();
    private final Map<String, LockInfo> lockInfos = new ConcurrentHashMap<>();
-   private final Map<String, CompletableFuture<?>> affinityFutures = new ConcurrentHashMap<>();
+   private final Map<String, PendingAffinityCall> affinityFutures = new ConcurrentHashMap<>();
    private final Timer timer = new Timer();
    private final ClusterFileTransfer clusterFileTransfer;
    private final Map<Integer, ExecutorService> executorServiceMap = new ConcurrentHashMap<>();
@@ -1937,6 +2178,10 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
    private final ExecutorService listenerExecutor;
 
    private static final int DEFAULT_BACKUP_COUNT = 2;
+   private static final int DEFAULT_AFFINITY_POOL_MAX_SIZE = 64;
+   private static final long SPRING_CONTEXT_WAIT_MILLIS = Duration.ofMinutes(2).toMillis();
+   private static final long DEFAULT_AFFINITY_CALL_TIMEOUT_MILLIS =
+      Duration.ofMinutes(5).toMillis();
    private static final long MIN_LOCK_DURATION_MILLIS = Duration.ofMinutes(10).toMillis();
    private static final String MESSAGE_TOPIC = IgniteCluster.class.getName() + ".messageTopic";
    private static final String AFFINITY_TOPIC = IgniteCluster.class.getName() + ".affinityTopic";
@@ -1969,17 +2214,18 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          if(message instanceof AffinityCallRequest request) {
             LOG.debug("RECEIVED AFFINITY REQUEST: {}", request);
             if(getNodeName(ignite.cluster().localNode()).equals(request.getRecipient())) {
-               LOG.debug("SUBMITTED AFFINITY REQUEST: {}", request);
-               affinityExecutor.submit(new AffinityCallRequestTask(request));
+               submitAffinityRequest(request);
             }
          }
          else if(message instanceof AffinityCallResponse response) {
             LOG.debug("RECEIVED AFFINITY RESPONSE: {}", response);
             if(getNodeName(ignite.cluster().localNode()).equals(response.getRecipient())) {
-               CompletableFuture future = affinityFutures.remove(response.getId());
-               LOG.debug("COMPLETING AFFINITY FUTURE: response={}, future={}", response, future);
+               PendingAffinityCall pending = affinityFutures.remove(response.getId());
+               LOG.debug("COMPLETING AFFINITY FUTURE: response={}, pending={}", response, pending);
 
-               if(future != null) {
+               if(pending != null) {
+                  CompletableFuture future = pending.future();
+
                   if(response.getError() != null) {
                      future.completeExceptionally(response.getError());
                   }
@@ -2086,18 +2332,9 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
          Throwable error = null;
 
          try {
-            // If the Spring application context has not been initialized yet (race between
-            // Ignite cluster join and Spring startup on a newly scaled pod), wait for it
-            // before executing the callable.  The affinity caller's own timeout (5 min) bounds
-            // the end-to-end wait, so 2 minutes here gives Spring plenty of time to start
-            // without risking an indefinite hang.
-            CompletableFuture<Void> ready = ConfigurationContext.getContext().getSpringContextReady();
-
-            if(!ready.isDone()) {
-               LOG.warn("Affinity request waiting for Spring context to initialize: {}", request);
-               ready.get(2L, TimeUnit.MINUTES);
-            }
-
+            // The wait for the Spring application context (race between Ignite cluster join and
+            // Spring startup on a newly scaled pod) happens in submitAffinityRequest, before a
+            // pool thread is claimed, so this task only ever runs against a ready context.
             result = request.getCallable().call();
          }
          catch(InterruptedException e) {
@@ -2208,17 +2445,43 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
                }
             });
          }
-         else if(event.type() == EventType.EVT_NODE_LEFT) {
+         else if(event.type() == EventType.EVT_NODE_LEFT ||
+                 event.type() == EventType.EVT_NODE_FAILED)
+         {
             String node;
             boolean client;
+            ClusterNode leftNode;
 
             if(event instanceof DiscoveryEvent discoveryEvent) {
-               node = discoveryEvent.eventNode().addresses().iterator().next();
-               client = discoveryEvent.eventNode().isClient();
+               leftNode = discoveryEvent.eventNode();
+               node = leftNode.addresses().iterator().next();
+               client = leftNode.isClient();
             }
             else {
-               node = getNodeName(event.node());
-               client = event.node().isClient();
+               leftNode = event.node();
+               node = getNodeName(leftNode);
+               client = leftNode.isClient();
+            }
+
+            // Fail anything still waiting on this node. The node is gone, so the affinity
+            // response that would complete those futures can never arrive and the callers would
+            // otherwise block for the full affinity call timeout.
+            //
+            // This runs for EVT_NODE_FAILED as well as EVT_NODE_LEFT. Ignite only fires
+            // EVT_NODE_LEFT for a graceful stop; a pod that is OOMKilled, SIGKILLed, segmented or
+            // partitioned away fires EVT_NODE_FAILED, which is the case that actually matters
+            // during a rolling update or a crash.
+            //
+            // Note this deliberately uses getNodeName(), which is how affinity recipients are
+            // addressed, rather than the bare address used for the MembershipEvent below.
+            failAffinityCallsTo(getNodeName(leftNode));
+
+            // memberRemoved is deliberately still fired only for a graceful EVT_NODE_LEFT, to
+            // keep this change to the affinity cleanup. That the MembershipListeners are never
+            // notified when a node crashes looks like a separate pre-existing gap; widening it
+            // here would change behaviour for every listener at once.
+            if(event.type() != EventType.EVT_NODE_LEFT) {
+               return true;
             }
 
             executor.submit(() -> {

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -403,7 +403,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
       }
       else if(ClientInfo.ANONYMOUS.equals(user.getLoginUserID().name)) {
          if(containsAnonymous(user.getUserIdentity().getOrgID())) {
-            principal = users.get(user.getCacheKey());
+            principal = getLoggedInUser(user);
 
             if(principal == null ||
                ((new Date()).getTime() - principal.getAge()) > 36000000L) {
@@ -416,9 +416,9 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
                      user.getUserIdentity().orgID,
                      secureID);
                   principal.setProperty("__internal__", "true");
-                  users.remove(user);
+                  removeLoggedInUser(user);
                   principal.setProperty("login.user", "true");
-                  users.put(user.getCacheKey(), principal);
+                  putLoggedInUser(user, principal);
                   ConnectionProcessor.getInstance().setAdditionalDatasource(principal);
                }
             }
@@ -444,7 +444,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
                user.setUserName(realUser.getIdentityID());
             }
 
-            principal = users.get(user.getCacheKey());
+            principal = getLoggedInUser(user);
 
             if(principal == null ||
                ((new Date()).getTime() - principal.getAge()) > 36000000L)
@@ -465,9 +465,9 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
                   principal.setUser(user.getCacheKey());
                }
 
-               users.remove(user);
+               removeLoggedInUser(user);
                principal.setProperty("login.user", "true");
-               users.put(user.getCacheKey(), principal);
+               putLoggedInUser(user, principal);
             }
          }
       }
@@ -522,7 +522,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
    private void logout(Principal principal) {
       if((principal instanceof SRPrincipal) && isLogin(principal)) {
          synchronized(this) {
-            users.remove(((SRPrincipal) principal).getUser());
+            removeLoggedInUser(((SRPrincipal) principal).getUser());
          }
       }
    }
@@ -1429,6 +1429,69 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
    }
 
    /**
+    * Looks up the registered principal for a logged-in user.
+    *
+    * <p>The map is keyed by {@link ClientInfo#getLoginKey()} rather than
+    * {@link ClientInfo#getCacheKey()}: the cache key includes the client address and the locale,
+    * which can differ once a principal has been serialized to another cluster node (for example
+    * when a viewsheet action is routed to the node that owns the sheet). That made the lookup miss
+    * and the user appear never to have logged in.
+    *
+    * @param user the client info of the user to look up.
+    *
+    * @return the registered principal, or {@code null} if the user is not logged in.
+    */
+   private SRPrincipal getLoggedInUser(ClientInfo user) {
+      if(user == null) {
+         return null;
+      }
+
+      SRPrincipal stored = users.get(user.getLoginKey());
+
+      if(stored == null) {
+         // Entries written by a node still running an older build are keyed by the full cache
+         // key. Fall back to it so users stay logged in across a rolling upgrade. This can be
+         // removed once no node can be writing the old key.
+         stored = users.get(user.getCacheKey());
+
+         if(stored == null && LOG.isDebugEnabled()) {
+            LOG.debug("No logged-in principal registered for user {} with session {}",
+                      user.getUserIdentity(), user.getSession());
+         }
+      }
+
+      return stored;
+   }
+
+   /**
+    * Registers a principal as logged in.
+    *
+    * <p>Writes under both the login key and the legacy cache key. The legacy write is what keeps
+    * a rolling upgrade working in the other direction: a node still running an older build reads
+    * {@code users.get(user.getCacheKey())} exclusively, so without it every login registered on an
+    * upgraded node would be invisible to a not-yet-upgraded one and those users would hit
+    * "did not log in" for the whole upgrade window. When the two keys coincide (no session id)
+    * this is a single entry. The legacy write can be dropped once no supported upgrade path
+    * starts from a build that reads the cache key.
+    */
+   private void putLoggedInUser(ClientInfo user, SRPrincipal principal) {
+      users.put(user.getLoginKey(), principal);
+      users.put(user.getCacheKey(), principal);
+   }
+
+   /**
+    * Removes a logged-in principal, under both the current and the legacy key.
+    */
+   private void removeLoggedInUser(ClientInfo user) {
+      if(user == null) {
+         return;
+      }
+
+      users.remove(user.getLoginKey());
+      users.remove(user.getCacheKey());
+   }
+
+   /**
     * Check whether this user has logged in or not.
     */
    private boolean isLogin(Principal principal) {
@@ -1443,7 +1506,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
             return true;
          }
 
-         SRPrincipal srPrincipal2 = users.get(srPrincipal.getUser().getCacheKey());
+         SRPrincipal srPrincipal2 = getLoggedInUser(srPrincipal.getUser());
 
          if(srPrincipal2 == null) {
             // anonymous users are not added to the users map. allow anonymous users if they exist
@@ -1492,7 +1555,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
          return false;
       }
 
-      SRPrincipal stored = users.get(srPrincipal.getUser().getCacheKey());
+      SRPrincipal stored = getLoggedInUser(srPrincipal.getUser());
 
       // Compare user identity to be resilient to serialization issues in clustered environments
       return stored != null &&
@@ -1513,7 +1576,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
             return true;
          }
 
-         SRPrincipal stored = users.get(sr.getUser().getCacheKey());
+         SRPrincipal stored = getLoggedInUser(sr.getUser());
 
          // Compare user identity to be resilient to serialization issues in clustered environments
          return stored != null &&

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -1470,9 +1470,12 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
     * a rolling upgrade working in the other direction: a node still running an older build reads
     * {@code users.get(user.getCacheKey())} exclusively, so without it every login registered on an
     * upgraded node would be invisible to a not-yet-upgraded one and those users would hit
-    * "did not log in" for the whole upgrade window. When the two keys coincide (no session id)
-    * this is a single entry. The legacy write can be dropped once no supported upgrade path
-    * starts from a build that reads the cache key.
+    * "did not log in" for the whole upgrade window. The two keys are equal, making this a
+    * single entry, only when the locale is null and the login key keeps the same address as the
+    * cache key -- that is, no session id (the address is retained) or an empty address. Note that
+    * a locale is commonly set on the client info after construction, so in practice both writes
+    * usually land on distinct entries. The legacy write can be dropped once no supported
+    * upgrade path starts from a build that reads the cache key.
     */
    private void putLoggedInUser(ClientInfo user, SRPrincipal principal) {
       users.put(user.getLoginKey(), principal);

--- a/core/src/main/java/inetsoft/util/FipsPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/FipsPasswordEncryption.java
@@ -204,7 +204,15 @@ class FipsPasswordEncryption extends LocalPasswordEncryption {
       try {
          return withLock(() -> {
             SecretKey key;
-            String property = SreeEnv.getProperty("password.hash.key");
+            // Storage first, snapshot only as a fallback: the in-memory property snapshot
+            // refreshes asynchronously, so the cluster lock alone does not stop two nodes from
+            // each seeing "absent" and generating a different key. See
+            // LocalPasswordEncryption.getJwtSigningKey() for the full rationale.
+            String property = SreeEnv.getPropertyFromStorage("password.hash.key");
+
+            if(property == null || property.isEmpty()) {
+               property = SreeEnv.getProperty("password.hash.key");
+            }
 
             if(property == null || property.isEmpty()) {
                key = createHmacKey();

--- a/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
@@ -239,15 +239,28 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
       // Guard the read-check-regenerate sequence with the cluster lock, matching
       // getSSOKeyPair(). Without it, an upgraded clustered FIPS deployment could have every
       // node independently regenerate and persist a different key at once (the self-heal
-      // branch below), causing transient cross-node JWT verification failures. Reading the
-      // property inside the lock also double-checks: once one node re-persists a valid key,
-      // the next node reads it and skips a redundant regeneration.
+      // branch below), causing transient cross-node JWT verification failures.
+      //
+      // The lock only serializes the nodes; it does not make the check correct on its own.
+      // SreeEnv.getProperty() serves this node's in-memory snapshot, which the key-value storage
+      // change listener refreshes asynchronously (debounced). Read the backing store FIRST and
+      // treat the snapshot only as a fallback for when storage is unreadable. Storage-first
+      // matters in two places:
+      //   - a simultaneous multi-node start, where a node can hold the lock and still see a stale
+      //     null for a key another node just persisted, and generate a second one;
+      //   - a re-read triggered by the property-change listener, which fires BEFORE the debounced
+      //     snapshot refresh, so the snapshot still holds the OLD key at that point. Checking the
+      //     store only when the snapshot is null would silently keep the stale key.
       Lock lock = Cluster.getInstance().getLock(LOCK_NAME);
       lock.lock();
 
       try {
          SecretKey signingKey;
-         String property = SreeEnv.getProperty("jwt.signing.key");
+         String property = SreeEnv.getPropertyFromStorage("jwt.signing.key");
+
+         if(property == null) {
+            property = SreeEnv.getProperty("jwt.signing.key");
+         }
 
          if(property == null) {
             signingKey = createAndStoreJwtSigningKey();
@@ -288,8 +301,20 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
       lock.lock();
 
       try {
-         String privateKeyProperty = SreeEnv.getPassword("sso.rsa.private.key");
-         String publicKeyProperty = SreeEnv.getProperty("sso.rsa.public.key");
+         // Read the backing store first; the in-memory snapshot is only a fallback for when
+         // storage is unreadable. See getJwtSigningKey() for why storage-first (rather than
+         // storage-as-a-null-fallback) is required: the snapshot is stale both during a
+         // simultaneous multi-node start and at the moment the property-change listener fires.
+         String privateKeyProperty = SreeEnv.getPasswordFromStorage("sso.rsa.private.key");
+         String publicKeyProperty = SreeEnv.getPropertyFromStorage("sso.rsa.public.key");
+
+         if(privateKeyProperty == null) {
+            privateKeyProperty = SreeEnv.getPassword("sso.rsa.private.key");
+         }
+
+         if(publicKeyProperty == null) {
+            publicKeyProperty = SreeEnv.getProperty("sso.rsa.public.key");
+         }
 
          if(privateKeyProperty == null || publicKeyProperty == null) {
             KeyPair keyPair = createSSOKeyPair();

--- a/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
+++ b/core/src/main/java/inetsoft/util/LocalPasswordEncryption.java
@@ -387,7 +387,16 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
             throw new IllegalArgumentException("The master password is incorrect.");
          }
 
-         String keyProperty = SreeEnv.getProperty("password.encryption.key");
+         // Storage first, for the same reason as getSecretKey(): a stale null from the
+         // in-memory snapshot here would skip re-encrypting the stored key under the new
+         // master password, leaving it decryptable only with the old one. A read failure is
+         // propagated -- this is an explicit administrative action, so refusing it is far
+         // better than half-applying it.
+         String keyProperty = SreeEnv.getPropertyFromStorage("password.encryption.key");
+
+         if(keyProperty == null) {
+            keyProperty = SreeEnv.getProperty("password.encryption.key");
+         }
 
          if(keyProperty != null) {
             SecretKey key = decryptSecretKey(keyProperty, oldMasterKey);
@@ -429,11 +438,37 @@ abstract class LocalPasswordEncryption extends AbstractPasswordEncryption {
 
       try {
          SecretKey key;
-         String property = SreeEnv.getProperty("password.encryption.key");
+         // Storage first, snapshot only as a fallback, matching getJwtSigningKey() and
+         // getSSOKeyPair(): the in-memory snapshot refreshes asynchronously, so the cluster
+         // lock alone does not stop two nodes from each seeing "absent" and generating a
+         // different key. Of the four keys read this way, this one is the highest-stakes: a
+         // second password.encryption.key would leave every already-stored password
+         // undecryptable.
+         //
+         // Unlike the other three, a storage read failure here does NOT propagate. This method
+         // is on the path of every password encrypt/decrypt in the process, so failing closed
+         // on a transient read error would take down unrelated work that the already-loaded
+         // snapshot can serve correctly. The safety property that must hold is the narrower
+         // one: never generate a new key while the stored state is unknown. So a read failure
+         // falls back to the snapshot, and if the snapshot has no key either, the failure is
+         // rethrown rather than answered by minting a second key.
+         String property;
+         RuntimeException storageError = null;
 
-         // Fallback to backing store if in-memory cache hasn't refreshed yet
-         if(property == null) {
+         try {
             property = SreeEnv.getPropertyFromStorage("password.encryption.key");
+         }
+         catch(RuntimeException e) {
+            storageError = e;
+            property = null;
+         }
+
+         if(property == null) {
+            property = SreeEnv.getProperty("password.encryption.key");
+         }
+
+         if(property == null && storageError != null) {
+            throw storageError;
          }
 
          if(property == null) {

--- a/core/src/test/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxyTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/cluster/ignite/DistributedLockProxyTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.internal.cluster.ignite;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * DistributedLockProxy.lock() retry scenario table:
+ *  [Acquired]        tryLock succeeds immediately          -> returns, no retry
+ *  [Late success]    tryLock times out repeatedly, then succeeds -> returns without throwing
+ *  [Contention]      tryLock keeps returning false         -> keeps waiting, does NOT throw
+ *
+ * The error path (tryLock throwing repeatedly, bounded at MAX_TRY_COUNT) is unchanged legacy
+ * behavior and is not covered here: exercising it means sleeping through the full RETRY_DELAY_MS
+ * budget, which costs ~27s for no coverage of anything this change touched.
+ *
+ * The contention case is the important one. lock() must honour the java.util.concurrent.locks.Lock
+ * contract and block until the lock is acquired: every caller uses the
+ * lock(); try { ... } finally { unlock(); } idiom and none of them handle a failure to acquire.
+ * Bounding that wait would turn ordinary contention -- an MV generation or asset import holding
+ * the lock for a while -- into a hard failure. Only repeated *errors* from the underlying
+ * distributed lock are bounded, at MAX_TRY_COUNT.
+ */
+@Tag("core")
+class DistributedLockProxyTest {
+   // [Scenario: acquired] the underlying lock is granted on the first try -> no retry loop
+   @Test
+   void lock_acquiredImmediately_returnsWithoutRetrying() throws Exception {
+      Lock realLock = mock(Lock.class);
+      when(realLock.tryLock(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+      new DistributedLockProxy("test", realLock).lock();
+
+      verify(realLock, times(1)).tryLock(anyLong(), any(TimeUnit.class));
+   }
+
+   // [Scenario: late success] many timeouts followed by success -> returns normally. The retry
+   // budget that bounds the *error* path must not apply here, so this deliberately times out more
+   // than MAX_TRY_COUNT times before succeeding.
+   @Test
+   void lock_timesOutMoreThanMaxTryCountThenSucceeds_returnsWithoutThrowing() throws Exception {
+      Lock realLock = mock(Lock.class);
+      Boolean[] timeouts = new Boolean[MAX_TRY_COUNT * 2];
+      Arrays.fill(timeouts, Boolean.FALSE);
+      when(realLock.tryLock(anyLong(), any(TimeUnit.class)))
+         .thenReturn(Boolean.FALSE, Arrays.copyOf(timeouts, timeouts.length))
+         .thenReturn(Boolean.TRUE);
+
+      assertTimeoutPreemptively(
+         java.time.Duration.ofSeconds(30),
+         () -> new DistributedLockProxy("test", realLock).lock(),
+         "lock() must keep waiting through contention rather than giving up");
+
+      verify(realLock, times(timeouts.length + 2)).tryLock(anyLong(), any(TimeUnit.class));
+   }
+
+   // [Scenario: contention] the lock is simply held elsewhere for a long time. lock() must keep
+   // waiting -- the Lock contract -- not throw. Guards against bounding the wait, which would turn
+   // ordinary contention into a hard failure at all 34 cluster-lock call sites, none of which
+   // handle a failure to acquire.
+   @Test
+   void lock_heldElsewhere_keepsWaitingInsteadOfThrowing() throws Exception {
+      Lock realLock = mock(Lock.class);
+      AtomicInteger calls = new AtomicInteger();
+      // Return false far more often than MAX_TRY_COUNT, then succeed, so the test still finishes.
+      when(realLock.tryLock(anyLong(), any(TimeUnit.class)))
+         .thenAnswer(inv -> calls.incrementAndGet() > MAX_TRY_COUNT * 5);
+
+      assertTimeoutPreemptively(
+         java.time.Duration.ofSeconds(30),
+         () -> new DistributedLockProxy("test", realLock).lock());
+
+      assertTrue(calls.get() > MAX_TRY_COUNT,
+                 "lock() gave up after " + calls.get() + " attempts; it must block until acquired");
+   }
+
+   private static final int MAX_TRY_COUNT = 10;
+}

--- a/core/src/test/java/inetsoft/sree/internal/cluster/ignite/IgniteClusterAffinityErrorTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/cluster/ignite/IgniteClusterAffinityErrorTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ */
+package inetsoft.sree.internal.cluster.ignite;
+
+import inetsoft.report.composition.ExpiredSheetException;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.ConfirmException;
+import inetsoft.util.MessageException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * IgniteCluster.rethrowAffinityCause scenario table:
+ *  [ExpiredSheet]       remote sheet expired       -> rethrown as ExpiredSheetException
+ *  [MessageException]   remote user-facing message -> rethrown as MessageException
+ *  [ConfirmException]   remote confirmation prompt -> rethrown as ConfirmException
+ *  [RuntimeException]   remote unchecked failure   -> rethrown as-is
+ *  [SecurityException]  remote permission failure  -> wrapped, but the cause is the
+ *                                                    SecurityException itself
+ *  [Checked exception]  remote checked failure     -> wrapped, cause preserved
+ *  [No cause]           ExecutionException w/ null cause -> wrapped, no NPE
+ *
+ * A remote affinity failure has to reach the caller looking like the same failure raised
+ * locally. Locally, affinityCall wraps a checked cause once: RuntimeException(cause). Remotely,
+ * every cause used to be wrapped around the ExecutionException instead, so the permission failure
+ * behind the "<user> did not log in" reports arrived as
+ * RuntimeException(ExecutionException(SecurityException)) -- one level deeper than the identical
+ * local failure, and unchecked causes lost their type entirely.
+ *
+ * Note inetsoft.sree.security.SecurityException is a checked exception, so it cannot be rethrown
+ * as-is from affinityCall; the guarantee for it is that it sits directly under the wrapper.
+ */
+@Tag("core")
+class IgniteClusterAffinityErrorTest {
+   // [Scenario: SecurityException] the case behind the "did not log in" reports. It is a checked
+   // exception, so it cannot be rethrown as-is, but it must sit directly under the wrapper -- the
+   // same shape the local branch of affinityCall produces -- rather than under an extra
+   // ExecutionException that hides it from callers inspecting getCause().
+   @Test
+   void securityExceptionCause_wrappedDirectlyNotUnderExecutionException() {
+      SecurityException cause = new SecurityException("admin(agile) did not log in.");
+
+      RuntimeException thrown = assertThrows(
+         RuntimeException.class,
+         () -> IgniteCluster.rethrowAffinityCause(new ExecutionException(cause)));
+
+      assertSame(cause, thrown.getCause(),
+                 "the remote failure must be the direct cause, matching the local branch");
+   }
+
+   // [Scenario: RuntimeException] an unchecked remote failure keeps its own type
+   @Test
+   void runtimeExceptionCause_rethrownWithOriginalType() {
+      IllegalStateException cause = new IllegalStateException("bad state");
+
+      assertSame(cause, assertThrows(
+         IllegalStateException.class,
+         () -> IgniteCluster.rethrowAffinityCause(new ExecutionException(cause))));
+   }
+
+   @Test
+   void expiredSheetExceptionCause_rethrownWithOriginalType() {
+      ExpiredSheetException cause = new ExpiredSheetException("sheet-1", null);
+
+      assertSame(cause, assertThrows(
+         ExpiredSheetException.class,
+         () -> IgniteCluster.rethrowAffinityCause(new ExecutionException(cause))));
+   }
+
+   @Test
+   void messageExceptionCause_rethrownWithOriginalType() {
+      MessageException cause = new MessageException("boom");
+
+      assertSame(cause, assertThrows(
+         MessageException.class,
+         () -> IgniteCluster.rethrowAffinityCause(new ExecutionException(cause))));
+   }
+
+   @Test
+   void confirmExceptionCause_rethrownWithOriginalType() {
+      ConfirmException cause = new ConfirmException("confirm");
+
+      assertSame(cause, assertThrows(
+         ConfirmException.class,
+         () -> IgniteCluster.rethrowAffinityCause(new ExecutionException(cause))));
+   }
+
+   // [Scenario: checked exception] a checked cause cannot be rethrown as-is, but it must not be
+   // buried an extra level deep either -- the wrapper's cause is the remote failure itself
+   @Test
+   void checkedExceptionCause_wrappedWithCausePreserved() {
+      IOException cause = new IOException("io");
+
+      RuntimeException thrown = assertThrows(
+         RuntimeException.class,
+         () -> IgniteCluster.rethrowAffinityCause(new ExecutionException(cause)));
+
+      assertSame(cause, thrown.getCause());
+   }
+
+   // [Scenario: no cause] a pattern switch over a null cause would NPE
+   @Test
+   void nullCause_wrappedWithoutNullPointerException() {
+      ExecutionException ex = new ExecutionException("no cause", null);
+
+      RuntimeException thrown = assertThrows(
+         RuntimeException.class, () -> IgniteCluster.rethrowAffinityCause(ex));
+
+      assertSame(ex, thrown.getCause());
+   }
+}

--- a/core/src/test/java/inetsoft/sree/security/SecurityEngineAuthenticationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityEngineAuthenticationTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.security.Principal;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -131,7 +132,10 @@ class SecurityEngineAuthenticationTest {
       @SuppressWarnings("unchecked")
       Map<ClientInfo, SRPrincipal> users =
          (Map<ClientInfo, SRPrincipal>) ReflectionTestUtils.getField(engine, "users");
-      assertSame(srPrincipal, users.get(user.getCacheKey()));
+      // Registered under the login key (user identity + session), not the full cache key: the
+      // cache key also includes the client address and locale, which can differ once the
+      // principal has been serialized to another cluster node.
+      assertSame(srPrincipal, users.get(user.getLoginKey()));
    }
 
    // [Scenario: auth failed] provider rejects the credential -> null returned and no cache entry created
@@ -312,6 +316,90 @@ class SecurityEngineAuthenticationTest {
       engine.fireLoginEvent(principal);
 
       verify(listener).userLogin(argThat(event -> event.getPrincipal() == principal));
+   }
+
+   // [Scenario: cross-node lookup] the same login arriving on another cluster node with a
+   // different client address and locale must still resolve to the registered principal.
+   // A viewsheet action routed by IgniteCluster.affinityCall runs on the node that owns the
+   // sheet, against a principal that has been serialized across the cluster; the map was keyed
+   // by ClientInfo.getCacheKey(), whose equals/hashCode include the address and the locale, so
+   // the lookup missed and SecurityEngine.checkPermission threw "<user> did not log in" for a
+   // user who was actively logged in.
+   // Setup: register a login, then look it up with an otherwise identical ClientInfo whose
+   // address and locale differ.
+   @Test
+   void isValidUser_sameSessionDifferentAddressAndLocale_stillRecognizedAsLoggedIn() {
+      SecurityProvider provider = mock(SecurityProvider.class);
+      ClientInfo user = clientInfo(USER_ID);
+
+      when(provider.authenticate(USER_ID, "secret")).thenReturn(true);
+      when(provider.getUser(USER_ID)).thenReturn(null);
+      when(provider.getRoles(USER_ID)).thenReturn(new IdentityID[0]);
+      when(provider.getUserGroups(USER_ID)).thenReturn(new String[0]);
+
+      SRPrincipal registered = (SRPrincipal) engine.authenticate(user, "secret", provider);
+      assertNotNull(registered);
+
+      ClientInfo roundTripped = new ClientInfo(
+         user.getUserIdentity(), "10.244.0.237", user.getSession(), Locale.FRANCE);
+      SRPrincipal remote = new SRPrincipal(roundTripped, new IdentityID[0], new String[0],
+         USER_ID.getOrgID(), registered.getSecureID());
+      remote.setProperty("login.user", "true");
+      remote.setIgnoreLogin(false);
+
+      assertTrue(engine.isActiveUser(remote),
+         "a principal serialized to another node must still resolve to its login");
+      assertTrue(engine.isValidUser(remote));
+   }
+
+   // [Scenario: different session] a different session for the same user is a different login
+   // and must not resolve. Guards against relaxing the login key so far that any principal
+   // naming an existing user is accepted.
+   // Setup: register a login, then look up the same user with a different session id.
+   @Test
+   void isValidUser_differentSession_notRecognizedAsLoggedIn() {
+      SecurityProvider provider = mock(SecurityProvider.class);
+      ClientInfo user = clientInfo(USER_ID);
+
+      when(provider.authenticate(USER_ID, "secret")).thenReturn(true);
+      when(provider.getUser(USER_ID)).thenReturn(null);
+      when(provider.getRoles(USER_ID)).thenReturn(new IdentityID[0]);
+      when(provider.getUserGroups(USER_ID)).thenReturn(new String[0]);
+
+      SRPrincipal registered = (SRPrincipal) engine.authenticate(user, "secret", provider);
+      assertNotNull(registered);
+
+      ClientInfo other = new ClientInfo(user.getUserIdentity(), "127.0.0.1", "session-2");
+      SRPrincipal otherPrincipal = new SRPrincipal(other, new IdentityID[0], new String[0],
+         USER_ID.getOrgID(), 99L);
+      otherPrincipal.setProperty("login.user", "true");
+      otherPrincipal.setIgnoreLogin(false);
+
+      assertFalse(engine.isValidUser(otherPrincipal));
+   }
+
+   // [Scenario: legacy key] an entry written by a node still running an older build is keyed by
+   // the full cache key. It must remain resolvable so a rolling upgrade does not log users out.
+   // Setup: seed the map under the legacy key only, as cachedLoginPrincipal does.
+   @Test
+   void isValidUser_entryStoredUnderLegacyCacheKey_stillResolves() {
+      ClientInfo user = clientInfo(USER_ID);
+      user.setLocale(Locale.US);
+      SRPrincipal principal = new SRPrincipal(user, new IdentityID[0], new String[0],
+         USER_ID.getOrgID(), 42L);
+      principal.setProperty("login.user", "true");
+      principal.setIgnoreLogin(false);
+
+      @SuppressWarnings("unchecked")
+      Map<ClientInfo, SRPrincipal> users =
+         (Map<ClientInfo, SRPrincipal>) ReflectionTestUtils.getField(engine, "users");
+      users.put(user.getCacheKey(), principal);
+
+      assertNull(users.get(user.getLoginKey()),
+         "precondition: the entry exists only under the legacy key");
+
+      assertTrue(engine.isValidUser(principal));
+      assertTrue(engine.isActiveUser(principal));
    }
 
    private ClientInfo clientInfo(IdentityID userId) {

--- a/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
+++ b/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
@@ -53,6 +53,7 @@ package inetsoft.util;
  */
 
 import com.nimbusds.jose.*;
+import inetsoft.sree.PropertiesEngine;
 import inetsoft.sree.SreeEnv;
 import inetsoft.test.*;
 import org.junit.jupiter.api.*;
@@ -238,6 +239,50 @@ class FipsPasswordEncryptionTest {
          assertTrue(jws.verify(encryption.createJwsVerifier(key)));
       }
 
+      // Clustered cold start: the cluster lock serializes nodes, but SreeEnv.getProperty() reads
+      // this node's in-memory snapshot, which is refreshed asynchronously from key-value storage.
+      // A node could therefore hold the lock, read a stale null for a key another node had
+      // already persisted, and generate and store a second one — leaving each pod signing JWTs
+      // with a different key. getJwtSigningKey() must consult the backing store before deciding
+      // that no key exists.
+      // Setup: persist a key, then evict it from the in-memory properties only, simulating the
+      // node whose snapshot has not caught up yet.
+      @Test
+      void getJwtSigningKey_staleInMemoryCache_readsStorageInsteadOfRegenerating() throws Exception {
+         SecretKey original = encryption.getJwtSigningKey();
+         String persisted = SreeEnv.getProperty("jwt.signing.key");
+         assertNotNull(persisted, "precondition: a key must have been persisted");
+
+         try {
+            evictFromInMemoryProperties("jwt.signing.key");
+            Assumptions.assumeTrue(SreeEnv.getProperty("jwt.signing.key") == null,
+               "could not simulate a stale in-memory property snapshot");
+            Assumptions.assumeTrue(SreeEnv.getPropertyFromStorage("jwt.signing.key") != null,
+               "the backing store is not readable in this test environment");
+
+            SecretKey reread = encryption.getJwtSigningKey();
+
+            assertArrayEquals(original.getEncoded(), reread.getEncoded(),
+               "a stale in-memory null must not cause a second signing key to be generated");
+         }
+         finally {
+            // Undo the in-memory eviction first so the property is in a known state, then clear
+            // it the same way the sibling test does.
+            SreeEnv.setProperty("jwt.signing.key", persisted);
+            SreeEnv.remove("jwt.signing.key");
+         }
+      }
+
+      // Removes a property from the in-memory snapshot without touching the backing store, so the
+      // node looks like one whose asynchronous property refresh has not arrived yet.
+      private void evictFromInMemoryProperties(String name) throws Exception {
+         PropertiesEngine engine = PropertiesEngine.getInstance();
+         java.lang.reflect.Method method =
+            PropertiesEngine.class.getDeclaredMethod("getInternalProperties");
+         method.setAccessible(true);
+         ((java.util.Properties) method.invoke(engine)).remove(name);
+      }
+
       // Bug #75541: self-heal path — an upgraded FIPS deployment with a persisted 128-bit
       // key must have getJwtSigningKey() regenerate and re-persist a 512-bit (64-byte) key.
       @Test
@@ -245,6 +290,10 @@ class FipsPasswordEncryptionTest {
          SecretKey legacyKey = new SecretKeySpec(new byte[16], "HmacSHA512");
          byte[] encrypted = encryption.encryptJwtSigningKey(legacyKey, encryption.getMasterKey());
          SreeEnv.setProperty("jwt.signing.key", Base64.getEncoder().encodeToString(encrypted));
+         // save() as well as setProperty: in the scenario this covers, an older build had
+         // *persisted* the undersized key, and getJwtSigningKey() reads the backing store rather
+         // than the in-memory snapshot so that a stale snapshot cannot drive key regeneration.
+         SreeEnv.save();
 
          try {
             SecretKey healed = encryption.getJwtSigningKey();

--- a/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
+++ b/core/src/test/java/inetsoft/util/FipsPasswordEncryptionTest.java
@@ -46,7 +46,8 @@ package inetsoft.util;
  *
  * updateMasterPassword() — reads/writes SreeEnv password.hash.key; needs mockStatic or full context
  * getSSOKeyPair() — Cluster distributed lock + SreeEnv persistence
- * encryptPassword() / decryptPassword() — getSecretKey() lifecycle + SreeEnv round-trip
+ * encryptPassword() / decryptPassword() — full SreeEnv round-trip; getSecretKey()'s
+ *    storage-first read is covered by getSecretKey_staleInMemoryValue_readsStorageInsteadOfSnapshot
  *
  * getJwtSigningKey() self-heal path (Bug #75541) is covered by
  * getJwtSigningKey_undersizedLegacyKey_regeneratesAndPersists.
@@ -83,6 +84,28 @@ import static org.junit.jupiter.api.Assertions.*;
 class FipsPasswordEncryptionTest {
 
    private FipsPasswordEncryption encryption;
+
+   // Removes a property from the in-memory snapshot without touching the backing store, so the
+   // node looks like one whose asynchronous property refresh has not arrived yet.
+   private static void evictFromInMemoryProperties(String name) throws Exception {
+      PropertiesEngine engine = PropertiesEngine.getInstance();
+      java.lang.reflect.Method method =
+         PropertiesEngine.class.getDeclaredMethod("getInternalProperties");
+      method.setAccessible(true);
+      ((java.util.Properties) method.invoke(engine)).remove(name);
+   }
+
+   // Overwrites a property in the in-memory snapshot without touching the backing store, so the
+   // node looks like one that still holds the value from before the last change. This is the
+   // state PropertiesEngine is in when it fires firePropertyChange, which happens before its
+   // debounced snapshot refresh.
+   private static void setInMemoryPropertyOnly(String name, String value) throws Exception {
+      PropertiesEngine engine = PropertiesEngine.getInstance();
+      java.lang.reflect.Method method =
+         PropertiesEngine.class.getDeclaredMethod("getInternalProperties");
+      method.setAccessible(true);
+      ((java.util.Properties) method.invoke(engine)).setProperty(name, value);
+   }
 
    @BeforeEach
    void setUp() {
@@ -201,6 +224,42 @@ class FipsPasswordEncryptionTest {
          assertArrayEquals(input, decrypted);
       }
 
+      // Same stale-snapshot hazard as getJwtSigningKey(), on the highest-stakes key of the set:
+      // reading a key other than the persisted one leaves every already-stored password
+      // undecryptable. A null-only fallback to storage is not enough — PropertiesEngine fires
+      // firePropertyChange BEFORE its debounced snapshot refresh, so at the moment a re-read is
+      // triggered the snapshot still holds the OLD value, not null. getSecretKey() must therefore
+      // read the backing store first and treat the snapshot only as a fallback.
+      // Setup: persist a key, then plant a different one in the in-memory properties only.
+      @Test
+      void getSecretKey_staleInMemoryValue_readsStorageInsteadOfSnapshot() throws Exception {
+         SecretKey persistedKey = encryption.getSecretKey(encryption.getMasterKey());
+         String persisted = SreeEnv.getPropertyFromStorage("password.encryption.key");
+         Assumptions.assumeTrue(
+            persisted != null, "the backing store is not readable in this test environment");
+
+         SecretKey otherKey = encryption.createSecretKey();
+         Assumptions.assumeTrue(
+            !Arrays.equals(persistedKey.getEncoded(), otherKey.getEncoded()),
+            "the generated keys collided");
+         String stale = Base64.getEncoder().encodeToString(
+            encryption.encryptSecretKey(otherKey, encryption.getMasterKey()));
+
+         try {
+            setInMemoryPropertyOnly("password.encryption.key", stale);
+            Assumptions.assumeTrue(stale.equals(SreeEnv.getProperty("password.encryption.key")),
+               "could not simulate a stale in-memory property snapshot");
+
+            SecretKey reread = encryption.getSecretKey(encryption.getMasterKey());
+
+            assertArrayEquals(persistedKey.getEncoded(), reread.getEncoded(),
+               "the persisted key must win over a stale in-memory snapshot value");
+         }
+         finally {
+            setInMemoryPropertyOnly("password.encryption.key", persisted);
+         }
+      }
+
       @Test
       void encryptWithMaster_roundTrip() {
          byte[] input = "my secret password".getBytes(StandardCharsets.UTF_16);
@@ -271,16 +330,6 @@ class FipsPasswordEncryptionTest {
             SreeEnv.setProperty("jwt.signing.key", persisted);
             SreeEnv.remove("jwt.signing.key");
          }
-      }
-
-      // Removes a property from the in-memory snapshot without touching the backing store, so the
-      // node looks like one whose asynchronous property refresh has not arrived yet.
-      private void evictFromInMemoryProperties(String name) throws Exception {
-         PropertiesEngine engine = PropertiesEngine.getInstance();
-         java.lang.reflect.Method method =
-            PropertiesEngine.class.getDeclaredMethod("getInternalProperties");
-         method.setAccessible(true);
-         ((java.util.Properties) method.invoke(engine)).remove(name);
       }
 
       // Bug #75541: self-heal path — an upgraded FIPS deployment with a persisted 128-bit


### PR DESCRIPTION
Fixes the community-side causes behind Bug #76412 (AKS Ignite cluster instability on multi-node topology changes).

The report attributed all of its symptoms to Ignite's `default-ds-group` partition inconsistency. Code review says otherwise — each symptom has an independent cause in our own code, and none of them require the Ignite bug to be true.

## Divergent JWT/SSO signing keys (fresh multi-replica cold start)

`LocalPasswordEncryption.getJwtSigningKey()` took the cluster lock and then read `SreeEnv.getProperty()`, which serves a node-local snapshot refreshed by a debounced storage listener. A node could hold the lock, read a stale `null`, and generate a second key. The lock was working; the check inside it was not.

Reads are now **storage-first**, with the in-memory snapshot only as a fallback. Storage-first rather than storage-as-a-null-fallback matters because `PropertiesEngine` fires `firePropertyChange` *before* its debounced snapshot refresh — so on a re-read the snapshot still holds the old key and a null-only fallback would be dead code. Same change in `getSSOKeyPair()` and `FipsPasswordEncryption.getPasswordHashKey()`.

`PropertiesEngine.getPropertyFromStorage()` also swallowed storage errors and returned `null`, indistinguishable from "no such key". Every caller uses it to decide whether to generate a key, so a transient read failure during exactly the instability this fixes could silently mint a divergent one. It now fails closed. That also covers the pre-existing caller for `password.encryption.key`, where a second key would render every stored password undecryptable.

## `affinityCall` hangs and unusable errors

- `EVT_NODE_LEFT` was not handled at all, so an in-flight call to a departing node blocked the caller for the full hard-coded 5 minutes.
- `EVT_NODE_FAILED` was never registered — and that is the event a crashed, OOMKilled or partitioned pod actually fires, i.e. the reported scenario.
- Send failures were only logged, then fell into the same wait.
- Errors surfaced as a bare `RuntimeException(TimeoutException)` with no cache/key/node; remote exceptions were double-wrapped; the cause `switch` NPE'd on a null cause.

Pending calls now track their recipient and are failed on node departure, on send failure and on `close()`. The timeout is configurable, remote exceptions keep their own type behind a null-cause guard, and messages carry the cache, key and node. The new `AffinityCallException` extends `MessageException`, so a transient topology failure reaches the user as a retriable message rather than a bare 500.

## Affinity pool starvation

Two *different* thread pools shared the name `IgniteMessages`, both sized to the CPU count. The affinity one runs service code that can nest another `affinityCall` — a self-deadlock on a small pod, behind an unbounded queue that hid the backlog. It is now growable, separately named `IgniteAffinity`, answers saturation with an error response, and no longer holds a pool thread during the Spring-readiness wait.

## `<user> did not log in` under cross-node routing

The cluster-wide logged-in principal map was keyed by `ClientInfo.getCacheKey()`, whose `equals`/`hashCode` include the client address and locale — both of which change when a principal is serialized to another node. The *value* comparison had already been relaxed for exactly this reason, with a comment saying so; the **lookup key** had not, so control never reached the relaxed comparison.

Lookups now use a login key of user identity + session. The address is retained when there is no session id, so sessionless entries stay distinct. Writes go to both keys and reads fall back to the legacy key, so a rolling upgrade works in both directions.

## Deliberately unchanged

`DistributedLockProxy.lock()` keeps its blocking behavior. Retrying while the lock is merely held elsewhere is the `Lock` contract, and all 34 cluster-lock callers use the blocking `try/finally` idiom with no handling for a failure to acquire — bounding it would turn ordinary contention into a hard failure. Only a periodic warning was added.

`memberRemoved` still fires only for a graceful `EVT_NODE_LEFT`. That listeners are never notified when a node crashes looks like a separate pre-existing gap; widening it here would change behavior for every listener at once.

## Testing

New: `DistributedLockProxyTest` (asserts the blocking contract), `IgniteClusterAffinityErrorTest` (exception mapping, including the null-cause NPE). Extended: `SecurityEngineAuthenticationTest` (cross-node address/locale change resolves; a different session does not; legacy-key entries still resolve), `FipsPasswordEncryptionTest` (stale-snapshot read — verified to fail without the fix, generating a second distinct key).

Targeted `core` sweep matches the pre-change `main` baseline exactly (same failures, same classes — all pre-existing).

## Not addressed here

- The `DeadlockHealthIndicator` hit is a genuine JVM lock cycle. These changes make the node degrade instead of wedge, but pinning the cycle needs the `StatusDumpService` dump the indicator already wrote.
- The `default-ds-group` partition mismatch: `AtomicConfiguration` derives from `minReplicas` like the app caches, so changing it requires a full cluster restart, not a rolling update. Filed separately.
- The MV `DefaultBlockSystem` blob-rename error during rollouts. Separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)