### PR TITLE
Bug #76414, restore the asset-tree fallback when get-current-user fails

### DIFF
--- a/web/projects/em/src/app/app.component.ts
+++ b/web/projects/em/src/app/app.component.ts
@@ -84,7 +84,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
    ngOnInit(): void {
       this.subscription.add(this.currentUserService.getEmCurrentUser().subscribe(userModel => {
-         this.name = userModel.name?.name;
+         this.name = userModel?.name?.name;
       }));
 
       this.subscription.add(this.authzService.getPermissions("").subscribe(p => this.permissions = p));

--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.risk.tl.spec.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.risk.tl.spec.ts
@@ -31,11 +31,13 @@
  *   Group 7  [Risk 2] — ngOnDestroy: calls assetClientService.disconnect(); unsubscribes subscriptions
  *   Group 8  [Risk 1] — setupAssetClientService: calls assetClientService.connect();
  *                        subscribes to assetChanged
+ *   Group 9  [Risk 3] — current-user failure: the tree must still load when
+ *                        getPortalCurrentUser() errors or emits null (Bug #74027)
  */
 
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { render } from "@testing-library/angular";
-import { NEVER, of, Subject } from "rxjs";
+import { NEVER, of, Subject, throwError } from "rxjs";
 
 import { AssetTreeComponent } from "./asset-tree.component";
 import { AssetTreeService } from "./asset-tree.service";
@@ -370,5 +372,42 @@ describe("AssetTreeComponent — setupAssetClientService", () => {
       const { comp } = await renderComponent({});
 
       expect(assetChangedSubject.observed).toBe(true);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 9: current-user failure [Risk 3]
+// ---------------------------------------------------------------------------
+
+describe("AssetTreeComponent — current-user failure", () => {
+   // 🔁 Regression-sensitive: Bug #74027. If getPortalCurrentUser() errors and ngOnInit has no
+   //    error handler, loadAssetTree() is never called and the tree stays blank for the life of
+   //    the component — no retry, no error shown. Bug #74480 dropped that handler once already.
+   it("should still load the tree when getPortalCurrentUser() errors", async () => {
+      ASSET_TREE_SERVICE_MOCK.getAssetTreeNode.mockReturnValue(makeTreeResponse());
+      CURRENT_USER_SERVICE_MOCK.getPortalCurrentUser.mockReturnValue(
+         throwError(() => new Error("500")));
+
+      const { comp } = await renderComponent({ datasources: true });
+
+      expect(ASSET_TREE_SERVICE_MOCK.getAssetTreeNode).toHaveBeenCalledTimes(1);
+      expect(comp.root).not.toBeNull();
+      expect(comp.root.data.identifier).toBe("root-id");
+   });
+
+   // 🔁 Regression-sensitive: CurrentUserService maps a failed call to null, so the null emission
+   //    is the path actually taken in production; the tree must load with the default org scope.
+   it("should load the tree with the default scope when the current user is null", async () => {
+      ASSET_TREE_SERVICE_MOCK.getAssetTreeNode.mockReturnValue(makeTreeResponse());
+      CURRENT_USER_SERVICE_MOCK.getPortalCurrentUser.mockReturnValue(of(null));
+
+      const defaultFolder = { path: "Sales", scope: 4 } as any;
+      const { comp } = await renderComponent({ defaultFolder });
+
+      expect(comp.root).not.toBeNull();
+      // currOrgID defaults to "" rather than "SELF", so defaultFolder.scope is used as-is
+      const callArg: LoadAssetTreeNodesEvent =
+         ASSET_TREE_SERVICE_MOCK.getAssetTreeNode.mock.calls[0][0];
+      expect(callArg.getScope()).toBe(4);
    });
 });

--- a/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
+++ b/web/projects/portal/src/app/widget/asset-tree/asset-tree.component.ts
@@ -146,9 +146,16 @@ export class AssetTreeComponent implements OnInit, OnDestroy, OnChanges {
    ngOnInit() {
       this.setupAssetClientService();
 
-      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe((user) => {
-         this.currOrgID = user?.name?.orgID ?? "";
-         this.loadAssetTree();
+      this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe({
+         next: (user) => {
+            this.currOrgID = user?.name?.orgID ?? "";
+            this.loadAssetTree();
+         },
+         error: () => {
+            // if the current-user call fails (e.g. during pod restart / cluster
+            // rebalancing), fall through with defaults so the tree still renders
+            this.loadAssetTree();
+         }
       }));
    }
 

--- a/web/projects/shared/ai-assistant/ai-assistant.service.ts
+++ b/web/projects/shared/ai-assistant/ai-assistant.service.ts
@@ -221,6 +221,11 @@ export class AiAssistantService {
          : this.currentUserService.getPortalCurrentUser();
 
       user$.subscribe(model => {
+         if(!model) {
+            // the current-user call failed; leave the user info unset
+            return;
+         }
+
          this.userId = convertToKey(model.name);
          this.email = model.email?.length > 0 ? model.email[0] : "";
       });

--- a/web/projects/shared/util/current-user.service.tl.spec.ts
+++ b/web/projects/shared/util/current-user.service.tl.spec.ts
@@ -1,0 +1,176 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * CurrentUserService — unit tests
+ *
+ * Risk-first coverage:
+ *   Group 1 [Risk 3] — getPortalCurrentUser(): request URL, caching, failure -> null, retry
+ *   Group 2 [Risk 2] — getEmCurrentUser(): request URL, failure -> null
+ *
+ * KEY contracts:
+ *   - A failed call emits null rather than erroring, so a bare subscribe() in a consumer cannot
+ *     silently skip its next callback (Bug #74027: a blank Composer asset tree with no recovery).
+ *   - Successful responses are cached and shared (Bug #74395: no duplicate API calls).
+ *   - A failure must NOT be cached: shareReplay resets on error, so the next subscriber re-issues
+ *     the request. The catchError lives in the getter for exactly this reason -- inside the shared
+ *     pipe it would complete the stream, and shareReplay never resets a completed buffer.
+ */
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+import { Subscription } from "rxjs";
+import { CurrentUser } from "../../portal/src/app/portal/current-user";
+import { CurrentUserService } from "./current-user.service";
+
+const PORTAL_URL = "../api/portal/get-current-user";
+const EM_URL = "../api/em/security/get-current-user";
+
+const USER = {
+   name: { name: "alice", orgID: "acme" },
+   email: ["alice@example.com"],
+} as CurrentUser;
+
+describe("CurrentUserService", () => {
+   let service: CurrentUserService;
+   let httpMock: HttpTestingController;
+
+   beforeEach(() => {
+      TestBed.configureTestingModule({
+         imports: [HttpClientTestingModule],
+         providers: [CurrentUserService],
+      });
+      service = TestBed.inject(CurrentUserService);
+      httpMock = TestBed.inject(HttpTestingController);
+   });
+
+   afterEach(() => httpMock.verify());
+
+   // ---------------------------------------------------------------------------
+   // Group 1 [Risk 3] — getPortalCurrentUser()
+   // ---------------------------------------------------------------------------
+   describe("getPortalCurrentUser()", () => {
+      it("[Risk 2] does not issue a request until subscribed", () => {
+         httpMock.expectNone(PORTAL_URL);
+      });
+
+      it("[Risk 2] requests the portal endpoint and emits the user", () => {
+         let emitted: CurrentUser;
+         service.getPortalCurrentUser().subscribe(user => (emitted = user));
+
+         const req = httpMock.expectOne(PORTAL_URL);
+         expect(req.request.method).toBe("GET");
+         req.flush(USER);
+
+         expect(emitted).toEqual(USER);
+      });
+
+      // 🔁 Regression-sensitive: Bug #74027/#74480. A consumer with a success-only subscribe()
+      //    (e.g. AssetTreeComponent.ngOnInit) never runs its callback if this errors, leaving the
+      //    asset tree permanently blank with no retry and no message.
+      it("[Risk 3] emits null instead of erroring when the call fails", () => {
+         const emitted: CurrentUser[] = [];
+         let errored = false;
+         let completed = false;
+
+         service.getPortalCurrentUser().subscribe({
+            next: user => emitted.push(user),
+            error: () => (errored = true),
+            complete: () => (completed = true),
+         });
+
+         httpMock.expectOne(PORTAL_URL).flush(null, { status: 500, statusText: "Server Error" });
+
+         expect(errored).toBe(false);
+         expect(emitted).toEqual([null]);
+         expect(completed).toBe(true);
+      });
+
+      // 🔁 Regression-sensitive: Bug #74395. Caching must survive so concurrent subscribers share
+      //    one request.
+      it("[Risk 3] shares a single request between concurrent subscribers", () => {
+         const first: CurrentUser[] = [];
+         const second: CurrentUser[] = [];
+         const sub = new Subscription();
+         sub.add(service.getPortalCurrentUser().subscribe(u => first.push(u)));
+         sub.add(service.getPortalCurrentUser().subscribe(u => second.push(u)));
+
+         httpMock.expectOne(PORTAL_URL).flush(USER);
+
+         expect(first).toEqual([USER]);
+         expect(second).toEqual([USER]);
+         sub.unsubscribe();
+      });
+
+      it("[Risk 3] replays the cached user to a later subscriber without a second request", () => {
+         const sub = service.getPortalCurrentUser().subscribe();
+         httpMock.expectOne(PORTAL_URL).flush(USER);
+
+         let emitted: CurrentUser;
+         service.getPortalCurrentUser().subscribe(user => (emitted = user));
+
+         expect(emitted).toEqual(USER);
+         httpMock.expectNone(PORTAL_URL);
+         sub.unsubscribe();
+      });
+
+      // 🔁 Regression-sensitive: a failure must not be cached. If the catchError were moved inside
+      //    the shareReplay pipe the stream would complete, the null would stick for the lifetime of
+      //    the page, and no consumer would ever see the current user again after one transient 500.
+      it("[Risk 3] re-issues the request for the next subscriber after a failure", () => {
+         service.getPortalCurrentUser().subscribe();
+         httpMock.expectOne(PORTAL_URL).flush(null, { status: 500, statusText: "Server Error" });
+
+         let emitted: CurrentUser;
+         service.getPortalCurrentUser().subscribe(user => (emitted = user));
+
+         httpMock.expectOne(PORTAL_URL).flush(USER);
+         expect(emitted).toEqual(USER);
+      });
+   });
+
+   // ---------------------------------------------------------------------------
+   // Group 2 [Risk 2] — getEmCurrentUser()
+   // ---------------------------------------------------------------------------
+   describe("getEmCurrentUser()", () => {
+      it("[Risk 2] requests the EM endpoint and emits the user", () => {
+         let emitted: CurrentUser;
+         service.getEmCurrentUser().subscribe(user => (emitted = user));
+
+         const req = httpMock.expectOne(EM_URL);
+         expect(req.request.method).toBe("GET");
+         req.flush(USER);
+
+         expect(emitted).toEqual(USER);
+      });
+
+      it("[Risk 3] emits null instead of erroring when the call fails", () => {
+         const emitted: CurrentUser[] = [];
+         let errored = false;
+
+         service.getEmCurrentUser().subscribe({
+            next: user => emitted.push(user),
+            error: () => (errored = true),
+         });
+
+         httpMock.expectOne(EM_URL).flush(null, { status: 500, statusText: "Server Error" });
+
+         expect(errored).toBe(false);
+         expect(emitted).toEqual([null]);
+      });
+   });
+});

--- a/web/projects/shared/util/current-user.service.ts
+++ b/web/projects/shared/util/current-user.service.ts
@@ -17,14 +17,20 @@
  */
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
-import { shareReplay } from "rxjs/operators";
+import { Observable, of } from "rxjs";
+import { catchError, shareReplay } from "rxjs/operators";
 import { CurrentUser } from "../../portal/src/app/portal/current-user";
 
 @Injectable({
    providedIn: "root"
 })
 export class CurrentUserService {
+   // only successful responses are cached: shareReplay uses resetOnError=true, so a failed
+   // call resets the replay buffer and the next subscriber re-issues the request. The
+   // catchError is applied per-subscriber in the getters rather than here, because a
+   // catchError inside this pipe would complete the stream and shareReplay never resets a
+   // completed buffer (resetOnComplete=false) -- the null would be cached for the lifetime
+   // of the page, leaving every later subscriber without a current user and no retry.
    private emCurrentUser$: Observable<CurrentUser> =
       this.http.get<CurrentUser>("../api/em/security/get-current-user").pipe(
          shareReplay({ bufferSize: 1, refCount: true })
@@ -38,10 +44,10 @@ export class CurrentUserService {
    constructor(private http: HttpClient) {}
 
    getEmCurrentUser(): Observable<CurrentUser> {
-      return this.emCurrentUser$;
+      return this.emCurrentUser$.pipe(catchError(() => of(null)));
    }
 
    getPortalCurrentUser(): Observable<CurrentUser> {
-      return this.portalCurrentUser$;
+      return this.portalCurrentUser$.pipe(catchError(() => of(null)));
    }
 }


### PR DESCRIPTION
## Problem

`AssetTreeComponent.ngOnInit()` subscribes to `CurrentUserService.getPortalCurrentUser()` with a success-only callback:

```ts
this.subscriptions.add(this.currentUserService.getPortalCurrentUser().subscribe((user) => {
   this.currOrgID = user?.name?.orgID ?? "";
   this.loadAssetTree();
}));
```

If `../api/portal/get-current-user` fails — security provider not yet initialized on a cold start, a transient 5xx during cluster rebalancing, or a plain network blip — `loadAssetTree()` is never invoked and the asset tree stays blank for the life of the component instance. No retry, no message; the user has to reload the page.

`AssetTreeComponent` backs both the Composer asset-tree sidebar and the "New Dashboard" dialog picker, so both come up empty. `CurrentUserService` has no `catchError`, and no portal `HttpInterceptor` or global `ErrorHandler` catches this (`SsoHeartbeatInterceptor` is the only portal interceptor; `ErrorHandlerService` is EM-only and explicitly invoked).

## This is a regression of Bug #74027

`ab6bd25e0` (#74027) fixed exactly this symptom by adding an `error:` handler to the `forkJoin` that `ngOnInit()` used at the time. `8177443f1` (#74480) then replaced that `forkJoin` with `getPortalCurrentUser()` — but its diff was computed against the *pre-#74027* base blob (`index d8a8541b9..` in both commits), and the hunk resolution took its own side, deleting the error handler again.

## Fix

Both levels, because the service is the shared cause and the component is what regressed.

**1. `CurrentUserService`** — `getPortalCurrentUser()`/`getEmCurrentUser()` map a failed call to `null` instead of erroring, so a bare `subscribe()` in any consumer cannot silently skip its next callback. There are eight subscribers of this service and **none** supplied an error callback.

The `catchError` is applied per-subscriber **in the getters, not inside the shared pipe**. `shareReplay` passes `resetOnComplete: false`, and `share()` skips its refCount-zero reset once the source has completed (`share.js:61`), so a `catchError` ahead of `shareReplay` would complete the stream and cache the `null` for the lifetime of the page — every later subscriber would get no current user and never retry, which is worse than the bug being fixed. Keeping it in the getter caches only successful responses (preserving the de-duplication added in Bug #74395) while a failure still resets the buffer, so the next subscriber re-issues the request.

**2. `AssetTreeComponent.ngOnInit()`** — supplies an `error:` callback that calls `loadAssetTree()` with default org state, restoring the #74027 behavior. Safe because `currOrgID` is only consulted for the `== "SELF"` user-scope check. Redundant given (1), but it keeps the tree correct if `CurrentUserService` changes again — which is exactly how this regressed the first time.

**3. Two consumers were not null-safe** on the emitted model and would have thrown on the `null` fallback — `AppComponent` (em) dereferenced `userModel.name`, and `AiAssistantService` called `convertToKey(model.name)`. Both now guard.

Deliberately out of scope: no user-visible error toast or retry button. Rendering the default-org tree restores function, and #74027 established silent fallback as the accepted behavior for this path; adding a notification surface to a generic widget used both in the sidebar and inside a dialog is a separate UX decision.

## Testing

Both new error tests were run against the reverted source to confirm they are not vacuous:

| Spec | With fix | Without fix |
|---|---|---|
| `current-user.service.tl.spec.ts` (new) | 8 pass | **2 fail** (portal + em error paths) |
| `asset-tree.component.risk.tl.spec.ts` | 16 pass | **1 fail** — `getAssetTreeNode` called 0 times |

That last failure is the reported symptom reproduced directly: the tree load never fires. The caching tests pass in both states by design — they guard against the `shareReplay` caching regression described above rather than the original bug.

Also run: `ng lint` — 0 errors (8 pre-existing warnings, all in untouched files). `tsc -p projects/em/tsconfig.spec.json --noEmit` — clean.

Not covered by a test: the one-character optional chain in em's `app.component.ts`, as no spec exists for that component; it is covered by the type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
