### PR TITLE
Bug #76403, group all multi-selected assemblies when dragged into a container

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/vs/LayoutOptionDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/LayoutOptionDialogModel.java
@@ -85,12 +85,25 @@ public class LayoutOptionDialogModel implements Serializable {
       this.columns = columns;
    }
 
+   /**
+    * Names of additional assemblies that were part of the same multi-selection as
+    * {@link #getObject()} and should be grouped into the same target. (Bug #76403)
+    */
+   public List<String> getAdditionalObjects() {
+      return additionalObjects;
+   }
+
+   public void setAdditionalObjects(List<String> additionalObjects) {
+      this.additionalObjects = additionalObjects;
+   }
+
    @Override
    public String toString() {
       return "LayoutOptionDialogModel{" +
          " selectedValue=" + selectedValue +
          ", object=" + object +
          ", target=" + target +
+         ", additionalObjects=" + additionalObjects +
          '}';
    }
 
@@ -101,4 +114,5 @@ public class LayoutOptionDialogModel implements Serializable {
    private int newObjectType;
    private AssetEntry vsEntry;
    private List<AssetEntry> columns;
+   private List<String> additionalObjects;
 }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogService.java
@@ -129,7 +129,9 @@ public class LayoutOptionDialogService {
       // to the rest of the selection so they aren't silently left out.
       if(model.getAdditionalObjects() != null) {
          for(String additionalName : model.getAdditionalObjects()) {
-            if(additionalName == null || additionalName.equals(target.getAbsoluteName())) {
+            if(additionalName == null || additionalName.equals(target.getAbsoluteName()) ||
+               additionalName.equals(model.getObject()))
+            {
                continue;
             }
 

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogService.java
@@ -123,6 +123,31 @@ public class LayoutOptionDialogService {
       }
 
       this.groupingService.groupComponents(rvs, target, object, selection, linkUri, dispatcher);
+
+      // Bug #76403: when several assemblies are dragged together as a multi-selection, only
+      // the one under the pointer is captured as model.getObject(); apply the same placement
+      // to the rest of the selection so they aren't silently left out.
+      if(model.getAdditionalObjects() != null) {
+         for(String additionalName : model.getAdditionalObjects()) {
+            if(additionalName == null || additionalName.equals(target.getAbsoluteName())) {
+               continue;
+            }
+
+            VSAssembly additionalObject = (VSAssembly) viewsheet.getAssembly(additionalName);
+
+            if(additionalObject == null) {
+               continue;
+            }
+
+            if(additionalObject.getContainer() instanceof GroupContainerVSAssembly) {
+               additionalObject = additionalObject.getContainer();
+            }
+
+            this.groupingService.groupComponents(rvs, target, additionalObject, selection,
+                                                  linkUri, dispatcher);
+         }
+      }
+
       VSObjectTreeNode tree = vsObjectTreeService.getObjectTree(rvs);
       PopulateVSObjectTreeCommand treeCommand = new PopulateVSObjectTreeCommand(tree);
       dispatcher.sendCommand(treeCommand);

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogServiceTest.java
@@ -41,6 +41,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -70,6 +71,61 @@ class LayoutOptionDialogServiceTest {
 
       service.setLayoutOptionDialogModel(runtimeViewsheetRef.getRuntimeId(), model, principal, null, dispatcher);
       verify(vsObjectTreeService, times(1)).getObjectTree(rvs);
+   }
+
+   // Bug #76403: dragging a multi-selection into a container should group every
+   // additional assembly into the same target, not just the primary one.
+   @Test
+   void additionalObjectsAreGroupedTest() throws Exception {
+      VSAssembly targetAssembly = mock(VSAssembly.class);
+      VSAssembly additionalAssembly1 = mock(VSAssembly.class);
+      VSAssembly additionalAssembly2 = mock(VSAssembly.class);
+
+      when(engine.getViewsheet(any(), any())).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly("Object1")).thenReturn(assembly);
+      when(viewsheet.getAssembly("Container1")).thenReturn(targetAssembly);
+      when(viewsheet.getAssembly("Object2")).thenReturn(additionalAssembly1);
+      when(viewsheet.getAssembly("Object3")).thenReturn(additionalAssembly2);
+      when(targetAssembly.getAbsoluteName()).thenReturn("Container1");
+      when(model.getSelectedValue()).thenReturn(1);
+      when(model.getNewObjectType()).thenReturn(-1);
+      when(model.getObject()).thenReturn("Object1");
+      when(model.getTarget()).thenReturn("Container1");
+      when(model.getAdditionalObjects()).thenReturn(List.of("Object2", "Object3"));
+
+      service.setLayoutOptionDialogModel(runtimeViewsheetRef.getRuntimeId(), model, principal, null, dispatcher);
+
+      verify(groupingService, times(1))
+         .groupComponents(rvs, targetAssembly, assembly, true, null, dispatcher);
+      verify(groupingService, times(1))
+         .groupComponents(rvs, targetAssembly, additionalAssembly1, true, null, dispatcher);
+      verify(groupingService, times(1))
+         .groupComponents(rvs, targetAssembly, additionalAssembly2, true, null, dispatcher);
+   }
+
+   // Bug #76403: an additionalObjects entry that duplicates the primary object or the
+   // target itself must not be grouped a second time.
+   @Test
+   void additionalObjectsSkipDuplicatesTest() throws Exception {
+      VSAssembly targetAssembly = mock(VSAssembly.class);
+
+      when(engine.getViewsheet(any(), any())).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly("Object1")).thenReturn(assembly);
+      when(viewsheet.getAssembly("Container1")).thenReturn(targetAssembly);
+      when(targetAssembly.getAbsoluteName()).thenReturn("Container1");
+      when(model.getSelectedValue()).thenReturn(1);
+      when(model.getNewObjectType()).thenReturn(-1);
+      when(model.getObject()).thenReturn("Object1");
+      when(model.getTarget()).thenReturn("Container1");
+      when(model.getAdditionalObjects()).thenReturn(List.of("Object1", "Container1"));
+
+      service.setLayoutOptionDialogModel(runtimeViewsheetRef.getRuntimeId(), model, principal, null, dispatcher);
+
+      verify(groupingService, times(1))
+         .groupComponents(eq(rvs), eq(targetAssembly), any(VSAssembly.class), eq(true), isNull(),
+                          eq(dispatcher));
    }
 
    @Mock RuntimeViewsheetRef runtimeViewsheetRef;

--- a/web/projects/portal/src/app/composer/data/vs/layout-option-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/layout-option-dialog-model.ts
@@ -25,4 +25,5 @@ export interface LayoutOptionDialogModel {
    newObjectType?: number;
    vsEntry: AssetEntry;
    columns?: any;
+   additionalObjects?: string[];
 }

--- a/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.ts
@@ -1108,19 +1108,20 @@ export class EditableObjectContainer extends AbstractActionComponent
             object = this.viewsheet.getAssembly(this.vsObject.container) || this.vsObject;
          }
 
-         this.layoutOptionDialogModel = {
-            selectedValue: 0,
-            object: name,
-            target: object.absoluteName,
-            showSelectionContainerOption: false,
-            vsEntry: null
-         };
+         const selectionContainerTarget = targetType === "VSSelectionContainer" && selectionObject;
+         const targetName = selectionContainerTarget ? this.vsObject.absoluteName : object.absoluteName;
 
-         if(targetType === "VSSelectionContainer" && selectionObject) {
-            this.layoutOptionDialogModel.showSelectionContainerOption = true;
-            this.layoutOptionDialogModel.selectedValue = 1;
-            this.layoutOptionDialogModel.target = this.vsObject.absoluteName;
-         }
+         this.layoutOptionDialogModel = {
+            selectedValue: selectionContainerTarget ? 1 : 0,
+            object: name,
+            target: targetName,
+            showSelectionContainerOption: selectionContainerTarget,
+            vsEntry: null,
+            // Bug #76403: only the assembly under the pointer drives the interact.js drop
+            // gesture, so gather the rest of a multi-selection to be grouped along with it.
+            additionalObjects: this.getAdditionalDragSelectionNames(
+               name, targetName, selectionContainerTarget)
+         };
 
          this.openLayoutOptionDialog().then(
             () => {
@@ -1131,6 +1132,26 @@ export class EditableObjectContainer extends AbstractActionComponent
             }
          );
       }
+   }
+
+   // Bug #76403: when several assemblies are multi-selected and dragged together, the
+   // interact.js drop event only identifies the assembly under the pointer (dragSource).
+   // Collect the rest of the current selection so they can be grouped into the same
+   // target instead of being silently left out.
+   private getAdditionalDragSelectionNames(primaryName: string, targetName: string,
+                                           selectionContainerTarget: boolean): string[]
+   {
+      return this.viewsheet.currentFocusedAssemblies
+         .filter((assembly: VSObjectModel) => assembly.absoluteName !== primaryName &&
+            assembly.absoluteName !== targetName &&
+            assembly.objectType !== "VSOval" &&
+            assembly.objectType !== "VSRectangle" &&
+            assembly.objectType !== "VSLine" &&
+            (!selectionContainerTarget ||
+               assembly.objectType === "VSSelectionList" ||
+               assembly.objectType === "VSRangeSlider" ||
+               assembly.objectType === "VSSelectionContainer"))
+         .map((assembly: VSObjectModel) => assembly.absoluteName);
    }
 
    //if the line handle is being dragged close enough to the object, its handles should appear


### PR DESCRIPTION
## Summary

When multiple filter assemblies (e.g. several Selection Lists) are multi-selected on the Composer canvas and dragged together onto a Selection Container, only one of them was actually added to the container — the rest of the selection was silently dropped from the operation. The same defect applies to dragging a multi-selection onto a Tab.

## Root Cause

Dragging an assembly onto a drop target on the viewsheet canvas is handled by `EditableObjectContainer.onDropzoneDrop()`. The interact.js drop gesture only identifies the single DOM element the pointer was tracking (`event.relatedTarget`), so only that one assembly's name was captured into `LayoutOptionDialogModel.object`. That model flows through `LayoutOptionDialogController` → `LayoutOptionDialogService.setLayoutOptionDialogModel()` → `GroupingService.groupComponents()`, which is a single-object API end to end — so even though the rest of a multi-selection visually moved along with the drag, only the one assembly under the pointer was grouped into the target.

## Fix

- Added an optional `additionalObjects: string[]` field to the `LayoutOptionDialogModel` (both the TypeScript interface and the Java DTO).
- In `onDropzoneDrop()`, a new helper (`getAdditionalDragSelectionNames`) collects the rest of `viewsheet.currentFocusedAssemblies` — excluding the primary dragged assembly, the target, and shape types, and (when the target is a Selection Container) restricted to filter-compatible types (`VSSelectionList` / `VSRangeSlider` / `VSSelectionContainer`) — and stores their names on the model.
- `LayoutOptionDialogService.setLayoutOptionDialogModel()` now loops `model.getAdditionalObjects()` after handling the primary object, calling `groupingService.groupComponents()` for each additional assembly against the same target, all within the same `@Undoable` transaction as the primary call (one atomic operation, one undo step).

## Test Plan

- [x] `core` module compiles cleanly (`mvnw test-compile -pl core -am`)
- [x] `portal` Angular project builds cleanly (`ng build portal`)
- [x] Relevant testing-library specs pass in isolation: `editable-object-container.component.{interaction,risk,display}.tl.spec.ts` (91 tests), `composer-selection-container-children.component.{interaction,risk}.tl.spec.ts` (30 tests), `vs-selection-container-children.component.tl.spec.ts` (18 tests)
- [x] ESLint clean on both changed TypeScript files
- [x] Manually verified in the Composer: multi-selecting several filters and dragging them onto a Selection Container now adds all of them

Fixes Redmine #76403.