### PR TITLE
Bug #75780, size input labels from the label font on export

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/AbstractVSExporter.java
@@ -3888,8 +3888,9 @@ public abstract class AbstractVSExporter implements VSExporter {
    }
 
    /**
-    * Get the font to use for rendering an input label. The default size 11
-    * matches LabelInfo.getRenderedHeight() so drawing and measurement agree.
+    * Get the font to use for rendering an input label. This is the single font
+    * source for both drawing and measurement (getLabelDimensions), and matches
+    * the fallback used by LabelInfo.getRenderedHeight().
     */
    protected static Font getLabelFont(LabelInfo labelInfo) {
       VSCompositeFormat fmt = labelInfo.getLabelFormat();
@@ -3954,7 +3955,7 @@ public abstract class AbstractVSExporter implements VSExporter {
          // Center the label text vertically relative to the widget height,
          // matching the Angular preview which uses flexbox vertical centering.
          labelBounds = new Rectangle2D.Double(x + fullW - labelW,
-            y + Math.max(0, (fullH - labelH) / 2.0), labelW, labelH);
+            y + (fullH - labelH) / 2.0, labelW, labelH);
          widgetBounds = new Rectangle2D.Double(x, y,
             Math.max(0, fullW - labelW - gap), fullH);
          break;
@@ -3962,7 +3963,7 @@ public abstract class AbstractVSExporter implements VSExporter {
       default:
          // Center the label text vertically relative to the widget height,
          // matching the Angular preview which uses flexbox vertical centering.
-         labelBounds = new Rectangle2D.Double(x, y + Math.max(0, (fullH - labelH) / 2.0),
+         labelBounds = new Rectangle2D.Double(x, y + (fullH - labelH) / 2.0,
             labelW, labelH);
          widgetBounds = new Rectangle2D.Double(x + labelW + gap, y,
             Math.max(0, fullW - labelW - gap), fullH);
@@ -4064,6 +4065,15 @@ public abstract class AbstractVSExporter implements VSExporter {
 
          maxW = Math.max(maxW, (int) Math.ceil(expanded.getMaxX()));
          maxH = Math.max(maxH, (int) Math.ceil(expanded.getMaxY()));
+
+         // A LEFT/RIGHT label taller than the widget row is centered on it and so overhangs
+         // the assembly (splitInputBounds), and those positions are not covered by
+         // expandBoundsForLabel. Include the label box itself so the page is not cut through
+         // it. An overhang above/left of the origin cannot be represented here -- the page
+         // has no room to grow in that direction -- so only the far edges are extended.
+         Rectangle2D labelBounds = splitInputBounds(expanded, labelInfo)[0];
+         maxW = Math.max(maxW, (int) Math.ceil(labelBounds.getMaxX()));
+         maxH = Math.max(maxH, (int) Math.ceil(labelBounds.getMaxY()));
       }
 
       return new Dimension(maxW, maxH);
@@ -4099,12 +4109,23 @@ public abstract class AbstractVSExporter implements VSExporter {
 
    /**
     * Get [width, height] for the label, matching VsToReportConverter.addInputLabel().
+    * The height is derived from the label font (not a fixed grid row height) so the
+    * space reserved for the label tracks the font size, the way the browser does with
+    * line-height on .vs-input-label.
     */
    private static int[] getLabelDimensions(LabelInfo labelInfo) {
       Font font = getLabelFont(labelInfo);
       int labelW = (int) Common.stringWidth(labelInfo.getLabelText(), font) + 6;
-      int labelH = AssetUtil.defh;
+      int labelH = getLabelHeight(font);
       return new int[] { labelW, labelH };
+   }
+
+   /**
+    * Get the rendered height of a label drawn with the given font. Matches
+    * LabelInfo.getRenderedHeight(), which is used by the layout code.
+    */
+   protected static int getLabelHeight(Font font) {
+      return (int) Math.ceil(Common.getHeight(font));
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
@@ -24,12 +24,12 @@ import inetsoft.report.composition.VSTableLens;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.gui.viewsheet.VSGroupContainer;
 import inetsoft.report.gui.viewsheet.VSImage;
-import inetsoft.report.internal.Common;
 import inetsoft.report.internal.table.TableFormat;
 import inetsoft.report.io.viewsheet.AbstractVSExporter;
 import inetsoft.report.io.viewsheet.ExportUtil;
 import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
 import inetsoft.util.*;
@@ -148,11 +148,12 @@ public class HTMLVSExporter extends AbstractVSExporter {
       // so we don't need to materialize a default font (PDF/SVG do, since
       // PDFPrinter.setFont(null) silently keeps a stale printer font). Passing the raw
       // labelFormat lets CSS inherit when no font is set, keeping the label close to
-      // the viewer's rendering (Roboto at the inherited size).
+      // the viewer's rendering (Roboto at the inherited size). splitInputBounds() already
+      // sizes the label box from the label font, so a label that has one needs no further
+      // vertical compensation; one that does not still needs the fallback below.
       VSCompositeFormat labelFormat = labelInfo.getLabelFormat();
-      Rectangle2D labelBounds = adjustLabelBoundsForFont(
-         bounds[0], labelFormat, labelInfo.getLabelPosition());
-      helper.writeText(writer, labelBounds,
+      helper.writeText(writer, adjustLabelBoundsForInheritedFont(bounds[0], labelFormat,
+                                                                labelInfo.getLabelPosition()),
          labelFormat != null ? labelFormat : new VSCompositeFormat(),
          labelInfo.getLabelText(), null, false, null, false, info.getZIndex());
 
@@ -160,35 +161,38 @@ public class HTMLVSExporter extends AbstractVSExporter {
    }
 
    /**
-    * Expand bounds vertically to fit the font (otherwise overflow:hidden clips it)
-    * and shift away from the widget to preserve the label-widget gap.
+    * Keep the label box at least the default row height when the label has no font of its
+    * own. writeText() emits the box height with overflow:hidden, but with no font in the
+    * format it emits no font-size either, so the browser renders the label in its inherited
+    * font -- a size this exporter cannot measure. splitInputBounds() sized the box from the
+    * AWT fallback font instead, which is shorter than the inherited text tends to be, and
+    * the text would then be clipped.
     */
-   private static Rectangle2D adjustLabelBoundsForFont(Rectangle2D labelBounds,
+   private static Rectangle2D adjustLabelBoundsForInheritedFont(Rectangle2D labelBounds,
       VSCompositeFormat labelFormat, String position)
    {
-      if(labelFormat == null || labelFormat.getFont() == null) {
+      if(labelFormat != null && labelFormat.getFont() != null) {
          return labelBounds;
       }
 
-      double fontHeight = Common.getHeight(labelFormat.getFont());
+      double extra = AssetUtil.defh - labelBounds.getHeight();
 
-      if(fontHeight <= labelBounds.getHeight()) {
+      if(extra <= 0) {
          return labelBounds;
       }
 
-      double extra = fontHeight - labelBounds.getHeight();
-      double newY = labelBounds.getY();
+      double y = labelBounds.getY();
 
       if(LabelInfo.LEFT.equals(position) || LabelInfo.RIGHT.equals(position)) {
-         newY -= extra / 2.0;  // recenter on widget
+         y -= extra / 2.0;  // stay centered on the widget
       }
       else if(LabelInfo.TOP.equals(position)) {
-         newY -= extra;  // grow upward; bottom anchored
+         y -= extra;  // grow upward; the widget is anchored below
       }
-      // BOTTOM: grow downward; top anchored
+      // BOTTOM: grow downward, away from the widget
 
-      return new Rectangle2D.Double(
-         labelBounds.getX(), newY, labelBounds.getWidth(), fontHeight);
+      return new Rectangle2D.Double(labelBounds.getX(), y, labelBounds.getWidth(),
+                                    AssetUtil.defh);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VsToReportConverter.java
@@ -1863,7 +1863,6 @@ public class VsToReportConverter {
       }
 
       String position = labelInfo.getLabelPosition();
-      int labelH = Math.round(AssetUtil.defh * scalefont);
 
       DefaultTextLens textlens = new DefaultTextLens(labelText);
       TextBoxElementDef textbox = new TextBoxElementDef(report, textlens);
@@ -1881,6 +1880,13 @@ public class VsToReportConverter {
       }
 
       int labelW = (int) Common.stringWidth(labelText, fn) + 6;
+      // Derive the label height from the label font (not a fixed grid row height) so the
+      // space reserved for the label tracks the font size, matching the browser preview and
+      // AbstractVSExporter.getLabelDimensions(). Not scaled by scalefont: applyScaleFont()
+      // only reaches formats in FormatInfo, and LabelInfo carries its own standalone format,
+      // so fn is the unscaled font the label is actually drawn with -- the same font labelW
+      // above is measured with.
+      int labelH = (int) Math.ceil(Common.getHeight(fn));
 
       Rectangle labelBounds;
       Rectangle contentBounds;

--- a/core/src/test/java/inetsoft/report/io/viewsheet/AbstractVSExporterLabelTest.java
+++ b/core/src/test/java/inetsoft/report/io/viewsheet/AbstractVSExporterLabelTest.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet;
+
+import inetsoft.report.internal.Common;
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.VSCompositeFormat;
+import inetsoft.uql.viewsheet.internal.LabelInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that the input-label geometry shared by every export format is derived
+ * from the label font rather than a fixed grid row height, so exports match the
+ * browser preview (Bug: label differs between preview and export).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AbstractVSExporterLabelTest {
+   private static final Font BIG_FONT = new Font("Dialog", Font.PLAIN, 24);
+   private static final double WIDGET_W = 100;
+   private static final double WIDGET_H = 20;
+
+   private static LabelInfo labelInfo(String position, int gap, Font font) {
+      LabelInfo info = new LabelInfo("label");
+      info.setLabelPositionValue(position);
+      info.setLabelGapValue(gap);
+
+      if(font != null) {
+         VSCompositeFormat fmt = new VSCompositeFormat();
+         fmt.getUserDefinedFormat().setFont(font);
+         info.setLabelFormat(fmt);
+      }
+
+      return info;
+   }
+
+   private static Rectangle2D widgetBounds() {
+      return new Rectangle2D.Double(0, 0, WIDGET_W, WIDGET_H);
+   }
+
+   private static double expectedLabelHeight(Font font) {
+      return Math.ceil(Common.getHeight(font));
+   }
+
+   @Test
+   void labelHeightFollowsFontNotDefaultRowHeight() {
+      LabelInfo info = labelInfo(LabelInfo.LEFT, 5, BIG_FONT);
+      Rectangle2D[] split = AbstractVSExporter.splitInputBounds(widgetBounds(), info);
+      double expected = expectedLabelHeight(BIG_FONT);
+
+      assertEquals(expected, split[0].getHeight(), 0.001,
+         "label box height should be the rendered height of the 24pt font");
+      assertTrue(expected > WIDGET_H,
+         "sanity: a 24pt label must be taller than the 20px widget row");
+   }
+
+   @Test
+   void leftLabelIsCenteredOnWidgetAndOverhangsWhenTaller() {
+      LabelInfo info = labelInfo(LabelInfo.LEFT, 5, BIG_FONT);
+      Rectangle2D[] split = AbstractVSExporter.splitInputBounds(widgetBounds(), info);
+      Rectangle2D label = split[0];
+      Rectangle2D widget = split[1];
+
+      // matches the browser's align-items:center — the taller label overhangs the row
+      assertEquals((WIDGET_H - label.getHeight()) / 2.0, label.getY(), 0.001,
+         "label should stay centered on the widget row, overhanging symmetrically");
+      assertTrue(label.getY() < 0, "a 24pt label must overhang a 20px row");
+
+      assertEquals(0.0, label.getX(), 0.001);
+      assertEquals(label.getWidth() + info.getLabelGap(), widget.getX(), 0.001,
+         "widget should start after the label plus the gap");
+      assertEquals(WIDGET_W - label.getWidth() - info.getLabelGap(), widget.getWidth(), 0.001);
+      assertEquals(WIDGET_H, widget.getHeight(), 0.001, "widget keeps the full row height");
+   }
+
+   @Test
+   void rightLabelMirrorsLeft() {
+      LabelInfo info = labelInfo(LabelInfo.RIGHT, 5, BIG_FONT);
+      Rectangle2D[] split = AbstractVSExporter.splitInputBounds(widgetBounds(), info);
+      Rectangle2D label = split[0];
+      Rectangle2D widget = split[1];
+
+      assertEquals(WIDGET_W - label.getWidth(), label.getX(), 0.001);
+      assertEquals(0.0, widget.getX(), 0.001);
+      assertEquals(WIDGET_W - label.getWidth() - info.getLabelGap(), widget.getWidth(), 0.001);
+   }
+
+   @Test
+   void topLabelExpandsBoundsByFontHeightAndGap() {
+      LabelInfo info = labelInfo(LabelInfo.TOP, 5, BIG_FONT);
+      double labelH = expectedLabelHeight(BIG_FONT);
+      Rectangle2D full = AbstractVSExporter.expandBoundsForLabel(widgetBounds(), info);
+
+      assertEquals(WIDGET_H + labelH + 5, full.getHeight(), 0.001,
+         "expanded height should reserve the font height plus the gap");
+
+      Rectangle2D[] split = AbstractVSExporter.splitInputBounds(full, info);
+      assertEquals(0.0, split[0].getY(), 0.001, "label sits at the top");
+      assertEquals(labelH, split[0].getHeight(), 0.001);
+      assertEquals(labelH + 5, split[1].getY(), 0.001);
+      assertEquals(WIDGET_H, split[1].getHeight(), 0.001,
+         "widget keeps its original height when the bounds are expanded");
+   }
+
+   @Test
+   void bottomLabelExpandsBoundsByFontHeightAndGap() {
+      LabelInfo info = labelInfo(LabelInfo.BOTTOM, 0, BIG_FONT);
+      double labelH = expectedLabelHeight(BIG_FONT);
+      Rectangle2D full = AbstractVSExporter.expandBoundsForLabel(widgetBounds(), info);
+
+      assertEquals(WIDGET_H + labelH, full.getHeight(), 0.001);
+
+      Rectangle2D[] split = AbstractVSExporter.splitInputBounds(full, info);
+      assertEquals(full.getHeight() - labelH, split[0].getY(), 0.001, "label sits at the bottom");
+      assertEquals(0.0, split[1].getY(), 0.001);
+      assertEquals(WIDGET_H, split[1].getHeight(), 0.001);
+   }
+
+   @Test
+   void leftAndRightLabelsDoNotExpandBounds() {
+      for(String pos : new String[]{ LabelInfo.LEFT, LabelInfo.RIGHT }) {
+         Rectangle2D full =
+            AbstractVSExporter.expandBoundsForLabel(widgetBounds(), labelInfo(pos, 5, BIG_FONT));
+         assertEquals(WIDGET_H, full.getHeight(), 0.001,
+            pos + " label should shrink within the existing bounds, like flex-shrink");
+      }
+   }
+
+   /**
+    * adjustSizeForInputLabels() has to widen/heighten the page by the label box, not just
+    * by expandBoundsForLabel(), because a LEFT/RIGHT label taller than the widget row
+    * sticks out past the assembly on both sides.
+    */
+   @Test
+   void tallSideLabelOverhangsTheAssemblyBounds() {
+      Rectangle2D bounds = widgetBounds();
+      LabelInfo info = labelInfo(LabelInfo.LEFT, 5, BIG_FONT);
+
+      assertEquals(bounds, AbstractVSExporter.expandBoundsForLabel(bounds, info),
+         "expandBoundsForLabel leaves LEFT/RIGHT alone, so it cannot report the overhang");
+
+      Rectangle2D label = AbstractVSExporter.splitInputBounds(bounds, info)[0];
+
+      assertTrue(label.getMaxY() > bounds.getMaxY(),
+         "label box must be reported as extending below the assembly");
+      assertTrue(label.getY() < bounds.getY(),
+         "label box must be reported as extending above the assembly");
+   }
+
+   @Test
+   void defaultFontStillProducesUsableLabelBox() {
+      // no label format at all — falls back to the default PLAIN 11 font
+      LabelInfo info = labelInfo(LabelInfo.LEFT, 5, null);
+      Rectangle2D[] split = AbstractVSExporter.splitInputBounds(widgetBounds(), info);
+
+      assertTrue(split[0].getHeight() > 0, "default-font label must have a positive height");
+      assertTrue(split[0].getHeight() <= WIDGET_H,
+         "an 11pt label should fit within the 20px row");
+      assertTrue(split[0].getWidth() > 0);
+      assertTrue(split[1].getWidth() > 0, "widget must retain some width");
+   }
+}

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -752,7 +752,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       }
 
       try {
-         Rectangle2D[] split = splitInputPixelBounds(info, viewsheet);
+         Rectangle2D[] split = splitInputBoundsForExcel(info);
 
          if(split == null) {
             writePicture(getImage(assembly), getAnchorPosition(info));
@@ -780,29 +780,133 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
    }
 
    /**
+    * Split an input assembly into [labelBounds, widgetBounds], pushing the widget over
+    * by the amount Excel draws a LEFT label wider than the shared geometry reserved.
+    *
+    * <p>The shared split measures the label in pixels, matching the browser, but
+    * translateFontStyle() writes the font to the workbook in points
+    * (VSFontHelper.getFontSize(), a ~0.85 px-to-pt rate) and Excel lays those points out
+    * at 96 dpi, so a 24px label is written as 20pt and drawn at ~26.7px. With word wrap
+    * off that surplus overflows to the right of the text box, which for a LEFT label runs
+    * into the widget when the label gap is small. RIGHT/TOP/BOTTOM labels overflow away
+    * from the widget, so they are left where the shared geometry placed them.
+    */
+   private Rectangle2D[] splitInputBoundsForExcel(VSAssemblyInfo info) {
+      Rectangle2D[] split = splitInputPixelBounds(info, viewsheet);
+
+      if(split == null) {
+         return null;
+      }
+
+      LabelInfo labelInfo = ((InputVSAssemblyInfo) info).getLabelInfo();
+
+      if(!LabelInfo.LEFT.equals(labelInfo.getLabelPosition())) {
+         return split;
+      }
+
+      double extra = getExcelLabelWidthSlack(labelInfo);
+
+      if(extra <= 0) {
+         return split;
+      }
+
+      Rectangle2D label = split[0];
+      Rectangle2D widget = split[1];
+
+      return new Rectangle2D[] {
+         new Rectangle2D.Double(label.getX(), label.getY(),
+                                label.getWidth() + extra, label.getHeight()),
+         new Rectangle2D.Double(widget.getX() + extra, widget.getY(),
+                                Math.max(0, widget.getWidth() - extra), widget.getHeight())
+      };
+   }
+
+   /**
+    * Get how much wider Excel draws the label than the pixel-based measurement used by
+    * the shared split, i.e. the width the label needs beyond what was reserved for it.
+    */
+   static double getExcelLabelWidthSlack(LabelInfo labelInfo) {
+      java.awt.Font font = getLabelFont(labelInfo);
+      double scale = getExcelFontScale(font);
+
+      if(scale <= 1) {
+         return 0;
+      }
+
+      // scale the measured width rather than re-measuring with a derived font: deriveFont()
+      // would drop the StyleFont subclass that Common.stringWidth() applies adjustments for.
+      return Math.ceil(Common.stringWidth(labelInfo.getLabelText(), font) * (scale - 1));
+   }
+
+   /**
+    * Get how much larger Excel draws the given font than its pixel size, i.e. the factor the
+    * pixel-based measurements the shared geometry uses are off by.
+    *
+    * <p>The workbook carries point sizes: applyFormat() gets the font from
+    * getPOIFont(.., isAdjust = true), so translateFontStyle() converts the pixel size at
+    * VSFontHelper's px-to-pt rate and then raises anything under 9pt to 9pt. Excel lays the
+    * result out at 96 dpi. Missing the 9pt floor would leave small fonts -- which Excel draws
+    * up to half again as wide -- with no compensation at all.
+    *
+    * @return the ratio of drawn size to pixel size, or 1 when Excel draws it no larger.
+    */
+   static double getExcelFontScale(java.awt.Font font) {
+      if(font == null || font.getSize() <= 0) {
+         return 1;
+      }
+
+      int points = Math.max(MIN_ADJUSTED_FONT_POINTS, VSFontHelper.getFontSize(font));
+      return Math.max(1, (points / POINTS_PER_PIXEL) / font.getSize());
+   }
+
+   /**
     * Write label text as an Excel text box at the given pixel bounds.
     */
    private void writeLabelTextBox(LabelInfo labelInfo, Rectangle2D pixelBounds) {
-      // Add extra width so Excel's font metrics (Calibri) don't cause the text to wrap.
-      // getLabelDimensions uses Java AWT string width which is narrower than Excel's rendering.
-      // For LEFT-positioned labels the widget starts immediately to the right, so cap the
-      // extra by the gap to prevent the text box from overlapping the widget when gap is small.
-      double extra = LabelInfo.LEFT.equals(labelInfo.getLabelPosition())
-         ? Math.min(30, labelInfo.getLabelGap())
-         : 30;
-      Rectangle2D padded = new Rectangle2D.Double(
-         pixelBounds.getX(), pixelBounds.getY(),
-         pixelBounds.getWidth() + extra, pixelBounds.getHeight());
-      XSSFClientAnchor anchor = (XSSFClientAnchor) getAnchorFromPixelRect(padded);
+      XSSFClientAnchor anchor = (XSSFClientAnchor) getAnchorFromPixelRect(pixelBounds);
       XSSFTextBox tb = patriarch.createTextbox(anchor);
+      // The browser renders the label with white-space:nowrap, so a label that is a few
+      // pixels wider in Excel's font metrics than in the AWT metrics used to size the box
+      // must overflow rather than break mid-word.
+      tb.setWordWrap(false);
+      // The browser label has no padding, but an Excel text box defaults to a 0.1in
+      // (~9.6px) inset that would shift the text off the position the split computed.
+      clearInsets(tb);
       // Default to vertical center to match browser flex-layout; applyFormat overrides if set.
       tb.setVerticalAlignment(VerticalAlignment.CENTER);
       XSSFRichTextString rts = (XSSFRichTextString)
          PoiExcelVSUtil.createRichTextString(book, labelInfo.getLabelText());
       tb.setText(rts);
-      // Use the original (unpadded) bounds for the round-corner radius calculation so the
-      // font-metric slack added to padded's width doesn't skew the shorter-side comparison.
-      applyFormat(tb, rts, getLabelFormat(labelInfo), false, pixelBounds);
+      applyFormat(tb, rts, getLabelFormat(labelInfo), false, roundCornerBounds(labelInfo, pixelBounds));
+   }
+
+   /**
+    * Get the bounds to derive a round-corner radius from. splitInputBoundsForExcel() widens
+    * a LEFT label box by the font slack, and applyRoundCorner() scales the radius off the
+    * shorter side, so the slack has to come back out before the two sides are compared.
+    */
+   private static Rectangle2D roundCornerBounds(LabelInfo labelInfo, Rectangle2D pixelBounds) {
+      double slack = LabelInfo.LEFT.equals(labelInfo.getLabelPosition())
+         ? getExcelLabelWidthSlack(labelInfo) : 0;
+
+      if(slack <= 0) {
+         return pixelBounds;
+      }
+
+      return new Rectangle2D.Double(pixelBounds.getX(), pixelBounds.getY(),
+                                    Math.max(1, pixelBounds.getWidth() - slack),
+                                    pixelBounds.getHeight());
+   }
+
+   /**
+    * Remove the default 0.1in internal margins of an Excel text box so the text is laid
+    * out from the box origin, the way the zero-padding label and input do in the browser.
+    */
+   private static void clearInsets(XSSFTextBox tb) {
+      tb.setLeftInset(0);
+      tb.setRightInset(0);
+      tb.setTopInset(0);
+      tb.setBottomInset(0);
    }
 
    /**
@@ -872,7 +976,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       TextInputVSAssemblyInfo info = (TextInputVSAssemblyInfo) assembly.getVSAssemblyInfo();
       Object value = assembly.getSelectedObject();
       String txt = value == null ? "" : Tool.getDataString(value, assembly.getDataType());
-      Rectangle2D[] split = splitInputPixelBounds(info, viewsheet);
+      Rectangle2D[] split = splitInputBoundsForExcel(info);
 
       if(split == null) {
          writeText(assembly, txt);
@@ -883,6 +987,9 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          writeLabelTextBox(((InputVSAssemblyInfo) info).getLabelInfo(), split[0]);
          XSSFClientAnchor anchor = (XSSFClientAnchor) getAnchorFromPixelRect(split[1]);
          XSSFTextBox tb = patriarch.createTextbox(anchor);
+         // single-line <input> in the browser, so don't let Excel break the value
+         tb.setWordWrap(false);
+         clearInsets(tb);
          XSSFRichTextString rts = (XSSFRichTextString)
             PoiExcelVSUtil.createRichTextString(book, txt);
          tb.setText(rts);
@@ -1113,6 +1220,10 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
     * margin most cells have around their text, while still visibly rounding the corner.
     */
    private static final int MAX_TABLE_ROUND_RADIUS = 8;
+   /** points per pixel at 96 dpi, for converting the workbook's point sizes back to pixels */
+   private static final float POINTS_PER_PIXEL = 0.75f;
+   /** minimum point size translateFontStyle() writes when isAdjust is set */
+   private static final int MIN_ADJUSTED_FONT_POINTS = 9;
 
    /**
     * Draw a rounded-rectangle outline around a table/crosstab's outer bounds when the

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporterLabelSlackTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporterLabelSlackTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet.excel;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PoiExcelVSExporter#getExcelFontScale(Font)}, which drives the extra width a
+ * LEFT input label is given because the workbook carries the font in points and Excel lays
+ * those out at 96 dpi, so the label draws wider than the pixel-based split reserved for it.
+ *
+ * <p>Only the scale is exercised here, not getExcelLabelWidthSlack(): measuring text goes
+ * through Common.stringWidth(), which reads SreeEnv properties and so needs a bootstrapped
+ * server this module's tests do not have (the same reason {@link PoiExcelVSExporterTest} mocks
+ * its assembly infos).</p>
+ */
+class PoiExcelVSExporterLabelSlackTest {
+   private static Font font(int pixelSize) {
+      return new Font("Dialog", Font.PLAIN, pixelSize);
+   }
+
+   @Test
+   void largeFontIsDrawnWiderThanItsPixelSize() {
+      assertTrue(PoiExcelVSExporter.getExcelFontScale(font(24)) > 1,
+         "a 24px label goes into the workbook as points and is drawn back at 96 dpi");
+   }
+
+   /**
+    * translateFontStyle() raises anything under 9pt to 9pt when isAdjust is set, which is how
+    * applyFormat() writes the label font. Without modelling that floor a small label gets no
+    * compensation at all while Excel draws it half again as wide, and with word wrap off it
+    * runs straight into the widget.
+    */
+   @Test
+   void smallFontIsClampedToTheMinimumPointSize() {
+      // 8px -> 7pt by the px-to-pt rate, floored to 9pt, drawn at 12px
+      assertEquals(12.0 / 8, PoiExcelVSExporter.getExcelFontScale(font(8)), 0.001);
+      assertTrue(PoiExcelVSExporter.getExcelFontScale(font(8)) >
+                    PoiExcelVSExporter.getExcelFontScale(font(24)),
+         "the floor hits small fonts hardest, so they need the most compensation");
+   }
+
+   @Test
+   void degenerateFontsNeedNoCompensation() {
+      assertEquals(1, PoiExcelVSExporter.getExcelFontScale(null), 0.001);
+      assertEquals(1, PoiExcelVSExporter.getExcelFontScale(font(0)), 0.001);
+   }
+
+   @Test
+   void scaleIsNeverBelowOne() {
+      for(int size = 1; size <= 96; size++) {
+         assertTrue(PoiExcelVSExporter.getExcelFontScale(font(size)) >= 1,
+            "size " + size + " must never shrink the reserved label width");
+      }
+   }
+}


### PR DESCRIPTION
## Problem

TextInput/ComboBox labels (`LabelInfo`) render differently in exports than in the viewsheet preview. In Excel the label wraps mid-word ("lab / el"), sits at the wrong distance from the widget, and overlaps it when the label gap is small.

Reproduced with a viewsheet of 8 assemblies (4 TextInput, 4 ComboBox) at 100×20px covering all four label positions with gaps 0 and 5, and a label font of `Default-PLAIN-24`. The large font is what exposes it.

## Root cause

`AbstractVSExporter.getLabelDimensions()` sized the label box with a fixed `AssetUtil.defh` (20px) row height regardless of the label font, while the browser derives it from the font (`line-height: 1` on `.vs-input-label`). A 24pt label got ~10px less room than it needs, which threw off the split, the vertical centering and the TOP/BOTTOM bounds expansion in every export format.

`HTMLVSExporter.adjustLabelBoundsForFont()` already worked around the same defect locally — evidence the shared helper was the wrong place to hard-code a height.

## Changes

**Shared geometry** (`AbstractVSExporter`)
- Label height is derived from the label font, matching `LabelInfo.getRenderedHeight()` which `Viewsheet`, `TabVSAssemblyInfo` and `GroupContainerVSAssembly` already use.
- Removed the `Math.max(0, …)` clamp on LEFT/RIGHT vertical centering so a label taller than the widget row overhangs it, as flexbox `align-items: center` does.
- `adjustSizeForInputLabels()` accounts for that overhang so the page is not cut through the label.

**Report converter** (`VsToReportConverter.addInputLabel`)
- Same font-derived height. It is also no longer multiplied by `scalefont`: `applyScaleFont()` only reaches formats in `FormatInfo` and `LabelInfo` carries its own standalone format, so the label font is never scaled — the same reason the label width beside it is unscaled.

**HTML** (`HTMLVSExporter`)
- `adjustLabelBoundsForFont()` replaced by a narrower fallback covering only the case the exporter cannot measure: a label with no font of its own, which the browser renders in its inherited font. `writeText` emits the box height with `overflow:hidden`, so that case still needs a floor.

**Excel** (`PoiExcelVSExporter`)
- `setWordWrap(false)` on the label and TextInput value boxes to match `white-space: nowrap` / a single-line `<input>`.
- Zero the text-box insets: Excel defaults to a 0.1in (~9.6px) internal margin that shifted the label text off the computed position, into the widget.
- `splitInputBoundsForExcel()` pushes the widget over by the amount Excel draws a LEFT label wider than the pixel-based split reserved. The workbook carries the font in points (`VSFontHelper.getFontSize`, with a 9pt floor for small sizes) and Excel lays those out at 96 dpi. RIGHT/TOP/BOTTOM overflow away from the widget and are left alone.
- Removed the old `extra = LEFT ? min(30, gap) : 30` width fudge, which was worth 0–5px for LEFT labels and did not scale with font size.

## Behavior change to be aware of

Labels using the **default** font (PLAIN 11) now reserve ~13px instead of 20px, so TOP/BOTTOM-labelled inputs sit tighter in every existing export. This moves toward the preview (the browser reserves 11px), but it is a visible change for existing assets.

## Testing

- New `AbstractVSExporterLabelTest` (8 cases): label height tracks the font, LEFT/RIGHT centering and overhang, TOP/BOTTOM bounds expansion, LEFT/RIGHT non-expansion, default-font fallback.
- New `PoiExcelVSExporterLabelSlackTest` (4 cases): pins the point-size conversion including the 9pt floor. Only the scale is exercised — measuring text goes through `Common.stringWidth`, which reads `SreeEnv` properties and needs a bootstrapped server this module's tests do not have.
- Verified end to end against the reported viewsheet: exported to Excel and compared all 8 assemblies against the preview — no mid-word wrapping, gaps match, no label/widget overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
