### PR TITLE
fix(shade): exclude Batik Rhino-scripting bridge from inetsoft-xml-formats shaded jar

### DIFF
--- a/utils/inetsoft-xml-formats/pom.xml
+++ b/utils/inetsoft-xml-formats/pom.xml
@@ -443,6 +443,9 @@
                     <exclude>META-INF/versions/**/*</exclude>
                     <exclude>**/BUILD.bazel</exclude>
                     <exclude>org/apache/batik/util/resources/XMLResourceDescriptor.properties</exclude>
+                    <exclude>org/apache/batik/bridge/*Rhino*</exclude>
+                    <exclude>org/apache/batik/script/rhino/**</exclude>
+                    <exclude>META-INF/services/org.apache.batik.script.InterpreterFactory</exclude>
                     <exclude>org/apache/xml/serializer/output_xml.properties</exclude>
                     <exclude>META-INF/services/javax.xml.datatype.DatatypeFactory</exclude>
                     <exclude>META-INF/services/javax.xml.parsers.DocumentBuilderFactory</exclude>


### PR DESCRIPTION
## Summary

`inetsoft-xml-formats-*-shaded.jar` (maven-shade-plugin relocating Apache Batik wholesale
under `inetsoft.xml.*`) still shipped Batik's own optional Rhino-based SVG-scripting
bridge — `RhinoInterpreter`, `SVG12RhinoInterpreter`, the `org/apache/batik/script/rhino/*`
helper classes — plus a `META-INF/services/...InterpreterFactory` ServiceLoader
registration naming `RhinoInterpreterFactory`. Batik's own `org.mozilla:rhino` dependency
is not included in the shade, so anything that caused this bridge to actually link would
hit `NoClassDefFoundError: org/mozilla/javascript/Scriptable`. Currently dormant/unreached
by any code path — build-hygiene fix, not a live-behavior fix.

Per standing direction that Rhino should no longer be used in StyleBI at all, this is a
strictly subtractive fix: exclude the bridge classes and the service-registration entry
from the `inetsoft-xml-formats` shade filter, rather than adding a real
`org.mozilla:rhino` dependency to make the bridge functional.

- `org/apache/batik/bridge/*Rhino*` — matches `RhinoInterpreter*` and
  `SVG12RhinoInterpreter` in `batik-bridge`
- `org/apache/batik/script/rhino/**` — the Rhino script-engine helper package in
  `batik-script`
- `META-INF/services/org.apache.batik.script.InterpreterFactory` — the un-relocated
  service file naming `RhinoInterpreterFactory` as the sole active registration

All three patterns use the original (pre-relocation) Batik paths, confirmed against the
actual `batik-bridge-1.17.jar`/`batik-script-1.17.jar` contents, since maven-shade-plugin
filters match source-jar paths before relocation is applied.

Fixes Redmine #76406.

## Test plan

- [x] Rebuilt `community/utils/inetsoft-xml-formats` before the fix: confirmed the
      shaded jar contains 20 Rhino-bridge class entries and one active
      `RhinoInterpreterFactory` service registration (matches the reported symptom).
- [x] Rebuilt after the fix: `unzip -l target/*-shaded.jar | grep -i rhino` returns
      nothing; the `InterpreterFactory` service file is gone entirely; unrelated Batik
      service files (`ImageWriter`, `DomExtension`, `RegistryEntry`, `BridgeExtension`)
      and the untouched `JPythonInterpreterFactory` (commented-out, out of scope) remain.
- [x] Existing module unit tests pass: `PoiExcelVSExporterTest` (9), `PoiPptxDeckMergerTest`
      (14) — 23/23, 0 failures/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)