### PR TITLE
Fix #76443: spurious unsaved-changes prompt on rapid security-action switching

### DIFF
--- a/web/projects/em/src/app/settings/security/security-actions/security-actions-permissions/security-actions-permissions.component.tl.spec.ts
+++ b/web/projects/em/src/app/settings/security/security-actions/security-actions-permissions/security-actions-permissions.component.tl.spec.ts
@@ -42,7 +42,7 @@ import { HttpErrorResponse } from "@angular/common/http";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { render } from "@testing-library/angular";
-import { EMPTY, Observable, of } from "rxjs";
+import { EMPTY, Observable, of, Subject } from "rxjs";
 
 import { Tool } from "../../../../../../../shared/util/tool";
 import { ResourcePermissionModel } from "../../resource-permission/resource-permission-model";
@@ -159,6 +159,37 @@ describe("SecurityActionsPermissionsComponent - action input and dirty baseline"
       comp.action = null;
 
       expect(comp.tableModel).toBeNull();
+      expect(comp.isModelChanged()).toBe(false);
+   });
+
+   // Regression test for bug #76443: selecting a new node must not report a spurious
+   // unsaved-changes state while the new node's permissions are still loading. Uses a
+   // manually-controlled Subject (not `of(model)`) so getPermissions() genuinely stays
+   // pending across the assertion - a bare `of(model)` would resolve synchronously inside
+   // the setter and mask the regression.
+   it("should not report unsaved changes while permissions are loading for a newly selected action", async () => {
+      const firstAction = makeAction({ type: "VIEWSHEET", resource: "/folder/view1" });
+      const secondAction = makeAction({ type: "VIEWSHEET", resource: "/folder/view2" });
+      const firstModel = makeModel({ securityEnabled: true });
+      const secondModel = makeModel({ securityEnabled: true, changed: true });
+      const secondModelSubject = new Subject<ResourcePermissionModel>();
+      const getPermissions = vi.fn()
+         .mockReturnValueOnce(of(firstModel))
+         .mockReturnValueOnce(secondModelSubject.asObservable());
+      const { comp } = await renderComponent({ action: firstAction, getPermissions });
+
+      expect(comp.isModelChanged()).toBe(false);
+
+      comp.action = secondAction;
+
+      // getPermissions() for secondAction has not resolved yet - tableModel must not be
+      // left holding firstModel while originalModel is null.
+      expect(comp.isModelChanged()).toBe(false);
+
+      secondModelSubject.next(secondModel);
+      secondModelSubject.complete();
+
+      expect(comp.tableModel).toEqual(secondModel);
       expect(comp.isModelChanged()).toBe(false);
    });
 });

--- a/web/projects/em/src/app/settings/security/security-actions/security-actions-permissions/security-actions-permissions.component.ts
+++ b/web/projects/em/src/app/settings/security/security-actions/security-actions-permissions/security-actions-permissions.component.ts
@@ -46,6 +46,7 @@ export class SecurityActionsPermissionsComponent {
       this._action = value;
 
       if(value) {
+         this.tableModel = null;
          this.originalModel = null;
          this.loadPermissions(value.type, value.resource, value.grant);
       }


### PR DESCRIPTION
## Summary
- Fixes bug #76443: switching between security action tree nodes quickly could trigger a spurious "Action Permission Settings Changed" confirmation dialog even though the user never edited a permission.
- Root cause: `SecurityActionsPermissionsComponent`'s `action` setter cleared `originalModel` synchronously when a new node was selected, but left the *previous* node's `tableModel` in place while the new node's permissions loaded asynchronously via `getPermissions()`. During that gap, `isModelChanged()` (`!isEqual(tableModel, originalModel)`) deterministically returned `true`. If the user clicked another node before the HTTP response landed, `SecurityActionsPageComponent` read `unsavedChanges === true` and showed the confirm dialog.
- Fix: clear `tableModel` alongside `originalModel` in the `if(value)` branch of the setter, mirroring the existing `else` (action = null) branch, so `isModelChanged()` evaluates `isEqual(null, null) === true` → `false` throughout the load.

## Test plan
- [x] Added a regression test in `security-actions-permissions.component.tl.spec.ts` using a manually-controlled `Subject` (not a synchronously-resolving `of(model)`, which would mask the bug) to keep `getPermissions()` pending while asserting `isModelChanged()` stays `false` across a rapid node switch.
- [x] Verified the new test fails against the pre-fix code (reverted the fix locally, confirmed `expected true to be false` failure) and passes with the fix restored.
- [x] Ran the full `security-actions-permissions.component.tl.spec.ts` suite (6 tests) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)