### PR TITLE
Bug #76403, group all multi-selected assemblies when dragged into a container

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/model/vs/LayoutOptionDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/LayoutOptionDialogModel.java
@@ -84,12 +84,25 @@ public class LayoutOptionDialogModel {
       this.columns = columns;
    }
 
+   /**
+    * Names of additional assemblies that were part of the same multi-selection as
+    * {@link #getObject()} and should be grouped into the same target. (Bug #76403)
+    */
+   public List<String> getAdditionalObjects() {
+      return additionalObjects;
+   }
+
+   public void setAdditionalObjects(List<String> additionalObjects) {
+      this.additionalObjects = additionalObjects;
+   }
+
    @Override
    public String toString() {
       return "LayoutOptionDialogModel{" +
          " selectedValue=" + selectedValue +
          ", object=" + object +
          ", target=" + target +
+         ", additionalObjects=" + additionalObjects +
          '}';
    }
 
@@ -100,4 +113,5 @@ public class LayoutOptionDialogModel {
    private int newObjectType;
    private AssetEntry vsEntry;
    private List<AssetEntry> columns;
+   private List<String> additionalObjects;
 }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogController.java
@@ -146,6 +146,33 @@ public class LayoutOptionDialogController {
       }
 
       this.groupingService.groupComponents(rvs, target, object, selection, linkUri, dispatcher);
+
+      // Bug #76403: when several assemblies are dragged together as a multi-selection, only
+      // the one under the pointer is captured as model.getObject(); apply the same placement
+      // to the rest of the selection so they aren't silently left out.
+      if(model.getAdditionalObjects() != null) {
+         for(String additionalName : model.getAdditionalObjects()) {
+            if(additionalName == null || additionalName.equals(target.getAbsoluteName()) ||
+               additionalName.equals(model.getObject()))
+            {
+               continue;
+            }
+
+            VSAssembly additionalObject = (VSAssembly) viewsheet.getAssembly(additionalName);
+
+            if(additionalObject == null) {
+               continue;
+            }
+
+            if(additionalObject.getContainer() instanceof GroupContainerVSAssembly) {
+               additionalObject = additionalObject.getContainer();
+            }
+
+            this.groupingService.groupComponents(rvs, target, additionalObject, selection,
+                                                  linkUri, dispatcher);
+         }
+      }
+
       VSObjectTreeNode tree = vsObjectTreeService.getObjectTree(rvs);
       PopulateVSObjectTreeCommand treeCommand = new PopulateVSObjectTreeCommand(tree);
       dispatcher.sendCommand(treeCommand);

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/LayoutOptionDialogControllerTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.Principal;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -63,6 +64,61 @@ class LayoutOptionDialogControllerTest {
 
       controller.setLayoutOptionDialogModel(model, principal, null, dispatcher);
       verify(vsObjectTreeService, times(1)).getObjectTree(rvs);
+   }
+
+   // Bug #76403: dragging a multi-selection into a container should group every
+   // additional assembly into the same target, not just the primary one.
+   @Test
+   void additionalObjectsAreGroupedTest() throws Exception {
+      VSAssembly targetAssembly = mock(VSAssembly.class);
+      VSAssembly additionalAssembly1 = mock(VSAssembly.class);
+      VSAssembly additionalAssembly2 = mock(VSAssembly.class);
+
+      when(engine.getViewsheet(any(), any())).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly("Object1")).thenReturn(assembly);
+      when(viewsheet.getAssembly("Container1")).thenReturn(targetAssembly);
+      when(viewsheet.getAssembly("Object2")).thenReturn(additionalAssembly1);
+      when(viewsheet.getAssembly("Object3")).thenReturn(additionalAssembly2);
+      when(targetAssembly.getAbsoluteName()).thenReturn("Container1");
+      when(model.getSelectedValue()).thenReturn(1);
+      when(model.getNewObjectType()).thenReturn(-1);
+      when(model.getObject()).thenReturn("Object1");
+      when(model.getTarget()).thenReturn("Container1");
+      when(model.getAdditionalObjects()).thenReturn(List.of("Object2", "Object3"));
+
+      controller.setLayoutOptionDialogModel(model, principal, null, dispatcher);
+
+      verify(groupingService, times(1))
+         .groupComponents(rvs, targetAssembly, assembly, true, null, dispatcher);
+      verify(groupingService, times(1))
+         .groupComponents(rvs, targetAssembly, additionalAssembly1, true, null, dispatcher);
+      verify(groupingService, times(1))
+         .groupComponents(rvs, targetAssembly, additionalAssembly2, true, null, dispatcher);
+   }
+
+   // Bug #76403: an additionalObjects entry that duplicates the primary object or the
+   // target itself must not be grouped a second time.
+   @Test
+   void additionalObjectsSkipDuplicatesTest() throws Exception {
+      VSAssembly targetAssembly = mock(VSAssembly.class);
+
+      when(engine.getViewsheet(any(), any())).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly("Object1")).thenReturn(assembly);
+      when(viewsheet.getAssembly("Container1")).thenReturn(targetAssembly);
+      when(targetAssembly.getAbsoluteName()).thenReturn("Container1");
+      when(model.getSelectedValue()).thenReturn(1);
+      when(model.getNewObjectType()).thenReturn(-1);
+      when(model.getObject()).thenReturn("Object1");
+      when(model.getTarget()).thenReturn("Container1");
+      when(model.getAdditionalObjects()).thenReturn(List.of("Object1", "Container1"));
+
+      controller.setLayoutOptionDialogModel(model, principal, null, dispatcher);
+
+      verify(groupingService, times(1))
+         .groupComponents(eq(rvs), eq(targetAssembly), any(VSAssembly.class), eq(true), isNull(),
+                          eq(dispatcher));
    }
 
    @Mock RuntimeViewsheetRef runtimeViewsheetRef;

--- a/web/projects/portal/src/app/composer/data/vs/layout-option-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/layout-option-dialog-model.ts
@@ -25,4 +25,5 @@ export interface LayoutOptionDialogModel {
    newObjectType?: number;
    vsEntry: AssetEntry;
    columns?: any;
+   additionalObjects?: string[];
 }

--- a/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/editable-object-container.component.ts
@@ -1050,19 +1050,20 @@ export class EditableObjectContainer extends AbstractActionComponent
             object = this.viewsheet.getAssembly(this.vsObject.container) || this.vsObject;
          }
 
-         this.layoutOptionDialogModel = {
-            selectedValue: 0,
-            object: name,
-            target: object.absoluteName,
-            showSelectionContainerOption: false,
-            vsEntry: null
-         };
+         const selectionContainerTarget = targetType === "VSSelectionContainer" && selectionObject;
+         const targetName = selectionContainerTarget ? this.vsObject.absoluteName : object.absoluteName;
 
-         if(targetType === "VSSelectionContainer" && selectionObject) {
-            this.layoutOptionDialogModel.showSelectionContainerOption = true;
-            this.layoutOptionDialogModel.selectedValue = 1;
-            this.layoutOptionDialogModel.target = this.vsObject.absoluteName;
-         }
+         this.layoutOptionDialogModel = {
+            selectedValue: selectionContainerTarget ? 1 : 0,
+            object: name,
+            target: targetName,
+            showSelectionContainerOption: selectionContainerTarget,
+            vsEntry: null,
+            // Bug #76403: only the assembly under the pointer drives the interact.js drop
+            // gesture, so gather the rest of a multi-selection to be grouped along with it.
+            additionalObjects: this.getAdditionalDragSelectionNames(
+               name, targetName, selectionContainerTarget)
+         };
 
          this.openLayoutOptionDialog().then(
             () => {
@@ -1073,6 +1074,26 @@ export class EditableObjectContainer extends AbstractActionComponent
             }
          );
       }
+   }
+
+   // Bug #76403: when several assemblies are multi-selected and dragged together, the
+   // interact.js drop event only identifies the assembly under the pointer (dragSource).
+   // Collect the rest of the current selection so they can be grouped into the same
+   // target instead of being silently left out.
+   private getAdditionalDragSelectionNames(primaryName: string, targetName: string,
+                                           selectionContainerTarget: boolean): string[]
+   {
+      return this.viewsheet.currentFocusedAssemblies
+         .filter((assembly: VSObjectModel) => assembly.absoluteName !== primaryName &&
+            assembly.absoluteName !== targetName &&
+            assembly.objectType !== "VSOval" &&
+            assembly.objectType !== "VSRectangle" &&
+            assembly.objectType !== "VSLine" &&
+            (!selectionContainerTarget ||
+               assembly.objectType === "VSSelectionList" ||
+               assembly.objectType === "VSRangeSlider" ||
+               assembly.objectType === "VSSelectionContainer"))
+         .map((assembly: VSObjectModel) => assembly.absoluteName);
    }
 
    //if the line handle is being dragged close enough to the object, its handles should appear


### PR DESCRIPTION
## Summary

Backport of #4960 to the v1.1.x maintenance branch.

When multiple filter assemblies (e.g. several Selection Lists) are multi-selected on the Composer canvas and dragged together onto a Selection Container, only one of them was actually added to the container — the rest of the selection was silently dropped from the operation. The same defect applies to dragging a multi-selection onto a Tab.

## Root Cause

Dragging an assembly onto a drop target on the viewsheet canvas is handled by `EditableObjectContainer.onDropzoneDrop()`. The interact.js drop gesture only identifies the single DOM element the pointer was tracking (`event.relatedTarget`), so only that one assembly's name was captured into `LayoutOptionDialogModel.object`. That model flows through `LayoutOptionDialogController.setLayoutOptionDialogModel()` → `GroupingService.groupComponents()`, which is a single-object API end to end — so even though the rest of a multi-selection visually moved along with the drag, only the one assembly under the pointer was grouped into the target.

## Fix

- Added an optional `additionalObjects: string[]` field to the `LayoutOptionDialogModel` (both the TypeScript interface and the Java DTO).
- In `onDropzoneDrop()`, a new helper (`getAdditionalDragSelectionNames`) collects the rest of `viewsheet.currentFocusedAssemblies` — excluding the primary dragged assembly, the target, and shape types, and (when the target is a Selection Container) restricted to filter-compatible types (`VSSelectionList` / `VSRangeSlider` / `VSSelectionContainer`) — and stores their names on the model.
- `LayoutOptionDialogController.setLayoutOptionDialogModel()` now loops `model.getAdditionalObjects()` after handling the primary object, calling `groupingService.groupComponents()` for each additional assembly against the same target (with a guard against a duplicate of the primary object or the target itself), all within the same `@Undoable` transaction as the primary call (one atomic operation, one undo step).

### Note on porting to v1.1.x

`main`'s fix lives in a separate `LayoutOptionDialogService` (`@ClusterProxy`) that this maintenance branch predates — on v1.1.x this logic still lives directly in `LayoutOptionDialogController`, so the fix and its guard were ported into the controller instead. Likewise the new unit tests were merged into the pre-existing `LayoutOptionDialogControllerTest` (analogous to `main`'s `LayoutOptionDialogServiceTest`). Frontend changes (`layout-option-dialog-model.ts`, `editable-object-container.component.ts`) are otherwise unchanged from the reviewed `main` fix.

## Test Plan

- [x] `core` module compiles cleanly and `LayoutOptionDialogControllerTest` passes (3/3 tests, including the two new tests covering the multi-object grouping loop and the duplicate guard)
- [x] TypeScript diff verified identical to the already-built, already-tested `main` fix (`editable-object-container.component.ts`, `layout-option-dialog-model.ts`)
- Frontend build not re-run on this branch (v1.1.x pins Angular 15.2, incompatible with the Angular 21 `node_modules` currently installed for `main` work)

Fixes Redmine #76403.