### PR TITLE
fix(security): stop identity delete from wiping co-granted identities' permissions (#76448)

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/Permission.java
+++ b/core/src/main/java/inetsoft/sree/security/Permission.java
@@ -1134,6 +1134,11 @@ public class Permission implements Serializable, Cloneable, XMLSerializable {
          return false;
       }
 
+      @Override
+      public int hashCode() {
+         return Objects.hash(name, organizationID);
+      }
+
       boolean equalsIgnoreCase(PermissionIdentity other) {
          if(other == null) {
             return false;

--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -2646,9 +2646,15 @@ public class IdentityService {
 
       if(orgScopedGrants != null) {
          // remove identity
-         if(newIdentityID == null && orgScopedGrants.contains(oldIdentityID)) {
+         Permission.PermissionIdentity oldPermissionIdentity =
+            oldIdentityID == null ? null : new Permission.PermissionIdentity(oldIdentityID);
+
+         boolean oldIdentityGranted = oldPermissionIdentity != null &&
+            orgScopedGrants.stream().anyMatch(pid -> pid.equals(oldPermissionIdentity));
+
+         if(newIdentityID == null && oldIdentityGranted) {
             orgScopedGrants.stream()
-               .filter(identityID -> !Tool.equals(identityID, oldIdentityID))
+               .filter(identityID -> !identityID.equals(oldPermissionIdentity))
                .forEach(identityID -> grants.add(identityID));
          }
          // sync id

--- a/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/IdentityServiceTest.java
@@ -20,7 +20,10 @@ package inetsoft.web.admin.security;
 import inetsoft.sree.security.AuthenticationProvider;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.IdentityInfo;
+import inetsoft.sree.security.Organization;
 import inetsoft.sree.security.OrganizationContextHolder;
+import inetsoft.sree.security.Permission;
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.util.Identity;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
@@ -215,5 +218,84 @@ class IdentityServiceTest {
       Method m = IdentityService.class.getDeclaredMethod("removeUserFavorites", Collection.class);
       m.setAccessible(true);
       m.invoke(service, ids);
+   }
+
+   // Bug 76448: deleting one identity (USER/GROUP/ROLE) was wiping every other identity's
+   // grant for the same action, because the delete-case guard compared a plain IdentityID
+   // against a Set<Permission.PermissionIdentity> -- a cross-type comparison that always
+   // returns false, so the "keep everyone but the deleted identity" branch never ran and an
+   // empty grant set was installed instead.
+   @Test
+   void updateIdentityPermission_deleteRole_keepsOtherRoleGrant() throws Exception {
+      IdentityID roleA = new IdentityID("RoleA", "org1");
+      IdentityID roleB = new IdentityID("RoleB", "org1");
+
+      Permission permission = new Permission();
+      permission.setRoleGrants(ResourceAction.READ, new HashSet<>(Set.of(
+         new Permission.PermissionIdentity(roleA), new Permission.PermissionIdentity(roleB))));
+
+      invokeUpdateIdentityPermission(Identity.ROLE, null, roleA, permission, ResourceAction.READ);
+
+      Set<Permission.PermissionIdentity> remaining = permission.getAllRoleGrants(ResourceAction.READ);
+      assertFalse(remaining.contains(new Permission.PermissionIdentity(roleA)),
+                  "deleted role's own grant should be removed");
+      assertTrue(remaining.contains(new Permission.PermissionIdentity(roleB)),
+                 "co-granted role's grant must survive the delete");
+   }
+
+   @Test
+   void updateIdentityPermission_deleteUser_keepsOtherUserGrant() throws Exception {
+      IdentityID alice = new IdentityID("alice", "org1");
+      IdentityID bob = new IdentityID("bob", "org1");
+
+      Permission permission = new Permission();
+      permission.setUserGrants(ResourceAction.READ, new HashSet<>(Set.of(
+         new Permission.PermissionIdentity(alice), new Permission.PermissionIdentity(bob))));
+
+      invokeUpdateIdentityPermission(Identity.USER, null, alice, permission, ResourceAction.READ);
+
+      Set<Permission.PermissionIdentity> remaining = permission.getAllUserGrants(ResourceAction.READ);
+      assertFalse(remaining.contains(new Permission.PermissionIdentity(alice)),
+                  "deleted user's own grant should be removed");
+      assertTrue(remaining.contains(new Permission.PermissionIdentity(bob)),
+                 "co-granted user's grant must survive the delete");
+   }
+
+   @Test
+   void updateIdentityPermission_deleteGroup_keepsOtherGroupGrant() throws Exception {
+      IdentityID groupA = new IdentityID("GroupA", "org1");
+      IdentityID groupB = new IdentityID("GroupB", "org1");
+
+      Permission permission = new Permission();
+      permission.setGroupGrants(ResourceAction.READ, new HashSet<>(Set.of(
+         new Permission.PermissionIdentity(groupA), new Permission.PermissionIdentity(groupB))));
+
+      invokeUpdateIdentityPermission(Identity.GROUP, null, groupA, permission, ResourceAction.READ);
+
+      Set<Permission.PermissionIdentity> remaining = permission.getAllGroupGrants(ResourceAction.READ);
+      assertFalse(remaining.contains(new Permission.PermissionIdentity(groupA)),
+                  "deleted group's own grant should be removed");
+      assertTrue(remaining.contains(new Permission.PermissionIdentity(groupB)),
+                 "co-granted group's grant must survive the delete");
+   }
+
+   @Test
+   void permissionIdentity_hashCode_matchesEqualsContract() {
+      Permission.PermissionIdentity a = new Permission.PermissionIdentity("RoleA", "org1");
+      Permission.PermissionIdentity b = new Permission.PermissionIdentity("RoleA", "org1");
+
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+      assertTrue(new HashSet<>(Set.of(a)).contains(b),
+                 "field-equal PermissionIdentity instances must collide in a HashSet");
+   }
+
+   private void invokeUpdateIdentityPermission(int type, IdentityID newIdentityID, IdentityID oldIdentityID,
+                                                Permission permission, ResourceAction action) throws Exception {
+      Method m = IdentityService.class.getDeclaredMethod("updateIdentityPermission", int.class,
+         IdentityID.class, IdentityID.class, Organization.class, String.class, Permission.class,
+         ResourceAction.class);
+      m.setAccessible(true);
+      m.invoke(service, type, newIdentityID, oldIdentityID, null, null, permission, action);
    }
 }


### PR DESCRIPTION
## Summary

Redmine #76448: deleting a USER, GROUP, or ROLE silently wiped every other identity's permission grants for the same resource+action, not just the deleted identity's own grant.

**Root cause (two independently-active bugs in `IdentityService.updateIdentityPermission`, `core/src/main/java/inetsoft/web/admin/security/IdentityService.java:2646-2653`):**

1. The delete-case guard compared a plain `IdentityID` against a `Set<Permission.PermissionIdentity>` via `Set.contains()` — a cross-type comparison whose `equals()` always returns `false` for both classes (each rejects any argument that isn't its own type), so the guard never fired. Because `Permission.setGrants()` unconditionally *replaces* the grant set for the action (not a merge/diff), the "keep everyone but the deleted identity" branch never running left an empty set to be installed — wiping every grantee of that identity type for that resource+action.
2. The `.filter()` line immediately below the guard had the identical cross-type bug (`Tool.equals()` falls through to `PermissionIdentity.equals(IdentityID)` for this argument shape), masked as dead code by bug 1 always short-circuiting first. Fixing only the guard while leaving this predicate as-is would have "fixed" the wipe but then removed nothing from the surviving set — silently keeping the deleted identity's own stale grant.

**Fix:** wrap `oldIdentityID` in a `Permission.PermissionIdentity` before comparing, and replace both the `Set.contains()` guard and the `.filter()` predicate with a same-type `equals()` comparison (linear `anyMatch()`/`equals()` scan rather than relying on `Set.contains()`'s hash-bucket dispatch). Also added the missing `Permission.PermissionIdentity.hashCode()` override (`Objects.hash(name, organizationID)`) — independently required regardless of the above, since `PermissionIdentity` instances live inside `HashSet<PermissionIdentity>` fields throughout `Permission.java`, and the missing override breaks same-type `Set.contains()`/`HashSet` dedup wherever it's used, not just this one call site.

## Test plan

- [x] Added `IdentityServiceTest` coverage: `updateIdentityPermission_deleteRole_keepsOtherRoleGrant`, `..._deleteUser_...`, `..._deleteGroup_...` — each reflectively invokes the private `updateIdentityPermission` method against a real `Permission` instance seeded with two co-granted identities, deletes one, and asserts the other survives. No Spring/`AuthorizationProvider` wiring needed since the method is a pure function of its parameters.
- [x] Added `permissionIdentity_hashCode_matchesEqualsContract` — standard equals/hashCode contract test plus a `HashSet.contains()` check.
- [x] **Mutation-tested the regression tests**: reverted just the `IdentityService.java` fix (keeping the `hashCode()` addition) and re-ran — all three delete-one-keeps-other tests failed as expected (`expected: <true> but was: <false>`, co-granted grant wiped), confirming they actually catch the bug rather than passing vacuously. Restored the fix and re-ran — all 13 tests in the class pass.
- [x] Ran the wider affected suite (`FileAuthorizationProviderTest`, `PermissionCheckerTest`, `PermissionIdentityTest`, `PermissionTest`, `RecycleBinOrgLifecycleTest`) — 96 tests, 0 failures, 1 pre-existing skip.
- [x] Full `community/core` module test run in progress as a broader regression check.

Follow-up: `stylebi-enterprise`'s outer submodule pointer needs to bump to include this commit — tracked as a separate companion PR per this batch's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)