### PR TITLE
Bug #75834, pin the docker image tag in the packaged release examples

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -128,7 +128,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package community examples
-        run: (cd community-examples && zip -r ../community-examples.zip .)
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          sed -i "s|stylebi-community:latest|stylebi-community:${version}|" community-examples/docker-compose.yaml community-examples/.env
+          (cd community-examples && zip -r ../community-examples.zip .)
 
       - name: Create GitHub release
         run: >


### PR DESCRIPTION
## Summary

`community-examples.zip`, attached to every GitHub release, is zipped straight from the working tree — so `docker-compose.yaml` and `.env` inside it always reference the `latest` Docker image tag instead of the tag for the release the user actually downloaded. Since this zip is the standalone artifact people download from the Releases page and run with `docker compose up -d` (no build step), a past release's zip permanently points at `latest`, which drifts to whatever the newest image is once future releases ship.

## Root Cause

The "Package community examples" step in `.github/workflows/publish-release.yml` zips `community-examples/` verbatim, with no substitution of the image tag.

## Fix

Before zipping, substitute the actual release version (from the pushed tag) into the packaged copy of `docker-compose.yaml` and `.env`, leaving the committed source files (used when cloning the repo) referencing `latest` as before.

## Test Plan

- Simulated the `sed` substitution against copies of the real `community-examples/docker-compose.yaml` and `.env` for both a standard release tag (`v1.1.0`) and a prerelease tag (`v1.1.0-beta-1`) — confirmed the image tag is pinned correctly in all 4 target lines, while the unrelated `busybox:latest` image and the commented-out nightly-build line in `.env` are left untouched.
- Validated the modified workflow YAML parses correctly.
- Verified the resulting version matches the Docker tag actually pushed by `docker/pom.xml`'s jib config for the same release tag.

Fixes Redmine #75834.