### PR TITLE
fix(chart): don't clobber a script-set colorFrame color on global-color sync (76111)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VSFrameVisitor.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSFrameVisitor.java
@@ -774,6 +774,11 @@ public class VSFrameVisitor {
       */
 
       for(Map.Entry<String, Color> entry : dimensionColors.entrySet()) {
+         // don't clobber a color explicitly set by script. (76111)
+         if(frame.isScripted(entry.getKey())) {
+            continue;
+         }
+
          final Color color = entry.getValue();
          frame.setColor(entry.getKey(), new Color(color.getRGB()));
       }

--- a/core/src/test/java/inetsoft/report/composition/graph/VSFrameVisitorTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/VSFrameVisitorTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.graph;
+
+import inetsoft.graph.aesthetic.CategoricalColorFrame;
+import inetsoft.graph.data.DataSet;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.graph.aesthetic.CategoricalColorFrameContext;
+import inetsoft.util.script.JavaScriptEngine;
+import inetsoft.util.script.graal.ScriptScope;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Color;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bug #76111: a script that mutates an already-live CategoricalColorFrame in place
+ * (e.g. {@code chart.colorFrame.setColor("NJ", RED)}) never goes through
+ * {@code AbstractChartBindingScriptable.setColorFrame()}'s useGlobal(false) fix (bug #45391) --
+ * that only fires on {@code chart.colorFrame = newFrame} reassignment, not get-then-mutate. So
+ * useGlobal stays true, and on the next redraw {@link VSFrameVisitor#applyGlobalColors} must not
+ * clobber the scripted color with the viewsheet's shared/global dimension color.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSFrameVisitorTest {
+   @Test
+   void scriptedColorSurvivesGlobalColorSync() {
+      DataSet data = new DefaultDataSet(new Object[][] {
+         { "State" }, { "NJ" }, { "NY" }
+      });
+
+      CategoricalColorFrame frame = new CategoricalColorFrame();
+      frame.setField("State");
+      frame.init(data);
+
+      JavaScriptEngine.pushExecScriptable(new ScriptScope() {
+         @Override
+         public Object getMember(String name) {
+            return null;
+         }
+
+         @Override
+         public boolean hasMember(String name) {
+            return false;
+         }
+
+         @Override
+         public void putMember(String name, Object value) {
+         }
+
+         @Override
+         public Object[] getMemberKeys() {
+            return new Object[0];
+         }
+      });
+
+      try {
+         frame.setColor("NJ", Color.RED);
+      }
+      finally {
+         JavaScriptEngine.popExecScriptable();
+      }
+
+      assertTrue(frame.isScripted("NJ"), "setColor on the script thread should mark NJ scripted");
+
+      CategoricalColorFrameContext.getContext().setDimensionColors(Map.of("NJ", Color.BLUE));
+
+      try {
+         VSFrameVisitor.syncCategoricalFrame(frame, data);
+      }
+      finally {
+         CategoricalColorFrameContext.getContext().setDimensionColors(Collections.emptyMap());
+      }
+
+      assertEquals(Color.RED, frame.getColor("NJ"),
+                   "script-assigned color must survive the global-color sync pass");
+   }
+}


### PR DESCRIPTION
## Summary

Bug #76111: a script that changes a chart's colorFrame color (e.g. "use the colorFrame attribute to change the color of state NJ to red") persists correctly and a full redraw is confirmed effective, but the override never appears in the rendered image.

**Root cause:** the natural script idiom for this, `chart.colorFrame.setColor("NJ", red)`, is a get-then-mutate on the live `CategoricalColorFrame` object (`AbstractChartBindingScriptable.getColorFrame()`), which never goes through `setColorFrame()`'s setter path — the only place that force-flips `useGlobal(false)` (the fix for bug #45391). So `useGlobal` stays at its default `true`, and on the next redraw `VSFrameVisitor.applyGlobalColors()` unconditionally overwrites the frame's per-value color from the viewsheet's shared/global dimension-color map for every key present, with no `isScripted` check — silently discarding the script's red whenever the viewsheet already holds any shared color for that dimension value (which an ordinary binding-apply round trip, e.g. the wizard/recommender, seeds by default). The `isScripted` guard added for bug #72594 only protects the sync loop that runs *after* `applyGlobalColors`, not `applyGlobalColors` itself — so the flag looks like it's protecting the color while `applyGlobalColors` clobbers it first.

**Fix:** `applyGlobalColors` now skips any value already marked `isScripted`, mirroring the guard the very next loop already applies. This is the narrower of the two options considered (the other being extending `useGlobal(false)`-on-script-thread into `CategoricalColorFrame.setColor()` itself) — it doesn't touch `useGlobal` semantics at all, so it can't interact with the already-fixed structured `set_visual_frame`/`ChartAestheticMutator` path, which writes via model setters and never populates `isScripted` in the first place (confirmed by running `ChartAestheticMutatorTest`/`VisualFrameAliasesTest` below).

Checked the sibling shape/size/line/texture frame sync methods in the same file and their script setters in `AbstractChartBindingScriptable` — none call `applyGlobalColors` or have an equivalent global-color-clobber path, so this is color-specific and there's no twin defect to fix there.

## Test plan

- Added `VSFrameVisitorTest.scriptedColorSurvivesGlobalColorSync`, simulating the script thread via `JavaScriptEngine.pushExecScriptable`/`popExecScriptable` and seeding `CategoricalColorFrameContext.getContext().setDimensionColors(...)` directly (the actual ThreadLocal `applyGlobalColors` reads, populated in production by `GraphGenerator.generate()` copying from the `Viewsheet`).
- RED (against unfixed code): `Tests run: 1, Failures: 1` — `expected: <Color[r=255,g=0,b=0]> but was: <Color[r=0,g=0,b=255]>` (the clobber, reproduced).
- GREEN (against this fix): `Tests run: 1, Failures: 0`.
- Full affected-suite regression check, `mvn -pl community/core test` on `VSFrameVisitorTest, EGraphVisualFramesTest, GraphUtilFixVisualFrameTest, ChangeChartTypeProcessorTest, VSChartBindingScriptableTest, VSDimensionRefCreateComparatorTest, PasteAestheticRefFirstBindFrameTest, ChartAestheticMutatorTest, PerMeasureFrameChannelsTest, VisualFrameAliasesTest, WizAutoBindingServiceSetChartColorsTest`: **258/258 passing**, including the already-fixed structured-tool path (`ChartAestheticMutatorTest` 101 tests, `VisualFrameAliasesTest` 68 tests) — confirms no regression there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)