### PR TITLE
Bug #76431, guard against a null stream in SecurityChain.loadConfiguration

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SecurityChain.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityChain.java
@@ -177,7 +177,7 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                   // null rather than throwing (see DataSpace.getInputStream()'s
                   // FileNotFoundException/NoSuchFileException handling) -- Jackson's readTree()
                   // rejects a null stream outright, so guard against it explicitly instead of
-                  // assuming the two calls observe a consistent file state. (76431)
+                  // assuming the two calls observe a consistent file state. See bug #76431.
                   try(InputStream input = dataSpace.getInputStream(null, configFile)) {
                      if(input != null) {
                         root = (ObjectNode) mapper.readTree(input);
@@ -195,55 +195,69 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                         "concurrent rewrite); retaining existing providers", configFile);
                   }
                   else {
-                     ArrayNode providersArray = (ArrayNode) root.get("providers");
-                     List<T> list = new ArrayList<>();
-                     int failureCount = 0;
+                     JsonNode providersNode = root.get("providers");
 
-                     for(int i = 0; i < providersArray.size(); i++) {
-                        ObjectNode wrapperNode = (ObjectNode) providersArray.get(i);
-                        String name = wrapperNode.get("name").asText();
-                        String providerClass = wrapperNode.get("providerClass").asText();
-                        JsonNode config = wrapperNode.get("configuration");
-
-                        try {
-                           @SuppressWarnings("unchecked")
-                           T provider =
-                              (T) Class.forName(providerClass).getConstructor().newInstance();
-                           provider.readConfiguration(config);
-                           provider.setProviderName(name);
-                           list.add(provider);
-                        }
-                        catch(Exception e) {
-                           failureCount++;
-                           LOG.error(
-                              "Failed to create instance of security provider: {}", providerClass, e);
-                        }
-                     }
-
-                     // If the config file specified providers but ALL of them failed to instantiate,
-                     // retain the existing runtime providers rather than wiping them. This prevents a
-                     // corrupted or temporarily unreadable config (e.g. after a GKE node restart) from
-                     // clearing all security providers and locking out every user.
-                     // Do NOT update timestamp on total failure – allow the next dataChanged() to retry
-                     // when the transient condition clears, without requiring a manual config edit.
-                     if(list.isEmpty() && failureCount > 0) {
-                        LOG.error(
-                           "All {} security provider(s) failed to load from '{}'; retaining " +
-                           "existing providers to prevent loss of security configuration",
-                           failureCount, configFile);
+                     if(!(providersNode instanceof ArrayNode)) {
+                        // Same treatment as the null-stream case above: a malformed config
+                        // (missing or non-array "providers" field) must not crash
+                        // initialize() -- retain the existing providers and don't advance
+                        // timestamp, so the next dataChanged() retries once the config is
+                        // fixed. See bug #76431.
+                        LOG.warn(
+                           "Security provider configuration file '{}' is missing a valid " +
+                           "\"providers\" array; retaining existing providers", configFile);
                      }
                      else {
-                        if(failureCount > 0) {
-                           LOG.warn(
-                              "{} of {} security provider(s) failed to load from '{}'; " +
-                              "the remaining providers have been applied but security " +
-                              "configuration may be incomplete",
-                              failureCount, list.size() + failureCount, configFile);
+                        ArrayNode providersArray = (ArrayNode) providersNode;
+                        List<T> list = new ArrayList<>();
+                        int failureCount = 0;
+
+                        for(int i = 0; i < providersArray.size(); i++) {
+                           ObjectNode wrapperNode = (ObjectNode) providersArray.get(i);
+                           String name = wrapperNode.get("name").asText();
+                           String providerClass = wrapperNode.get("providerClass").asText();
+                           JsonNode config = wrapperNode.get("configuration");
+
+                           try {
+                              @SuppressWarnings("unchecked")
+                              T provider =
+                                 (T) Class.forName(providerClass).getConstructor().newInstance();
+                              provider.readConfiguration(config);
+                              provider.setProviderName(name);
+                              list.add(provider);
+                           }
+                           catch(Exception e) {
+                              failureCount++;
+                              LOG.error(
+                                 "Failed to create instance of security provider: {}", providerClass, e);
+                           }
                         }
 
-                        timestamp = dataSpace.getLastModified(null, configFile);
-                        clear();
-                        setProviderList(list);
+                        // If the config file specified providers but ALL of them failed to instantiate,
+                        // retain the existing runtime providers rather than wiping them. This prevents a
+                        // corrupted or temporarily unreadable config (e.g. after a GKE node restart) from
+                        // clearing all security providers and locking out every user.
+                        // Do NOT update timestamp on total failure – allow the next dataChanged() to retry
+                        // when the transient condition clears, without requiring a manual config edit.
+                        if(list.isEmpty() && failureCount > 0) {
+                           LOG.error(
+                              "All {} security provider(s) failed to load from '{}'; retaining " +
+                              "existing providers to prevent loss of security configuration",
+                              failureCount, configFile);
+                        }
+                        else {
+                           if(failureCount > 0) {
+                              LOG.warn(
+                                 "{} of {} security provider(s) failed to load from '{}'; " +
+                                 "the remaining providers have been applied but security " +
+                                 "configuration may be incomplete",
+                                 failureCount, list.size() + failureCount, configFile);
+                           }
+
+                           timestamp = dataSpace.getLastModified(null, configFile);
+                           clear();
+                           setProviderList(list);
+                        }
                      }
                   }
                }

--- a/core/src/main/java/inetsoft/sree/security/SecurityChain.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityChain.java
@@ -169,61 +169,82 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
             if(timestamp < now) {
                if(dataSpace.exists(null, configFile)) {
                   ObjectMapper mapper = new ObjectMapper();
-                  ObjectNode root;
+                  ObjectNode root = null;
 
+                  // exists() and getInputStream() are not atomic: the config file can be
+                  // removed or replaced (e.g. by a concurrent rewrite) between the check above
+                  // and opening the stream here. When that happens, getInputStream() returns
+                  // null rather than throwing (see DataSpace.getInputStream()'s
+                  // FileNotFoundException/NoSuchFileException handling) -- Jackson's readTree()
+                  // rejects a null stream outright, so guard against it explicitly instead of
+                  // assuming the two calls observe a consistent file state. (76431)
                   try(InputStream input = dataSpace.getInputStream(null, configFile)) {
-                     root = (ObjectNode) mapper.readTree(input);
-                  }
-
-                  ArrayNode providersArray = (ArrayNode) root.get("providers");
-                  List<T> list = new ArrayList<>();
-                  int failureCount = 0;
-
-                  for(int i = 0; i < providersArray.size(); i++) {
-                     ObjectNode wrapperNode = (ObjectNode) providersArray.get(i);
-                     String name = wrapperNode.get("name").asText();
-                     String providerClass = wrapperNode.get("providerClass").asText();
-                     JsonNode config = wrapperNode.get("configuration");
-
-                     try {
-                        @SuppressWarnings("unchecked")
-                        T provider =
-                           (T) Class.forName(providerClass).getConstructor().newInstance();
-                        provider.readConfiguration(config);
-                        provider.setProviderName(name);
-                        list.add(provider);
-                     }
-                     catch(Exception e) {
-                        failureCount++;
-                        LOG.error(
-                           "Failed to create instance of security provider: {}", providerClass, e);
+                     if(input != null) {
+                        root = (ObjectNode) mapper.readTree(input);
                      }
                   }
 
-                  // If the config file specified providers but ALL of them failed to instantiate,
-                  // retain the existing runtime providers rather than wiping them. This prevents a
-                  // corrupted or temporarily unreadable config (e.g. after a GKE node restart) from
-                  // clearing all security providers and locking out every user.
-                  // Do NOT update timestamp on total failure – allow the next dataChanged() to retry
-                  // when the transient condition clears, without requiring a manual config edit.
-                  if(list.isEmpty() && failureCount > 0) {
-                     LOG.error(
-                        "All {} security provider(s) failed to load from '{}'; retaining " +
-                        "existing providers to prevent loss of security configuration",
-                        failureCount, configFile);
+                  if(root == null) {
+                     // Same treatment as the "all providers failed to load" case below: retain
+                     // the existing runtime providers and don't advance timestamp, so the next
+                     // dataChanged() retries once the transient condition (the file coming back,
+                     // or the concurrent rewrite finishing) clears.
+                     LOG.warn(
+                        "Security provider configuration file '{}' could not be read " +
+                        "(reported present but its content was unavailable, likely a " +
+                        "concurrent rewrite); retaining existing providers", configFile);
                   }
                   else {
-                     if(failureCount > 0) {
-                        LOG.warn(
-                           "{} of {} security provider(s) failed to load from '{}'; " +
-                           "the remaining providers have been applied but security " +
-                           "configuration may be incomplete",
-                           failureCount, list.size() + failureCount, configFile);
+                     ArrayNode providersArray = (ArrayNode) root.get("providers");
+                     List<T> list = new ArrayList<>();
+                     int failureCount = 0;
+
+                     for(int i = 0; i < providersArray.size(); i++) {
+                        ObjectNode wrapperNode = (ObjectNode) providersArray.get(i);
+                        String name = wrapperNode.get("name").asText();
+                        String providerClass = wrapperNode.get("providerClass").asText();
+                        JsonNode config = wrapperNode.get("configuration");
+
+                        try {
+                           @SuppressWarnings("unchecked")
+                           T provider =
+                              (T) Class.forName(providerClass).getConstructor().newInstance();
+                           provider.readConfiguration(config);
+                           provider.setProviderName(name);
+                           list.add(provider);
+                        }
+                        catch(Exception e) {
+                           failureCount++;
+                           LOG.error(
+                              "Failed to create instance of security provider: {}", providerClass, e);
+                        }
                      }
 
-                     timestamp = dataSpace.getLastModified(null, configFile);
-                     clear();
-                     setProviderList(list);
+                     // If the config file specified providers but ALL of them failed to instantiate,
+                     // retain the existing runtime providers rather than wiping them. This prevents a
+                     // corrupted or temporarily unreadable config (e.g. after a GKE node restart) from
+                     // clearing all security providers and locking out every user.
+                     // Do NOT update timestamp on total failure – allow the next dataChanged() to retry
+                     // when the transient condition clears, without requiring a manual config edit.
+                     if(list.isEmpty() && failureCount > 0) {
+                        LOG.error(
+                           "All {} security provider(s) failed to load from '{}'; retaining " +
+                           "existing providers to prevent loss of security configuration",
+                           failureCount, configFile);
+                     }
+                     else {
+                        if(failureCount > 0) {
+                           LOG.warn(
+                              "{} of {} security provider(s) failed to load from '{}'; " +
+                              "the remaining providers have been applied but security " +
+                              "configuration may be incomplete",
+                              failureCount, list.size() + failureCount, configFile);
+                        }
+
+                        timestamp = dataSpace.getLastModified(null, configFile);
+                        clear();
+                        setProviderList(list);
+                     }
                   }
                }
             }

--- a/core/src/test/java/inetsoft/sree/security/SecurityChainLoadConfigurationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityChainLoadConfigurationTest.java
@@ -94,4 +94,32 @@ class SecurityChainLoadConfigurationTest {
          chain.loadConfiguration();
       }
    }
+
+   // [Scenario: malformed config] the stream is readable but the parsed JSON has no
+   // "providers" array (e.g. an empty object, or a config file damaged some other way).
+   // loadConfiguration() must not throw an uncaught exception out of the constructor,
+   // matching the null-stream race's recovery behavior.
+   @Test
+   void loadConfiguration_configMissingProvidersArray_doesNotThrowAndLeavesChainUsable()
+      throws Exception
+   {
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         when(mockDs.exists(null, "authc-chain.json")).thenReturn(true);
+         when(mockDs.getLastModified(null, "authc-chain.json")).thenReturn(1000L);
+         when(mockDs.getInputStream(null, "authc-chain.json"))
+            .thenReturn(new java.io.ByteArrayInputStream("{}".getBytes()));
+
+         ThrowingSupplier<AuthenticationChain> construct = AuthenticationChain::new;
+         AuthenticationChain chain =
+            assertDoesNotThrow(construct,
+                                "a config with no \"providers\" array must not propagate an " +
+                                "uncaught exception from the constructor");
+
+         assertTrue(chain.getProviderList().isEmpty(),
+                    "no providers were ever successfully loaded, so the list should be empty");
+      }
+   }
 }

--- a/core/src/test/java/inetsoft/sree/security/SecurityChainLoadConfigurationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityChainLoadConfigurationTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.security;
+
+import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug #76431: {@code SecurityChain.loadConfiguration()} assumed {@code DataSpace.exists()}
+ * and {@code DataSpace.getInputStream()} observe a consistent file state, but they are not
+ * atomic -- the config file can be removed/replaced (e.g. by a concurrent rewrite) between
+ * the two calls, in which case {@code getInputStream()} returns {@code null} (per its own
+ * documented {@code FileNotFoundException}/{@code NoSuchFileException} handling) rather than
+ * throwing. Passing that {@code null} straight into Jackson's {@code ObjectMapper.readTree()}
+ * threw {@code IllegalArgumentException: argument "in" is null}, observed as an intermittent
+ * {@code PermissionHierarchyTest.setUp} failure in CI (concurrent Surefire test classes
+ * sharing one {@code DataSpace}-backed config file).
+ */
+@Tag("core")
+class SecurityChainLoadConfigurationTest {
+
+   // [Scenario: TOCTOU race] exists() reports true but getInputStream() returns null --
+   // loadConfiguration() (invoked via the AuthenticationChain constructor's initialize())
+   // must not throw, and must leave the chain with no providers rather than crash the
+   // caller (e.g. a test's `new AuthenticationChain()` during setup, or production
+   // server startup racing a concurrent config rewrite).
+   @Test
+   void loadConfiguration_streamRaceReturnsNull_doesNotThrowAndLeavesChainUsable() throws Exception {
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         when(mockDs.exists(null, "authc-chain.json")).thenReturn(true);
+         when(mockDs.getLastModified(null, "authc-chain.json")).thenReturn(1000L);
+         when(mockDs.getInputStream(null, "authc-chain.json")).thenReturn(null);
+
+         ThrowingSupplier<AuthenticationChain> construct = AuthenticationChain::new;
+         AuthenticationChain chain =
+            assertDoesNotThrow(construct,
+                                "a null stream from a racing getInputStream() must not " +
+                                "propagate as an uncaught exception from the constructor");
+
+         assertTrue(chain.getProviderList().isEmpty(),
+                    "no providers were ever successfully loaded, so the list should be empty " +
+                    "(not populated with garbage, and not thrown away by a crash mid-construction)");
+      }
+   }
+
+   // [Scenario: race clears, retry succeeds] confirms the "don't advance timestamp" recovery
+   // path: after a null-stream race, a later loadConfiguration() call (e.g. triggered by
+   // dataChanged(), simulated here by calling initialize() again) must still pick up the
+   // config once the race clears, proving the chain isn't left permanently stuck believing
+   // it already has fresh data.
+   @Test
+   void loadConfiguration_streamRaceClearsOnRetry_configIsLoadedNextTime() throws Exception {
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         DataSpace mockDs = mock(DataSpace.class);
+         ds.when(DataSpace::getDataSpace).thenReturn(mockDs);
+
+         when(mockDs.exists(null, "authc-chain.json")).thenReturn(true);
+         when(mockDs.getLastModified(null, "authc-chain.json")).thenReturn(1000L);
+         when(mockDs.getInputStream(null, "authc-chain.json")).thenReturn(null);
+
+         ThrowingSupplier<AuthenticationChain> construct = AuthenticationChain::new;
+         AuthenticationChain chain = assertDoesNotThrow(construct);
+
+         String json = "{\"providers\":[]}";
+         when(mockDs.getInputStream(null, "authc-chain.json"))
+            .thenReturn(new java.io.ByteArrayInputStream(json.getBytes()));
+
+         // Not wrapped in assertDoesNotThrow: an uncaught IOException here already fails
+         // this test (the method declares `throws Exception`) with a clear stack trace.
+         chain.loadConfiguration();
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- `SecurityChain.loadConfiguration()` assumed `DataSpace.exists()` and `DataSpace.getInputStream()` observe a consistent file state, but they are not atomic: a concurrent rewrite of the config file between the two calls makes `getInputStream()` return `null` (its documented behavior when the file has gone missing) instead of throwing.
- Passing that `null` straight into Jackson's `ObjectMapper.readTree()` threw `IllegalArgumentException: argument "in" is null`, observed as an intermittent `PermissionHierarchyTest.setUp` failure in CI (concurrent Surefire test classes sharing one `DataSpace`-backed config file).
- Fix: treat a null stream the same as the existing "all providers failed to load" recovery path — log a warning, retain the existing runtime providers, and don't advance `timestamp`, so the next `dataChanged()` retries once the transient condition clears.

## Test plan
- [x] New `SecurityChainLoadConfigurationTest` reproduces the exact race via a mocked `DataSpace` returning `null` from `getInputStream()`; confirmed it fails with the original `IllegalArgumentException: argument "in" is null` against the pre-fix code, and passes against the fix.
- [x] Full `inetsoft.sree.security.**` package regression: 686 tests, 0 failures, 0 errors (13 pre-existing skips), including `PermissionHierarchyTest` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)