### PR TITLE
Bug #76407, reconcile scaled-space bottom-tabs position on Composer toggle

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
@@ -174,6 +174,9 @@ public class TabPropertyDialogService {
 
          TabVSAssemblyInfo.repositionForBottomTabs(tabAssemblyInfo, vs,
                                                    tabGeneralPaneModel.getBottomTabs());
+         // scaled space: keep mobile/responsive layout preview flush too (Bug #76407)
+         TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(tabAssemblyInfo, vs,
+                                                   tabGeneralPaneModel.getBottomTabs());
 
          // sync position model only when the user didn't explicitly change the position;
          // if they did, let setContainerPosition translate the whole group to the new Y

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
@@ -172,6 +172,21 @@ public class TabPropertyDialogService {
          int originalTop = tabAssemblyInfo.getPixelOffset() != null
             ? tabAssemblyInfo.getPixelOffset().y : -1;
 
+         // getAssemblyPosition() (which populated this dialog, in getTabPropertyDialogModel
+         // above) prefers the tab's scaled position over its master pixel position whenever
+         // one is set -- so if this tab has a scaled position, the value the client actually
+         // submitted back in sizePositionPaneModel is the ORIGINAL SCALED top, not the master
+         // top captured above. Capture it before reposition so the sync check below compares
+         // against the coordinate space the model's value actually came from (Bug #76407
+         // round 2 -- without this, the sync below never fires for a scaled-position tab,
+         // sizePositionPaneModel keeps the stale scaled top, and setContainerPosition's own
+         // scaled/master-collapsing behavior a few lines down overwrites the scaled position
+         // we're about to reconcile with that stale value, undoing this fix within the same
+         // request).
+         Point originalScaledPos = tabAssemblyInfo.getLayoutPosition(true);
+         boolean hasScaledPos = originalScaledPos != tabAssemblyInfo.getLayoutPosition(false);
+         int originalScaledTop = hasScaledPos ? originalScaledPos.y : -1;
+
          TabVSAssemblyInfo.repositionForBottomTabs(tabAssemblyInfo, vs,
                                                    tabGeneralPaneModel.getBottomTabs());
          // scaled space: keep mobile/responsive layout preview flush too (Bug #76407)
@@ -180,7 +195,16 @@ public class TabPropertyDialogService {
 
          // sync position model only when the user didn't explicitly change the position;
          // if they did, let setContainerPosition translate the whole group to the new Y
-         if(sizePositionPaneModel.getTop() == originalTop) {
+         if(hasScaledPos) {
+            if(sizePositionPaneModel.getTop() == originalScaledTop) {
+               Point newScaledPos = tabAssemblyInfo.getLayoutPosition(true);
+
+               if(newScaledPos != null) {
+                  sizePositionPaneModel.setTop(newScaledPos.y);
+               }
+            }
+         }
+         else if(sizePositionPaneModel.getTop() == originalTop) {
             Point newTabPos = tabAssemblyInfo.getPixelOffset();
 
             if(newTabPos != null) {

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
@@ -184,7 +184,7 @@ public class TabPropertyDialogService {
          // we're about to reconcile with that stale value, undoing this fix within the same
          // request).
          Point originalScaledPos = tabAssemblyInfo.getLayoutPosition(true);
-         boolean hasScaledPos = originalScaledPos != tabAssemblyInfo.getLayoutPosition(false);
+         boolean hasScaledPos = tabAssemblyInfo.isScaled();
          int originalScaledTop = hasScaledPos ? originalScaledPos.y : -1;
 
          TabVSAssemblyInfo.repositionForBottomTabs(tabAssemblyInfo, vs,

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogServiceTest.java
@@ -43,6 +43,7 @@ import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -88,7 +89,8 @@ class TabPropertyDialogServiceTest {
 
       when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
       when(rvs.getViewsheet()).thenReturn(realVS);
-      when(rvs.getID()).thenReturn("vs1");
+      // lenient: only consumed when the container-position sync path runs (left/top >= 0)
+      lenient().when(rvs.getID()).thenReturn("vs1");
       when(vsObjectTreeService.getObjectTree(any(RuntimeViewsheet.class)))
          .thenReturn(new VSObjectTreeNode());
    }
@@ -275,6 +277,51 @@ class TabPropertyDialogServiceTest {
 
       assertEquals(530, child.getVSAssemblyInfo().getPixelOffset().y,
                    "child top edge (530) must be flush with tab bottom");
+   }
+
+   /**
+    * Bug #76407: flipping to bottom-tabs must reconcile the scaled/mobile-layout
+    * position too, not just the master-pixel position -- otherwise a distinct,
+    * previously-computed scaled-space child position is left stale and can overlap
+    * the tab bar in mobile/responsive preview, exactly like the reported symptom
+    * ("radio button bottom edge extends beyond the tab boundary"), just in scaled
+    * space rather than the master view.
+    *
+    * left/top are submitted as -1 so {@code VSDialogService.setContainerPosition}
+    * (an unrelated, pre-existing position-sync path with its own scaled/master
+    * coordinate-mixing quirk -- see 03-fix.md) does not run and confound the
+    * assertions; this isolates exactly the effect of the new scaled-space
+    * reposition call added to this method.
+    */
+   @Test
+   void testFlipToBottomTabsReconcilesScaledSpacePosition() throws Exception {
+      TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) tab.getVSAssemblyInfo();
+      // stale scaled-space layout: tab bar sits at scaled Y=50 while the child's
+      // scaled bottom edge (300 + 100 = 400) is far below it -- a large overlap.
+      tabInfo.setScaledPosition(new Point(10, 50));
+      tabInfo.setScaledSize(new Dimension(200, 30));
+      child.getVSAssemblyInfo().setScaledPosition(new Point(10, 300));
+      child.getVSAssemblyInfo().setScaledSize(new Dimension(200, 100));
+
+      TabPropertyDialogModel model = buildModel("Tab1", true, -1, -1, 200, 30);
+
+      service.setTabPropertyDialogModel("vs1", "Tab1", model, "", null, commandDispatcher);
+
+      ArgumentCaptor<TabVSAssemblyInfo> captor = ArgumentCaptor.forClass(TabVSAssemblyInfo.class);
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), captor.capture(), anyString(), anyString(),
+         anyString(), nullable(Principal.class), any(CommandDispatcher.class));
+
+      TabVSAssemblyInfo captured = captor.getValue();
+      assertTrue(captured.getBottomTabsValue(), "bottomTabs must be persisted as true");
+      // scaled tab bar reconciled to the child's scaled bottom edge (300 + 100 = 400),
+      // eliminating the overlap -- was left stale at 50 before this fix.
+      assertEquals(400, captured.getLayoutPosition(true).y,
+                   "scaled-space tab bar must move flush with the child's scaled bottom edge");
+      // child's scaled position already defined the extent -- stays flush at 300,
+      // now genuinely flush against the reconciled tab bar (400 - 100 = 300).
+      assertEquals(300, child.getVSAssemblyInfo().getLayoutPosition(true).y,
+                   "child scaled position must remain flush with the reconciled tab bar");
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogServiceTest.java
@@ -324,6 +324,60 @@ class TabPropertyDialogServiceTest {
                    "child scaled position must remain flush with the reconciled tab bar");
    }
 
+   /**
+    * Bug #76407 round 2: the realistic Composer flow -- an automated review found
+    * that {@link #testFlipToBottomTabsReconcilesScaledSpacePosition} above only
+    * proves the reposition math in isolation, by submitting left/top=-1 specifically
+    * to skip {@code setContainerPosition}. In the ordinary "open dialog, toggle
+    * bottomTabs, click OK without touching position" flow, {@code getAssemblyPosition}
+    * (which populates this dialog) prefers the tab's scaled position when one is set,
+    * so left/top come back non-negative -- equal to the CURRENT (stale) scaled
+    * position -- and {@code setContainerPosition} DOES run afterward.
+    *
+    * Before the round-2 fix, that path would collapse the just-reconciled scaled
+    * position back down using the stale submitted value: {@code setContainerPosition}
+    * calls {@code info.setLayoutPosition(pos)}, which unconditionally nulls
+    * {@code scaledPosition} and replaces it with a plain {@code layoutPosition} set to
+    * whatever {@code pos} was -- the STALE value from before this method ran, since
+    * nothing had synced {@code sizePositionPaneModel} to reflect the newly-reconciled
+    * scaled position. Net effect: the fix's own reconciliation was silently undone
+    * within the same request.
+    */
+   @Test
+   void testFlipToBottomTabsReconcilesScaledSpacePositionRealisticFlow() throws Exception {
+      TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) tab.getVSAssemblyInfo();
+      // same stale scaled-space layout as the isolated test above.
+      tabInfo.setScaledPosition(new Point(10, 50));
+      tabInfo.setScaledSize(new Dimension(200, 30));
+      child.getVSAssemblyInfo().setScaledPosition(new Point(10, 300));
+      child.getVSAssemblyInfo().setScaledSize(new Dimension(200, 100));
+
+      // Realistic submission: left/top = the tab's CURRENT position as
+      // getAssemblyPosition() would have returned it (scaled-first) when this
+      // dialog was opened -- i.e. the stale scaled Y=50, not -1 and not the
+      // master pixel Y (200). The user did not touch position; only bottomTabs.
+      TabPropertyDialogModel model = buildModel("Tab1", true, 10, 50, 200, 30);
+
+      service.setTabPropertyDialogModel("vs1", "Tab1", model, "", null, commandDispatcher);
+
+      ArgumentCaptor<TabVSAssemblyInfo> captor = ArgumentCaptor.forClass(TabVSAssemblyInfo.class);
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), captor.capture(), anyString(), anyString(),
+         anyString(), nullable(Principal.class), any(CommandDispatcher.class));
+
+      TabVSAssemblyInfo captured = captor.getValue();
+      assertTrue(captured.getBottomTabsValue(), "bottomTabs must be persisted as true");
+      // The scaled position must survive setContainerPosition's own scaled/master
+      // collapsing behavior: the reconciled value (400) must be what the tab actually
+      // ends up at, not reverted to the stale pre-toggle value (50).
+      assertEquals(400, captured.getLayoutPosition(true).y,
+                   "scaled-space tab bar must remain flush after the full method call, " +
+                   "including setContainerPosition -- not reverted to the stale pre-toggle value");
+      assertEquals(300, child.getVSAssemblyInfo().getLayoutPosition(true).y,
+                   "child scaled position must remain flush with the reconciled tab bar " +
+                   "after the full method call");
+   }
+
    // -------------------------------------------------------------------------
    // Helpers
    // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The Composer's `bottomTabs` checkbox toggle (`TabPropertyDialogService.setTabPropertyDialogModel`) only reconciled the master-pixel-space positions of a Tab and its children via `TabVSAssemblyInfo.repositionForBottomTabs(...)`, never the scaled/mobile-layout counterpart (`repositionForBottomTabsInScaledSpace`) -- unlike the runtime script path (`TabVSAScriptable.setBottomTabs`), which already calls both together.
- This left a child's scaled-space position stale after a plain design-time `bottomTabs` toggle, able to overlap the tab bar in mobile/responsive layout preview.
- Fix: call `TabVSAssemblyInfo.repositionForBottomTabsInScaledSpace(...)` alongside the existing master-pixel-space call, mirroring `TabVSAScriptable.setBottomTabs()`.
- `ViewsheetSandbox.executeView()`'s per-assembly bottom-tabs hook was deliberately **not** extended to also call the scaled-space method -- that method recomputes the *entire* tab bar's scaled position from all children's current extents (unlike the master-pixel `repositionChildForBottomTabs`, which only touches one child) and has no "did bottomTabs actually change" guard at that call site, so wiring it in unconditionally on every view execution risked silently overwriting a user's deliberately-set mobile-layout tab position. See `docs/teams/2026-09-02-bugs-batch1/bug-76407/03-fix.md` in the enterprise repo for the full reasoning.

## Important caveat

This fixes a **demonstrated, real gap** in the reposition mechanism (confirmed via a passing regression test showing the scaled position is left stale without this change and reconciled with it). However, it is **not confirmed** to resolve the exact symptom reported in bug #76407: the reporter's "tab" viewsheet asset does not exist anywhere in this repo and no live Composer/portal was available during this investigation, so it is unverified whether that specific viewsheet actually uses a scaled/mobile layout at all. If it doesn't, this is still a genuine improvement to the reposition mechanism, but would not be the root cause of the reported repro. Live-Composer/portal confirmation against the original repro is still needed to fully close #76407.

## Test plan

- [x] Added `testFlipToBottomTabsReconcilesScaledSpacePosition` to `TabPropertyDialogServiceTest` (existing Spring-wired, `@Tag("core")` test class) -- sets up a Tab+child with stale scaled-space positions overlapping the tab bar, flips `bottomTabs`, asserts the scaled tab position reconciles to be flush with the child.
- [x] Verified the test fails without the fix (temporarily reverted the new call, reran in isolation: `expected: <400> but was: <50>`), then restored the fix and confirmed all 7 tests in the class pass.
- [x] Ran `TabVSAScriptableTest` (12 tests) as a sanity check on the shared `TabVSAssemblyInfo` reposition methods -- unaffected, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)