### PR TITLE
fix(PC-002): ranking n<=0 with groupOthers collapses to Others instead of no-op

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
@@ -1762,8 +1762,11 @@ public class SummaryFilter extends AbstractGroupedTable
    public void setTopN(int col, int scol, int topn, boolean reverse,
                        boolean kept, boolean others)
    {
-      if(col >= 0 && col < cols.length && scol >= 0 && scol < sums.length && topn >= 1) {
-         InnerTopNInfo info = new InnerTopNInfo(scol, topn, reverse, kept, others);
+      if(col >= 0 && col < cols.length && scol >= 0 && scol < sums.length) {
+         // n <= 0 (e.g. a bound variable resolving to 0) means "keep nothing";
+         // clamp to 0 so it's still registered and applied instead of being
+         // silently dropped as if no ranking had been requested at all (PC-002).
+         InnerTopNInfo info = new InnerTopNInfo(scol, Math.max(topn, 0), reverse, kept, others);
          topnmap.put(col, info);
       }
    }

--- a/core/src/test/java/inetsoft/report/filter/SummaryFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/SummaryFilterTest.java
@@ -116,6 +116,57 @@ public class SummaryFilterTest {
       });
    }
 
+   // PC-002: n<=0 with groupOthers must collapse every row into "Others" rather than
+   // silently no-op (the topn>=1 guard in setTopN used to drop the ranking entirely).
+   @Test
+   public void rankZeroAndOthers_collapsesAllRowsToOthers() {
+      DefaultTableLens tbl1 = new DefaultTableLens(new Object[][] {
+         {"col1", "col2", "col3"},
+         {"a", 1, 5},
+         {"a", 1, 2},
+         {"b", 1, 2.5},
+         {"b", 3, 10},
+         {"c", 1, 1},
+         {"d", 2, 2},
+         {"e", 1, 3}
+      });
+
+      final SummaryFilter summary =
+         new SummaryFilter(tbl1, new int[] {0, 1}, new int[] {2}, new SumFormula(), null);
+      summary.setTopN(0, 0, 0, false, true, true);
+      summary.moreRows(Integer.MAX_VALUE);
+
+      XTableUtil.assertEquals(summary, new Object[][] {
+         {"col1", "col2", "col3"},
+         {"Others", 1, 13.5},
+         {"Others", 2, 2.0},
+         {"Others", 3, 10.0},
+      });
+   }
+
+   // n<=0 without groupOthers keeps the same "keep top N" semantics extended to N=0:
+   // no rows survive, rather than the pre-fix no-op that returned the unranked table.
+   @Test
+   public void rankZeroWithoutOthers_keepsNoRows() {
+      DefaultTableLens tbl1 = new DefaultTableLens(new Object[][] {
+         {"col1", "col2", "col3"},
+         {"a", 1, 5},
+         {"a", 1, 2},
+         {"b", 1, 2.5},
+         {"b", 3, 10},
+         {"c", 1, 1}
+      });
+
+      final SummaryFilter summary =
+         new SummaryFilter(tbl1, new int[] {0, 1}, new int[] {2}, new SumFormula(), null);
+      summary.setTopN(0, 0, 0, false);
+      summary.moreRows(Integer.MAX_VALUE);
+
+      XTableUtil.assertEquals(summary, new Object[][] {
+         {"col1", "col2", "col3"},
+      });
+   }
+
    @Test
    public void grandTotal() {
       DefaultTableLens tbl1 = new DefaultTableLens(new Object[][] {


### PR DESCRIPTION
## Summary

Fixes stylebi-wiz PC-002: `set_ranking` with `n:0` and `groupOthers:true` silently no-ops
server-side instead of collapsing everything into an "Others" row.

**Root cause**: `SummaryFilter.setTopN()` only registered the ranking's `InnerTopNInfo` when
`topn >= 1`; when `n` resolves to `0` (either via a bound `$(variable)` at runtime, since the
client-side guard added in stylebi-wiz#1954 only rejects a *literal* `n:0`), the ranking info was
silently dropped from `topnmap`. Downstream, `applyTopNFilter()` sees no topn info registered for
that group level and returns immediately, so the table renders completely unranked — no "Others"
row, `groupOthers` not honored, byte-identical to `set_ranking` never having been called at all.

**Fix**: clamp `n<=0` to `0` and register it like any other topN, instead of dropping it. Once
registered, the existing `applyTopNFilter()` logic already does the right thing: with
`groupOthers:true`, keeping the top-0 rows means every row falls into "Others" (collapses into one
merged group per inner subgroup); with `groupOthers:false`, keeping top-0 means zero rows survive.
Both extend "top N" semantics consistently to N=0 rather than silently ignoring the ranking.

Confirmed live repro in `stylebi-wiz`'s `docs/teams/2026-09-02-bugs-p0-p2-composer/bug-PC-002/03-live-verify.md`:
worksheet grouped by `STATE` with `Count(CUSTOMER_ID)`, ranking `n` bound to a variable resolving
to `0` with `groupOthers:true` rendered all 14 states individually/unranked (no "Others" row) —
exactly reproduced here as a unit test.

## Changes
- `core/src/main/java/inetsoft/report/filter/SummaryFilter.java`: `setTopN()` no longer requires
  `topn >= 1`; negative/zero values are clamped to `0` and registered.
- `core/src/test/java/inetsoft/report/filter/SummaryFilterTest.java`: two new regression tests —
  `rankZeroAndOthers_collapsesAllRowsToOthers` and `rankZeroWithoutOthers_keepsNoRows` — plus
  existing `topTwo`/`topTwoAndOthers` (n>=1) continue to pass unaffected.

## Test plan
- [x] `./mvnw -o -pl core -am -Dtest=SummaryFilterTest,TableSummaryFilterTest,RankingConditionTest -Dsurefire.failIfNoSpecifiedTests=false test` — all pass (14/14 in `SummaryFilterTest`, including the 2 new cases; existing suites unaffected)

Refs: stylebi-wiz PC-002 (`docs/teams/2026-09-02-bugs-p0-p2-composer/bug-PC-002/`)