### PR TITLE
Fix #76408: link worksheet sandbox to originating viewsheet on open

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
@@ -131,7 +131,7 @@ public class OpenWorksheetController extends WorksheetController {
       entry.setProperty("openAutoSaved", event.openAutoSavedFile() + "");
       entry.setProperty("gettingStarted", event.gettingStartedWs() + "");
       String runtimeId = eventService.openWorksheet(
-         principal, entry, event.openAutoSavedFile(), event.createQuery(),
+         principal, entry, event.openAutoSavedFile(), event.createQuery(), event.vsId(),
          commandDispatcher);
 
       getRuntimeViewsheetRef().setRuntimeId(runtimeId);

--- a/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
@@ -20,8 +20,11 @@ package inetsoft.web.composer.ws.assembly;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
+import inetsoft.report.composition.ExpiredSheetException;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.WorksheetEngine;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.asset.*;
 import inetsoft.util.Catalog;
 import inetsoft.web.composer.model.ws.WorksheetModel;
@@ -29,6 +32,8 @@ import inetsoft.web.composer.ws.TableModeService;
 import inetsoft.web.composer.ws.command.*;
 import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
@@ -50,12 +55,21 @@ public class WorksheetEventService {
                                boolean gettingStartedCreateQuery,
                                CommandDispatcher commandDispatcher) throws Exception
    {
+      return openWorksheet(user, entry, openAutoSaved, gettingStartedCreateQuery, null,
+                           commandDispatcher);
+   }
+
+   public String openWorksheet(Principal user, AssetEntry entry, boolean openAutoSaved,
+                               boolean gettingStartedCreateQuery, String vsId,
+                               CommandDispatcher commandDispatcher) throws Exception
+   {
       String runtimeId = engine.openWorksheet(entry, user);
       WorksheetEventServiceProxy p = proxy.getIfAvailable();
 
       if(p != null) {
          return p.openWorksheet(
-            runtimeId, user, entry, openAutoSaved, gettingStartedCreateQuery, commandDispatcher);
+            runtimeId, user, entry, openAutoSaved, gettingStartedCreateQuery, vsId,
+            commandDispatcher);
       }
 
       return null;
@@ -65,11 +79,12 @@ public class WorksheetEventService {
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public String openWorksheet(@ClusterProxyKey String id, Principal user, AssetEntry entry,
                                boolean openAutoSaved, boolean gettingStartedCreateQuery,
-                               CommandDispatcher commandDispatcher) throws Exception
+                               String vsId, CommandDispatcher commandDispatcher) throws Exception
    {
       RuntimeWorksheet rws = engine.getWorksheet(id, user);
       fixWorksheetMode(rws);
       clearGettingStatedRuntimeWs(rws, gettingStartedCreateQuery);
+      linkViewsheetSandbox(rws, vsId, user);
 
       List errors = (List) AssetRepository.ASSET_ERRORS.get();
 
@@ -165,6 +180,40 @@ public class WorksheetEventService {
       return id;
    }
 
+   /**
+    * Links the sandbox of the worksheet opened as its own document back to the
+    * sandbox of the viewsheet it was opened from (e.g. the base worksheet link in
+    * the composer's bottom status bar), so script expressions referencing viewsheet
+    * assemblies (e.g. worksheet['TextInput1'].value) can resolve. No-op when the
+    * worksheet was not opened from a running viewsheet (vsId is null) or that
+    * viewsheet is no longer open.
+    */
+   private void linkViewsheetSandbox(RuntimeWorksheet rws, String vsId, Principal user) {
+      if(rws == null || vsId == null) {
+         return;
+      }
+
+      try {
+         RuntimeViewsheet rvs = engine.getViewsheet(vsId, user);
+
+         if(rvs == null) {
+            return;
+         }
+
+         ViewsheetSandbox vsbox = rvs.getViewsheetSandbox().orElse(null);
+
+         if(vsbox != null) {
+            rws.getAssetQuerySandbox().setViewsheetSandbox(vsbox);
+         }
+      }
+      catch(ExpiredSheetException e) {
+         // the originating viewsheet is no longer open; nothing to link to
+      }
+      catch(Exception e) {
+         LOG.debug("Unable to link worksheet sandbox to viewsheet {}", vsId, e);
+      }
+   }
+
    private static void clearGettingStatedRuntimeWs(RuntimeWorksheet rws,
                                                    boolean gettingStartedCreateQuery)
    {
@@ -228,4 +277,5 @@ public class WorksheetEventService {
 
    private final ViewsheetService engine;
    private final ObjectProvider<WorksheetEventServiceProxy> proxy;
+   private static final Logger LOG = LoggerFactory.getLogger(WorksheetEventService.class);
 }

--- a/core/src/main/java/inetsoft/web/composer/ws/event/OpenWorksheetEvent.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/event/OpenWorksheetEvent.java
@@ -20,6 +20,8 @@ package inetsoft.web.composer.ws.event;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
+
 @Value.Immutable
 @JsonDeserialize(builder = OpenWorksheetEvent.Builder.class)
 public abstract class OpenWorksheetEvent {
@@ -30,6 +32,16 @@ public abstract class OpenWorksheetEvent {
    public abstract boolean gettingStartedWs();
 
    public abstract boolean createQuery();
+
+   /**
+    * The runtime identifier of the viewsheet this worksheet is being opened from
+    * (e.g. clicking the base worksheet link in the composer's bottom status bar),
+    * so the new worksheet's sandbox can be linked back to it. Null when the
+    * worksheet is opened with no originating viewsheet (e.g. from the portal or
+    * repository tree).
+    */
+   @Nullable
+   public abstract String vsId();
 
    public static Builder builder() {
       return new Builder();

--- a/core/src/test/java/inetsoft/web/composer/ws/OpenWorksheetControllerSandboxLinkTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/OpenWorksheetControllerSandboxLinkTest.java
@@ -1,0 +1,212 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.util.script.ScriptEnv;
+import inetsoft.util.script.ScriptException;
+import inetsoft.web.composer.ws.assembly.WorksheetEventService;
+import inetsoft.web.composer.ws.assembly.WorksheetEventServiceProxy;
+import inetsoft.web.messaging.MessageAttributes;
+import inetsoft.web.messaging.MessageContextHolder;
+import inetsoft.web.viewsheet.event.OpenViewsheetEvent;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.CommandDispatcherService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug #76408 - opening a worksheet as its own document (e.g. clicking the base
+ * worksheet link in the composer's bottom status bar) never linked the new
+ * worksheet's {@link AssetQuerySandbox} back to the originating viewsheet's
+ * {@link inetsoft.report.composition.execution.ViewsheetSandbox}, so script
+ * expressions like {@code worksheet['TableView1'].visible} could never resolve
+ * the viewsheet assembly. Exercises the real production method
+ * (WorksheetEventService#openWorksheet, the body OpenWorksheetController calls)
+ * and executes the script through the real GraalJS engine
+ * (AssetQuerySandbox#getScriptEnv()), not just raw scope hasMember/getMember
+ * checks.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, IntegrationTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome(importResources = "/inetsoft/report/script/viewsheet/ViewsheetScopeTest.vso")
+@Tag("core")
+@Tag("integration")
+public class OpenWorksheetControllerSandboxLinkTest {
+   @RegisterExtension
+   RuntimeViewsheetExtension viewsheetResource =
+      new RuntimeViewsheetExtension(createOpenViewsheetEvent());
+
+   private ViewsheetService viewsheetService;
+   private WorksheetEventService eventService;
+   private String openedWorksheetId;
+
+   @org.junit.jupiter.api.BeforeEach
+   void setUp(org.springframework.context.ApplicationContext ctx) {
+      viewsheetService = ctx.getBean(ViewsheetService.class);
+      ObjectProvider<WorksheetEventServiceProxy> noProxy = new ObjectProvider<>() {
+         @Override
+         public WorksheetEventServiceProxy getObject() {
+            throw new NoSuchBeanDefinitionException(WorksheetEventServiceProxy.class);
+         }
+
+         @Override
+         public WorksheetEventServiceProxy getIfAvailable() {
+            return null;
+         }
+      };
+      eventService = new WorksheetEventService(viewsheetService, noProxy);
+   }
+
+   @AfterEach
+   void tearDown() throws Exception {
+      if(openedWorksheetId != null) {
+         viewsheetService.closeWorksheet(openedWorksheetId, null);
+         openedWorksheetId = null;
+      }
+   }
+
+   /**
+    * Worksheet opened from within a running viewsheet (vsId set, mirroring the
+    * composer's "click link to worksheet in the bottom bar" flow) must resolve
+    * viewsheet assemblies through its worksheet scope.
+    */
+   @Test
+   void testWorksheetOpenedFromViewsheetResolvesViewsheetAssembly() throws Exception {
+      RuntimeViewsheet rvs = viewsheetResource.getRuntimeViewsheet();
+      Principal user = rvs.getUser();
+      AssetEntry wsEntry = rvs.getViewsheet().getBaseEntry();
+      assertNotNull(wsEntry, "fixture viewsheet must have a base worksheet entry");
+
+      openedWorksheetId = openWorksheet(wsEntry, rvs.getID(), user);
+
+      RuntimeWorksheet rws = viewsheetService.getWorksheet(openedWorksheetId, user);
+      AssetQuerySandbox wbox = rws.getAssetQuerySandbox();
+      assertNotNull(wbox.getViewsheetSandbox(),
+                    "worksheet opened from a viewsheet must be linked to that viewsheet's sandbox");
+
+      Object visible = execute(wbox, "worksheet['TableView1'].visible");
+      assertEquals(Boolean.TRUE, visible);
+   }
+
+   /**
+    * Worksheet opened with no originating viewsheet (e.g. from the portal or
+    * repository tree) must keep vsbox == null, same as before the fix.
+    */
+   @Test
+   void testWorksheetOpenedWithoutViewsheetHasNoSandboxLink() throws Exception {
+      RuntimeViewsheet rvs = viewsheetResource.getRuntimeViewsheet();
+      Principal user = rvs.getUser();
+      AssetEntry wsEntry = rvs.getViewsheet().getBaseEntry();
+      assertNotNull(wsEntry, "fixture viewsheet must have a base worksheet entry");
+
+      openedWorksheetId = openWorksheet(wsEntry, null, user);
+
+      RuntimeWorksheet rws = viewsheetService.getWorksheet(openedWorksheetId, user);
+      AssetQuerySandbox wbox = rws.getAssetQuerySandbox();
+      assertNull(wbox.getViewsheetSandbox(),
+                 "worksheet opened with no originating viewsheet must not be linked to any sandbox");
+
+      ScriptException ex = assertThrows(ScriptException.class,
+                                        () -> execute(wbox, "worksheet['TableView1'].visible"));
+      assertTrue(ex.getMessage().contains("visible"));
+   }
+
+   private Object execute(AssetQuerySandbox wbox, String cmd) throws Exception {
+      ScriptEnv senv = wbox.getScriptEnv();
+      Object script = senv.compile(cmd);
+      return senv.exec(script, wbox.getScope(), wbox.getScope(), null);
+   }
+
+   /**
+    * Opens a worksheet through the real {@link WorksheetEventService#openWorksheet}
+    * method body (the same one {@code OpenWorksheetController} calls for the STOMP
+    * /ws/open message), including the new vsId-based sandbox linking.
+    */
+   private String openWorksheet(AssetEntry wsEntry, String vsId, Principal user) throws Exception {
+      GenericMessage<String> message = new GenericMessage<>("test");
+      MessageAttributes messageAttributes = new MessageAttributes(message);
+      StompHeaderAccessor headerAccessor = messageAttributes.getHeaderAccessor();
+      headerAccessor.setUser(user);
+      SimpMessagingTemplate messagingTemplate = new SimpMessagingTemplate(new MessageChannel() {
+         @Override
+         public boolean send(Message<?> message) {
+            return true;
+         }
+
+         @Override
+         public boolean send(Message<?> message, long timeout) {
+            return true;
+         }
+      });
+      CommandDispatcherService dispatcherService = new CommandDispatcherService(messagingTemplate, null) {
+         @Override
+         public void convertAndSendToUser(String user, String destination, Object payload,
+                                          Map<String, Object> headers) throws MessagingException
+         {
+            // NO-OP
+         }
+      };
+      CommandDispatcher commandDispatcher = new CommandDispatcher(headerAccessor, dispatcherService, null);
+      MessageContextHolder.setMessageAttributes(messageAttributes);
+
+      try {
+         String id = viewsheetService.openWorksheet((AssetEntry) wsEntry.clone(), user);
+         eventService.openWorksheet(id, user, (AssetEntry) wsEntry.clone(), false, false, vsId,
+                                     commandDispatcher);
+         return id;
+      }
+      finally {
+         MessageContextHolder.setMessageAttributes(null);
+      }
+   }
+
+   private static OpenViewsheetEvent createOpenViewsheetEvent() {
+      OpenViewsheetEvent event = new OpenViewsheetEvent();
+      event.setEntryId(ASSET_ID);
+      event.setViewer(true);
+      return event;
+   }
+
+   public static final String ASSET_ID = "1^128^__NULL__^ViewsheetScopeTest";
+}

--- a/web/projects/portal/src/app/composer/data/open-sheet-event.ts
+++ b/web/projects/portal/src/app/composer/data/open-sheet-event.ts
@@ -20,5 +20,9 @@ import { SheetType } from "./sheet";
 export interface OpenSheetEvent {
    type: SheetType;
    assetId: string;
-   meta?: boolean
+   meta?: boolean;
+   // runtime id of the viewsheet a worksheet is being opened from (e.g. the
+   // base worksheet link in the composer's bottom status bar), so the new
+   // worksheet's sandbox can be linked back to the viewsheet's sandbox.
+   vsId?: string;
 }

--- a/web/projects/portal/src/app/composer/data/ws/worksheet.ts
+++ b/web/projects/portal/src/app/composer/data/ws/worksheet.ts
@@ -35,6 +35,9 @@ export class Worksheet extends Sheet {
    public autoSaveFile: string;
    public closeProhibited: boolean = false;
    public singleQuery: boolean;
+   // runtime id of the viewsheet this worksheet was opened from (e.g. the base
+   // worksheet link in the composer's bottom status bar), if any.
+   public vsId: string;
    private _callback?: () => any;
 
    constructor(sheet: Worksheet = null) {

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -1727,6 +1727,7 @@ export class ComposerMainComponent implements OnInit, OnDestroy, AfterViewInit {
                ws.localId = sheetCounter++;
                ws.newSheet = newSheet;
                ws.gettingStarted = gettingStarted;
+               ws.vsId = event.vsId;
 
                index = this.sheets.push(ws) - 1;
                this.openedTabs.push(new ComposerTabModel(ws.type, ws));

--- a/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/editor/viewsheet-pane.component.ts
@@ -2444,6 +2444,7 @@ export class VSPane extends CommandProcessor implements OnInit, OnDestroy, After
       this.onOpenSheet.emit({
          type: "worksheet",
          assetId: this.vs.baseEntry.identifier,
+         vsId: this.vs.runtimeId,
       });
    }
 

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
@@ -784,6 +784,7 @@ export class WSPaneComponent extends CommandProcessor implements OnDestroy, OnIn
    private openExistingWorksheet(): void {
       const event = new OpenWorksheetEvent();
       event.setId(this.worksheet.id);
+      event.setVsId(this.worksheet.vsId);
 
       if(this.worksheet.gettingStarted) {
          event.setGettingStartedWs(true);

--- a/web/projects/portal/src/app/composer/gui/ws/socket/open-ws/open-ws-event.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/socket/open-ws/open-ws-event.ts
@@ -20,6 +20,7 @@ export class OpenWorksheetEvent {
    private openAutoSavedFile: boolean = false;
    private gettingStartedWs: boolean = false;
    private createQuery: boolean = false;
+   private vsId: string = null;
 
    public setId(id: string) {
       this.id = id;
@@ -35,5 +36,9 @@ export class OpenWorksheetEvent {
 
    public setCreateQuery(createQuery: boolean) {
       this.createQuery = createQuery;
+   }
+
+   public setVsId(vsId: string) {
+      this.vsId = vsId;
    }
 }


### PR DESCRIPTION
## Summary
- Opening a worksheet as its own document (e.g. clicking the base worksheet link in the composer's bottom status bar) never linked the new worksheet's `AssetQuerySandbox` back to the originating viewsheet's `ViewsheetSandbox`, so script expressions like `worksheet['TextInput1'].value` could never resolve the viewsheet assembly (`findInChain()` correctly reported nothing found because there was nothing to find).
- Threads a `vsId` (the originating viewsheet's runtime id) from the composer's worksheet-link click (`viewsheet-pane.component.ts`) through `composer-main.component.ts` → `ws-pane.component.ts` → `OpenWorksheetEvent` → `OpenWorksheetController` → `WorksheetEventService#openWorksheet`, which now calls `AssetQuerySandbox#setViewsheetSandbox(...)` on the newly-created worksheet sandbox when `vsId` resolves to a still-open viewsheet.
- No-op (`vsbox` stays `null`, same as before) when the worksheet is opened with no originating viewsheet (portal/repository tree) or the originating viewsheet has since closed/expired.

Ruled out the alternative "read the existing `sheetRuntimeId` STOMP header via `RuntimeViewsheetRef`" approach: traced `viewsheet-client.service.ts` and found each composer pane (`ws-pane`/`viewsheet-pane`) gets its own `ViewsheetClientService` instance with its own independent `_runtimeId` state (provided per-component), so the worksheet pane's outgoing `/ws/open` message never carries the viewsheet's runtime id in that header — it's architecturally the wrong data source for this. Went with explicit client-to-server plumbing instead.

## Test plan
- Added `core/src/test/java/inetsoft/web/composer/ws/OpenWorksheetControllerSandboxLinkTest.java`, exercising the real `WorksheetEventService#openWorksheet` method body against the `ViewsheetScopeTest.vso` fixture, executing `worksheet['TableView1'].visible` through the real GraalJS engine (`AssetQuerySandbox#getScriptEnv()`/`compile`/`exec`), not just scope-level `hasMember`/`getMember` checks:
  - [x] Worksheet opened with `vsId` set (simulating "opened from within a viewsheet") resolves the viewsheet assembly and has a non-null `ViewsheetSandbox` link.
  - [x] Worksheet opened with no `vsId` (simulating portal/repository-tree open) keeps `vsbox == null` and still throws the pre-fix `TypeError` shape.
- Verified the new test fails (assertion on the linked sandbox) when the fix is temporarily reverted, and passes with the fix restored — confirming it actually catches the regression.
- Ran `AssetQueryScopeTest` and `ViewsheetScopeTest` (the related #75858/#75807 chain-walk regression tests) — all pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)