### PR TITLE
Carry column description, label and declared kind through the tabular catalog SPI

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/TabularColumn.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularColumn.java
@@ -26,5 +26,33 @@ package inetsoft.uql.tabular;
  *             not exhaustive: the actual, closed vocabulary is every {@code public static final
  *             String} constant {@code XSchema} itself declares. The connector maps its own native
  *             type onto this vocabulary; the native type name does not cross this boundary.
+ * @param description the column's own description as the source declares it, verbatim — not a
+ *                     sentence the connector composes. {@code null} when the source declares
+ *                     nothing, never an empty string standing in for "nothing". Where "nothing" is
+ *                     represented is source-specific (a protobuf getter never returns null, so a
+ *                     connector reading one must translate its own empty string to {@code null}
+ *                     here); that translation belongs to the connector, which is the only party
+ *                     that knows its source's convention.
+ * @param label the column's own display name as the source declares it. {@code null} when blank.
+ *              May equal {@code name} — that is still a true statement about the source.
+ * @param isDimension three-valued. {@code TRUE}/{@code FALSE} only when the source itself sorts
+ *                    this column into one of two disjoint dimension/measure lists; {@code null}
+ *                    when the source does not say. Deliberately not an inference: a connector must
+ *                    not guess from the column's type (numeric therefore a measure, or similar).
+ *                    The three-valued form is required, not merely cautious — {@code FALSE} ("the
+ *                    source says this is a measure") and {@code null} ("the source did not say")
+ *                    are different facts downstream.
  */
-public record TabularColumn(String name, String type) {}
+public record TabularColumn(String name, String type, String description, String label,
+                             Boolean isDimension)
+{
+   /**
+    * Compatibility constructor for callers written before description/label/isDimension existed —
+    * every existing connector's construction site. All three default to null, which
+    * {@code TabularCatalogService} treats identically to "the connector said nothing": the key is
+    * omitted from the projection entirely, not written empty or false.
+    */
+   public TabularColumn(String name, String type) {
+      this(name, type, null, null, null);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/osi/OsiField.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/osi/OsiField.java
@@ -84,31 +84,11 @@ public class OsiField {
       this.customExtensions = customExtensions;
    }
 
-   /**
-    * Whether this column is a dimension, as the data source itself declares it (three-valued:
-    * null means the source did not say). Not to be confused with {@link #getDimension()}, which
-    * carries only the time-dimension flag ({@code is_time}) and is a different JSON key.
-    *
-    * <p>Deliberately named {@code getIsDimension}, not {@code isDimension} — Jackson's is-getter
-    * rule applies to {@code Boolean} the same as {@code boolean}, and {@code isDimension()} would
-    * derive the property name {@code dimension}, colliding with {@link #getDimension()}'s own JSON
-    * key. The explicit {@code @JsonProperty} pins the key regardless of naming strategy.
-    */
-   @JsonProperty("isDimension")
-   public Boolean getIsDimension() {
-      return isDimension;
-   }
-
-   public void setIsDimension(Boolean isDimension) {
-      this.isDimension = isDimension;
-   }
-
    private String name;
    private OsiExpression expression;
    private OsiDimension dimension;
    private String label;
    private String description;
-   private Boolean isDimension;
 
    @JsonProperty("ai_context")
    private Object aiContext;

--- a/core/src/main/java/inetsoft/web/wiz/model/osi/OsiField.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/osi/OsiField.java
@@ -84,11 +84,31 @@ public class OsiField {
       this.customExtensions = customExtensions;
    }
 
+   /**
+    * Whether this column is a dimension, as the data source itself declares it (three-valued:
+    * null means the source did not say). Not to be confused with {@link #getDimension()}, which
+    * carries only the time-dimension flag ({@code is_time}) and is a different JSON key.
+    *
+    * <p>Deliberately named {@code getIsDimension}, not {@code isDimension} — Jackson's is-getter
+    * rule applies to {@code Boolean} the same as {@code boolean}, and {@code isDimension()} would
+    * derive the property name {@code dimension}, colliding with {@link #getDimension()}'s own JSON
+    * key. The explicit {@code @JsonProperty} pins the key regardless of naming strategy.
+    */
+   @JsonProperty("isDimension")
+   public Boolean getIsDimension() {
+      return isDimension;
+   }
+
+   public void setIsDimension(Boolean isDimension) {
+      this.isDimension = isDimension;
+   }
+
    private String name;
    private OsiExpression expression;
    private OsiDimension dimension;
    private String label;
    private String description;
+   private Boolean isDimension;
 
    @JsonProperty("ai_context")
    private Object aiContext;

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -353,7 +353,20 @@ public class TabularCatalogService {
             field.setDimension(new OsiDimension(true));
          }
 
-         field.setCustomExtensions(List.of(buildFieldExtension(column.type(), objectMapper)));
+         if(column.label() != null && !column.label().isBlank()) {
+            field.setLabel(column.label());
+         }
+
+         if(column.description() != null && !column.description().isBlank()) {
+            field.setDescription(column.description());
+         }
+
+         if(column.isDimension() != null) {
+            field.setIsDimension(column.isDimension());
+         }
+
+         field.setCustomExtensions(
+            List.of(buildFieldExtension(column.type(), column.isDimension(), objectMapper)));
          fields.add(field);
       }
 
@@ -369,10 +382,27 @@ public class TabularCatalogService {
       return dataset;
    }
 
-   private static OsiCustomExtension buildFieldExtension(String type, ObjectMapper objectMapper) {
+   /**
+    * {@code declaredIsDimension} is the second half of this extension's existing "the column's
+    * declared type as the source reports it" role (see {@code "type"} below): written only when
+    * the source itself sorted the column into a dimension/measure list ({@code isDimension} is
+    * non-null), never inferred and never defaulted to {@code false}. It is deliberately placed
+    * here, in the field-level COMMON extension, rather than only on {@link OsiField#isDimension},
+    * because the annotation merge overwrites {@code OsiField.isDimension} with the LLM's own
+    * judgment on every run (see {@code applyAnnotationToDoc} in wiz), while this extension's
+    * {@code custom_extensions} survives that merge untouched. A save-time cross-check in wiz reads
+    * this key back to confirm the annotation didn't contradict what the source declared.
+    */
+   private static OsiCustomExtension buildFieldExtension(String type, Boolean isDimension,
+                                                          ObjectMapper objectMapper)
+   {
       try {
          Map<String, Object> extData = new LinkedHashMap<>();
          extData.put("type", type);
+
+         if(isDimension != null) {
+            extData.put("declaredIsDimension", isDimension);
+         }
 
          OsiCustomExtension ext = new OsiCustomExtension();
          ext.setVendorName("COMMON");

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -361,10 +361,6 @@ public class TabularCatalogService {
             field.setDescription(column.description());
          }
 
-         if(column.isDimension() != null) {
-            field.setIsDimension(column.isDimension());
-         }
-
          field.setCustomExtensions(
             List.of(buildFieldExtension(column.type(), column.isDimension(), objectMapper)));
          fields.add(field);
@@ -386,12 +382,16 @@ public class TabularCatalogService {
     * {@code declaredIsDimension} is the second half of this extension's existing "the column's
     * declared type as the source reports it" role (see {@code "type"} below): written only when
     * the source itself sorted the column into a dimension/measure list ({@code isDimension} is
-    * non-null), never inferred and never defaulted to {@code false}. It is deliberately placed
-    * here, in the field-level COMMON extension, rather than only on {@link OsiField#isDimension},
-    * because the annotation merge overwrites {@code OsiField.isDimension} with the LLM's own
-    * judgment on every run (see {@code applyAnnotationToDoc} in wiz), while this extension's
-    * {@code custom_extensions} survives that merge untouched. A save-time cross-check in wiz reads
-    * this key back to confirm the annotation didn't contradict what the source declared.
+    * non-null), never inferred and never defaulted to {@code false}. It lives ONLY here, in the
+    * field-level COMMON extension — {@link OsiField} has no top-level key for it, and must not:
+    * OSI's {@code Field} schema ({@code core-spec/ossie-schema.json}, {@code $defs/Field}) sets
+    * {@code additionalProperties: false} over a fixed key list that does not include
+    * {@code isDimension}, so a top-level key would make this a non-conformant Field.
+    * {@code custom_extensions} is the spec's own sanctioned extension point, and it is also the
+    * durable one: wiz's annotation merge overwrites a doc field's other properties with the LLM's
+    * own judgment on every run (see {@code applyAnnotationToDoc} in wiz), but leaves
+    * {@code custom_extensions} untouched. A save-time cross-check in wiz reads this key back to
+    * confirm the annotation didn't contradict what the source declared.
     */
    private static OsiCustomExtension buildFieldExtension(String type, Boolean isDimension,
                                                           ObjectMapper objectMapper)

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogFieldDeclarationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogFieldDeclarationTest.java
@@ -40,8 +40,12 @@ import static org.mockito.Mockito.when;
  * Covers the field-level part of GA4's contribution to the SPI: {@link TabularColumn}'s three new
  * components (description/label/isDimension), the compatibility constructor that keeps all six
  * pre-existing connectors' construction sites unchanged, and {@link TabularCatalogService}'s
- * projection of those components onto {@link OsiField} and its field-level COMMON extension
- * ({@code declaredIsDimension}). Driven by {@link FakeCatalogRuntime}, the same as
+ * projection of those components onto {@link OsiField} (description/label only) and the
+ * field-level COMMON extension ({@code declaredIsDimension}). {@code isDimension} does NOT get a
+ * top-level {@code OsiField} key: OSI's {@code Field} schema (`core-spec/ossie-schema.json`,
+ * {@code $defs/Field}) sets {@code additionalProperties: false} over a fixed key list that does
+ * not include it, so the declared kind's only conformant home is {@code custom_extensions} — the
+ * spec's own sanctioned extension point. Driven by {@link FakeCatalogRuntime}, the same as
  * {@link TabularCatalogServiceTest} — this is not a GA4-specific test, it verifies the neutral SPI
  * type and the one service that projects it.
  */
@@ -88,14 +92,13 @@ class TabularCatalogFieldDeclarationTest {
       assertNull(column.isDimension());
    }
 
-   // ----- #2: isDimension == null -> neither key written -----
+   // ----- #2: isDimension == null -> the COMMON extension key is omitted -----
 
    @Test
-   void isDimensionNull_omitsBothOsiFieldKeyAndCommonExtensionKey() throws Exception {
+   void isDimensionNull_omitsCommonExtensionKey() throws Exception {
       OsiField field =
          describeSingleField(new TabularColumn("Name", XSchema.STRING, null, null, null));
 
-      assertNull(field.getIsDimension());
       assertFalse(fieldExtensionData(field).has("declaredIsDimension"));
    }
 
@@ -110,34 +113,44 @@ class TabularCatalogFieldDeclarationTest {
       assertNull(field.getLabel());
    }
 
-   // ----- #4: isDimension and the unrelated is_time dimension flag do not collide -----
+   // ----- #4: declaredIsDimension and the unrelated is_time dimension flag do not collide, and
+   //           no top-level "isDimension" key is ever serialized (OSI Field conformance) -----
 
    @Test
-   void isDimensionKey_doesNotCollideWithTimeDimensionKey() throws Exception {
+   void declaredIsDimensionKey_doesNotCollideWithTimeDimensionKey_andNoTopLevelIsDimensionKey()
+      throws Exception
+   {
       OsiField field = describeSingleField(
          new TabularColumn("EventDate", XSchema.DATE, null, null, Boolean.TRUE));
 
-      assertEquals(Boolean.TRUE, field.getIsDimension());
       assertNotNull(field.getDimension());
       assertTrue(field.getDimension().isTime());
 
       ObjectMapper mapper = new ObjectMapper();
       JsonNode json = mapper.valueToTree(field);
-      assertTrue(json.get("isDimension").asBoolean());
+      // OSI's Field schema ($defs/Field, additionalProperties: false) does not list "isDimension"
+      // among its allowed keys -- a top-level isDimension key would make this Field
+      // non-conformant. The declared kind must live ONLY in custom_extensions.
+      assertFalse(json.has("isDimension"));
       assertTrue(json.get("dimension").get("is_time").asBoolean());
+
+      JsonNode extData = fieldExtensionData(field);
+      assertTrue(extData.get("declaredIsDimension").asBoolean());
    }
 
-   // ----- #5: declaredIsDimension and OsiField.isDimension are both written -----
+   // ----- #5: declaredIsDimension is written in the COMMON extension, and nowhere else -----
 
    @Test
-   void isDimensionFalse_writesBothOsiFieldKeyAndCommonExtensionKey() throws Exception {
+   void isDimensionFalse_writesDeclaredIsDimensionInCommonExtensionOnly() throws Exception {
       OsiField field = describeSingleField(
          new TabularColumn("activeUsers", XSchema.DOUBLE, "A count.", "Active users",
             Boolean.FALSE));
 
-      assertEquals(Boolean.FALSE, field.getIsDimension());
       assertEquals("A count.", field.getDescription());
       assertEquals("Active users", field.getLabel());
+
+      ObjectMapper mapper = new ObjectMapper();
+      assertFalse(mapper.valueToTree(field).has("isDimension"));
 
       JsonNode extData = fieldExtensionData(field);
       assertEquals(XSchema.DOUBLE, extData.get("type").asText());

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogFieldDeclarationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogFieldDeclarationTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import inetsoft.web.wiz.model.osi.OsiCustomExtension;
+import inetsoft.web.wiz.model.osi.OsiDataset;
+import inetsoft.web.wiz.model.osi.OsiField;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the field-level part of GA4's contribution to the SPI: {@link TabularColumn}'s three new
+ * components (description/label/isDimension), the compatibility constructor that keeps all six
+ * pre-existing connectors' construction sites unchanged, and {@link TabularCatalogService}'s
+ * projection of those components onto {@link OsiField} and its field-level COMMON extension
+ * ({@code declaredIsDimension}). Driven by {@link FakeCatalogRuntime}, the same as
+ * {@link TabularCatalogServiceTest} — this is not a GA4-specific test, it verifies the neutral SPI
+ * type and the one service that projects it.
+ */
+@Tag("core")
+class TabularCatalogFieldDeclarationTest {
+
+   private static final String DS_NAME = "Fake Declaration Source";
+
+   private TabularCatalogService createService(Function<String, TabularRuntime> runtimeResolver)
+      throws Exception
+   {
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(new FakeTabularDataSource());
+      return new TabularCatalogService(xrepository, new ObjectMapper(), runtimeResolver);
+   }
+
+   private OsiField describeSingleField(TabularColumn column) throws Exception {
+      TabularDatasetSchema schema =
+         new TabularDatasetSchema("Widgets", List.of(column), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(
+         new TabularCatalog(List.of(), List.of()), Map.of("Widgets", schema));
+      TabularCatalogService service = createService(dsName -> runtime);
+
+      OsiDataset dataset = service.describeTable(DS_NAME, "Widgets");
+      assertEquals(1, dataset.getFields().size());
+      return dataset.getFields().get(0);
+   }
+
+   private JsonNode fieldExtensionData(OsiField field) throws Exception {
+      OsiCustomExtension ext = field.getCustomExtensions().get(0);
+      assertEquals("COMMON", ext.getVendorName());
+      return new ObjectMapper().readTree(ext.getData());
+   }
+
+   // ----- #1: compatibility constructor -----
+
+   @Test
+   void compatibilityConstructor_leavesNewComponentsNull() {
+      TabularColumn column = new TabularColumn("ID", XSchema.LONG);
+      assertEquals("ID", column.name());
+      assertEquals(XSchema.LONG, column.type());
+      assertNull(column.description());
+      assertNull(column.label());
+      assertNull(column.isDimension());
+   }
+
+   // ----- #2: isDimension == null -> neither key written -----
+
+   @Test
+   void isDimensionNull_omitsBothOsiFieldKeyAndCommonExtensionKey() throws Exception {
+      OsiField field =
+         describeSingleField(new TabularColumn("Name", XSchema.STRING, null, null, null));
+
+      assertNull(field.getIsDimension());
+      assertFalse(fieldExtensionData(field).has("declaredIsDimension"));
+   }
+
+   // ----- #3: blank description/label are not written -----
+
+   @Test
+   void blankDescriptionAndLabel_areNotWrittenAsEmptyStrings() throws Exception {
+      OsiField field =
+         describeSingleField(new TabularColumn("Name", XSchema.STRING, "", "  ", null));
+
+      assertNull(field.getDescription());
+      assertNull(field.getLabel());
+   }
+
+   // ----- #4: isDimension and the unrelated is_time dimension flag do not collide -----
+
+   @Test
+   void isDimensionKey_doesNotCollideWithTimeDimensionKey() throws Exception {
+      OsiField field = describeSingleField(
+         new TabularColumn("EventDate", XSchema.DATE, null, null, Boolean.TRUE));
+
+      assertEquals(Boolean.TRUE, field.getIsDimension());
+      assertNotNull(field.getDimension());
+      assertTrue(field.getDimension().isTime());
+
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode json = mapper.valueToTree(field);
+      assertTrue(json.get("isDimension").asBoolean());
+      assertTrue(json.get("dimension").get("is_time").asBoolean());
+   }
+
+   // ----- #5: declaredIsDimension and OsiField.isDimension are both written -----
+
+   @Test
+   void isDimensionFalse_writesBothOsiFieldKeyAndCommonExtensionKey() throws Exception {
+      OsiField field = describeSingleField(
+         new TabularColumn("activeUsers", XSchema.DOUBLE, "A count.", "Active users",
+            Boolean.FALSE));
+
+      assertEquals(Boolean.FALSE, field.getIsDimension());
+      assertEquals("A count.", field.getDescription());
+      assertEquals("Active users", field.getLabel());
+
+      JsonNode extData = fieldExtensionData(field);
+      assertEquals(XSchema.DOUBLE, extData.get("type").asText());
+      assertFalse(extData.get("declaredIsDimension").asBoolean());
+   }
+}


### PR DESCRIPTION
`TabularColumn` gains `description`, `label` and `isDimension`, and `TabularCatalogService.toDataset()` projects them onto `OsiField`. Additive, with a compatibility constructor, following exactly how `params` and `columnsMayBeIncomplete` were added to `TabularDatasetSchema`.

Motivated by GA4 (stylebi-enterprise#TBD), which is the first source to *declare* which columns are dimensions and which are metrics rather than leaving it to be inferred from type, and the first whose column metadata carries real prose descriptions.

`isDimension` is projected into the field-level COMMON extension as `declaredIsDimension`, not onto `OsiField.isDimension` alone. That distinction is load-bearing: `OsiField.isDimension` is overwritten by the first annotation, so a source's own classification would not survive it. The COMMON extension is not written by the annotator, so the declaration outlives annotation and can be cross-checked against it on the wiz side.

**The regression surface is seven implementers plus two test doubles**, not one connector. `ODataRuntime`, `SharepointOnlineRuntime`, `CassandraRuntime`, `HiveRuntime`, `AerospikeRuntime`, `OrientDBRuntime` and `SForceRuntime` all implement the SPI; `FakeCatalogRuntime` and `FakeFailingCatalogRuntime` in this module's own test tree do too. Those two are the useful canary — a compatibility constructor done wrong breaks core's own tests before any connector's, at compile time. None of the nine is modified by this PR.

42 tests, of which 37 predate this change and pass unaltered:

```
./mvnw -pl core -am -Dtest=TabularCatalogFieldDeclarationTest,TabularCatalogServiceTest,TabularCatalogServiceContractValidationTest,TabularCatalogDatasetExtensionTest -Dsurefire.failIfNoSpecifiedTests=false test
```

`-Dsurefire.failIfNoSpecifiedTests=false` is needed because `-am` pulls upstream modules into the reactor and `-Dtest` applies to all of them; without it a module with no matching test fails the build with a message that reads like a mistyped class name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)