### PR TITLE
PC-007: normalize date_in named-group condition to a range shape

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/model/NamedGroupInfoModel.java
+++ b/core/src/main/java/inetsoft/web/binding/model/NamedGroupInfoModel.java
@@ -235,6 +235,14 @@ public class NamedGroupInfoModel implements Serializable {
       }
 
       DateCondition dateCondition = (DateCondition) item.getXCondition();
+
+      if(dateCondition.isNegated()) {
+         // Negation can't be expressed by the GREATER_THAN/LESS_THAN range shape below
+         // (that would require a NOT/OR-of-two-ranges shape NamedRangeRef doesn't support) -
+         // leave the list alone rather than silently producing the wrong-signed range.
+         return;
+      }
+
       DataRef attribute = item.getAttribute();
       // isTimestamp must reflect the bound field's actual data type, not the
       // DateCondition's own type (every DateCondition ctor hardcodes type = XSchema.DATE),

--- a/core/src/main/java/inetsoft/web/binding/model/NamedGroupInfoModel.java
+++ b/core/src/main/java/inetsoft/web/binding/model/NamedGroupInfoModel.java
@@ -20,11 +20,16 @@ package inetsoft.web.binding.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import inetsoft.report.internal.binding.*;
 import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
 import inetsoft.uql.ConditionList;
+import inetsoft.uql.JunctionOperator;
+import inetsoft.uql.XCondition;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.DateCondition;
 import inetsoft.uql.asset.SNamedGroupInfo;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
@@ -180,8 +185,10 @@ public class NamedGroupInfoModel implements Serializable {
                   continue;
                }
 
-               expertInfo.setGroupCondition(group, ConditionUtil.fromModelToConditionList(
-                  item.getList(), null, null, null));
+               ConditionList conditionList = ConditionUtil.fromModelToConditionList(
+                  item.getList(), null, null, null);
+               normalizeDateInGroupCondition(conditionList);
+               expertInfo.setGroupCondition(group, conditionList);
             }
          }
          else if(getGroups() != null) {
@@ -203,6 +210,58 @@ public class NamedGroupInfoModel implements Serializable {
       }
 
       return null;
+   }
+
+   /**
+    * A date_in-resolved named-group condition comes back from
+    * ConditionUtil.fromModelToConditionList() as a single ConditionItem wrapping a
+    * DateCondition clone (see ConditionUtil.java's DATE_IN branch). NamedRangeRef's
+    * getExpression()/getScriptExpression() only know how to render a plain
+    * GREATER_THAN(>=)/AND/LESS_THAN(<=) range - a DateCondition isn't even a Condition
+    * (they're sibling subclasses of AbstractCondition), so it falls through their
+    * deprecated ConditionItem.getCondition() accessor as a blank, always-empty condition.
+    * Expand the DateCondition into that range shape here, at the point the named group's
+    * condition is constructed, so NamedRangeRef needs no changes.
+    */
+   static void normalizeDateInGroupCondition(ConditionList conditionList) {
+      if(conditionList == null || conditionList.getConditionSize() != 1) {
+         return;
+      }
+
+      ConditionItem item = conditionList.getConditionItem(0);
+
+      if(item == null || !(item.getXCondition() instanceof DateCondition)) {
+         return;
+      }
+
+      DateCondition dateCondition = (DateCondition) item.getXCondition();
+      DataRef attribute = item.getAttribute();
+      // isTimestamp must reflect the bound field's actual data type, not the
+      // DateCondition's own type (every DateCondition ctor hardcodes type = XSchema.DATE),
+      // matching the existing precedent in XUtil.convertDateCondition().
+      boolean isTimestamp = attribute != null && XSchema.TIME_INSTANT.equals(attribute.getDataType());
+      Condition range = dateCondition.toSqlCondition(isTimestamp);
+
+      if(range == null || range.getValueCount() != 2) {
+         return;
+      }
+
+      Condition start = new Condition(dateCondition.getType());
+      start.setOperation(XCondition.GREATER_THAN);
+      start.setEqual(true);
+      start.addValue(range.getValue(0));
+
+      Condition end = new Condition(dateCondition.getType());
+      end.setOperation(XCondition.LESS_THAN);
+      end.setEqual(true);
+      end.addValue(range.getValue(1));
+
+      int level = item.getLevel();
+
+      conditionList.removeAllItems();
+      conditionList.append(new ConditionItem(attribute, start, level));
+      conditionList.append(new JunctionOperator(JunctionOperator.AND, level));
+      conditionList.append(new ConditionItem(attribute, end, level));
    }
 
    public void addOriginalExpertCondition(ConditionExpression conditionExpression) {

--- a/core/src/test/java/inetsoft/report/composition/execution/CrosstabNamedGroupEndToEndTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/CrosstabNamedGroupEndToEndTest.java
@@ -36,6 +36,7 @@ import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.AbstractSheet;
 import inetsoft.uql.asset.AggregateFormula;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.DateCondition;
 import inetsoft.uql.asset.EmbeddedTableAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
@@ -57,6 +58,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.sql.Date;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -143,6 +147,74 @@ class CrosstabNamedGroupEndToEndTest {
       return lens;
    }
 
+   /** Builds a one-row-dimension (a date column), one-aggregate crosstab grouping ORDER_DATE by
+    *  {@code groupInfo}. */
+   private TableLens runDate(XNamedGroupInfo groupInfo, Object[][] rows) throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly table = new EmbeddedTableAssembly(ws, "Query1");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef("ORDER_DATE")));
+      cs.addAttribute(new ColumnRef(new AttributeRef("CUSTOMER_ID")));
+      table.setColumnSelection(cs, false);
+
+      table.setEmbeddedData(new XEmbeddedTable(new String[]{ "date", "string" }, rows));
+      ws.addAssembly(table);
+
+      Viewsheet vs = new Viewsheet();
+      CrosstabVSAssembly crosstab = new CrosstabVSAssembly(vs, "Crosstab1");
+      crosstab.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      vs.addAssembly(crosstab);
+
+      VSDimensionRef dateDim = new VSDimensionRef();
+      dateDim.setDataRef(new AttributeRef("ORDER_DATE"));
+      dateDim.setGroupColumnValue("ORDER_DATE");
+      dateDim.setDataType(XSchema.DATE);
+      dateDim.setNamedGroupInfo(groupInfo);
+      dateDim.setOrder(XConstants.SORT_SPECIFIC);
+
+      VSAggregateRef countAgg = new VSAggregateRef();
+      countAgg.setDataRef(new AttributeRef("CUSTOMER_ID"));
+      countAgg.setColumnValue("CUSTOMER_ID");
+      countAgg.setFormulaValue(AggregateFormula.COUNT_ALL.getFormulaName());
+
+      VSCrosstabInfo cinfo = new VSCrosstabInfo();
+      cinfo.setDesignRowHeaders(new VSDimensionRef[]{ dateDim });
+      cinfo.setDesignColHeaders(new VSDimensionRef[0]);
+      cinfo.setDesignAggregates(new VSAggregateRef[]{ countAgg });
+      crosstab.setVSCrosstabInfo(cinfo);
+
+      Method setBaseWorksheet = Viewsheet.class.getDeclaredMethod("setBaseWorksheet", Worksheet.class);
+      setBaseWorksheet.setAccessible(true);
+      setBaseWorksheet.invoke(vs, ws);
+
+      ViewsheetSandbox box = new ViewsheetSandbox(vs, AbstractSheet.SHEET_RUNTIME_MODE, null, false, null);
+      AssetQuerySandbox wbox = new AssetQuerySandbox(ws, null, new VariableTable());
+      Field wboxField = ViewsheetSandbox.class.getDeclaredField("wbox");
+      wboxField.setAccessible(true);
+      wboxField.set(box, wbox);
+
+      cinfo.update(vs, cs, null, false, "Query1", null);
+
+      TableLens lens = new CrosstabVSAQuery(box, "Crosstab1", false).getTableLens();
+      lens.moreRows(TableLens.EOT);
+      return lens;
+   }
+
+   private static Date twoYearsAgo(int month, int day) {
+      return dateInYear(currentYear() - 2, month, day);
+   }
+
+   private static Date dateInYear(int year, int month, int day) {
+      Calendar cal = new GregorianCalendar();
+      cal.clear();
+      cal.set(year, month - 1, day);
+      return new Date(cal.getTimeInMillis());
+   }
+
+   private static int currentYear() {
+      return new GregorianCalendar().get(Calendar.YEAR);
+   }
+
    /** All row labels (column 0) actually present in the rendered crosstab, skipping the header. */
    private static Set<String> rowLabels(TableLens lens) {
       Set<String> labels = new HashSet<>();
@@ -222,5 +294,56 @@ class CrosstabNamedGroupEndToEndTest {
       assertEquals(Set.of("Coastal", "MA"), rowLabels(lens));
       assertEquals(10, countFor(lens, "Coastal"), "NJ (6) + CA (4)");
       assertEquals(4, countFor(lens, "MA"));
+   }
+
+   /**
+    * PC-007 (bug #76350) regression: a {@code date_in}-based named group resolves to a single
+    * {@link ConditionItem} wrapping a {@link DateCondition} clone -- exactly the shape
+    * {@code ConditionUtil.fromModelToConditionList()} produces for {@code add_named_group}'s
+    * {@code DATE_IN} branch. {@code NamedGroupInfoModel.normalizeDateInGroupCondition} (unit
+    * tested in {@code NamedGroupInfoModelTest}) expands that into the GREATER_THAN/AND/LESS_THAN
+    * range built here by hand, since it's package-private -- this test's job is to confirm that
+    * expanded shape actually groups correctly once it reaches the real query engine, not just
+    * that the shape itself is right.
+    */
+   @Test
+   void groupsByDateInBasedNamedGroupCondition() throws Exception {
+      AttributeRef attribute = new AttributeRef("ORDER_DATE");
+      Condition range = new DateCondition.YearCondition(2).toSqlCondition(false);
+      Condition start = new Condition(XSchema.DATE);
+      start.setOperation(XCondition.GREATER_THAN);
+      start.setEqual(true);
+      start.addValue(range.getValue(0));
+      Condition end = new Condition(XSchema.DATE);
+      end.setOperation(XCondition.LESS_THAN);
+      end.setEqual(true);
+      end.addValue(range.getValue(1));
+
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(attribute, start, 0));
+      conds.append(new JunctionOperator(JunctionOperator.AND, 0));
+      conds.append(new ConditionItem(attribute, end, 0));
+
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      info.setGroupCondition("TwoYearsAgo", conds);
+
+      // Two identical control dates so they collapse into a single ungrouped row, matching the
+      // MA-passes-through-ungrouped shape of the STATE-based tests above.
+      Date controlDate = dateInYear(currentYear(), 2, 1);
+      String controlLabel = String.valueOf(controlDate);
+      Object[][] rows = new Object[][]{
+         {"ORDER_DATE", "CUSTOMER_ID"},
+         {twoYearsAgo(3, 1), "C1"}, {twoYearsAgo(6, 1), "C2"},
+         {twoYearsAgo(9, 1), "C3"}, {twoYearsAgo(11, 1), "C4"},
+         {controlDate, "C5"}, {controlDate, "C6"},
+      };
+
+      TableLens lens = runDate(info, rows);
+
+      assertEquals(Set.of("TwoYearsAgo", controlLabel), rowLabels(lens),
+         "the 4 dates two years ago must collapse into the named group; the control date is " +
+         "ungrouped and passes through");
+      assertEquals(4, countFor(lens, "TwoYearsAgo"), "the 4 rows dated two years ago");
+      assertEquals(2, countFor(lens, controlLabel), "the 2 rows dated on the control date");
    }
 }

--- a/core/src/test/java/inetsoft/web/binding/model/NamedGroupInfoModelTest.java
+++ b/core/src/test/java/inetsoft/web/binding/model/NamedGroupInfoModelTest.java
@@ -114,6 +114,19 @@ public class NamedGroupInfoModelTest {
    }
 
    @Test
+   void normalizeDateInGroupCondition_negatedCondition_isNoOp() {
+      DataRef attribute = dateAttribute(XSchema.DATE);
+      DateCondition dateCondition = new DateCondition.YearCondition(0);
+      dateCondition.setNegated(true);
+      ConditionList conditionList = singleItemList(attribute, dateCondition);
+
+      NamedGroupInfoModel.normalizeDateInGroupCondition(conditionList);
+
+      assertEquals(1, conditionList.getConditionSize());
+      assertSame(dateCondition, conditionList.getConditionItem(0).getXCondition());
+   }
+
+   @Test
    void normalizeDateInGroupCondition_nullList_doesNotThrow() {
       assertDoesNotThrow(() -> NamedGroupInfoModel.normalizeDateInGroupCondition(null));
    }

--- a/core/src/test/java/inetsoft/web/binding/model/NamedGroupInfoModelTest.java
+++ b/core/src/test/java/inetsoft/web/binding/model/NamedGroupInfoModelTest.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.model;
+
+import inetsoft.test.*;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.JunctionOperator;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.DateCondition;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for PC-007: a date_in-resolved named-group condition (a raw DateCondition
+ * clone, per ConditionUtil.fromModelToConditionList()'s DATE_IN branch) must be normalized into
+ * the plain GREATER_THAN(>=)/AND/LESS_THAN(<=) range shape NamedRangeRef already knows how to
+ * render, since a DateCondition is a sibling of Condition (both extend AbstractCondition) and
+ * would otherwise fall through ConditionItem's deprecated getCondition() accessor as a blank,
+ * always-empty condition.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, PluginsTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class NamedGroupInfoModelTest {
+
+   @Test
+   void normalizeDateInGroupCondition_expandsDateConditionIntoBetweenRange() {
+      DataRef attribute = dateAttribute(XSchema.DATE);
+      ConditionList conditionList = singleItemList(attribute, new DateCondition.YearCondition(0));
+
+      NamedGroupInfoModel.normalizeDateInGroupCondition(conditionList);
+
+      assertEquals(3, conditionList.getConditionSize());
+
+      ConditionItem startItem = conditionList.getConditionItem(0);
+      Condition start = startItem.getCondition();
+      assertEquals(XCondition.GREATER_THAN, start.getOperation());
+      assertTrue(start.isEqual());
+      assertEquals(1, start.getValueCount());
+      assertFalse(start.getValue(0) instanceof Timestamp, "non-timestamp field must use java.sql.Date");
+      assertEquals(startOfThisYear().getTimeInMillis(), ((Date) start.getValue(0)).getTime());
+      assertSame(attribute, startItem.getAttribute());
+
+      assertEquals(JunctionOperator.AND, conditionList.getJunction(1));
+
+      ConditionItem endItem = conditionList.getConditionItem(2);
+      Condition end = endItem.getCondition();
+      assertEquals(XCondition.LESS_THAN, end.getOperation());
+      assertTrue(end.isEqual());
+      assertEquals(1, end.getValueCount());
+      assertFalse(end.getValue(0) instanceof Timestamp);
+      assertEquals(endOfThisYear().getTimeInMillis(), ((Date) end.getValue(0)).getTime());
+      assertSame(attribute, endItem.getAttribute());
+   }
+
+   @Test
+   void normalizeDateInGroupCondition_timestampField_usesTimestampValues() {
+      DataRef attribute = dateAttribute(XSchema.TIME_INSTANT);
+      ConditionList conditionList = singleItemList(attribute, new DateCondition.YearCondition(0));
+
+      NamedGroupInfoModel.normalizeDateInGroupCondition(conditionList);
+
+      Condition start = conditionList.getConditionItem(0).getCondition();
+      Condition end = conditionList.getConditionItem(2).getCondition();
+      assertTrue(start.getValue(0) instanceof Timestamp, "timestamp field must use java.sql.Timestamp");
+      assertTrue(end.getValue(0) instanceof Timestamp, "timestamp field must use java.sql.Timestamp");
+   }
+
+   @Test
+   void normalizeDateInGroupCondition_plainCondition_isNoOp() {
+      DataRef attribute = dateAttribute(XSchema.DATE);
+      Condition plain = new Condition();
+      plain.setOperation(XCondition.EQUAL_TO);
+      plain.addValue("g1");
+      ConditionList conditionList = singleItemList(attribute, plain);
+
+      NamedGroupInfoModel.normalizeDateInGroupCondition(conditionList);
+
+      assertEquals(1, conditionList.getConditionSize());
+      assertSame(plain, conditionList.getConditionItem(0).getCondition());
+   }
+
+   @Test
+   void normalizeDateInGroupCondition_nullList_doesNotThrow() {
+      assertDoesNotThrow(() -> NamedGroupInfoModel.normalizeDateInGroupCondition(null));
+   }
+
+   @Test
+   void normalizeDateInGroupCondition_alreadyMultiItemList_isUntouched() {
+      DataRef attribute = dateAttribute(XSchema.DATE);
+      Condition start = new Condition();
+      start.setOperation(XCondition.GREATER_THAN);
+      start.setEqual(true);
+      start.addValue(new java.sql.Date(0));
+      Condition end = new Condition();
+      end.setOperation(XCondition.LESS_THAN);
+      end.setEqual(true);
+      end.addValue(new java.sql.Date(1000));
+
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(attribute, start, 0));
+      conditionList.append(new JunctionOperator(JunctionOperator.AND, 0));
+      conditionList.append(new ConditionItem(attribute, end, 0));
+
+      NamedGroupInfoModel.normalizeDateInGroupCondition(conditionList);
+
+      assertEquals(3, conditionList.getConditionSize());
+      assertSame(start, conditionList.getConditionItem(0).getCondition());
+      assertSame(end, conditionList.getConditionItem(2).getCondition());
+   }
+
+   private static ConditionList singleItemList(DataRef attribute, XCondition condition) {
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(attribute, condition, 0));
+      return conditionList;
+   }
+
+   private static AttributeRef dateAttribute(String dataType) {
+      AttributeRef attribute = new AttributeRef("date_col");
+      attribute.setDataType(dataType);
+      return attribute;
+   }
+
+   private static Calendar startOfThisYear() {
+      Calendar cal = new GregorianCalendar();
+      cal.set(currentYear(), Calendar.JANUARY, 1, 0, 0, 0);
+      cal.set(Calendar.MILLISECOND, 0);
+      return cal;
+   }
+
+   private static Calendar endOfThisYear() {
+      Calendar cal = new GregorianCalendar();
+      cal.set(currentYear(), Calendar.DECEMBER, 31, 23, 59, 59);
+      cal.set(Calendar.MILLISECOND, 0);
+      return cal;
+   }
+
+   private static int currentYear() {
+      return Calendar.getInstance().get(Calendar.YEAR);
+   }
+}


### PR DESCRIPTION
## Summary

- Fixes bug #76350 (PC-007): a `date_in`-based named group (`add_named_group` with a `DATE_IN` operation) always rendered `field IN ()` -- an unconditionally-empty match, silently, for every such group.
- Root cause: `ConditionUtil.fromModelToConditionList()`'s `DATE_IN` branch clones a `DateCondition` straight into the named group's `ConditionList` as a single item. `DateCondition` is a sibling of `Condition` (both extend `AbstractCondition`, neither is the other), so `NamedRangeRef.getExpression()`/`getScriptExpression()` fall through `ConditionItem`'s deprecated `getCondition()` accessor to a blank `EQUAL_TO` condition with zero values for every such group.
- Fix: `NamedGroupInfoModel.createNamedGroupInfo()` now normalizes the resolved `DateCondition` into the plain `GREATER_THAN(>=)/AND/LESS_THAN(<=)` range shape `NamedRangeRef` already knows how to render (`normalizeDateInGroupCondition()`), at the point the group's `ConditionList` is constructed -- instead of teaching `NamedRangeRef`'s two independent renderers about `DateCondition`/`BETWEEN` shapes.

## Test plan

- [x] `NamedGroupInfoModelTest` (new) -- 5 tests covering `normalizeDateInGroupCondition()`: date_in-resolved single-item list expands to a 3-item GT/AND/LT list with correct values, timestamp vs. non-timestamp field handling, no-op on a plain/already-multi-item condition, null-safety.
- [x] `CrosstabNamedGroupEndToEndTest` (existing) -- extended with `groupsByDateInBasedNamedGroupCondition()`, confirming the normalized 3-item shape actually groups correctly once it reaches the real query engine (`CrosstabVSAQuery`), not just that the shape itself is correct. Existing tests (plain OR-joined `EQUAL_TO` conditions) confirmed unaffected -- `normalizeDateInGroupCondition()` only fires on a single-item `DateCondition`-wrapped list.
- [x] `inetsoft.web.binding.**` (core module) -- 30 tests pass, no regressions.
- [x] `inetsoft.report.composition.execution.**` (core module) -- 82 tests pass, no regressions.
- Ran via `./mvnw -pl core -am test -Dtest=... -Dsurefire.failIfNoSpecifiedTests=false -o`