### PR TITLE
Bug #76422, fix selection container child reorder failing to deserialize

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/event/MoveSelectionChildEvent.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/event/MoveSelectionChildEvent.java
@@ -18,6 +18,8 @@
 package inetsoft.web.viewsheet.event;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 import org.immutables.serial.Serial;
 
@@ -28,8 +30,12 @@ import org.immutables.serial.Serial;
  */
 @Value.Immutable
 @Serial.Structural
+@JsonDeserialize(as = ImmutableMoveSelectionChildEvent.class)
 public interface MoveSelectionChildEvent {
    int getFromIndex();
    int getToIndex();
+   // Immutables does not strip the "is" prefix, so the property must be named explicitly
+   // to match the payload sent by the client.
+   @JsonProperty("currentSelection")
    boolean isCurrentSelection();
 }

--- a/core/src/test/java/inetsoft/web/viewsheet/event/MoveSelectionChildEventTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/event/MoveSelectionChildEventTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the payload sent by the selection container child drag-and-drop can be
+ * deserialized. Without @JsonDeserialize on the immutable interface, Jackson fails with
+ * "Cannot construct instance of MoveSelectionChildEvent".
+ */
+@Tag("core")
+class MoveSelectionChildEventTest {
+   @Test
+   void deserializeMoveChildPayload() throws Exception {
+      final String json = "{\"fromIndex\":1,\"toIndex\":0,\"currentSelection\":false}";
+      MoveSelectionChildEvent event =
+         new ObjectMapper().readValue(json, MoveSelectionChildEvent.class);
+
+      assertEquals(1, event.getFromIndex());
+      assertEquals(0, event.getToIndex());
+      assertFalse(event.isCurrentSelection());
+   }
+
+   @Test
+   void deserializeCurrentSelectionPayload() throws Exception {
+      final String json = "{\"fromIndex\":0,\"toIndex\":2,\"currentSelection\":true}";
+      MoveSelectionChildEvent event =
+         new ObjectMapper().readValue(json, MoveSelectionChildEvent.class);
+
+      assertEquals(0, event.getFromIndex());
+      assertEquals(2, event.getToIndex());
+      assertTrue(event.isCurrentSelection());
+   }
+}


### PR DESCRIPTION
## Problem

In the viewsheet composer (and the viewer), dragging one child of a Selection Container over another — e.g. moving a RangeSlider above a Selection List — pops up:

> An unexpected error has occurred. Could not read JSON: Cannot construct instance of `inetsoft.web.viewsheet.event.MoveSelectionChildEvent` (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information

The reorder never reaches the server, so the child order is never updated.

## Root cause

Two separate defects on the same class, both on the inbound path for `@MessageMapping("/selectionContainer/moveChild/{name}")` (`VSSelectionContainerController`):

1. **Missing `@JsonDeserialize`.** `MoveSelectionChildEvent` is an Immutables `@Value.Immutable` interface but carried no `@JsonDeserialize(as = ImmutableMoveSelectionChildEvent.class)`. The application `ObjectMapper` (`inetsoft/web/WebConfig.java`) registers only `Jdk8Module`, `JavaTimeModule`, `ThirdPartySupportModule` and `GuavaModule` — there is no Immutables Jackson module, so every immutable that gets deserialized must carry the annotation itself. Jackson saw a bare interface and failed. This was the only `@Value.Immutable` type in `inetsoft/web/viewsheet/event/` lacking it; all 13 siblings (`ChangeTabStateEvent`, `MaxObjectEvent`, `VSRefreshEvent`, …) have it.

2. **Property name mismatch on the boolean.** Adding the annotation alone is not enough. Immutables strips the `get` prefix but *not* `is`, so the generated deserializer expected `isCurrentSelection`, while both senders post `currentSelection` — failing with `UnrecognizedPropertyException`. Named the property explicitly with `@JsonProperty("currentSelection")`. This is the only Immutables-based event in the package with an `is` accessor; every other `is` getter there is on a plain POJO, where Jackson's own bean naming strips the prefix.

## Changes

- `core/src/main/java/inetsoft/web/viewsheet/event/MoveSelectionChildEvent.java` — add `@JsonDeserialize(as = ImmutableMoveSelectionChildEvent.class)` and `@JsonProperty("currentSelection")`.
- `core/src/test/java/inetsoft/web/viewsheet/event/MoveSelectionChildEventTest.java` — new regression test that deserializes the literal client payloads for both the child-reorder and current-selection cases.

No frontend change was needed: both senders already post `{fromIndex, toIndex, currentSelection}` — the composer (`editable-object-container.component.ts`) and the viewer (`vs-selection-container-children.component.ts`) — so the single backend change fixes both paths.

## Side effects

None expected. The event is client→server only and is never Jackson-serialized, so `@JsonProperty` has no outbound impact. `@Serial.Structural` (used for the `@ClusterProxyMethod` hop to `VSSelectionContainerService`) is untouched, and no Java code constructs the event via the generated builder.

## Testing

- `./mvnw -pl core test -Dtest=MoveSelectionChildEventTest` → `Tests run: 2, Failures: 0, Errors: 0`. Both tests fail against the pre-fix code (first with `InvalidDefinitionException`, then with `UnrecognizedPropertyException`), so they pin both halves of the fix.
- Manual: open a viewsheet with a Selection Container holding a Selection List and a RangeSlider, drag the RangeSlider above the Selection List in the composer — no error dialog, children reorder and the container refreshes. Repeat in the viewer for the second sender path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
