### PR TITLE
fix(wiz): ModifyCalculateFieldService NPEs for any session-less caller (PCB-006)

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/controller/ModifyCalculateFieldService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ModifyCalculateFieldService.java
@@ -65,7 +65,7 @@ import java.util.*;
 public class ModifyCalculateFieldService {
    public ModifyCalculateFieldService(
       VSBindingService bindingFactory,
-      VSBindingTreeController bindingTreeController,
+      VSBindingTreeControllerServiceProxy vsBindingTreeService,
       VSChartHandler chartHandler,
       XRepository xrepository,
       VSWizardBindingHandler wizardBindingHandler,
@@ -75,7 +75,7 @@ public class ModifyCalculateFieldService {
       DataSourceRegistry dataSourceRegistry)
    {
       this.bindingFactory = bindingFactory;
-      this.bindingTreeController = bindingTreeController;
+      this.vsBindingTreeService = vsBindingTreeService;
       this.chartHandler = chartHandler;
       this.xrepository = xrepository;
       this.wizardBindingHandler = wizardBindingHandler;
@@ -354,7 +354,20 @@ public class ModifyCalculateFieldService {
       else {
          RefreshBindingTreeEvent refreshBindingTreeEvent = new RefreshBindingTreeEvent();
          refreshBindingTreeEvent.setName(event.name());
-         bindingTreeController.getBinding(refreshBindingTreeEvent, principal, dispatcher);
+
+         // Was VSBindingTreeController.getBinding(refreshBindingTreeEvent, principal,
+         // dispatcher), which re-derives the runtime id from RuntimeViewsheetRef -- a
+         // WebSocket-session-scoped bean the native Formula Editor dialog's own STOMP session
+         // populates, but which a caller with no live WebSocket session (the wiz agent surface)
+         // never gets to set. That left it null, and VSBindingTreeControllerServiceProxy's own
+         // cluster-affinity routing (keyed on the id) throws NullPointerException("Ouch! Argument
+         // cannot be null: key") before the real method body ever runs -- confirmed live via
+         // CalcFieldAgentService, which calls this method with no session-scoped
+         // RuntimeViewsheetRef bound at all. This call already has the correct, verified-live
+         // runtime id in `id` (this method's own @ClusterProxyKey parameter) -- using it directly
+         // is equivalent for the native flow (RuntimeViewsheetRef.getRuntimeId() and this `id`
+         // are the same value there) and also correct for a session-less caller.
+         vsBindingTreeService.getBinding(id, refreshBindingTreeEvent, principal, dispatcher);
       }
 
       boolean wizardNewVs =
@@ -711,7 +724,7 @@ public class ModifyCalculateFieldService {
    }
 
    private final VSBindingService bindingFactory;
-   private final VSBindingTreeController bindingTreeController;
+   private final VSBindingTreeControllerServiceProxy vsBindingTreeService;
    private final VSRefreshController refreshController;
    private final VSChartHandler chartHandler;
    private final XRepository xrepository;

--- a/core/src/test/java/inetsoft/web/binding/controller/ModifyCalculateFieldServiceTest.java
+++ b/core/src/test/java/inetsoft/web/binding/controller/ModifyCalculateFieldServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.erm.ExpressionRef;
+import inetsoft.uql.viewsheet.CalculateRef;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.drm.CalculateRefModel;
+import inetsoft.web.binding.event.ModifyCalculateFieldEvent;
+import inetsoft.web.binding.event.RefreshBindingTreeEvent;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSChartHandler;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.uql.service.DataSourceRegistry;
+import inetsoft.uql.XRepository;
+import inetsoft.web.viewsheet.controller.VSRefreshController;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression coverage for the NullPointerException a session-less caller (the wiz agent surface's
+ * {@code CalcFieldAgentService}) hit live: {@code modifyCalculateField}'s non-wizard branch used
+ * to ask {@code VSBindingTreeController} to refresh the binding tree, which re-derives the
+ * runtime id from the WebSocket-session-scoped {@code RuntimeViewsheetRef} instead of using the
+ * id already passed into this very method -- null for any caller with no live WebSocket session,
+ * which then blew up in {@code VSBindingTreeControllerServiceProxy}'s cluster-affinity routing
+ * before the real binding-tree read ever ran.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ModifyCalculateFieldServiceTest {
+   /**
+    * The exact shape CalcFieldAgentService drives live: create a new, non-wizard, non-SQL,
+    * detail-level calc field with no target assembly named. Before the fix this threw
+    * NullPointerException("Ouch! Argument cannot be null: key") from deep inside
+    * VSBindingTreeControllerServiceProxy's cluster routing, because VSBindingTreeController
+    * re-derived a null runtime id from RuntimeViewsheetRef rather than using the id already known
+    * here. The fix calls vsBindingTreeService (VSBindingTreeControllerServiceProxy) directly with
+    * this method's own id -- this test's core assertion is exactly that: the CORRECT, non-null id
+    * reaches the binding-tree refresh, not a null one silently swallowed by mocking.
+    */
+   @Test
+   void refreshesBindingTreeWithTheCallsOwnRuntimeIdNotANullSessionScopedOne() throws Exception {
+      String id = "rt-calcfield-1";
+      Principal principal = mock(Principal.class);
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+
+      ExpressionRef exprRef = new ExpressionRef();
+      exprRef.setName("NetTotal");
+      exprRef.setExpression("1");
+      CalculateRef cref = new CalculateRef(true);
+      cref.setDataRef(exprRef);
+      cref.setSQL(false);
+
+      CalculateRefModel calcModel = mock(CalculateRefModel.class);
+      when(calcModel.createDataRef()).thenReturn(cref);
+
+      ModifyCalculateFieldEvent event = mock(ModifyCalculateFieldEvent.class);
+      when(event.calculateRef()).thenReturn(calcModel);
+      when(event.tableName()).thenReturn("Orders");
+      when(event.refName()).thenReturn("NetTotal");
+      when(event.create()).thenReturn(true);
+      when(event.remove()).thenReturn(false);
+      when(event.name()).thenReturn(null);
+      when(event.wizard()).thenReturn(false);
+      when(event.wizardOriginalMode()).thenReturn(null);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssemblies()).thenReturn(new Assembly[0]);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(mock(ViewsheetSandbox.class)));
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      when(viewsheetService.getViewsheet(eq(id), eq(principal))).thenReturn(rvs);
+
+      VSBindingTreeControllerServiceProxy vsBindingTreeService =
+         mock(VSBindingTreeControllerServiceProxy.class);
+
+      ModifyCalculateFieldService service = new ModifyCalculateFieldService(
+         mock(VSBindingService.class), vsBindingTreeService, mock(VSChartHandler.class),
+         mock(XRepository.class), mock(VSWizardBindingHandler.class),
+         mock(VSRefreshController.class), viewsheetService, mock(VSAssemblyInfoHandler.class),
+         mock(DataSourceRegistry.class));
+
+      service.modifyCalculateField(id, event, principal, dispatcher, "");
+
+      verify(vsBindingTreeService).getBinding(
+         eq(id), any(RefreshBindingTreeEvent.class), eq(principal), eq(dispatcher));
+      verify(vs).addCalcField(eq("Orders"), eq(cref));
+   }
+}


### PR DESCRIPTION
## Summary
- **Live-verified via a real connected composer-chat session** (not just code review): every call to the wiz agent's `add_calc_field`/`edit_calc_field`/`remove_calc_field` — i.e. every create, and every edit/remove of a calc field that actually exists — returned a generic 500 ("This is a StyleBI-side bug"). The server log's real stack trace: `NullPointerException: Ouch! Argument cannot be null: key` from Ignite's cluster-affinity routing, inside `ModifyCalculateFieldService.modifyCalculateField` → `VSBindingTreeController.getBinding` → `VSBindingTreeControllerServiceProxy.getBinding` → `WorksheetEngine.isLocal` → `RuntimeSheetCache.getAffinityKey`.
- **Root cause**: the method's non-wizard branch (refreshing the Composer's live binding-tree panel after a calc-field change) asked `VSBindingTreeController.getBinding(event, principal, dispatcher)` to do the refresh. That controller re-derives the runtime id from `RuntimeViewsheetRef` — a WebSocket-session-scoped bean the native Formula Editor dialog's own STOMP session populates — which is never set for a caller with no live WebSocket session, like the wiz agent surface. The re-derived id came back null, and the generated cluster-proxy's affinity-key routing (keyed on that id) throws before the real binding-tree read ever runs.
- **Fix**: `modifyCalculateField` already has the correct, verified-live runtime id as its own `@ClusterProxyKey id` parameter (used moments earlier in the same method to resolve the `RuntimeViewsheet` in the first place). Calling `VSBindingTreeControllerServiceProxy.getBinding(id, ...)` directly with it, instead of asking `VSBindingTreeController` to re-derive a broken one, fixes this for any caller — and is behaviorally identical for the native WebSocket flow, since `RuntimeViewsheetRef.getRuntimeId()` and this `id` are the same value there.
- Adds `ModifyCalculateFieldServiceTest` — this method had **zero** existing unit test coverage, which is presumably why this was never caught: every existing wiz-agent test for this area (`CalcFieldAgentServiceTest`) mocks `ModifyCalculateFieldServiceProxy` entirely, so the real method body — including this exact call — never actually ran in any test suite before.

## Severity
This affects **every real create/edit/remove** through the new `add_calc_field`/`edit_calc_field`/`remove_calc_field` tools (PCB-006, stylebi-wiz#2107 + stylebi#4951) — only a `remove_calc_field` on an *already-nonexistent* field name (a degenerate no-op, since the method early-returns before reaching this code) was unaffected. Blocking for that feature actually working end to end.

## Test plan
- [x] `ModifyCalculateFieldServiceTest` (new) — exercises the real method body end-to-end for a create, asserts the binding-tree refresh receives the correct non-null id. 1/1 pass.
- [x] Confirmed via a live paired composer-chat session against a real running StyleBI instance, with the server's own log showing the exact NPE stack trace before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)