### PR TITLE
Bug #76399, fix mini-toolbar mispositioned after selecting a crosstab cell in a data tip popup

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
@@ -83,6 +83,19 @@ export class VSDataTipDirective implements DoCheck, OnInit, OnDestroy {
       return this.dataTipService.isCurrentDataTip(this.dataTipName, this.popContainerName);
    }
 
+   /**
+    * Whether this directive instance currently owns (imperatively writes) the position of
+    * its host element, i.e. whether it is the active, visible data tip. Used by MiniToolbar
+    * (see mini-toolbar.component.ts) to suppress its own static top/left template bindings
+    * on the same element while this is true, so there is exactly one writer of those style
+    * properties at any given time -- see the two-writer note above ngDoCheck's setStyle calls.
+    */
+   isActiveDataTipOwner(): boolean {
+      return this.isCurrentDataTip() &&
+         (this.dataTipService.isDataTipVisible(this.dataTipName) ||
+          this.dataTipService.isDataTipVisible(this.popContainerName));
+   }
+
    get dataTipClass(): string {
       const name = this.dataTipService.dataTipName;
       return "current-datatip-" + (name || "none").replace(/ /g, "_");
@@ -103,9 +116,7 @@ export class VSDataTipDirective implements DoCheck, OnInit, OnDestroy {
       if(this.dataTipService.isDataTip(this.dataTipName) ||
          this.dataTipService.isDataTip(this.popContainerName))
       {
-         if(this.isCurrentDataTip() &&
-            (this.dataTipService.isDataTipVisible(this.dataTipName) ||
-             this.dataTipService.isDataTipVisible(this.popContainerName)))
+         if(this.isActiveDataTipOwner())
          {
             // cancel existing hide events
             this.debounceService.cancel(DataTipService.DEBOUNCE_KEY);

--- a/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.html
@@ -18,7 +18,7 @@
 <div class="mini-toolbar"
   [class.hidden-mini-toolbar]="forceHide"
   [style.top.px]="topY"
-  [style.left.px]="left"
+  [style.left.px]="leftPx"
   [style.z-index]="zIndex">
   @if (!mobileDevice) {
     <div

--- a/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.spec.ts
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Component, DebugElement } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { Subject } from "rxjs";
+import { ContextProvider } from "../../context-provider.service";
+import { DebounceService } from "../../../widget/services/debounce.service";
+import { DataTipService } from "../data-tip/data-tip.service";
+import { PopComponentService } from "../data-tip/pop-component.service";
+import { VSDataTipDirective } from "../data-tip/vs-data-tip.directive";
+import { MiniToolbar } from "./mini-toolbar.component";
+import { MiniToolbarService } from "./mini-toolbar.service";
+
+// Mirrors the real composition in vs-object-container.component.html: a <mini-toolbar> that
+// also carries [VSDataTip][miniToolbar]=true, plus the assembly's own main element (looked up
+// by id inside VSDataTipDirective.ngDoCheck) that the data tip popup is positioned relative to.
+@Component({
+   standalone: true,
+   imports: [MiniToolbar, VSDataTipDirective],
+   template: `
+      <div id="Tip1_main"></div>
+      <mini-toolbar VSDataTip [dataTipName]="'Tip1'" [miniToolbar]="true"
+         [assembly]="'Tip1'" [top]="500" [left]="500" [width]="200">
+      </mini-toolbar>
+   `
+})
+class TestApp {
+}
+
+describe("MiniToolbar Tests", () => {
+   let fixture: ComponentFixture<TestApp>;
+   let miniToolbarDebugEl: DebugElement;
+   let dataTipService: any;
+
+   function toolbarDiv(): HTMLElement {
+      return miniToolbarDebugEl.nativeElement.querySelector(".mini-toolbar");
+   }
+
+   beforeEach(() => {
+      dataTipService = {
+         isDataTip: vi.fn((name: string) => name === "Tip1"),
+         isCurrentDataTip: vi.fn(() => false),
+         isDataTipVisible: vi.fn(() => false),
+         isFrozen: vi.fn(() => false),
+         getVSObjectId: vi.fn(() => "Tip1_main"),
+         dataTipX: 100,
+         dataTipY: 200,
+         dataTipName: "Tip1",
+         dataTipAlpha: 1,
+         scrolled: new Subject<void>(),
+         viewerOffset: {width: 1000, height: 1000, scrollLeft: 0, scrollTop: 0}
+      };
+
+      TestBed.configureTestingModule({
+         imports: [TestApp],
+         providers: [
+            {provide: DataTipService, useValue: dataTipService},
+            {
+               provide: PopComponentService,
+               useValue: {
+                  getPopComponent: vi.fn(() => null),
+                  hasPopUpComponentShowing: vi.fn(() => false),
+                  getPopInfo: vi.fn(() => null),
+                  isPopComponentShow: vi.fn(() => false)
+               }
+            },
+            {provide: DebounceService, useValue: {debounce: vi.fn(), cancel: vi.fn()}},
+            {
+               provide: ContextProvider,
+               useValue: {composer: false, vsWizard: false, binding: false}
+            },
+            MiniToolbarService
+         ]
+      });
+
+      fixture = TestBed.createComponent(TestApp);
+      miniToolbarDebugEl = fixture.debugElement.query(By.directive(MiniToolbar));
+   });
+
+   // Bug #76399: while this mini-toolbar is the active, visible data tip, VSDataTipDirective
+   // (co-located via [VSDataTip][miniToolbar]=true) imperatively owns its position. Before the
+   // fix, MiniToolbar's own [style.top.px]/[style.left.px] template bindings independently wrote
+   // the static `top`/`left` Inputs to the same element and -- because MiniToolbar's child view
+   // refreshes after the parent-view directive's ngDoCheck on the very same change detection
+   // pass -- clobbered the directive's correct value back to the static one whenever the static
+   // binding's own value changed (e.g. because a toolbar action's visibility changed the
+   // computed `left`). This asserts the directive's mouse-tracked value wins and stays applied,
+   // not the static `top`/`left` Inputs (500/500), when the tip is active.
+   it("lets VSDataTipDirective own the position while this is the active data tip", () => {
+      dataTipService.isCurrentDataTip.mockReturnValue(true);
+      dataTipService.isDataTipVisible.mockReturnValue(true);
+
+      fixture.detectChanges();
+
+      const div = toolbarDiv();
+      expect(div.style.left).toBe("101px");
+      expect(div.style.top).toBe("173px");
+      expect(div.style.left).not.toBe("500px");
+   });
+
+   // Control: when this mini-toolbar is not an active data tip (the ordinary case for the vast
+   // majority of mini-toolbars), the static top/left Inputs still drive its position exactly as
+   // before this fix.
+   it("uses the static top/left Inputs when not an active data tip", () => {
+      fixture.detectChanges();
+
+      const div = toolbarDiv();
+      expect(div.style.left).toBe("500px");
+      // topY = top - MINI_TOOLBAR_HEIGHT(28) since top(500) > minTop(20)
+      expect(div.style.top).toBe("472px");
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/mini-toolbar/mini-toolbar.component.ts
@@ -15,12 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, ElementRef, HostListener, Input, OnChanges, OnDestroy, SimpleChanges } from "@angular/core";
+import {
+   Component, ElementRef, HostListener, Input, OnChanges, OnDestroy, Optional, Self, SimpleChanges
+} from "@angular/core";
 import { AssemblyActionGroup } from "../../../common/action/assembly-action-group";
 import { GuiTool } from "../../../common/util/gui-tool";
 import { AbstractVSActions } from "../../action/abstract-vs-actions";
 import { ContextProvider } from "../../context-provider.service";
 import { PopComponentService } from "../data-tip/pop-component.service";
+import { VSDataTipDirective } from "../data-tip/vs-data-tip.directive";
 import { NavigationKeys } from "../navigation-keys";
 import { AssemblyAction } from "../../../common/action/assembly-action";
 import { Observable ,  Subscription } from "rxjs";
@@ -108,7 +111,13 @@ export class MiniToolbar implements OnChanges, OnDestroy {
    constructor(private contextProvider: ContextProvider,
                private element: ElementRef,
                private miniToolbarService: MiniToolbarService,
-               private popComponentService: PopComponentService) {
+               private popComponentService: PopComponentService,
+               // Present only when this <mini-toolbar> also carries [VSDataTip][miniToolbar]=true
+               // (see vs-object-container.component.html). Injected directly (rather than via
+               // DataTipService) so there is a single source of truth for "is this element
+               // currently the active, position-owning data tip" shared with the directive's
+               // own imperative positioning -- see isActiveDataTip below.
+               @Optional() @Self() private dataTipDirective: VSDataTipDirective) {
    }
 
    ngOnChanges(changes: SimpleChanges): void {
@@ -269,7 +278,7 @@ export class MiniToolbar implements OnChanges, OnDestroy {
    }
 
    get topY(): number {
-      if(this.isPopComponent) {
+      if(this.isPopComponent || this.isActiveDataTip) {
          return Number.NaN;
       }
 
@@ -280,7 +289,22 @@ export class MiniToolbar implements OnChanges, OnDestroy {
         : this.top;
    }
 
+   // NaN makes the [style.left.px] binding produce an invalid CSS value, which the browser
+   // ignores -- leaving whatever position VSDataTipDirective last imperatively set on this
+   // same element via Renderer2.setStyle in place, instead of clobbering it back to the
+   // static design-time `left`. Mirrors the isPopComponent guard on topY above. Without this,
+   // this binding and the directive's setStyle race to own the same style property whenever
+   // this.left's value itself changes while a tip is active (e.g. the toolbar's action set,
+   // and so its clamped position, changes because an action's visibility changed -- see #76399).
+   get leftPx(): number {
+      return this.isActiveDataTip ? Number.NaN : this.left;
+   }
+
    get isPopComponent(): boolean {
       return this.popComponentService.isPopComponentShow(this.assembly);
+   }
+
+   get isActiveDataTip(): boolean {
+      return !!this.dataTipDirective && this.dataTipDirective.isActiveDataTipOwner();
    }
 }


### PR DESCRIPTION
## Summary

Fixes a mini-toolbar mispositioning bug: hover a chart whose data-tip view is a crosstab (opening the data-tip popup), then click/select a cell inside that crosstab -- the crosstab's mini-toolbar jumps to its static design-time canvas position instead of staying pinned to the floating popup.

## Root cause

`VSDataTipDirective` imperatively owns a mini-toolbar's position (`Renderer2.setStyle` on `.mini-toolbar`) while its assembly is the active, visible data tip. But `MiniToolbar`'s own template independently binds `[style.top.px]`/`[style.left.px]` to the assembly's static design-time `top`/`left` on that *same* element. Angular's per-binding memoization normally lets the directive's write "stick" against this competing binding (the static value doesn't change tick-to-tick), but selecting a cell in a crosstab shown as data-tip content flips the crosstab's "Show Details" toolbar action's visibility, which changes `MiniToolbarService.getToolbarLeft()`'s clamped return value -- a genuine value change that defeats the memoization and lets the static template binding clobber the directive's correct, mouse-tracked position on that exact tick.

This is the fourth bug against this same two-writer mechanism (#74751, #75512, #75820), each of which patched one more specific trigger the previous fix didn't anticipate (a scroll case, an OnPush-host case, etc.).

## Fix

Rather than adding another narrow trigger to the existing cache-guard/`ngDoCheck` mechanism, this makes `MiniToolbar`'s own `top`/`left` template bindings inert whenever a co-located `VSDataTipDirective` is the active position owner for that element -- mirroring the existing `isPopComponent`/`NaN` guard already used for the analogous "pop component" case (`get topY()`). With this, there is exactly one writer of these style properties at any given time, regardless of what causes the static value to change, closing off the whole class of trigger rather than one more instance of it.

- `vs-data-tip.directive.ts`: extracted the directive's "am I the active, visible data tip" condition into a new public `isActiveDataTipOwner()` method (previously inlined in `ngDoCheck`), reused by both `ngDoCheck` and `MiniToolbar`.
- `mini-toolbar.component.ts`: `MiniToolbar` now optionally self-injects a co-located `VSDataTipDirective` (present only when composed as `<mini-toolbar VSDataTip [miniToolbar]="true">`, as in `vs-object-container.component.html`) and adds an `isActiveDataTip` getter; `topY` and a new `leftPx` getter return `NaN` (an invalid CSS value the browser ignores, leaving the directive's own imperatively-set value in place) while that's true.
- `mini-toolbar.component.html`: `[style.left.px]` now binds to `leftPx` instead of the raw `left` Input.

Reproduction requires the tip-target crosstab's own design-time canvas position to be near/past the container's right edge (a common "park it off to the side" pattern for data-tip-only assemblies) -- not the browser viewport or where the popup visually renders -- since that's what makes `MiniToolbarService`'s clamp branch active in the first place.

## Test plan

- [x] Added `mini-toolbar.component.spec.ts` with a regression test that composes `MiniToolbar` with `VSDataTip` on the same host (mirroring `vs-object-container.component.html`) and asserts the directive's mouse-tracked position wins when active; verified this test fails (reproducing the bug: static `500px` wins) when the `leftPx` fix is reverted, and passes with it restored.
- [x] `vs-data-tip.directive.spec.ts` (existing, covers bugs #75512/#75820) still passes unmodified after the `isActiveDataTipOwner()` extraction.
- [x] Full `.tl.spec.ts` suites for `vs-object-container`, `vs-crosstab`, and `mini-menu` (165 tests) still pass -- no regressions to normal (non-data-tip) mini-toolbar positioning, crosstab rendering/interaction, or pop-component handling.
- [ ] Live visual confirmation in the portal is still needed -- no browser automation was available in this environment. Deferred to a human reviewer or a follow-up check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)