### PR TITLE
fix(wiz): track position/size writes rejected by non-runtime sandbox mode (#76104)

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java
@@ -78,6 +78,26 @@ public class VSAScriptable
    }
 
    /**
+    * Clear the names recorded by {@link #getRejectedWrites()}, so a caller can scope tracking
+    * to a single script execution.
+    */
+   public void resetRejectedWrites() {
+      rejectedWrites.clear();
+   }
+
+   /**
+    * Names passed to {@link #putMember(String, Object)} since the last {@link
+    * #resetRejectedWrites()} that DID match a registered {@code propmap} property, but whose
+    * setter declined to apply the value -- e.g. {@link #setSize}/{@link #setPosition} when
+    * {@code box.isRuntime()} is false, which is always the case for a Composer design-mode
+    * session. Distinct from {@link #getUnrecognizedWrites()}, which is for names that were never
+    * registered as a scriptable property at all.
+    */
+   public List<String> getRejectedWrites() {
+      return new ArrayList<>(rejectedWrites);
+   }
+
+   /**
     * Add properties.
     */
    private void init() {
@@ -453,6 +473,9 @@ public class VSAScriptable
 
          info.setPixelSize(dim);
       }
+      else {
+         rejectedWrites.add("size");
+      }
    }
 
    /**
@@ -493,6 +516,9 @@ public class VSAScriptable
 
       if(box.isRuntime()) {
          setPosition(info, p);
+      }
+      else {
+         rejectedWrites.add("position");
       }
    }
 
@@ -1130,6 +1156,11 @@ public class VSAScriptable
    // Names that missed propmap and fell back to the expando map in putMember(); see
    // resetUnrecognizedWrites()/getUnrecognizedWrites().
    private final List<String> unrecognizedWrites = Collections.synchronizedList(new ArrayList<>());
+
+   // Names that DID match a propmap property but whose setter declined to apply the value
+   // (currently only setSize/setPosition, gated on box.isRuntime()); see
+   // resetRejectedWrites()/getRejectedWrites().
+   private final List<String> rejectedWrites = Collections.synchronizedList(new ArrayList<>());
 
    private static final Logger LOG = LoggerFactory.getLogger(VSAScriptable.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
@@ -151,11 +151,13 @@ public class ScriptExecuteService {
 
       for(VSAScriptable scriptable : trackedScriptables.values()) {
          scriptable.resetUnrecognizedWrites();
+         scriptable.resetRejectedWrites();
       }
 
       try {
          Object value = scope.execute(text, assemblyName);
          List<String> unrecognized = new ArrayList<>();
+         List<String> rejected = new ArrayList<>();
 
          for(Map.Entry<String, VSAScriptable> entry : trackedScriptables.entrySet()) {
             for(String name : entry.getValue().getUnrecognizedWrites()) {
@@ -165,23 +167,55 @@ public class ScriptExecuteService {
                // e.g. two different assemblies' own unrecognized "label".
                unrecognized.add(assemblyName != null ? name : entry.getKey() + "." + name);
             }
+
+            // Recognized properties (e.g. position/size) whose setter declined to apply the
+            // value -- distinct from "unrecognized" above, which never even matched propmap.
+            for(String name : entry.getValue().getRejectedWrites()) {
+               rejected.add(assemblyName != null ? name : entry.getKey() + "." + name);
+            }
          }
 
-         List<String> changed = unrecognized.isEmpty() ? List.of(target.toString()) : List.of();
-         String summary = unrecognized.isEmpty() ? "Executed " + target + "." :
-            "Executed " + target + ", but assigned " + unrecognized +
-            " which " + (unrecognized.size() == 1 ? "is not a recognized scriptable property" :
-               "are not recognized scriptable properties") +
-            (assemblyName != null ? " for this assembly type (" +
-               assemblyTypeName(rvs, assemblyName) + ")" : "") + " — the value " +
-            (unrecognized.size() == 1 ? "was" : "were") + " NOT applied; " +
-            (unrecognized.size() == 1 ? "it" : "they") + " only became an ad hoc script " +
-            "variable nothing else reads. Call get_script_context for " +
-            (assemblyName != null ? assemblyName + "'s" : "the named assembly's") +
-            " real scriptable properties, or use get_assembly_properties/update_binding if " +
-            "you meant a different, non-scripted property.";
+         List<String> notApplied = new ArrayList<>();
+         notApplied.addAll(unrecognized);
+         notApplied.addAll(rejected);
+
+         List<String> changed = notApplied.isEmpty() ? List.of(target.toString()) : List.of();
+         String summary;
+
+         if(notApplied.isEmpty()) {
+            summary = "Executed " + target + ".";
+         }
+         else {
+            List<String> clauses = new ArrayList<>();
+
+            if(!unrecognized.isEmpty()) {
+               clauses.add("assigned " + unrecognized + " which " +
+                  (unrecognized.size() == 1 ? "is not a recognized scriptable property" :
+                     "are not recognized scriptable properties") +
+                  (assemblyName != null ? " for this assembly type (" +
+                     assemblyTypeName(rvs, assemblyName) + ")" : "") + " — the value " +
+                  (unrecognized.size() == 1 ? "was" : "were") + " NOT applied; " +
+                  (unrecognized.size() == 1 ? "it" : "they") + " only became an ad hoc script " +
+                  "variable nothing else reads");
+            }
+
+            if(!rejected.isEmpty()) {
+               clauses.add("assigned " + rejected + ", " +
+                  (rejected.size() == 1 ? "a recognized property whose value was" :
+                     "recognized properties whose values were") + " NOT applied because the " +
+                  "connected session is a Composer design-mode session, not a live viewer " +
+                  "runtime");
+            }
+
+            summary = "Executed " + target + ", but " + String.join("; and ", clauses) +
+               ". Call get_script_context for " +
+               (assemblyName != null ? assemblyName + "'s" : "the named assembly's") +
+               " real scriptable properties, or use get_assembly_properties/update_binding if " +
+               "you meant a different, non-scripted property.";
+         }
+
          return new ScriptExecResult(true, stringify(value), null, changed, false, null, summary,
-            unrecognized.isEmpty() ? null : unrecognized);
+            notApplied.isEmpty() ? null : notApplied);
       }
       catch(Exception ex) {
          return new ScriptExecResult(false, null, toScriptError(ex), null, false, null, null, null);

--- a/core/src/test/java/inetsoft/report/script/viewsheet/SubmitVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/SubmitVSAScriptableTest.java
@@ -24,6 +24,8 @@ import inetsoft.uql.viewsheet.SubmitVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.SubmitVSAssemblyInfo;
 import org.junit.jupiter.api.BeforeEach;
+import java.awt.Dimension;
+import java.awt.Point;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Tag;
@@ -136,5 +138,52 @@ public class SubmitVSAScriptableTest {
 
       assertEquals(List.of("myScratchFlag"), submitVSAScriptable.getUnrecognizedWrites());
       assertEquals(true, submitVSAScriptable.getMember("myScratchFlag"));
+   }
+
+   /**
+    * Bug #76104: "position"/"size" ARE registered propmap properties (dispatched to
+    * VSAScriptable's own setPosition/setSize), so a write to them never falls into
+    * putMember()'s unrecognized-write branch above -- but the setters themselves silently no-op
+    * when box.isRuntime() is false (viewsheetSandbox is a bare Mockito mock here, so
+    * isRuntime() defaults to false, matching every Composer-paired agent session). The write
+    * must not silently look like it applied: it should be recorded as rejected (recognized, but
+    * not applied) rather than being untracked.
+    */
+   @Test
+   void testPutMemberOnPositionNotAppliedAndRecordedAsRejectedWhenNotRuntime() {
+      Point original = submitVSAssemblyInfo.getPixelOffset();
+
+      vsaScriptable.putMember("position", new Point(180, 100));
+
+      assertEquals(original, submitVSAssemblyInfo.getPixelOffset());
+      assertEquals(List.of(), vsaScriptable.getUnrecognizedWrites());
+      assertEquals(List.of("position"), vsaScriptable.getRejectedWrites());
+   }
+
+   @Test
+   void testPutMemberOnSizeNotAppliedAndRecordedAsRejectedWhenNotRuntime() {
+      Dimension original = submitVSAssemblyInfo.getPixelSize();
+
+      vsaScriptable.putMember("size", new Dimension(200, 150));
+
+      assertEquals(original, submitVSAssemblyInfo.getPixelSize());
+      assertEquals(List.of(), vsaScriptable.getUnrecognizedWrites());
+      assertEquals(List.of("size"), vsaScriptable.getRejectedWrites());
+   }
+
+   /**
+    * Regression guard for the currently-working runtime-viewer case: when box.isRuntime() is
+    * true, position/size writes must still apply normally and must NOT be recorded as rejected.
+    */
+   @Test
+   void testPutMemberOnPositionAndSizeAppliesAndNotRejectedWhenRuntime() {
+      when(viewsheetSandbox.isRuntime()).thenReturn(true);
+
+      vsaScriptable.putMember("position", new Point(180, 100));
+      vsaScriptable.putMember("size", new Dimension(200, 150));
+
+      assertEquals(new Point(180, 100), submitVSAssemblyInfo.getPixelOffset());
+      assertEquals(new Dimension(200, 150), submitVSAssemblyInfo.getPixelSize());
+      assertEquals(List.of(), vsaScriptable.getRejectedWrites());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
@@ -110,6 +110,40 @@ class ScriptExecuteServiceTest {
       verify(scriptable).resetUnrecognizedWrites();
    }
 
+   /**
+    * Bug #76104: "position" IS a registered scriptable property (unlike "label" above), so it
+    * must not be reported as "not a recognized scriptable property" -- but its setter silently
+    * declined to apply the value (Composer design-mode session, not a live viewer runtime), so
+    * execute() must still exclude the target from changed via the new rejected-writes tracking,
+    * with wording that doesn't misrepresent the write as unrecognized.
+    */
+   @Test
+   void executeExcludesTargetFromChangedAndDoesNotClaimUnrecognizedForARejectedPositionWrite()
+      throws Exception
+   {
+      String script = "Submit1.position = new Point(180, 100);";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), eq("Submit1"))).thenReturn(null);
+
+      VSAScriptable scriptable = mock(VSAScriptable.class);
+      when(scriptable.getUnrecognizedWrites()).thenReturn(List.of());
+      when(scriptable.getRejectedWrites()).thenReturn(List.of("position"));
+
+      RuntimeViewsheet rvs = viewsheetWithAssemblyScript(script, scope, scriptable);
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Submit1"), false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(), result.changed());
+      assertEquals(List.of("position"), result.unrecognizedProperties());
+      assertTrue(result.summary().contains("position"), result.summary());
+      assertFalse(result.summary().contains("not a recognized scriptable property"), result.summary());
+      assertFalse(result.summary().contains("not recognized scriptable properties"), result.summary());
+      verify(scriptable).resetUnrecognizedWrites();
+      verify(scriptable).resetRejectedWrites();
+   }
+
    @Test
    void executeReportsRealPropertyWriteNormallyWithNoUnrecognizedProperties() throws Exception {
       String script = "Submit1.enabled = false;";


### PR DESCRIPTION
## Summary

Redmine #76104: `execute_script`/`run_script_live` reported `changed` for a `Submit1.position = ...` (or `.size`) assignment even though the write silently no-op'd — a subsequent independent read showed the position never actually changed, while toggling `enabled` on the same assembly persisted correctly.

**Root cause:** `VSAScriptable.setSize`/`setPosition` (`community/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java`) silently no-op (no log, no exception, no tracking) when `ViewsheetSandbox.isRuntime()` is false — which is always the case for a Composer-paired agent session (every runtimeId an agent session pairs against is exactly whatever `RuntimeViewsheet` the browser's own Composer tab already has open, and Composer-opened sheets are always `VIEWSHEET_DESIGN_MODE`, never `VIEWSHEET_RUNTIME_MODE`). Because `position`/`size` ARE registered scriptable properties (dispatched straight to these setters, never falling into `putMember()`'s `unrecognizedWrites` fallback), `ScriptExecuteService.execute()` had no signal the write didn't apply, and reported the target in `changed` regardless. `enabled` persists correctly because it's wired directly to `VSAssemblyInfo.setEnabled()` via reflection, bypassing this gate entirely.

**Fix:** extend the existing `unrecognizedWrites` tracking pattern (added for #4733/#4749) with a second, parallel list — `rejectedWrites`/`getRejectedWrites()`/`resetRejectedWrites()` — for properties that ARE recognized but whose setter declined to apply the value. `setSize`/`setPosition` now record "size"/"position" into this list when `box.isRuntime()` is false. `ScriptExecuteService.execute()` excludes the target from `changed` for either cause, with a generalized summary message that does not misrepresent a recognized-but-rejected write as "not a recognized scriptable property" (which would be false and misleading — chose message-generalization over a new `ScriptExecResult` field to avoid a coordinated cross-repo type change into `stylebi-wiz` for zero logic-bearing benefit there).

## Test plan

- [x] Added `SubmitVSAScriptableTest`: `testPutMemberOnPositionNotAppliedAndRecordedAsRejectedWhenNotRuntime`, `testPutMemberOnSizeNotAppliedAndRecordedAsRejectedWhenNotRuntime` (RED before fix — compile failure against `getRejectedWrites()`, GREEN after), plus `testPutMemberOnPositionAndSizeAppliesAndNotRejectedWhenRuntime` (regression guard for the currently-working runtime-viewer case).
- [x] Added `ScriptExecuteServiceTest#executeExcludesTargetFromChangedAndDoesNotClaimUnrecognizedForARejectedPositionWrite` — asserts `changed` excludes the target and the summary does not claim "not a recognized scriptable property".
- [x] Ran the wider affected suite (14 classes across `report/script/viewsheet` and `web/wiz/script`, including every `*VSAScriptableTest` that exercises `setSize`/`setPosition`) — all green, no regressions.

Follow-ups (out of scope for this PR, noted for whoever picks them up):
- `stylebi-enterprise`'s outer submodule pointer still needs to bump to include this commit — not done here per this run's convention (kept as a separate follow-up, same as sibling PRs in this batch).
- `ChartVSAScriptable.java:505` has a structurally similar `box.getMode() != Viewsheet.SHEET_DESIGN_MODE` runtime check, flagged by the original diagnosis as possibly relevant to bug #76111 (colorFrame) — not investigated here, different bug's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)