### PR TITLE
Bug #76410, refresh the cached provider list so a new provider loads in the Users tab

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/AuthenticationProviderService.java
@@ -895,8 +895,13 @@ public class AuthenticationProviderService extends BaseSubscribeChangeHandler {
          getSubscribers().stream()
             .filter(sub -> sub.getUser() instanceof XPrincipal)
             .forEach(sub -> {
-               this.debouncer.debounce(((XPrincipal) sub.getUser()).getSessionID(), 1L, TimeUnit.SECONDS,
-                                       () -> sendToSubscriber(sub));
+               // key on the subscriber, not just the user session: a user with more than one
+               // live subscription (two EM tabs, or a reconnected socket whose old subscriber
+               // has not been removed yet) would otherwise collapse into a single debounce
+               // entry and only one arbitrarily-chosen subscriber would be notified
+               String key = ((XPrincipal) sub.getUser()).getSessionID() + ":" +
+                  sub.getSessionId() + ":" + sub.getSubscriptionId();
+               this.debouncer.debounce(key, 1L, TimeUnit.SECONDS, () -> sendToSubscriber(sub));
             });
       }
    }

--- a/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/SecurityTreeServer.java
@@ -65,6 +65,16 @@ public class SecurityTreeServer {
       final AuthenticationProvider provider = providerName == null ?
          securityProvider.getAuthenticationProvider() :
          authenticationProviderService.getProviderByName(providerName);
+
+      // getProviderByName() returns null when the name is not in this node's authentication
+      // chain -- e.g. a client that is still holding a provider name that has since been
+      // renamed or removed, or a cluster node that has not yet reloaded authc-chain.json.
+      // Report that plainly instead of NPEing on the first provider dereference below.
+      if(provider == null) {
+         throw new MessageException(
+            Catalog.getCatalog().getString("em.security.provider.notFound", providerName));
+      }
+
       boolean editable = providerName == null || provider instanceof EditableAuthenticationProvider;
 
       try {

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4724,6 +4724,7 @@ em.security.provider.deleteError=Failed to remove the provider. See the log file
 em.security.provider.listError=Failed to get the list of providers. See the log file for details.
 em.security.provider.name=Provider name is required.
 em.security.provider.nameSpecialChars=Name cannot include special characters
+em.security.provider.notFound=The security provider "{0}" no longer exists. Please refresh the page.
 em.security.provider.reorderError=Failed to change the provider order. See the log file for details.
 em.security.providerNotFound=Could not find provider
 em.security.provider.db.failedConnected=Cannot get security identites since the selected database provider cannot be connected!

--- a/core/src/test/java/inetsoft/web/admin/security/user/SecurityTreeServerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/user/SecurityTreeServerTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security.user;
+
+/*
+ * Test strategy
+ *
+ * Class type: request-scoped orchestration service — SecurityTreeServer resolves the
+ * requested authentication provider and then delegates the per-identity-type tree building
+ * to UserTreeService.
+ *
+ * Coverage scope:
+ *   [unknown provider name]  getProviderByName() returns null -> MessageException, not NPE
+ *   [no default provider]    provider name omitted and the chain has none -> same guard
+ *
+ * Regression context: the EM Users tab sends whatever provider name the client has cached.
+ * When that provider has been renamed or removed, getProviderByName() returns null and the
+ * old code dereferenced it at provider.getOrganizationIDs(), producing a 500
+ * "Cannot invoke ...getOrganizationIDs() because \"provider\" is null" with no usable message.
+ *
+ * Static singletons (SUtil, Catalog) are intercepted with Mockito.mockStatic() using lenient().
+ */
+
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.MessageException;
+import inetsoft.web.admin.security.AuthenticationProviderService;
+import inetsoft.web.admin.server.ServerService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class SecurityTreeServerTest {
+   @Mock private AuthenticationProviderService authenticationProviderService;
+   @Mock private ServerService serverService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private UserTreeService userTreeService;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private Catalog catalog;
+   @Mock private Principal principal;
+
+   private SecurityTreeServer server;
+
+   private MockedStatic<SUtil> sutilStatic;
+   private MockedStatic<Catalog> catalogStatic;
+
+   @BeforeEach
+   void setUp() {
+      when(serverService.getLicenseInfos()).thenReturn(List.of());
+      server = new SecurityTreeServer(
+         authenticationProviderService, serverService, securityEngine, userTreeService);
+
+      sutilStatic = mockStatic(SUtil.class, withSettings().lenient());
+      catalogStatic = mockStatic(Catalog.class, withSettings().lenient());
+
+      sutilStatic.when(SUtil::isMultiTenant).thenReturn(false);
+      catalogStatic.when(Catalog::getCatalog).thenReturn(catalog);
+      // any(Object.class) rather than any(): it pins the getString(String, Object...) overload
+      // instead of letting javac pick getString(String, boolean)
+      lenient().when(catalog.getString(anyString(), any(Object.class)))
+         .thenReturn("provider does not exist");
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sutilStatic.close();
+      catalogStatic.close();
+   }
+
+   // [Scenario: unknown provider name] the client asked for a provider that is no longer in
+   // this node's authentication chain (renamed/removed, or a node that has not reloaded
+   // authc-chain.json yet). Must report the missing provider instead of NPEing.
+   @Test
+   void getSecurityTree_unknownProviderName_throwsMessageExceptionNotNpe() {
+      when(authenticationProviderService.getProviderByName("gone")).thenReturn(null);
+
+      MessageException ex = assertThrows(MessageException.class,
+         () -> server.getSecurityTree("gone", principal, false, false));
+
+      assertEquals("provider does not exist", ex.getMessage());
+      verify(catalog).getString("em.security.provider.notFound", "gone");
+      verifyNoInteractions(userTreeService);
+   }
+
+   // [Scenario: no default provider] with the provider name omitted the chain's own
+   // authentication provider is used; the same guard must cover a null there.
+   @Test
+   void getSecurityTree_noDefaultProvider_throwsMessageExceptionNotNpe() {
+      when(securityProvider.getAuthenticationProvider()).thenReturn(null);
+
+      assertThrows(MessageException.class,
+         () -> server.getSecurityTree(null, principal, false, false));
+
+      verifyNoInteractions(userTreeService);
+   }
+}

--- a/web/projects/em/src/app/settings/security/security-provider/authentication-provider-list-page/authentication-provider-list-page.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/authentication-provider-list-page/authentication-provider-list-page.component.tl.spec.ts
@@ -156,6 +156,27 @@ describe("AuthenticationProviderViewComponent — removeProvider(): stale-index 
       expect(windowOpenSpy).not.toHaveBeenCalled();
    });
 
+   // 🔁 Regression-sensitive: same stale-cache contract as copyProvider above -- a removed
+   // provider must disappear from the shared list too, otherwise it stays selectable on the
+   // Users tab and the tree request 500s
+   it("should refresh the shared provider list when a non-current provider is removed", async () => {
+      server.use(
+         http.delete("*/api/em/security/remove-authentication-provider/1", () => HttpResponse.json({})),
+      );
+
+      const { comp, dialogSpy, orgDropdownSpy } = await renderComponent({
+         initialProviders: [makeProvider("A"), makeProvider("B")],
+      });
+      await waitForProviderNames(comp, ["A", "B"]);
+      comp["currentProvider"] = "A";
+      dialogSpy.open.mockReturnValue({ afterClosed: () => of(true) });
+      orgDropdownSpy.refreshProviders.mockClear();
+
+      comp.removeProvider(1);
+
+      await waitFor(() => expect(orgDropdownSpy.refreshProviders).toHaveBeenCalled());
+   });
+
    // 🔁 Regression-sensitive: logout must fire whenever the active provider is deleted
    it("should call window.open to force logout when the currently-active provider is removed", async () => {
       server.use(
@@ -393,6 +414,28 @@ describe("AuthenticationProviderViewComponent — copyProvider(): duplicate-name
       await waitFor(() =>
          expect(comp.authenticationProviders.map(p => p.name)).toEqual(["A", "A_copy"]),
       );
+   });
+
+   // 🔁 Regression-sensitive: the Users tab and page header read the provider list cached on
+   // OrganizationDropdownService, not this page's local array. Without a refresh the copy is
+   // invisible there for the rest of the browser session and selecting a stale name makes
+   // get-security-tree-root fail (NPE on a null provider).
+   it("should refresh the shared provider list after a successful copy", async () => {
+      server.use(
+         http.get("*/api/em/security/copy-authentication-provider/A", () =>
+            HttpResponse.json(makeProvider("A_copy")),
+         ),
+      );
+
+      const { comp, orgDropdownSpy } = await renderComponent({
+         initialProviders: [makeProvider("A")],
+      });
+      await waitForProviderNames(comp, ["A"]);
+      orgDropdownSpy.refreshProviders.mockClear();
+
+      comp.copyProvider(0);
+
+      await waitFor(() => expect(orgDropdownSpy.refreshProviders).toHaveBeenCalled());
    });
 
    // 🔁 Regression-sensitive: two rows with the same name break reorder and remove index arithmetic

--- a/web/projects/em/src/app/settings/security/security-provider/authentication-provider-list-page/authentication-provider-list-page.component.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/authentication-provider-list-page/authentication-provider-list-page.component.ts
@@ -160,6 +160,9 @@ export class AuthenticationProviderViewComponent implements OnInit, OnDestroy {
                      if(current) {
                         window.open("../logout?fromEm=true", "_self");
                      }
+                     else {
+                        this.orgDropdownService.refreshProviders();
+                     }
                   });
             }
          }
@@ -183,6 +186,11 @@ export class AuthenticationProviderViewComponent implements OnInit, OnDestroy {
             if(this.authenticationProviders.findIndex(p => p.name == status.name) == -1) {
                this.authenticationProviders.push(status);
             }
+
+            // the Users tab and page header read the provider list cached on
+            // OrganizationDropdownService, which otherwise stays stale for the whole
+            // browser session
+            this.orgDropdownService.refreshProviders();
          });
    }
 

--- a/web/projects/em/src/app/settings/security/security-provider/security-provider.service.logic.spec.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/security-provider.service.logic.spec.ts
@@ -116,7 +116,8 @@ describe("SecurityProviderService — logic layer", () => {
 
    beforeEach(() => {
       // Pure logic methods use no injected dependencies; null is safe here.
-      service = new SecurityProviderService(null as any, null as any, null as any, null as any, null as any);
+      service = new SecurityProviderService(
+         null as any, null as any, null as any, null as any, null as any, null as any);
    });
 
    // ---------------------------------------------------------------------------

--- a/web/projects/em/src/app/settings/security/security-provider/security-provider.service.scene.spec.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/security-provider.service.scene.spec.ts
@@ -49,6 +49,7 @@ import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { EMPTY, NEVER, of } from "rxjs";
 import { ErrorHandlerService } from "../../../common/util/error/error-handler.service";
+import { OrganizationDropdownService } from "../../../navbar/organization-dropdown.service";
 import { SecurityProviderService } from "./security-provider.service";
 import { SecurityProviderType } from "./security-provider-model/security-provider-type.enum";
 
@@ -82,12 +83,16 @@ describe("SecurityProviderService — scene layer", () => {
    let dialogSpy: { open: Mock };
    let bottomSheetSpy: { open: Mock };
    let errorServiceSpy: { showSnackBar: Mock };
+   let orgDropdownSpy: { refreshProviders: Mock };
 
    beforeEach(() => {
       routerSpy = { navigate: vi.fn() };
       dialogSpy = { open: vi.fn() };
       bottomSheetSpy = { open: vi.fn() };
       errorServiceSpy = { showSnackBar: vi.fn() };
+      // stubbed out: the real service opens a STOMP connection and pulls in
+      // SsoHeartbeatService, none of which this scene exercises
+      orgDropdownSpy = { refreshProviders: vi.fn() };
 
       TestBed.configureTestingModule({
          imports: [HttpClientTestingModule],
@@ -96,7 +101,8 @@ describe("SecurityProviderService — scene layer", () => {
             { provide: Router, useValue: routerSpy },
             { provide: MatDialog, useValue: dialogSpy },
             { provide: MatBottomSheet, useValue: bottomSheetSpy },
-            { provide: ErrorHandlerService, useValue: errorServiceSpy }
+            { provide: ErrorHandlerService, useValue: errorServiceSpy },
+            { provide: OrganizationDropdownService, useValue: orgDropdownSpy }
          ]
       });
 
@@ -189,6 +195,22 @@ describe("SecurityProviderService — scene layer", () => {
          req.flush({});
 
          expect(routerSpy.navigate).toHaveBeenCalledWith(["/settings/security/provider"]);
+      });
+
+      // 🔁 Regression-sensitive: the Users tab and page header read the provider list cached
+      //    on OrganizationDropdownService for the whole browser session. Without this refresh an
+      //    added or renamed provider is invisible there, and a stale cached name stays selected —
+      //    get-security-tree-root then fails on a null provider until the user logs out and in.
+      it("[Risk 3] should refresh the cached provider list on success but not on error", () => {
+         service.updateAuthenticationProvider("", makeFileAuthnForm());
+         httpMock.expectOne("../api/em/security/add-authentication-provider").flush({});
+         expect(orgDropdownSpy.refreshProviders).toHaveBeenCalledTimes(1);
+
+         errorServiceSpy.showSnackBar.mockReturnValue(EMPTY);
+         service.updateAuthenticationProvider("existingProvider", makeFileAuthnForm());
+         httpMock.expectOne("../api/em/security/edit-authentication-provider/existingProvider")
+            .flush("Server Error", { status: 500, statusText: "Server Error" });
+         expect(orgDropdownSpy.refreshProviders).toHaveBeenCalledTimes(1);
       });
    });
 

--- a/web/projects/em/src/app/settings/security/security-provider/security-provider.service.ts
+++ b/web/projects/em/src/app/settings/security/security-provider/security-provider.service.ts
@@ -25,6 +25,7 @@ import { NEVER, Observable, of, of as observableOf } from "rxjs";
 import { catchError, map, switchMap } from "rxjs/operators";
 import { MapModel } from "../../../../../../portal/src/app/common/data/map-model";
 import { ErrorHandlerService } from "../../../common/util/error/error-handler.service";
+import { OrganizationDropdownService } from "../../../navbar/organization-dropdown.service";
 import { convertToKey, IdentityId } from "../users/identity-id";
 import { BaseQueryResult } from "./base-query-result/base-query-result.component";
 import { InputQueryParamsDialogComponent } from "./input-query-params-dialog/input-query-params-dialog.component";
@@ -51,7 +52,8 @@ export class SecurityProviderService {
                private http: HttpClient,
                private dialog: MatDialog,
                private bottomSheet: MatBottomSheet,
-               private errorService: ErrorHandlerService)
+               private errorService: ErrorHandlerService,
+               private orgDropdownService: OrganizationDropdownService)
    {
    }
 
@@ -130,7 +132,13 @@ export class SecurityProviderService {
 
       return this.http.post(url, model).pipe(
          catchError((error: HttpErrorResponse) => this.errorService.showSnackBar(error, this.defaultErrMsg))
-      ).subscribe(() => this.routeToListView());
+      ).subscribe(() => {
+         // the Users tab and page header read the provider list cached on
+         // OrganizationDropdownService; without this an added or renamed provider stays
+         // invisible (and a stale name stays selected) for the whole browser session
+         this.orgDropdownService.refreshProviders();
+         this.routeToListView();
+      });
    }
 
    testConnection(authenticationForm: UntypedFormGroup) {

--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.tl.spec.ts
@@ -55,7 +55,7 @@ import { render } from "@testing-library/angular";
 import { provideHttpClient } from "@angular/common/http";
 import { MatDialog } from "@angular/material/dialog";
 import { MatSnackBar } from "@angular/material/snack-bar";
-import { of, Subject } from "rxjs";
+import { firstValueFrom, of, Subject } from "rxjs";
 import { http, HttpResponse } from "msw";
 
 import { server } from "@test-mocks/server";
@@ -107,7 +107,11 @@ const makeUserNode = (name: string, orgID = "TestOrg"): SecurityTreeNode =>
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface RenderOpts {
-   /** Simulates the provider returned by getProvider() on construction. Empty = skip initial load. */
+   /**
+    * Simulates the provider returned by getProvider(). The component no longer reads it on
+    * construction -- ngOnInit calls refreshProviders() instead (a no-op in these mocks), so
+    * the initial tree load is driven by an onRefresh emission.
+    */
    initialProvider?: string;
    dialogClosesWith?: unknown;
    isSysAdmin?: boolean;
@@ -120,8 +124,8 @@ async function renderComponent(opts: RenderOpts = {}) {
 
    const orgDropdownSpy = {
       onRefresh: onRefreshSubject,
-      // Return "" so changeProvider early-returns and skips the constructor HTTP call.
-      // Tests that need a loaded tree set comp.selectedProvider + comp.model directly.
+      // Tests that need a loaded tree set comp.selectedProvider + comp.model directly, or
+      // push a provider through onRefreshSubject.
       getProvider: vi.fn().mockReturnValue(opts.initialProvider ?? ""),
       authenticationProviders: ["TestProvider"],
       loginUserOrgName: opts.loginUserOrgName ?? "CurrentUser",
@@ -661,6 +665,64 @@ describe("UsersSettingsPageComponent — selfRefreshing guard: ignores self-trig
       onRefreshSubject.next({ provider: "NewProvider", providerChanged: false });
 
       await vi.waitFor(() => expect(comp.selectedProvider).toBe("NewProvider"));
+   });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Group 7b [Risk 3] — init: provider list must be reloaded, never assumed current
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("UsersSettingsPageComponent — init: provider list must be reloaded", () => {
+
+   // 🔁 Regression-sensitive: OrganizationDropdownService caches the provider list for the
+   // whole browser session. A provider added, copied, renamed or removed since the EM page was
+   // loaded is missing from that cache, and getProvider() can name a provider that no longer
+   // exists -- get-security-tree-root then 500s with an NPE on a null provider, and only a
+   // logout/login clears it. ngOnInit must re-fetch the list instead of trusting the cache.
+   it("should reload the provider list on init", async () => {
+      const { orgDropdownSpy } = await renderComponent();
+
+      expect(orgDropdownSpy.refreshProviders).toHaveBeenCalled();
+   });
+
+   // Corollary: the tree request must wait for the reloaded list, so it can never be issued
+   // with a provider name the server no longer knows.
+   it("should not request the security tree until the reloaded list emits a provider", async () => {
+      const { comp, onRefreshSubject } = await renderComponent({
+         initialProvider: "StaleProvider",
+      });
+
+      // treeData is only assigned by refreshTree(), so an unset treeData means no tree
+      // request was prepared for the stale cached provider name
+      expect(comp.treeData).toBeUndefined();
+
+      // registered after render so it takes precedence over renderComponent's catch-all
+      const treeRequests: string[] = [];
+      server.use(
+         http.get("*/api/em/security/user/get-security-tree-root/*", ({ request }) => {
+            treeRequests.push(new URL(request.url).pathname);
+            return HttpResponse.json(DEFAULT_TREE_ROOT);
+         }),
+      );
+
+      onRefreshSubject.next({ provider: "ValidatedProvider", providerChanged: true });
+
+      expect(comp.treeData).toBeDefined();
+      await firstValueFrom(comp.treeData);
+      expect(treeRequests).toEqual([expect.stringContaining("/ValidatedProvider/true")]);
+   });
+
+   // 🔁 Regression-sensitive: the onRefresh subscription used to outlive the component, so a
+   // destroyed Users page kept issuing tree requests for every provider/org change.
+   it("should stop reacting to onRefresh after ngOnDestroy", async () => {
+      const { comp, fixture, onRefreshSubject } = await renderComponent();
+      fixture.destroy();
+
+      onRefreshSubject.next({ provider: "AfterDestroy", providerChanged: false });
+
+      // the handler never ran, so refreshTree() never assigned a new tree request
+      expect(comp.treeData).toBeUndefined();
+      expect(comp.selectedProvider).not.toBe("AfterDestroy");
    });
 });
 

--- a/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
+++ b/web/projects/em/src/app/settings/security/users/users-settings-page/users-settings-page.component.ts
@@ -20,7 +20,7 @@ import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { MatDialog, MatDialogConfig } from "@angular/material/dialog";
 import {MatSnackBar} from "@angular/material/snack-bar";
-import { EMPTY, Observable, of, Subject } from "rxjs";
+import { EMPTY, Observable, of, Subject, Subscription } from "rxjs";
 import {catchError, finalize, map, tap} from "rxjs/operators";
 import {IdentityType} from "../../../../../../../shared/data/identity-type";
 import {Tool} from "../../../../../../../shared/util/tool";
@@ -89,6 +89,7 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    currOrg: string;
    loading: boolean = false;
    private selfRefreshing = false;
+   private subscriptions = new Subscription();
    newUserIdentity: IdentityId | null = null;
 
    get hasIncompleteNewUser(): boolean {
@@ -106,16 +107,14 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
                private orgDropDownService: OrganizationDropdownService,
                private orgBusy: SecurityBusyService)
    {
-      orgDropdownService.onRefresh.subscribe(res => {
+      this.subscriptions.add(orgDropdownService.onRefresh.subscribe(res => {
          if(this.selfRefreshing) {
             return;
          }
 
          this.selectedProvider = res.provider;
          this.refreshProvider(this.selectedProvider, res.providerChanged)
-      });
-
-      this.refreshProvider(orgDropdownService.getProvider(), false);
+      }));
    }
 
    get authenticationProviders(): string[] {
@@ -142,6 +141,13 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
 
       this.http.get<string>("../api/em/navbar/organization")
          .subscribe((org) => this.currOrg = org);
+
+      // Reload the provider list rather than trusting the copy cached on
+      // OrganizationDropdownService: it can be stale (a provider added, renamed or removed
+      // since this page was loaded), and the cached selection can name a provider that no
+      // longer exists, which makes get-security-tree-root fail. refreshProviders() re-emits
+      // through onRefresh with a validated provider name, which drives the initial tree load.
+      this.orgDropdownService.refreshProviders();
    }
 
    refreshProvider(provider: string, providerChanged: boolean = true) {
@@ -695,6 +701,7 @@ export class UsersSettingsPageComponent implements OnInit, OnDestroy {
    }
 
    ngOnDestroy(): void {
+      this.subscriptions.unsubscribe();
       this.identityEditable.complete();
    }
 }


### PR DESCRIPTION
Redmine: Bug #76410 — new/copied provider cannot load in Users tab

## Problem

Create or copy an authentication provider in EM → Settings → Security, then switch to the **Users** tab: the new provider cannot be loaded until you log out and log back in.

The Users tab does not fetch the provider list itself — it renders the array cached on `OrganizationDropdownService`, a root singleton populated once per page load (a one-shot `getEmCurrentUser()` subscription plus a STOMP handler on `/user/security/providers-change`). None of the provider mutations refreshed it: `copyProvider()`, `removeProvider()` and `SecurityProviderService.updateAuthenticationProvider()` all skipped `orgDropdownService.refreshProviders()`, which only `reorder()` called.

So the tab kept showing the list as it was when the EM page loaded, and `getProvider()` could still name a provider that had since been renamed or removed. Selecting it sent that dead name to `get-security-tree-root`, where `SecurityTreeServer` dereferenced the null result of `getProviderByName()`:

```
GET /api/em/security/user/get-security-tree-root/testdb/false  ->  500

java.lang.NullPointerException: Cannot invoke
  "inetsoft.sree.security.AuthenticationProvider.getOrganizationIDs()" because "provider" is null
    at inetsoft.web.admin.security.user.SecurityTreeServer.getSecurityTree(SecurityTreeServer.java:88)
    at inetsoft.web.admin.security.user.RoleController.getSecurityTreeRoot(RoleController.java:77)
```

Only a full page reload — i.e. logging out and back in — cleared the cache.

## Fix

- **Refresh the cached list after every provider mutation** — copy and remove in `AuthenticationProviderViewComponent`, and add/edit (including rename) in `SecurityProviderService.updateAuthenticationProvider()`.
- **`UsersSettingsPageComponent` no longer trusts the cache on init.** `ngOnInit` calls `refreshProviders()` instead of loading the tree eagerly from the cached name in the constructor; the initial tree load is driven by the resulting `onRefresh` emission, whose provider name has just been validated against the server's list. The tab therefore cannot request a provider the server no longer knows, even if a future mutation path forgets to refresh. Also tracks and tears down the `onRefresh` subscription, which previously outlived the component and kept a destroyed Users page issuing tree requests.
- **`SecurityTreeServer.getSecurityTree()` guards a null provider** and throws a `MessageException` naming it (new `em.security.provider.notFound` message) instead of NPEing. Every prior null path already NPE'd on the same dereference, so this only turns a 500 into a readable error; it also covers the cluster case where a node has not yet reloaded `authc-chain.json`.
- **`AuthenticationProviderService.messageReceived()` debounce key.** It keyed on the user session, so a user with more than one live subscription (two EM tabs, or a reconnected socket whose old subscriber had not been removed) had them collapse into a single debounce entry and only one arbitrarily-chosen subscriber was notified. The key now includes the subscriber's own STOMP session and subscription id. Hardening — the explicit `refreshProviders()` calls are what guarantee the list is current.

## Testing

Reporter confirmed the fix with a live test.

Automated:

- New `SecurityTreeServerTest` — both null-provider paths report `MessageException`, not NPE.
- Frontend specs — refresh on copy/remove, refresh on add/edit success but not on error, provider reload on Users tab init, no tree request before the list resolves, no reaction to `onRefresh` after destroy.
- Full EM suites green: `ng test em` 372 passed, `ng run em:test-tl` 842 passed, `ng lint em` 0 errors.
- Related Java tests pass: `RoleControllerTest`, `SecurityTreeControllerTest`, `ResourcePermissionTreeControllerTest`, `AuthenticationProviderControllerTest`, `EmPageHeaderControllerTest`.

Manual, on a multi-tenant install as a site admin, without reloading the page between steps:

1. Copy a provider, switch to Users — the copy is listed and its tree loads.
2. Add a provider (File and Database), switch to Users — same.
3. Rename a provider, switch to Users — the old name is gone and the tree loads under the new name.
4. Delete a non-current provider, switch to Users — it is gone from the dropdown.
5. Reorder still works; the page-header organization dropdown still populates after each of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
