### PR TITLE
test(vsfilt-009): real-execution coverage for numeric TimeSlider min/max range

### DIFF
--- a/core/src/test/java/inetsoft/report/composition/execution/TimeSliderVSAQueryNumericRangeTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/TimeSliderVSAQueryNumericRangeTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.IntegrationTestConfiguration;
+import inetsoft.test.SreeHome;
+import inetsoft.test.SwapperTestConfiguration;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.asset.AbstractSheet;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.EmbeddedTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.uql.viewsheet.SingleTimeInfo;
+import inetsoft.uql.viewsheet.TimeInfo;
+import inetsoft.uql.viewsheet.TimeSliderVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * VSFILT-009 part 2: a real (non-mocked) execution of {@link TimeSliderVSAQuery#getData()} for
+ * a {@code TimeSliderVSAssembly} bound to a numeric measure column via {@code SingleTimeInfo}
+ * with {@code TimeInfo.NUMBER} -- exactly the shape {@code WizVsService.bindColumn} produces
+ * (see {@code WizVsService.java:848-870}) and, per case-vsfilt-009's diagnosis docs, the one
+ * combination with zero real-execution test coverage anywhere in the repo. Mirrors
+ * {@link CrosstabNamedGroupEndToEndTest}'s from-scratch worksheet/sandbox wiring, and adds the
+ * "S_"+table selection-mirror table that every {@code AbstractSelectionVSAssembly} query
+ * requires (normally built by {@code Viewsheet.createSelectionTables()}, which needs a live
+ * {@code AssetRepository} this from-scratch test doesn't have).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, IntegrationTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class TimeSliderVSAQueryNumericRangeTest {
+   @Test
+   void numericTimeSliderResolvesRealMinMaxRange() throws Exception {
+      Worksheet ws = new Worksheet();
+      Object[][] rows = new Object[][] {
+         { "DISCOUNT" },
+         { 0.00 }, { 0.05 }, { 0.10 }, { 0.15 }, { 0.20 },
+      };
+
+      buildEmbeddedTable(ws, "Query1", rows, true);
+      // the "S_"+table selection-mirror table every AbstractSelectionVSAssembly query is bound
+      // against -- normally created by Viewsheet.createSelectionTables()/resetWS()
+      buildEmbeddedTable(ws, "S_Query1", rows, false);
+
+      Viewsheet vs = new Viewsheet();
+      TimeSliderVSAssembly slider = new TimeSliderVSAssembly(vs, "RangeSlider1");
+      slider.setTableName("Query1");
+
+      ColumnRef discountRef = new ColumnRef(new AttributeRef("DISCOUNT"));
+      discountRef.setDataType(XSchema.DOUBLE);
+      SingleTimeInfo tinfo = new SingleTimeInfo();
+      tinfo.setDataRef(discountRef);
+      tinfo.setRangeTypeValue(TimeInfo.NUMBER);
+      slider.setTimeInfo(tinfo);
+      vs.addAssembly(slider);
+
+      Method setBaseWorksheet = Viewsheet.class.getDeclaredMethod("setBaseWorksheet", Worksheet.class);
+      setBaseWorksheet.setAccessible(true);
+      setBaseWorksheet.invoke(vs, ws);
+
+      ViewsheetSandbox box = new ViewsheetSandbox(vs, AbstractSheet.SHEET_RUNTIME_MODE, null, false, null);
+      AssetQuerySandbox wbox = new AssetQuerySandbox(ws, null, new VariableTable());
+      Field wboxField = ViewsheetSandbox.class.getDeclaredField("wbox");
+      wboxField.setAccessible(true);
+      wboxField.set(box, wbox);
+
+      Object data = new TimeSliderVSAQuery(box, "RangeSlider1").getData();
+
+      assertNotNull(data, "getData() must resolve a real min/max range for a populated " +
+         "numeric column, not silently return null");
+      Object[] range = (Object[]) data;
+      assertEquals(0.00, ((Number) range[0]).doubleValue(), 0.0001, "min");
+      assertEquals(0.20, ((Number) range[1]).doubleValue(), 0.0001, "max");
+   }
+
+   private static void buildEmbeddedTable(
+      Worksheet ws, String name, Object[][] rows, boolean visible)
+   {
+      EmbeddedTableAssembly table = new EmbeddedTableAssembly(ws, name);
+      ColumnSelection cs = new ColumnSelection();
+      ColumnRef discountCol = new ColumnRef(new AttributeRef("DISCOUNT"));
+      discountCol.setDataType(XSchema.DOUBLE);
+      cs.addAttribute(discountCol);
+      table.setColumnSelection(cs, false);
+      table.setEmbeddedData(new XEmbeddedTable(new String[]{ "double" }, rows));
+      table.setVisible(visible);
+      ws.addAssembly(table);
+   }
+}


### PR DESCRIPTION
## Summary
- Adds `TimeSliderVSAQueryNumericRangeTest`, a real (non-mocked) from-scratch worksheet/sandbox test for `TimeSliderVSAQuery.getData()` against a `TimeSliderVSAssembly` bound to a numeric measure column via `SingleTimeInfo`/`TimeInfo.NUMBER` — exactly the shape `WizVsService.bindColumn` produces. This combination had zero real-execution test coverage anywhere in the repo (see VSFILT-009 diagnosis docs).
- The test required wiring in `IntegrationTestConfiguration` (for the `MVManager` bean `ViewsheetSandbox.getBoundTable` needs) — this was a test Spring-context gap, not a source bug.
- **Result: the test passes.** `TimeSliderVSAQuery`'s NUMBER-range query logic correctly resolves the real min (0.00) / max (0.20) from 5 embedded rows. No source change was needed or made.

## Why this closes off (not confirms) the leading hypothesis
Two prior diagnosis passes (source-reading only, no live tool access) suspected a bug in one of three `TimeSliderVSAQuery.getData()`/`getTableAssembly()` early-outs. This real-execution test — mirroring the exact binding shape wiz produces — exercises all three candidate lines and passes cleanly, so the core query-engine logic itself is not the defect. Combined with a live MCP repro (see the case doc) that also succeeded in creating the control, the remaining VSFILT-009 numeric-range symptom (`undefined _#(to) undefined` labels observed in the browser, described separately from this PR's scope) most likely lives in the saved-and-reopened runtime path or portal rendering, not in this query logic — see `docs/teams/2026-09-02-test-visualizations-boards/case-vsfilt-009-timeslider-range/03-fix-part2-range.md` in the wiz-services repo for the full writeup and recommended next step (a live-attached-debugger session against the saved-and-reopened case).

## Test plan
- [x] `TimeSliderVSAQueryNumericRangeTest` passes
- [x] Regression sweep green: `WizVsService*Test`, `WizFilterLayoutTest`, `WizFilterOperationTest`, `WizVisualizationServiceTest` (all existing tests, no changes)