### PR TITLE
Bug #76442, fix serverTime getter to use per-node serverDateTimeMap

### DIFF
--- a/web/projects/em/src/app/monitoring/summary/summary-monitoring-page/summary-monitoring-page.component.spec.ts
+++ b/web/projects/em/src/app/monitoring/summary/summary-monitoring-page/summary-monitoring-page.component.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { SummaryMonitoringPageComponent } from "./summary-monitoring-page.component";
+import { ServerModel } from "../summary-monitoring-view/server-model";
+
+describe("SummaryMonitoringPageComponent", () => {
+   let component: SummaryMonitoringPageComponent;
+   let monitoringDataService: { cluster: string };
+
+   beforeEach(() => {
+      monitoringDataService = { cluster: "" };
+
+      component = new SummaryMonitoringPageComponent(
+         null, null, null, monitoringDataService as any, null, null, null, null, null, null);
+
+      component.serverModel = <ServerModel> {
+         serverUpTimeMap: {},
+         serverDateTimeMap: {
+            "node1": "10:00:00 AM",
+            "node2": "3:00:00 PM",
+            "local": "12:00:00 PM"
+         },
+         schedulerUpTimeMap: {},
+         timestamp: Date.now(),
+         isCloud: false,
+         externalStoragePath: ""
+      };
+   });
+
+   it("should read the local server time when clustering is disabled", () => {
+      component.clusterNodes = [];
+
+      expect(component.serverTime).toBe("12:00:00 PM");
+   });
+
+   it("should read the selected node's server time when clustering is enabled", () => {
+      component.clusterNodes = ["node1", "node2"];
+
+      component.selectedClusterNode = "node1";
+      expect(component.serverTime).toBe("10:00:00 AM");
+
+      component.selectedClusterNode = "node2";
+      expect(component.serverTime).toBe("3:00:00 PM");
+   });
+});

--- a/web/projects/em/src/app/monitoring/summary/summary-monitoring-page/summary-monitoring-page.component.ts
+++ b/web/projects/em/src/app/monitoring/summary/summary-monitoring-page/summary-monitoring-page.component.ts
@@ -421,11 +421,14 @@ export class SummaryMonitoringPageComponent implements OnInit, OnDestroy, AfterC
    }
 
    get serverTime(): string {
-      if(this.serverModel && this.serverModel.timestamp) {
-         return new Date(this.serverModel.timestamp).toLocaleString();
+      let serverTime = "";
+
+      if(this.serverModel) {
+         const node = this.clusterEnabled ? this.selectedClusterNode : "local";
+         serverTime = this.serverModel.serverDateTimeMap[node];
       }
 
-      return "";
+      return serverTime;
    }
 
    get schedulerUpTime(): string {


### PR DESCRIPTION
## Summary
- Reverts an accidental regression introduced in the #3763 squash merge: `serverTime` in `summary-monitoring-page.component.ts` had stopped indexing `serverDateTimeMap` by cluster node and instead formatted `serverModel.timestamp` in the browser's local timezone, so switching the selected cluster node had no effect on the displayed server time.
- Restores the pre-#3763 behavior: `serverTime` now reads `serverDateTimeMap[node]` where `node` is the selected cluster node (or `"local"` when clustering is disabled), matching the still-correct `serverUpTime`/`schedulerUpTime` getters in the same file.

## Test plan
- [x] Added `summary-monitoring-page.component.spec.ts` (did not exist before) asserting `serverTime` reads the `"local"` key when clustering is disabled, and switches correctly between per-node values when clustering is enabled.
- [x] Verified the new test fails against the pre-fix getter (temporarily reverted the fix, ran the test, saw both assertions fail with the wrong browser-local-time value) and passes once the fix is restored.
- [x] `npx ng test em --include=".../summary-monitoring-page.component.spec.ts"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)