### PR TITLE
Bug #76416: Fix four shadow-settings follow-ups from #76073

### DIFF
--- a/core/src/main/java/inetsoft/report/PageLayout.java
+++ b/core/src/main/java/inetsoft/report/PageLayout.java
@@ -20,6 +20,7 @@ package inetsoft.report;
 import inetsoft.graph.internal.GTool;
 import inetsoft.report.internal.*;
 import inetsoft.sree.SreeEnv;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,6 +124,20 @@ public class PageLayout implements Serializable, Cloneable {
       }
 
       /**
+       * Set the drop shadow to draw behind this shape, or null for none.
+       */
+      public void setShadow(ShapeShadow shadow) {
+         this.shadow = shadow;
+      }
+
+      /**
+       * Get the drop shadow to draw behind this shape, or null for none.
+       */
+      public ShapeShadow getShadow() {
+         return shadow;
+      }
+
+      /**
        * Scale the shape.
        * @param xs x scale 0 to 1.
        * @param ys y scale 0 to 1.
@@ -199,6 +214,7 @@ public class PageLayout implements Serializable, Cloneable {
          style = shape.style;
          xs = shape.xs;
          ys = shape.ys;
+         shadow = shape.shadow;
       }
 
 		/**
@@ -221,6 +237,7 @@ public class PageLayout implements Serializable, Cloneable {
 		private int zindex; // just for previewing vs printlayout.
       private Color color = Color.black; // shape color
       private int style = StyleConstants.THIN_LINE; // line style
+      private ShapeShadow shadow; // drop shadow, null if none
       double xs = 1, ys = 1;
    }
 
@@ -519,6 +536,27 @@ public class PageLayout implements Serializable, Cloneable {
       @Override
       public void paint(Graphics g) {
          Color oc = g.getColor();
+
+         // draw behind the shape's own fill/outline, matching the shadow
+         // direction convention ShapeShadow already establishes on the
+         // viewsheet side. paint(Graphics) is fed whatever the active
+         // export/print pipeline provides (PDF content-stream graphics,
+         // raster graphics, etc.) rather than a single BufferedImage, so this
+         // draws the shadow as its own filled shape offset by direction and
+         // distance instead of reusing VSFaceUtil.addShadow's raster blur --
+         // the blur radius is not applied here, a simplification accepted
+         // because a genuine Gaussian blur is not practical in a
+         // Graphics-only context.
+         ShapeShadow shadow = getShadow();
+
+         if(shadow != null) {
+            Graphics2D sg = (Graphics2D) g.create();
+            sg.translate((int) (shadow.getOffsetX() * xs), (int) (shadow.getOffsetY() * ys));
+            sg.setColor(shadow.getShadowColor());
+            sg.fillRect((int) (getX() * xs), (int) (getY() * ys),
+               (int) (getWidth() * xs), (int) (getHeight() * ys));
+            sg.dispose();
+         }
 
          if(fill != null) {
             Graphics2D g2 = (Graphics2D) g.create();
@@ -999,6 +1037,19 @@ public class PageLayout implements Serializable, Cloneable {
       @Override
       public void paint(Graphics g) {
          Color oc = g.getColor();
+
+         // see Rectangle.paint() for why this is an unblurred offset fill
+         // rather than VSFaceUtil.addShadow's raster blur.
+         ShapeShadow shadow = getShadow();
+
+         if(shadow != null) {
+            Graphics2D sg = (Graphics2D) g.create();
+            sg.translate((int) (shadow.getOffsetX() * xs), (int) (shadow.getOffsetY() * ys));
+            sg.setColor(shadow.getShadowColor());
+            sg.fillOval((int) (getX() * xs), (int) (getY() * ys),
+               (int) (getWidth() * xs), (int) (getHeight() * ys));
+            sg.dispose();
+         }
 
          if(fill != null) {
             Graphics2D g2 = (Graphics2D) g.create();

--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSShape.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSShape.java
@@ -52,14 +52,26 @@ public abstract class VSShape extends VSFloatable {
       g2.dispose();
 
       if(isShadow()) {
-         ShapeShadow shadow = getInfo().getShadowInfo();
-         // must match the insets getImage() grew the canvas by
-         Insets insets = ShapeShadowUtil.getScaledShadowInsets(getInfo());
-         image = VSFaceUtil.addShadow(image, shadow, insets);
-         // the shape sits at (left, top) inside the composite; draw it back by
-         // that much so the shape itself still lands on the origin, which is
-         // where getImage() has already translated to
-         g.drawImage(image, -insets.left, -insets.top, null);
+         ShapeVSAssemblyInfo info = getInfo();
+
+         // Line predates configurable shadow settings (#76073) and has no
+         // UI/script path to configure one -- keep its old fixed gray shadow
+         // rather than silently switching a legacy shadowValue="true" asset
+         // over to the new configurable defaults.
+         if(info instanceof LineVSAssemblyInfo) {
+            image = VSFaceUtil.addShadow(image, 6);
+            g.drawImage(image, 0, 0, null);
+         }
+         else {
+            ShapeShadow shadow = info.getShadowInfo();
+            // must match the insets getImage() grew the canvas by
+            Insets insets = ShapeShadowUtil.getScaledShadowInsets(info);
+            image = VSFaceUtil.addShadow(image, shadow, insets);
+            // the shape sits at (left, top) inside the composite; draw it back by
+            // that much so the shape itself still lands on the origin, which is
+            // where getImage() has already translated to
+            g.drawImage(image, -insets.left, -insets.top, null);
+         }
       }
       else {
          g.drawImage(image, 0, 0, null);

--- a/core/src/main/java/inetsoft/report/io/viewsheet/ShapeShadowUtil.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/ShapeShadowUtil.java
@@ -41,9 +41,15 @@ public final class ShapeShadowUtil {
 
    /**
     * Check whether the assembly is a shape drawing a configurable shadow.
+    *
+    * Line is excluded: it predates configurable shadow settings and has no
+    * UI/script path to configure one, so it keeps its old fixed-size shadow
+    * (VSShape.paintComponent) instead of the configurable-shadow insets this
+    * class computes.
     */
    public static boolean isShapeShadow(VSAssemblyInfo info) {
       return info instanceof ShapeVSAssemblyInfo &&
+         !(info instanceof LineVSAssemblyInfo) &&
          ((ShapeVSAssemblyInfo) info).isShadow();
    }
 

--- a/core/src/main/java/inetsoft/report/script/PropertyDescriptor.java
+++ b/core/src/main/java/inetsoft/report/script/PropertyDescriptor.java
@@ -28,6 +28,7 @@ import inetsoft.uql.XTable;
 import inetsoft.uql.util.XTableDataSet;
 import inetsoft.uql.viewsheet.BorderColors;
 import inetsoft.uql.viewsheet.GradientColor;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.util.script.*;
 import inetsoft.util.script.graal.ScriptValueConverter;
 import org.graalvm.polyglot.Value;
@@ -541,6 +542,38 @@ public class PropertyDescriptor {
                gradientColor.setColors(colors.toArray(new GradientColor.ColorStop[colors.size()]));
 
                return gradientColor;
+            }
+         }
+         else if(type == ShapeShadow.class) {
+            if(JSObject.isObject(val)) {
+               ShapeShadow shadow = new ShapeShadow();
+               Object color = JSObject.get(val, "color");
+               Object alpha = JSObject.get(val, "alpha");
+               Object direction = JSObject.get(val, "direction");
+               Object distance = JSObject.get(val, "distance");
+               Object blur = JSObject.get(val, "blur");
+
+               if(color != null) {
+                  shadow.setColor(color.toString());
+               }
+
+               if(alpha instanceof Number) {
+                  shadow.setAlpha(((Number) alpha).intValue());
+               }
+
+               if(direction != null) {
+                  shadow.setDirection(direction.toString());
+               }
+
+               if(distance instanceof Number) {
+                  shadow.setDistance(((Number) distance).intValue());
+               }
+
+               if(blur instanceof Number) {
+                  shadow.setBlur(((Number) blur).intValue());
+               }
+
+               return shadow;
             }
          }
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -2690,6 +2690,11 @@ public class VsToReportConverter {
 
       rect.setStyle(info.getLineStyle());
       rect.setZIndex(assembly.getZIndex());
+
+      if(info.isShadow()) {
+         rect.setShadow(info.getShadowInfo());
+      }
+
       addShape(rect, sectionName);
    }
 
@@ -2728,6 +2733,11 @@ public class VsToReportConverter {
       oval.setColor(info.getFormat().getForeground());
       oval.setStyle(info.getLineStyle());
       oval.setZIndex(assembly.getZIndex());
+
+      if(info.isShadow()) {
+         oval.setShadow(info.getShadowInfo());
+      }
+
       addShape(oval, sectionName);
    }
 

--- a/core/src/test/java/inetsoft/report/PageLayoutShapeShadowTest.java
+++ b/core/src/test/java/inetsoft/report/PageLayoutShapeShadowTest.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report;
+
+import inetsoft.uql.viewsheet.ShapeShadow;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug #76416 (#1): Print Layout rectangles/ovals never carried any shadow
+ * state and never drew one. These are lightweight, scaffolding-free checks
+ * (no existing PageLayout/PageLayout.Shape test coverage to extend) proving
+ * the shadow field round-trips and paint() renders without throwing --
+ * not a pixel-level assertion of the (intentionally unblurred, see
+ * PageLayout.Rectangle/Oval.paint()) shadow rendering itself.
+ */
+@Tag("core")
+class PageLayoutShapeShadowTest {
+   @Test
+   void rectangleHasNoShadowByDefault() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(0, 0, 10, 10);
+      assertNull(rect.getShadow());
+   }
+
+   @Test
+   void rectangleShadowRoundTrips() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(0, 0, 10, 10);
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.SOUTH_EAST);
+      shadow.setDistance(5);
+
+      rect.setShadow(shadow);
+
+      assertSame(shadow, rect.getShadow());
+   }
+
+   @Test
+   void rectangleCopyCarriesOverTheShadow() {
+      PageLayout.Rectangle src = new PageLayout.Rectangle(0, 0, 10, 10);
+      ShapeShadow shadow = new ShapeShadow();
+      src.setShadow(shadow);
+
+      PageLayout.Rectangle dest = new PageLayout.Rectangle(0, 0, 10, 10);
+      dest.copy(src);
+
+      assertSame(shadow, dest.getShadow());
+   }
+
+   @Test
+   void rectanglePaintsWithoutThrowingWhenAShadowIsSet() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(5, 5, 20, 20);
+      rect.setColor(Color.BLACK);
+      rect.setFillColor(Color.WHITE);
+
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.SOUTH_EAST);
+      shadow.setDistance(5);
+      shadow.setBlur(6);
+      rect.setShadow(shadow);
+
+      paintOnABlankCanvas(rect);
+   }
+
+   @Test
+   void ovalHasNoShadowByDefault() {
+      PageLayout.Oval oval = new PageLayout.Oval(0, 0, 10, 10);
+      assertNull(oval.getShadow());
+   }
+
+   @Test
+   void ovalShadowRoundTrips() {
+      PageLayout.Oval oval = new PageLayout.Oval(0, 0, 10, 10);
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.NORTH_WEST);
+      shadow.setDistance(3);
+
+      oval.setShadow(shadow);
+
+      assertSame(shadow, oval.getShadow());
+   }
+
+   @Test
+   void ovalPaintsWithoutThrowingWhenAShadowIsSet() {
+      PageLayout.Oval oval = new PageLayout.Oval(5, 5, 20, 20);
+      oval.setColor(Color.BLACK);
+      oval.setFillColor(Color.WHITE);
+
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.NORTH_WEST);
+      shadow.setDistance(4);
+      shadow.setBlur(0);
+      oval.setShadow(shadow);
+
+      paintOnABlankCanvas(oval);
+   }
+
+   @Test
+   void shapeWithNoShadowStillPaintsUnchanged() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(0, 0, 10, 10);
+      rect.setColor(Color.BLACK);
+
+      assertDoesNotThrow(() -> paintOnABlankCanvas(rect));
+   }
+
+   private static void paintOnABlankCanvas(PageLayout.Shape shape) {
+      BufferedImage img = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = img.createGraphics();
+
+      try {
+         assertDoesNotThrow(() -> shape.paint(g));
+      }
+      finally {
+         g.dispose();
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/ShapeShadowTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/ShapeShadowTest.java
@@ -20,6 +20,7 @@ package inetsoft.uql.viewsheet;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.report.script.PropertyDescriptor;
+import inetsoft.uql.viewsheet.internal.LineVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.ShapeVSAssemblyInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -296,6 +297,20 @@ class ShapeShadowTest {
       assertEquals(ShapeShadow.NORTH, shadow.getDirection());
       assertEquals(ShapeShadow.DEFAULT_DISTANCE, shadow.getDistance());
       assertEquals(ShapeShadow.DEFAULT_BLUR, shadow.getBlur());
+   }
+
+   @Test
+   void lineIsExcludedFromTheConfigurableShadowGateEvenWithLegacyShadowValueTrue() {
+      // Line predates configurable shadow settings and has no UI/script path
+      // to configure one; a legacy shadowValue="true" asset should keep its
+      // old fixed shadow (VSShape.paintComponent) rather than picking up the
+      // new configurable-shadow insets this gate feeds the exporters.
+      LineVSAssemblyInfo info = Mockito.mock(LineVSAssemblyInfo.class);
+      Mockito.when(info.isShadow()).thenReturn(true);
+      Mockito.when(info.getShadowInfo()).thenReturn(new ShapeShadow());
+
+      assertFalse(ShapeShadowUtil.isShapeShadow(info));
+      assertNoInsets(ShapeShadowUtil.getShadowInsets(info));
    }
 
    private static void assertNoInsets(Insets insets) {

--- a/core/src/test/java/inetsoft/uql/viewsheet/ShapeShadowTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/ShapeShadowTest.java
@@ -19,6 +19,7 @@ package inetsoft.uql.viewsheet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.report.io.viewsheet.ShapeShadowUtil;
+import inetsoft.report.script.PropertyDescriptor;
 import inetsoft.uql.viewsheet.internal.ShapeVSAssemblyInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 
 import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -259,6 +262,40 @@ class ShapeShadowTest {
       Insets insets = ShapeShadowUtil.getShadowInsets(info);
       assertEquals(0, insets.top);
       assertEquals(4, insets.bottom);
+   }
+
+   @Test
+   void propertyDescriptorConvertsAnObjectLiteralToAShapeShadow() {
+      Map<String, Object> literal = new HashMap<>();
+      literal.put("color", "#ff0000");
+      literal.put("alpha", 40);
+      literal.put("direction", ShapeShadow.WEST);
+      literal.put("distance", 20);
+      literal.put("blur", 8);
+
+      Object converted = PropertyDescriptor.convert(literal, ShapeShadow.class);
+
+      assertTrue(converted instanceof ShapeShadow, "expected a ShapeShadow, got " + converted);
+      ShapeShadow shadow = (ShapeShadow) converted;
+      assertEquals("#ff0000", shadow.getColor());
+      assertEquals(40, shadow.getAlpha());
+      assertEquals(ShapeShadow.WEST, shadow.getDirection());
+      assertEquals(20, shadow.getDistance());
+      assertEquals(8, shadow.getBlur());
+   }
+
+   @Test
+   void propertyDescriptorConvertLeavesDefaultsWhenFieldsAreMissing() {
+      Map<String, Object> literal = new HashMap<>();
+      literal.put("direction", ShapeShadow.NORTH);
+
+      ShapeShadow shadow = (ShapeShadow) PropertyDescriptor.convert(literal, ShapeShadow.class);
+
+      assertEquals(ShapeShadow.DEFAULT_COLOR, shadow.getColor());
+      assertEquals(ShapeShadow.DEFAULT_ALPHA, shadow.getAlpha());
+      assertEquals(ShapeShadow.NORTH, shadow.getDirection());
+      assertEquals(ShapeShadow.DEFAULT_DISTANCE, shadow.getDistance());
+      assertEquals(ShapeShadow.DEFAULT_BLUR, shadow.getBlur());
    }
 
    private static void assertNoInsets(Insets insets) {

--- a/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.spec.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { AlphaDropdown } from "../../../widget/format/alpha-dropdown.component";
+import { ColorEditor } from "../../../widget/color-picker/color-editor.component";
+import { DebounceService } from "../../../widget/services/debounce.service";
+import { ShadowPropPaneModel } from "../../data/vs/shadow-prop-pane-model";
+import { ShadowPropPane } from "./shadow-prop-pane.component";
+
+let createModel: () => ShadowPropPaneModel = () => {
+   return {
+      apply: true,
+      color: "#000000",
+      alpha: 30,
+      direction: "SE",
+      distance: 50,
+      blur: 0
+   };
+};
+
+describe("shadow prop pane unit case: ", () => {
+   let fixture: ComponentFixture<ShadowPropPane>;
+   let shadowPropPane: ShadowPropPane;
+
+   beforeEach(() => {
+      TestBed.configureTestingModule({
+         imports: [FormsModule, ShadowPropPane, AlphaDropdown, ColorEditor],
+         providers: [DebounceService],
+         schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ShadowPropPane);
+      shadowPropPane = fixture.componentInstance;
+      shadowPropPane.model = createModel();
+      fixture.detectChanges();
+   });
+
+   // Bug #76416 (#2): typing another out-of-range value into a field already
+   // at the clamp boundary is a no-op transition for [ngModel], so without a
+   // forced reflow the <input> keeps showing the stale, out-of-range text
+   // even though model.distance is already correctly clamped.
+   it("re-clamps and forces the distance input to redisplay the clamped value", () => {
+      const input: HTMLInputElement =
+         fixture.nativeElement.querySelector("input[data-test=shadowDistance]");
+
+      // model.distance is already at the clamp boundary (50); typing another
+      // out-of-range value clamps back to the same 50.
+      shadowPropPane.clamp("distance", "999");
+      fixture.detectChanges();
+
+      expect(shadowPropPane.model.distance).toBe(50);
+      expect(input.value).toBe("50");
+   });
+
+   it("re-clamps and forces the blur input to redisplay the clamped value", () => {
+      const input: HTMLInputElement =
+         fixture.nativeElement.querySelector("input[data-test=shadowBlur]");
+
+      // model.blur is already at the clamp boundary (0); typing another
+      // out-of-range negative value clamps back to the same 0.
+      shadowPropPane.clamp("blur", "-5");
+      fixture.detectChanges();
+
+      expect(shadowPropPane.model.blur).toBe(0);
+      expect(input.value).toBe("0");
+   });
+
+   it("clamps an in-range value without forcing a redundant reflow", () => {
+      const changeRef = (shadowPropPane as any).changeRef;
+      const detectSpy = vi.spyOn(changeRef, "detectChanges");
+
+      shadowPropPane.clamp("distance", "20");
+
+      expect(shadowPropPane.model.distance).toBe(20);
+      expect(detectSpy).not.toHaveBeenCalled();
+   });
+
+   it("treats a cleared field as 0 and forces the reflow", () => {
+      const changeRef = (shadowPropPane as any).changeRef;
+      const detectSpy = vi.spyOn(changeRef, "detectChanges");
+
+      shadowPropPane.clamp("distance", "");
+
+      expect(shadowPropPane.model.distance).toBe(0);
+      expect(detectSpy).toHaveBeenCalled();
+   });
+});

--- a/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, Input, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, Input, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { ShadowPropPaneModel } from "../../data/vs/shadow-prop-pane-model";
 import { ShapeShadowUtil } from "../../../common/util/shape-shadow-util";
@@ -51,6 +51,9 @@ export class ShadowPropPane implements OnInit {
       { value: "NW", label: "_#(js:Northwest)" }
    ];
 
+   constructor(private changeRef: ChangeDetectorRef) {
+   }
+
    ngOnInit() {
       // guard against a model persisted before these settings existed
       if(!this.model.color) {
@@ -76,7 +79,21 @@ export class ShadowPropPane implements OnInit {
 
    /** Keep a cleared or out-of-range entry from reaching the server. */
    clamp(field: "distance" | "blur", value: any): void {
-      const num = parseInt(value, 10);
-      this.model[field] = isNaN(num) ? 0 : Math.max(0, Math.min(MAX_LENGTH, num));
+      const raw = parseInt(value, 10);
+      const clamped = isNaN(raw) ? 0 : Math.max(0, Math.min(MAX_LENGTH, raw));
+      this.model[field] = clamped;
+
+      // If the clamped result happens to equal the value the model already
+      // held (e.g. re-typing another out-of-range number into a field
+      // already at the clamp boundary), the [ngModel] binding sees no change
+      // and never re-writes the input's DOM value, leaving the raw,
+      // out-of-range text on screen. Force a real transition so NgModel
+      // always re-renders the clamped value, mirroring AlphaDropdown's
+      // changeAlpha0().
+      if(clamped !== raw) {
+         this.model[field] = null;
+         this.changeRef.detectChanges();
+         this.model[field] = clamped;
+      }
    }
 }


### PR DESCRIPTION
## Summary

Four independent follow-up issues found while verifying #76073 "Add configurable shadow settings for rectangle and oval" (PR #4767). Each is a separate root cause in a different subsystem; committed as four separate commits for reviewability.

- **#3** — `Rectangle1.shadowInfo = {...}` script assignments threw a reflection type-mismatch because `PropertyDescriptor.convert()` had no branch for `ShapeShadow.class`. Added one, mirroring the existing `GradientColor`/`BorderColors` object-literal branches.
- **#4** — `LineVSAssemblyInfo` inherits `ShapeVSAssemblyInfo.isShadow()`/`getShadowInfo()`, so a legacy `shadowValue="true"` Line asset silently switched from the old fixed gray shadow to the new configurable shadow's hardcoded defaults. `VSShape.paintComponent()` now special-cases Line to keep using the old fixed `VSFaceUtil.addShadow(image, 6)` overload; `ShapeShadowUtil.isShapeShadow()` excludes Line so exporters don't grow bounds using the new configurable-shadow insets math. **Note**: this deviates from the initially proposed fix of excluding Line from `VSFloatable.isShadow()` — that would have disabled Line's shadow entirely rather than restoring the old one (see commit message and `docs/teams/2026-09-02-bugs-batch1/bug-76416/03-fix.md` in the enterprise repo for the full trace).
- **#1** — Print Layout (`VsToReportConverter`/`PageLayout.Shape`) predates `ShapeShadow` and never drew any shadow at all for rectangle/oval. Added a `ShapeShadow` field to `PageLayout.Shape`, populated by the converter, and drawn behind the shape's fill/outline in `Rectangle.paint()`/`Oval.paint()`. Simplification: drawn as an unblurred offset fill, since `paint(Graphics)` is format-agnostic (PDF/raster/etc.) rather than a single `BufferedImage`, so the raster-blur `VSFaceUtil.addShadow` overload can't be reused directly.
- **#2** — `ShadowPropPane`'s Distance/Blur `<input>`s could show stale out-of-range text after clamping, when the clamped result equalled the model's prior value (a no-op transition for Angular's `[ngModel]` diffing). Applied the same forced-reflow idiom already used by `alpha-dropdown.component.ts` for the identical class of bug.

## Test plan

- [x] `ShapeShadowTest` (core module, `@Tag("core")`) — 28 tests, 0 failures (covers #3 and #4)
- [x] New `PageLayoutShapeShadowTest` (core module) — 8 tests, 0 failures (covers #1)
- [x] New `shadow-prop-pane.component.spec.ts` (Angular TestBed/vitest) — 4 tests, 0 failures, asserting the actual `<input>` DOM value snaps to the clamped number, not just the model field (covers #2)
- [x] Full `core` module compiles clean (`./mvnw -pl core -am -DskipTests install`)
- [ ] Live-Composer visual confirmation of #2's fix still recommended before merge (UI-timing behavior; flagged in the diagnosis/refute docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)