### PR TITLE
Bug #76392, cache date-level-examples requests to stop duplicate popup-triggered POSTs

### DIFF
--- a/web/projects/portal/src/app/common/services/date-level-examples.service.ts
+++ b/web/projects/portal/src/app/common/services/date-level-examples.service.ts
@@ -18,6 +18,7 @@
 import { Injectable } from "@angular/core";
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Observable } from "rxjs";
+import { shareReplay, tap } from "rxjs/operators";
 
 export const DATE_LEVEL_EXAMPLES_URI = "../api/date-level-examples";
 
@@ -25,12 +26,30 @@ export const DATE_LEVEL_EXAMPLES_URI = "../api/date-level-examples";
    providedIn: "root"
 })
 export class DateLevelExamplesService {
+   // Cached by (dataType, dateLevels) since the result is a pure function of those inputs.
+   // Prevents duplicate/uncancelled requests piling up when a component re-issues the same
+   // request every time it is (re)created, e.g. on every dropdown/dialog open.
+   private readonly cache = new Map<string, Observable<Object>>();
+
    constructor(private http: HttpClient) {
    }
 
    loadDateLevelExamples(dateLevels: string[], dataType: string): Observable<Object> {
-      let params = new HttpParams().set("dataType", dataType);
-      return this.http.post(DATE_LEVEL_EXAMPLES_URI, dateLevels, {params});
+      const key = dataType + ":" + dateLevels.join(",");
+      let cached = this.cache.get(key);
+
+      if(!cached) {
+         let params = new HttpParams().set("dataType", dataType);
+         cached = this.http.post(DATE_LEVEL_EXAMPLES_URI, dateLevels, {params})
+            .pipe(
+               // don't let a transient failure be cached forever; allow retry on next call
+               tap({ error: () => this.cache.delete(key) }),
+               shareReplay(1)
+            );
+         this.cache.set(key, cached);
+      }
+
+      return cached;
    }
 }
 


### PR DESCRIPTION
## Summary

Opening/closing a chart binding editor "Dimension Editor" popup (and 7 other similar dialog/dropdown components) repeatedly fires duplicate, uncancelled `POST ../api/date-level-examples` requests, because `DateLevelExamplesService.loadDateLevelExamples()` is called unconditionally from `ngOnInit()` at every call site, and those components are recreated fresh on every popup/dialog open. On viewsheets bound to very large datasets, this adds needless pressure to the browser's small per-origin HTTP connection pool, which is already strained by concurrently-loading, genuinely slow chart-tile and table-data requests — worsening the perceived UI freeze reported in the issue.

## Root Cause

- `DimensionEditor.ngOnInit()` (and 7 other components: `GroupOptionComponent`, `CalcGroupOptionComponent`, `HierarchyEditorComponent`, `DateRangeOptionDialogComponent`, `CrosstabPaneComponent`, `AggregatePaneComponent`, `WizardGroupItemComponent`) call `DateLevelExamplesService.loadDateLevelExamples()` unconditionally on every instantiation, with no caching or in-flight dedup.
- The chart binding editor's `DimensionEditor` popup, hosted via `[fixedDropdown]` (`FixedDropdownDirective.toggleDropdown()`), gets a brand-new component instance on every open, so each open/close cycle queues another duplicate request.
- The backend endpoint (`DateLevelExamplesController.getDateLevelExamples()`) is confirmed to be a pure, stateless, microsecond-scale computation depending only on `(dateLevel, dataType)` — it does not touch the bound table, session, or any lock, so it isn't itself a source of a sustained hang, but every duplicate in-flight request still occupies one of the browser's few available connections while queued.

## Fix

Added a permanent, keyed cache to `DateLevelExamplesService.loadDateLevelExamples()` (`shareReplay(1)`, keyed by `dataType:dateLevels`, evicted on error so a transient failure can still be retried). Concurrent or later calls with the same inputs share the already-resolved (or in-flight) result instead of firing a new HTTP request, eliminating the duplicate-request pile-up at all 8 call sites for the life of the page session.

## Test Plan

- [x] Code review (code-reviewer subagent): no findings.
- [x] `npm run build` — all bundles (elements, viewer-element, em, portal) built cleanly.
- [x] Unit tests: `dimension-editor.spec.ts` (7), `hierarchy-property-pane.spec.ts` (1), `aggregate-pane.spec.ts` (2), `calc-group-option.component.spec.ts` (11) — all passing.
- [x] Testing-library (real HTTP interception) tests: `dimension-editor.component.tl.spec.ts` (21), `chart-fieldmc.component.interaction.tl.spec.ts` (19), `chart-fieldmc.component.display.tl.spec.ts` (43) — all passing.
- [x] Manually confirmed (via issue reporter) that the fix resolves the reported behavior.

Fixes Redmine #76392.