### PR TITLE
PCB-004: establish crosstab/table source on set_table_fields/add_table_field

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -381,13 +381,16 @@ public class BindingAgentController {
                                   request.measure(), linkUri);
    }
 
-   public record TableShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}
+   /** @param table see {@link ShelfRequest#table()}. */
+   public record TableShelfRequest(String assembly, String shelf, List<FieldRef> fields,
+                                   String table) {}
 
    /** {@code force} discards fields already bound to the old source; absent means false. */
    public record ChartSourceRequest(String assembly, String table, Boolean force) {}
    public record TableSourceRequest(String assembly, String table, Boolean force) {}
+   /** @param table see {@link ShelfRequest#table()}. */
    public record TableFieldRequest(String assembly, String shelf, FieldRef field,
-                                   Integer position) {}
+                                   Integer position, String table) {}
    public record TableRemoveRequest(String assembly, String shelf, String column) {}
    public record TableMoveRequest(String assembly, String fromShelf, String toShelf,
                                   String column, Integer position) {}
@@ -409,9 +412,10 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
-      requireBindableColumns(sessionToken, user, request.assembly(), request.fields());
+      String source = resolveSourceTable(sessionToken, user, request.assembly(), request.table(),
+                                         request.fields());
       tableService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
-                            request.fields());
+                            request.fields(), source);
    }
 
    public record SelectionSourceRequest(String assembly, String table, List<String> columns,
@@ -460,9 +464,10 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
-      requireBindableColumns(sessionToken, user, request.assembly(), List.of(request.field()));
+      String source = resolveSourceTable(sessionToken, user, request.assembly(), request.table(),
+                                         List.of(request.field()));
       tableService.addField(sessionToken, user, request.assembly(), request.shelf(),
-                            request.field(), request.position());
+                            request.field(), request.position(), source);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/field/remove")
@@ -726,32 +731,6 @@ public class BindingAgentController {
    private final SheetJoinService joinService;
    private final SheetSessionService sessionService;
    private final ViewsheetSessionService sessions;
-   /**
-    * Refuses a field naming a column the assembly cannot bind.
-    *
-    * <p>Such a column bound cleanly and rendered nothing — a crosstab with no rows, which reads as
-    * empty data rather than a bad column name. Checked here because the controller already holds
-    * the field listing; the alternative was injecting it into the service, which would change a
-    * constructor and so require a full reactor build for a validation fix.
-    *
-    * <p>A failure to read the listing is swallowed on purpose: it is a different problem, and
-    * turning it into a refusal would block writes whenever the tree happens to be unreadable.
-    */
-   private void requireBindableColumns(String sessionToken, Principal user, String assembly,
-                                       java.util.Collection<FieldRef> fields)
-   {
-      try {
-         BindableColumns.require(
-            fieldsService.list(sessions.runtimeId(sessionToken, user), assembly, user),
-            assembly, fields);
-      }
-      catch(IllegalArgumentException e) {
-         throw e;
-      }
-      catch(Exception e) {
-         LOG.debug("Could not list bindable columns for {}; skipping the check", assembly, e);
-      }
-   }
 
    /**
     * Validates the columns and answers which table the write is against, in one listing.
@@ -760,9 +739,9 @@ public class BindingAgentController {
     * bindable at all, and — for an assembly with no source yet — which table they come from, so it
     * can be established the way the Composer's drag does.
     *
-    * <p>A listing failure is logged and skipped rather than propagated, matching
-    * {@link #requireBindableColumns}: not being able to read the tree is a different fault, and
-    * refusing the write on the strength of it would turn a read problem into a write problem.
+    * <p>A listing failure is logged and skipped rather than propagated: not being able to read the
+    * tree is a different fault, and refusing the write on the strength of it would turn a read
+    * problem into a write problem.
     *
     * @return the source table to establish, or {@code null} for none
     */

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -65,16 +65,24 @@ public class TableBindingService {
       this.refModelService = refModelService;
    }
 
+   /**
+    * @param sourceTable the table to point the assembly at as part of this write, or {@code null}
+    *                    to leave its source alone. A crosstab/table with no source renders nothing
+    *                    however correctly its shelves are filled in — see {@link #setSource} — and
+    *                    this establishes it the same way {@code ChartBindingService.setShelf} does
+    *                    for a chart, one call rather than two.
+    */
    public void setShelf(String sessionToken, Principal user, String assemblyName, String shelf,
-                        List<FieldRef> fields) throws Exception
+                        List<FieldRef> fields, String sourceTable) throws Exception
    {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          BaseTableBindingModel model = requireTableBinding(rvs, assemblyName);
+         applySource(model, sourceTable);
          Viewsheet vs = rvs.getViewsheet();
          VSAssembly assembly = vs.getAssembly(assemblyName);
          inetsoft.uql.asset.SourceInfo source = assembly instanceof DataVSAssembly data
             ? data.getSourceInfo() : null;
-         requireSourceForFieldWrite(assemblyName, shelf, source,
+         requireSourceForFieldWrite(assemblyName, shelf, model.getSource(),
                                     fields == null ? 0 : fields.size());
          TableBindingMutator.setShelf(model, shelf, fields, rvs, source, refModelService);
 
@@ -83,6 +91,20 @@ public class TableBindingService {
          event.setBinding(model);
          bindingModelService.setBinding(runtimeId, event, user, dispatcher);
       });
+   }
+
+   /**
+    * Establishes the source, if one was worked out and the model has none.
+    *
+    * <p>Guarded on the model already being sourceless rather than trusting the caller: a repoint
+    * deletes bound fields, so it stays behind {@code set_table_source}'s explicit {@code force} and
+    * can never happen as a side effect of binding a field. Mirrors
+    * {@code ChartBindingService.applySource}.
+    */
+   static void applySource(BaseTableBindingModel model, String sourceTable) {
+      if(sourceTable != null && model != null && model.getSource() == null) {
+         model.setSource(BindingSources.assetSource(sourceTable));
+      }
    }
 
    /**
@@ -216,12 +238,15 @@ public class TableBindingService {
       }
    }
 
+   /** @param sourceTable see {@link #setShelf}. */
    public void addField(String sessionToken, Principal user, String assemblyName, String shelf,
-                        FieldRef field, Integer position) throws Exception
+                        FieldRef field, Integer position, String sourceTable) throws Exception
    {
       applyWithContext(sessionToken, user, assemblyName,
          (model, rvs, source) -> {
-            requireSourceForFieldWrite(assemblyName, shelf, source, field == null ? 0 : 1);
+            applySource(model, sourceTable);
+            requireSourceForFieldWrite(assemblyName, shelf, model.getSource(),
+                                       field == null ? 0 : 1);
             TableBindingMutator.addField(model, shelf, field, position, rvs, source,
                                          refModelService);
          });
@@ -235,10 +260,15 @@ public class TableBindingService {
     * {@link #removeField}/{@link #moveField} must not call this — a sourceless assembly can never
     * have anything on its shelves to remove or move in the first place, once this guard is in
     * place on the calls that put fields there.
+    *
+    * <p>Checked against the model's own source, taken after {@link #applySource} has had a
+    * chance to establish one from the caller's {@code sourceTable} — that is what {@code
+    * setShelf}/{@code addField} are about to write back, whereas the assembly's own {@code
+    * SourceInfo} (used elsewhere in this method for named-group resolution) does not reflect
+    * this call's mutation until the write is applied at the end of it.
     */
    private static void requireSourceForFieldWrite(String assemblyName, String shelf,
-                                                   inetsoft.uql.asset.SourceInfo source,
-                                                   int fieldCount)
+                                                   SourceInfo source, int fieldCount)
    {
       if(source == null && fieldCount > 0) {
          throw new IllegalArgumentException(

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -348,11 +348,12 @@ class BindingAgentControllerTest {
    }
 
    /**
-    * PCB-004: set_table_fields does not go through resolveSourceTable/BindableColumns.requireSource
-    * like the chart callers above -- its own request carries no {@code table} param to resolve
-    * against, so the guard lives directly in {@link TableBindingService#setShelf}. Driven through
-    * a real (not mocked) {@code TableBindingService} to confirm the exception surfaces through the
-    * controller endpoint the plugin actually calls, not just at the service-unit level.
+    * Drives a real (not mocked) {@code TableBindingService} through the controller endpoint,
+    * unlike the mocked-service tests below. {@code resolveSourceTable} falls back to {@code null}
+    * -- rather than throwing -- when the bindable-fields listing itself fails to read (a
+    * different fault than an inconclusive listing); this confirms that in that case the write
+    * still reaches {@code TableBindingService#setShelf} with no source, and it is that method's
+    * own guard which refuses it, not merely {@code resolveSourceTable}'s.
     */
    @Test
    void setTableFieldsRefusesWhenAssemblyHasNoSource() throws Exception {
@@ -385,14 +386,12 @@ class BindingAgentControllerTest {
          sessions, binding, mock(inetsoft.web.binding.controller.VSBindingModelService.class),
          mock(inetsoft.web.binding.service.DataRefModelFactoryService.class));
 
-      // A plausible column name present on some other worksheet table, with none marked
-      // "current" -- the exact "no source set yet" shape BindableColumns.require() is documented
-      // to let through, so this listing must not be what refuses the write; the assembly's real
-      // SourceInfo is.
+      // A listing failure -- not merely an inconclusive listing -- is what reaches this guard:
+      // resolveSourceTable's own try/catch turns a read failure into a null source rather than a
+      // thrown refusal, so the write proceeds into TableBindingService with nothing established.
       BindableFieldsService fields = mock(BindableFieldsService.class);
-      when(fields.list(eq("rt1"), eq("Crosstab1"), any(Principal.class))).thenReturn(
-         List.of(new inetsoft.web.wiz.binding.model.BindableTable("ORDERS", null,
-            List.of(new inetsoft.web.wiz.binding.model.BindableField("Region", "string", null)))));
+      when(fields.list(eq("rt1"), eq("Crosstab1"), any(Principal.class)))
+         .thenThrow(new RuntimeException("tree read failed"));
 
       BindingAgentController controller = new BindingAgentController(
          feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
@@ -403,13 +402,111 @@ class BindingAgentControllerTest {
 
       BindingAgentController.TableShelfRequest request =
          new BindingAgentController.TableShelfRequest(
-            "Crosstab1", "rows", List.of(new FieldRef("Region", "dimension", null, null, null)));
+            "Crosstab1", "rows", List.of(new FieldRef("Region", "dimension", null, null, null)),
+            null);
 
       IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
          () -> controller.setTableFields("tok", request, principal()));
 
       assertTrue(thrown.getMessage().contains("Crosstab1"), thrown.getMessage());
       assertTrue(thrown.getMessage().contains("set_table_source"), thrown.getMessage());
+   }
+
+   // ---------------------------------------------------------------------------
+   // Bug #76350, PCB-004: set_table_fields/add_table_field never resolved or established a
+   // source for a sourceless crosstab/table -- unlike the three chart endpoints above, which all
+   // call resolveSourceTable. Reported ok:true and rendered empty, with no error naming the
+   // missing source.
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void setTableFieldsRefusesATableTheListingDoesNotHave() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), eq("Crosstab1"), any(Principal.class))).thenReturn(List.of());
+      TableBindingService tableService = mock(TableBindingService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), mock(ChartBindingService.class),
+         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      BindingAgentController.TableShelfRequest request = new BindingAgentController.TableShelfRequest(
+         "Crosstab1", "rows", List.of(new FieldRef("Region", "dimension", null, null, null)),
+         "Sales");
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.setTableFields("tok", request, principal()));
+
+      assertTrue(thrown.getMessage().contains("Sales"), thrown.getMessage());
+      verifyNoInteractions(tableService);
+   }
+
+   /** @see #setTableFieldsRefusesATableTheListingDoesNotHave -- add_table_field shares the gap. */
+   @Test
+   void addTableFieldRefusesATableTheListingDoesNotHave() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), eq("Crosstab1"), any(Principal.class))).thenReturn(List.of());
+      TableBindingService tableService = mock(TableBindingService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), mock(ChartBindingService.class),
+         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      BindingAgentController.TableFieldRequest request = new BindingAgentController.TableFieldRequest(
+         "Crosstab1", "rows", new FieldRef("Region", "dimension", null, null, null), null, "Sales");
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.addTableField("tok", request, principal()));
+
+      assertTrue(thrown.getMessage().contains("Sales"), thrown.getMessage());
+      verifyNoInteractions(tableService);
+   }
+
+   /**
+    * The other half of the fix: when the listing resolves a single unambiguous table, that table
+    * is forwarded to the service to establish as the assembly's source -- not just validated and
+    * discarded, which is what left the assembly sourceless before this fix.
+    */
+   @Test
+   void setTableFieldsForwardsTheResolvedSourceToTheService() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), eq("Crosstab1"), any(Principal.class))).thenReturn(List.of(
+         new inetsoft.web.wiz.binding.model.BindableTable("ORDERS", null, List.of(
+            new inetsoft.web.wiz.binding.model.BindableField("Region", "string", "dimension")))));
+      TableBindingService tableService = mock(TableBindingService.class);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions, fields,
+         mock(BindingReadService.class), mock(ChartBindingService.class),
+         mock(ChartAestheticAgentService.class), tableService, mock(CalcTableService.class),
+         mock(SelectionBindingService.class), mock(CalcFieldAgentService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      BindingAgentController.TableShelfRequest request = new BindingAgentController.TableShelfRequest(
+         "Crosstab1", "rows", List.of(new FieldRef("Region", "dimension", null, null, null)),
+         null);
+
+      controller.setTableFields("tok", request, principal());
+
+      verify(tableService).setShelf(eq("tok"), any(Principal.class), eq("Crosstab1"), eq("rows"),
+                                    eq(request.fields()), eq("ORDERS"));
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -57,7 +57,7 @@ class TableBindingServiceTest {
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
 
       harness(assembly, existing, bindings)
-         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")), null);
 
       ApplyVSAssemblyInfoEvent event = capture(bindings);
       CrosstabBindingModel posted = (CrosstabBindingModel) event.getBinding();
@@ -78,7 +78,7 @@ class TableBindingServiceTest {
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
 
       harness(assembly, new CrosstabBindingModel(), bindings)
-         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")), null);
 
       assertTrue(capture(bindings).isCheckTrap());
    }
@@ -107,9 +107,58 @@ class TableBindingServiceTest {
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
 
       harness(assembly, existing, bindings)
-         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null);
+         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null, null);
 
       assertEquals(1, ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
+   }
+
+   // ── bug #76350, PCB-004: set_table_fields/add_table_field reported ok:true and never
+   // established a source on a sourceless crosstab/table, so the assembly rendered empty with no
+   // error -- the identical shape PCB-002 already fixed for charts (ChartBindingService.setShelf
+   // + applySource). BindingAgentControllerTest drives the resolve-then-refuse half through the
+   // controller endpoint; these assert the service actually applies a resolved source.
+   @Test
+   void setShelfEstablishesTheGivenSourceWhenTheModelHasNone() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")), "ORDERS");
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertNotNull(posted.getSource(), "the model must carry a source after the write");
+      assertEquals("ORDERS", posted.getSource().getSource());
+      assertEquals(1, posted.getRows().size(), "the shelf write itself must still land");
+   }
+
+   @Test
+   void setShelfLeavesAnAlreadyBoundSourceAlone() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")), "CUSTOMERS");
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals("ORDERS", posted.getSource().getSource(),
+                   "a bound source is never repointed as a side effect of a shelf write -- " +
+                   "that is set_table_source with force, not this");
+   }
+
+   @Test
+   void addFieldEstablishesTheGivenSourceWhenTheModelHasNone() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null, "ORDERS");
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertNotNull(posted.getSource(), "the model must carry a source after the write");
+      assertEquals("ORDERS", posted.getSource().getSource());
+      assertEquals(1, posted.getRows().size(), "the field write itself must still land");
    }
 
    @Test
@@ -141,7 +190,8 @@ class TableBindingServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> service.setShelf("tok", principal(), "Chart1", "rows", List.of(dim("Region"))));
+         () -> service.setShelf("tok", principal(), "Chart1", "rows", List.of(dim("Region")),
+                                null));
       assertTrue(thrown.getMessage().contains("Chart1"));
       assertTrue(thrown.getMessage().contains("chart"));
    }
@@ -308,7 +358,8 @@ class TableBindingServiceTest {
 
       Exception thrown = assertThrows(
          Exception.class,
-         () -> service.setShelf("tok", principal(), "Calc1", "rows", List.of(dim("Region"))));
+         () -> service.setShelf("tok", principal(), "Calc1", "rows", List.of(dim("Region")),
+                                null));
       assertTrue(thrown.getMessage().contains("cell layout"));
    }
 
@@ -328,7 +379,8 @@ class TableBindingServiceTest {
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> service.setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region"))));
+         () -> service.setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")),
+                                null));
       assertTrue(thrown.getMessage().contains("Crosstab1"));
       assertTrue(thrown.getMessage().contains("set_table_source"));
    }
@@ -340,7 +392,7 @@ class TableBindingServiceTest {
       VSBindingModelService bindings = mock(VSBindingModelService.class);
 
       harness(assembly, new CrosstabBindingModel(), bindings)
-         .setShelf("tok", principal(), "Crosstab1", "rows", List.of());
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(), null);
 
       assertEquals(0,
          ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
@@ -350,10 +402,13 @@ class TableBindingServiceTest {
    void setShelfProceedsWhenAssemblyHasASource() throws Exception {
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
       VSBindingModelService bindings = mock(VSBindingModelService.class);
 
-      harness(assembly, new CrosstabBindingModel(), bindings)
-         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
+      harness(assembly, existing, bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")), null);
 
       assertEquals(1,
          ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
@@ -369,7 +424,8 @@ class TableBindingServiceTest {
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> service.addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null));
+         () -> service.addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null,
+                                null));
       assertTrue(thrown.getMessage().contains("Crosstab1"));
       assertTrue(thrown.getMessage().contains("set_table_source"));
    }
@@ -378,10 +434,13 @@ class TableBindingServiceTest {
    void addFieldProceedsWhenAssemblyHasASource() throws Exception {
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
       VSBindingModelService bindings = mock(VSBindingModelService.class);
 
-      harness(assembly, new CrosstabBindingModel(), bindings)
-         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null);
+      harness(assembly, existing, bindings)
+         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null, null);
 
       assertEquals(1,
          ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -52,6 +52,8 @@ class TableBindingServiceTest {
    void setShelfPostsTheModelItReadRatherThanAFreshOne() throws Exception {
       CrosstabBindingModel existing = new CrosstabBindingModel();
       existing.getName2Labels().put("Region", "Sales Region");
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
       VSBindingModelService bindings = mock(VSBindingModelService.class);
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
@@ -76,8 +78,11 @@ class TableBindingServiceTest {
       VSBindingModelService bindings = mock(VSBindingModelService.class);
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
 
-      harness(assembly, new CrosstabBindingModel(), bindings)
+      harness(assembly, existing, bindings)
          .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")), null);
 
       assertTrue(capture(bindings).isCheckTrap());
@@ -102,6 +107,8 @@ class TableBindingServiceTest {
    @Test
    void addAndRemoveDelegate() throws Exception {
       CrosstabBindingModel existing = new CrosstabBindingModel();
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
       VSBindingModelService bindings = mock(VSBindingModelService.class);
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());


### PR DESCRIPTION
## Summary

- Fixes bug #76350 (PCB-004): `set_table_fields`/`add_table_field` never resolved or established a source for a sourceless crosstab/table assembly. The write reported success and the assembly rendered completely empty, with no error naming the missing source.
- `BindingAgentController.setTableFields`/`addTableField` now call `resolveSourceTable` (the same helper the three chart shelf endpoints already use), instead of the plain `requireBindableColumns` check. `TableShelfRequest`/`TableFieldRequest` gain a `table` field, mirroring `ShelfRequest`.
- `TableBindingService.setShelf`/`addField` gain a `sourceTable` parameter and an `applySource` helper (mirroring `ChartBindingService.applySource`): if the model has no source yet and a source was resolved, it's established as part of the same write. The existing no-source refusal (`requireSourceForFieldWrite`, from #4924) now checks the model's source *after* `applySource` runs, rather than the assembly's stored source — necessary so establishing a source and using it can happen in one call, rather than requiring `set_table_source` first every time.
- This complements, not duplicates, #4924 (which added the no-source refusal itself, based on the assembly's already-stored source, for the "no source and no table given" case). This PR adds the ability to actually resolve/establish a source in the same call.

## Test plan

- [x] `TableBindingServiceTest`, `BindingAgentControllerTest` (core module) — 41 tests pass
- [x] Full `inetsoft.web.wiz.binding` package — 559 tests pass, no regressions
- Ran via `./mvnw -pl core -am test -Dtest=... -Dsurefire.failIfNoSpecifiedTests=false -o`

Companion plugin PR: inetsoft-technology/stylebi-wiz — adds the `table` param to `set_table_fields`/`add_table_field` in `plugin/composer` and forwards it to this endpoint.