### PR TITLE
Bug #76441, surface cloud vault credential resolution failures

### DIFF
--- a/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
+++ b/core/src/main/java/inetsoft/uql/jdbc/JDBCHandler.java
@@ -35,6 +35,8 @@ import inetsoft.uql.table.XObjectColumn;
 import inetsoft.uql.table.XTableColumnCreator;
 import inetsoft.uql.util.*;
 import inetsoft.util.*;
+import inetsoft.util.credential.CloudCredential;
+import inetsoft.util.credential.PasswordCredential;
 import inetsoft.util.log.LogManager;
 import inetsoft.web.admin.monitoring.MonitorLevelService;
 import org.slf4j.Logger;
@@ -1487,6 +1489,9 @@ public class JDBCHandler extends XHandler {
    public void testDataSource(XDataSource datasource,
                               VariableTable params) throws Exception
    {
+      // clone() deep copies the credential, so the retry has to happen on the original for the
+      // cached data source to be healed rather than a throwaway copy
+      refreshUnavailableCredential((JDBCDataSource) datasource);
       Connection conn = connect((JDBCDataSource) datasource.clone(), params);
 
       if(conn == null) {
@@ -3364,9 +3369,52 @@ public class JDBCHandler extends XHandler {
             Tool.refreshDatabaseCredentials(xds);
             conn = connect0(xds, params);
          }
+         else if(e instanceof MessageException) {
+            // there is no retry for this, and the message is the actionable reason for the
+            // failure, so propagate it instead of letting the caller report a generic error
+            // against a null connection
+            throw e;
+         }
       }
 
       return conn;
+   }
+
+   /**
+    * Re-fetches a cloud credential whose previous resolution failed. Called once per connection
+    * attempt, before the user and password are read from the data source.
+    */
+   private static void refreshUnavailableCredential(JDBCDataSource xds) {
+      PasswordCredential credential = xds == null ? null : xds.getCredential();
+
+      if(credential instanceof CloudCredential cloudCredential &&
+         !Tool.isEmptyString(credential.getId()))
+      {
+         cloudCredential.ensureCredentialAvailable();
+      }
+   }
+
+   /**
+    * Fails with an actionable message when the data source references a secret that could not be
+    * resolved from the secrets manager. This must only be called after the per-user and
+    * parameterized logins have been resolved, so that those flows are not affected.
+    */
+   private static void checkCredentialAvailable(JDBCDataSource xds) {
+      PasswordCredential credential = xds == null ? null : xds.getCredential();
+
+      if(credential instanceof CloudCredential cloudCredential &&
+         !Tool.isEmptyString(credential.getId()) && cloudCredential.isCredentialUnavailable())
+      {
+         // the secret id is an internal reference and may carry deployment detail, so it is kept
+         // out of the message shown to whoever runs the dashboard. this fires on every attempt,
+         // so it is logged at debug level, the actionable error is logged by the secrets manager
+         // when the fetch itself fails.
+         LOG.debug("Data source \"{}\" cannot be used, its secret \"{}\" could not be resolved " +
+                   "from the secrets manager", xds.getFullName(), credential.getId());
+
+         throw new SecretsUnavailableException(Catalog.getCatalog().getString(
+            "common.datasource.credentialUnavailable", xds.getFullName()));
+      }
    }
 
    /**
@@ -3380,6 +3428,10 @@ public class JDBCHandler extends XHandler {
          throw new ClassNotFoundException(Catalog.getCatalog().getString(
             "common.datasource.classNotFound" ,xds.getDriver()));
       }
+
+      // retry a secret that failed to resolve when the data source was loaded, so that a
+      // corrected secret is picked up without reloading the data source
+      refreshUnavailableCredential(xds);
 
       String url = xds.getURL();
       String user = xds.isRequireLogin() ? xds.getUser() : null;
@@ -3402,6 +3454,12 @@ public class JDBCHandler extends XHandler {
          if(passwd == null) {
             passwd = "";
          }
+      }
+
+      // only fail here when nothing else supplied a login, so that prompted and parameterized
+      // logins still work for a data source whose stored secret is unavailable
+      if(xds.isRequireLogin() && user.isEmpty() && passwd.isEmpty()) {
+         checkCredentialAvailable(xds);
       }
 
       Connection conn = null;
@@ -3496,7 +3554,14 @@ public class JDBCHandler extends XHandler {
       throws Exception
    {
       Connection connection;
-      xds = (JDBCDataSource) ConnectionProcessor.getInstance().getDatasource(user, xds, additional).clone();
+      // an additional connection resolves to a different data source with its own credential, so
+      // the retry must happen after the resolution. it is done before the clone so that the
+      // cached data source is healed as well, and before the connection pool key, which includes
+      // the user, is computed.
+      JDBCDataSource resolved =
+         (JDBCDataSource) ConnectionProcessor.getInstance().getDatasource(user, xds, additional);
+      refreshUnavailableCredential(resolved);
+      xds = (JDBCDataSource) resolved.clone();
 
       if(xds.isRequireLogin()) {
          if(StringUtils.isEmpty(xds.getUser())) {
@@ -3523,6 +3588,11 @@ public class JDBCHandler extends XHandler {
             }
 
             xds.setPassword(password);
+         }
+
+         // only fail here when nothing else supplied a login
+         if(StringUtils.isEmpty(xds.getUser()) && StringUtils.isEmpty(xds.getPassword())) {
+            checkCredentialAvailable(xds);
          }
       }
 

--- a/core/src/main/java/inetsoft/util/AbstractSecretsManager.java
+++ b/core/src/main/java/inetsoft/util/AbstractSecretsManager.java
@@ -50,29 +50,76 @@ public abstract class AbstractSecretsManager extends AbstractPasswordEncryption 
       }
 
       String id = credential.getId();
-      ObjectMapper mapper = new ObjectMapper();
+      String dbType = credential.getDBType();
+      String result;
 
       try {
-         String dbType = credential.getDBType();
-         String result = null;
-
          if(Tool.isVaultDatabaseSecretsEngine(dbType)) {
             result = decryptDBPassword(id, dbType);
          }
          else {
             result = decryptPassword(id);
          }
+      }
+      catch(Exception ex) {
+         String message = "Failed to read secret \"" + id + "\" for " +
+            describeCredential(credential) + " from " + getClass().getSimpleName();
+         LOG.error(message, ex);
 
+         throw new SecretsUnavailableException(message, ex);
+      }
+
+      // the secrets manager implementations log and return null when the fetch fails
+      if(result == null || result.isBlank()) {
+         String message = "Secret \"" + id + "\" could not be retrieved from " +
+            getClass().getSimpleName() + " for " + describeCredential(credential) +
+            "; the secrets manager returned " + (result == null ? "no value" : "an empty value");
+         LOG.error(message);
+
+         throw new SecretsUnavailableException(message);
+      }
+
+      try {
+         // never log the result itself, it is the secret payload
+         ObjectMapper mapper = new ObjectMapper();
          Credential converted = mapper.convertValue(mapper.readTree(result), credential.getClass());
+
+         // checked before the id is set, so that isEmpty() reports on the values that were
+         // actually carried by the secret. a secret that parses but holds nothing usable, such
+         // as an empty object or fields that do not match this credential type, is no more
+         // usable than one that could not be read at all.
+         if(converted == null || converted.isEmpty()) {
+            String message = "Secret \"" + id + "\" retrieved from " + getClass().getSimpleName() +
+               " does not contain any value for " + describeCredential(credential);
+            LOG.error(message);
+
+            throw new SecretsUnavailableException(message);
+         }
+
          converted.setId(id);
 
          return converted;
       }
-      catch(Exception ex) {
-         LOG.error("Failed to decrypt password", ex);
+      catch(SecretsUnavailableException ex) {
+         throw ex;
       }
+      catch(Exception ex) {
+         String message = "Secret \"" + id + "\" retrieved from " + getClass().getSimpleName() +
+            " is not a valid " + describeCredential(credential) + " payload";
+         LOG.error(message, ex);
 
-      return null;
+         throw new SecretsUnavailableException(message, ex);
+      }
+   }
+
+   /**
+    * Describes a credential for a log or error message, without exposing any secret value.
+    */
+   private static String describeCredential(Credential credential) {
+      String dbType = credential.getDBType();
+
+      return credential.getClass().getSimpleName() +
+         (dbType == null || dbType.isEmpty() ? "" : " (dbType=" + dbType + ")");
    }
 
    public String encryptCredential(Credential credential) {

--- a/core/src/main/java/inetsoft/util/SecretsUnavailableException.java
+++ b/core/src/main/java/inetsoft/util/SecretsUnavailableException.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import inetsoft.util.log.LogLevel;
+
+/**
+ * Thrown when a credential that is referenced by a secret id cannot be resolved from the
+ * configured secrets manager, either because the secret could not be fetched, because it does
+ * not exist, or because its content is not a valid credential payload.
+ * <p>
+ * This is distinct from a credential that is simply not configured, which is represented by an
+ * empty credential id and never raises this exception.
+ */
+public class SecretsUnavailableException extends MessageException {
+   /**
+    * Creates a new instance of SecretsUnavailableException. The stack trace is not dumped
+    * because the condition is already logged with the full context at the point of failure.
+    *
+    * @param message the error message.
+    */
+   public SecretsUnavailableException(String message) {
+      super(message, LogLevel.ERROR, false);
+   }
+
+   /**
+    * Creates a new instance of SecretsUnavailableException.
+    *
+    * @param message the error message.
+    * @param cause   the root cause of this exception.
+    */
+   public SecretsUnavailableException(String message, Throwable cause) {
+      this(message);
+      initCause(cause);
+   }
+}

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -2100,7 +2100,11 @@ public final class Tool extends CoreTool {
          if(newCredential != null) {
             newCredential.setId(credential.getId());
             ((CloudCredential) credential).refreshCredential(newCredential);
+            ((CloudCredential) credential).setCredentialUnavailable(false);
          }
+         // a null result is not marked unavailable here: decryptPasswordToCredential swallows
+         // every cause, so it cannot distinguish a missing secret from a transient failure, and
+         // the credential may still hold usable values from the original fetch
       }
    }
 

--- a/core/src/main/java/inetsoft/util/credential/AbstractCloudCredential.java
+++ b/core/src/main/java/inetsoft/util/credential/AbstractCloudCredential.java
@@ -44,6 +44,12 @@ public abstract class AbstractCloudCredential extends AbstractCredential impleme
 
    @Override
    public void setId(String id) {
+      if(!Tool.equals(this.id, id)) {
+         // the unavailable state describes one specific secret, so it does not carry over when a
+         // different secret is referenced
+         setCredentialUnavailable(false);
+      }
+
       this.id = id;
    }
 
@@ -64,6 +70,43 @@ public abstract class AbstractCloudCredential extends AbstractCredential impleme
       }
 
       return Tool.equals(((AbstractCloudCredential) obj).id, id);
+   }
+
+   @Override
+   public boolean isCredentialUnavailable() {
+      return credentialUnavailable;
+   }
+
+   @Override
+   public void setCredentialUnavailable(boolean unavailable) {
+      // the timestamp is written first so that a thread which reads the flag as true is
+      // guaranteed to see the matching timestamp and not throttle against a stale one
+      this.lastFetchFailure = unavailable ? System.currentTimeMillis() : 0L;
+      this.credentialUnavailable = unavailable;
+   }
+
+   @Override
+   public boolean isFetchRetryDue() {
+      return System.currentTimeMillis() - lastFetchFailure >= FETCH_RETRY_INTERVAL;
+   }
+
+   @Override
+   public boolean beginFetchRetry() {
+      synchronized(this) {
+         if(fetchingCredential) {
+            return false;
+         }
+
+         fetchingCredential = true;
+         return true;
+      }
+   }
+
+   @Override
+   public void endFetchRetry() {
+      synchronized(this) {
+         fetchingCredential = false;
+      }
    }
 
    @Override
@@ -176,5 +219,15 @@ public abstract class AbstractCloudCredential extends AbstractCredential impleme
    }
 
    private String id;
-   private String dbType;;
+   private String dbType;
+   // runtime only state, it must not be written to XML or cross java serialization where it
+   // would go stale. it is read by every thread that connects to the data source that owns this
+   // credential, so it is volatile.
+   private transient volatile boolean credentialUnavailable;
+   private transient volatile long lastFetchFailure;
+   // a primitive so that java deserialization, which does not run the constructor, still leaves
+   // it in a usable state
+   private transient boolean fetchingCredential;
+
+   private static final long FETCH_RETRY_INTERVAL = 30000L;
 }

--- a/core/src/main/java/inetsoft/util/credential/CloudCredential.java
+++ b/core/src/main/java/inetsoft/util/credential/CloudCredential.java
@@ -19,18 +19,108 @@
 package inetsoft.util.credential;
 
 import inetsoft.util.*;
+import org.slf4j.LoggerFactory;
 
 public interface CloudCredential extends Credential {
    default void fetchCredential() {
       if(Tool.isEmptyString(getId())) {
+         // no credential configured, which is not a failure
+         setCredentialUnavailable(false);
          return;
       }
 
-      Credential credential = getSecretsManager().getCredential(this);
+      try {
+         Credential credential = getSecretsManager().getCredential(this);
 
-      if(credential != null) {
-         refreshCredential(credential);
+         if(credential != null) {
+            refreshCredential(credential);
+            setCredentialUnavailable(false);
+         }
+         else {
+            setCredentialUnavailable(true);
+         }
       }
+      catch(Exception ex) {
+         // a SecretsUnavailableException is already logged with the full context by the secrets
+         // manager, anything else is not. it is not propagated so that the data source still
+         // loads and remains listable and editable, the unavailable state is reported when the
+         // credential is actually used.
+         if(!(ex instanceof SecretsUnavailableException)) {
+            LoggerFactory.getLogger(CloudCredential.class).error(
+               "Failed to fetch secret \"{}\" for {}", getId(), getClass().getSimpleName(), ex);
+         }
+
+         setCredentialUnavailable(true);
+      }
+   }
+
+   /**
+    * Determines if this credential references a secret that could not be resolved from the
+    * secrets manager. This is distinct from an empty credential id, which means that no
+    * credential is configured at all.
+    *
+    * @return <tt>true</tt> if the credential is configured but unavailable.
+    */
+   default boolean isCredentialUnavailable() {
+      return false;
+   }
+
+   /**
+    * Sets whether the referenced secret could not be resolved from the secrets manager.
+    */
+   default void setCredentialUnavailable(boolean unavailable) {
+   }
+
+   /**
+    * Determines if enough time has passed since the last failed fetch to attempt another one.
+    * This keeps a data source whose secret is genuinely missing from calling the secrets manager,
+    * and logging the failure, on every single connection attempt.
+    */
+   default boolean isFetchRetryDue() {
+      return true;
+   }
+
+   /**
+    * Re-fetches the credential if a previous attempt failed, so that a corrected secret is
+    * picked up without requiring the data source to be reloaded. At most one fetch is made, and
+    * only if the retry interval has elapsed.
+    *
+    * @return <tt>true</tt> if the credential is usable, either because it resolved or because
+    *         none is configured.
+    */
+   default boolean ensureCredentialAvailable() {
+      if(Tool.isEmptyString(getId()) || !isCredentialUnavailable()) {
+         return true;
+      }
+
+      // this credential is shared by every thread that connects to the data source that owns it.
+      // only one thread re-fetches, and the others carry on with the current state rather than
+      // blocking on a secrets manager call that may be slow or hung.
+      if(isFetchRetryDue() && beginFetchRetry()) {
+         try {
+            fetchCredential();
+         }
+         finally {
+            endFetchRetry();
+         }
+      }
+
+      return !isCredentialUnavailable();
+   }
+
+   /**
+    * Claims the right to re-fetch this credential.
+    *
+    * @return <tt>true</tt> if the caller may fetch, <tt>false</tt> if another thread already is.
+    */
+   default boolean beginFetchRetry() {
+      return true;
+   }
+
+   /**
+    * Releases the claim taken by {@link #beginFetchRetry()}.
+    */
+   default void endFetchRetry() {
    }
 
    void refreshCredential(Credential credential);

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3313,6 +3313,7 @@ common.dataModelNotFound=Data model does not exist
 common.datasource.classNotFound=Could not find the database driver class ''{0}''. Please add the appropriate driver JAR file on the ''Classpath'' tab of the Configuration dialog box.
 common.datasource.connectFailed=Failed to connect to datasource [{0}]\! Please check the connection information.
 common.datasource.connectionUsedByExtendedModel="{0}" connection is used by an extended logical model or extended partition. Continue?
+common.datasource.credentialUnavailable=Unable to resolve the stored credentials for data source "{0}" from the secrets manager. Contact your administrator, the server log identifies the secret that could not be resolved.
 common.datasource.datasourceUsed=Data source "{0}" used by queries\:\n"{1}"\nContinue to delete all related queries?
 common.datasource.duplicateName=Name already exists
 common.datasource.goonAndmodelsDeleted="{0}" within this data model will be deleted. Continue?

--- a/core/src/test/java/inetsoft/util/AbstractSecretsManagerTest.java
+++ b/core/src/test/java/inetsoft/util/AbstractSecretsManagerTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import inetsoft.util.credential.CloudPasswordCredential;
+import inetsoft.util.credential.Credential;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the failure handling of {@link AbstractSecretsManager#getCredential(Credential)}.
+ * <p>
+ * The manager is mocked with CALLS_REAL_METHODS so that its constructor, which resolves the
+ * local encryption instance, is never run. Every credential leaves the dbType null so that
+ * {@link Tool#isVaultDatabaseSecretsEngine(String)} short circuits before it looks up the
+ * configured password encryption.
+ */
+@Tag("core")
+class AbstractSecretsManagerTest {
+   @Test
+   void nullCredentialReturnsNull() {
+      AbstractSecretsManager manager = createManager();
+
+      assertNull(manager.getCredential(null));
+      verify(manager, never()).decryptPassword(anyString());
+   }
+
+   @Test
+   void credentialWithoutIdIsReturnedUnchanged() {
+      AbstractSecretsManager manager = createManager();
+      CloudPasswordCredential credential = new CloudPasswordCredential();
+
+      assertSame(credential, manager.getCredential(credential));
+      verify(manager, never()).decryptPassword(anyString());
+   }
+
+   @ParameterizedTest
+   @NullAndEmptySource
+   @ValueSource(strings = { "   " })
+   void unresolvedSecretThrows(String result) {
+      AbstractSecretsManager manager = createManager();
+      doReturn(result).when(manager).decryptPassword(anyString());
+
+      SecretsUnavailableException ex = assertThrows(
+         SecretsUnavailableException.class, () -> manager.getCredential(createCredential()));
+
+      assertTrue(ex.getMessage().contains(SECRET_ID), ex.getMessage());
+      assertTrue(ex.getMessage().contains("CloudPasswordCredential"), ex.getMessage());
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {
+      "not json at all",
+      "{\"user\":\"admin\",password:\"secret\"}",
+      "{\"user\":\"admin\""
+   })
+   void malformedSecretThrowsWithoutLeakingThePayload(String result) {
+      AbstractSecretsManager manager = createManager();
+      doReturn(result).when(manager).decryptPassword(anyString());
+
+      SecretsUnavailableException ex = assertThrows(
+         SecretsUnavailableException.class, () -> manager.getCredential(createCredential()));
+
+      assertNotNull(ex.getCause());
+      assertTrue(ex.getMessage().contains(SECRET_ID), ex.getMessage());
+      // the payload is the secret and must never reach the message
+      assertFalse(ex.getMessage().contains(result), ex.getMessage());
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "{}", "{\"username\":\"admin\",\"secret\":\"s3cr3t\"}" })
+   void secretWithoutAnyUsableValueThrows(String result) {
+      AbstractSecretsManager manager = createManager();
+      doReturn(result).when(manager).decryptPassword(anyString());
+
+      SecretsUnavailableException ex = assertThrows(
+         SecretsUnavailableException.class, () -> manager.getCredential(createCredential()));
+
+      assertTrue(ex.getMessage().contains(SECRET_ID), ex.getMessage());
+      assertTrue(ex.getMessage().contains("does not contain any value"), ex.getMessage());
+   }
+
+   @Test
+   void fetchFailureThrows() {
+      AbstractSecretsManager manager = createManager();
+      doThrow(new IllegalStateException("vault down")).when(manager).decryptPassword(anyString());
+
+      SecretsUnavailableException ex = assertThrows(
+         SecretsUnavailableException.class, () -> manager.getCredential(createCredential()));
+
+      assertInstanceOf(IllegalStateException.class, ex.getCause());
+      assertTrue(ex.getMessage().contains(SECRET_ID), ex.getMessage());
+   }
+
+   @Test
+   void validSecretIsConvertedAndKeepsTheId() {
+      AbstractSecretsManager manager = createManager();
+      doReturn("{\"user\":\"scott\",\"password\":\"tiger\"}")
+         .when(manager).decryptPassword(anyString());
+
+      Credential converted = manager.getCredential(createCredential());
+
+      assertInstanceOf(CloudPasswordCredential.class, converted);
+      assertEquals("scott", ((CloudPasswordCredential) converted).getUser());
+      assertEquals("tiger", ((CloudPasswordCredential) converted).getPassword());
+      assertEquals(SECRET_ID, converted.getId());
+   }
+
+   private static AbstractSecretsManager createManager() {
+      return Mockito.mock(AbstractSecretsManager.class, Mockito.CALLS_REAL_METHODS);
+   }
+
+   private static CloudPasswordCredential createCredential() {
+      CloudPasswordCredential credential = new CloudPasswordCredential();
+      credential.setId(SECRET_ID);
+
+      return credential;
+   }
+
+   private static final String SECRET_ID = "6f1d0b8e-test-secret-id";
+}

--- a/core/src/test/java/inetsoft/util/credential/CloudCredentialTest.java
+++ b/core/src/test/java/inetsoft/util/credential/CloudCredentialTest.java
@@ -1,0 +1,206 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.credential;
+
+import inetsoft.util.AbstractSecretsManager;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests that a credential which cannot be resolved from the secrets manager is marked as
+ * unavailable instead of silently loading blank values.
+ */
+@Tag("core")
+class CloudCredentialTest {
+   @Test
+   void failureMarksUnavailableWithoutThrowing() {
+      AbstractSecretsManager manager = createManager();
+      doReturn(null).when(manager).decryptPassword(anyString());
+      TestCloudCredential credential = new TestCloudCredential(manager, SECRET_ID);
+
+      assertDoesNotThrow(credential::fetchCredential);
+      assertTrue(credential.isCredentialUnavailable());
+      assertNull(credential.getUser());
+      assertNull(credential.getPassword());
+   }
+
+   @Test
+   void successClearsTheFlag() {
+      AbstractSecretsManager manager = createManager();
+      doReturn(VALID_SECRET).when(manager).decryptPassword(anyString());
+      TestCloudCredential credential = new TestCloudCredential(manager, SECRET_ID);
+      credential.setCredentialUnavailable(true);
+
+      credential.fetchCredential();
+
+      assertFalse(credential.isCredentialUnavailable());
+      assertEquals("scott", credential.getUser());
+      assertEquals("tiger", credential.getPassword());
+   }
+
+   @Test
+   void emptyIdIsNotAFailure() {
+      AbstractSecretsManager manager = createManager();
+      TestCloudCredential credential = new TestCloudCredential(manager, null);
+      credential.setCredentialUnavailable(true);
+
+      credential.fetchCredential();
+
+      assertFalse(credential.isCredentialUnavailable());
+      assertTrue(credential.ensureCredentialAvailable());
+      verify(manager, never()).decryptPassword(anyString());
+   }
+
+   @Test
+   void ensureCredentialAvailableRetriesExactlyOnce() {
+      AbstractSecretsManager manager = createManager();
+      doReturn(null, VALID_SECRET).when(manager).decryptPassword(anyString());
+      TestCloudCredential credential = new TestCloudCredential(manager, SECRET_ID);
+      credential.retryDue = true;
+
+      credential.fetchCredential();
+      assertTrue(credential.isCredentialUnavailable());
+
+      assertTrue(credential.ensureCredentialAvailable());
+      assertFalse(credential.isCredentialUnavailable());
+      assertEquals("scott", credential.getUser());
+
+      // already resolved, so no further vault call is made
+      assertTrue(credential.ensureCredentialAvailable());
+      verify(manager, times(2)).decryptPassword(anyString());
+   }
+
+   @Test
+   void ensureCredentialAvailableIsThrottledAfterAFailure() {
+      AbstractSecretsManager manager = createManager();
+      doReturn(null).when(manager).decryptPassword(anyString());
+      TestCloudCredential credential = new TestCloudCredential(manager, SECRET_ID);
+      credential.retryDue = false;
+
+      credential.fetchCredential();
+      assertTrue(credential.isCredentialUnavailable());
+
+      // the retry interval has not elapsed, so the secrets manager is not called again
+      assertFalse(credential.ensureCredentialAvailable());
+      assertFalse(credential.ensureCredentialAvailable());
+      verify(manager, times(1)).decryptPassword(anyString());
+   }
+
+   @Test
+   void retryIsNotDueImmediatelyAfterAFailure() {
+      AbstractSecretsManager manager = createManager();
+      CloudPasswordCredential credential = new CloudPasswordCredential();
+      credential.setId(SECRET_ID);
+
+      assertTrue(credential.isFetchRetryDue());
+
+      credential.setCredentialUnavailable(true);
+      assertFalse(credential.isFetchRetryDue());
+
+      credential.setCredentialUnavailable(false);
+      assertTrue(credential.isFetchRetryDue());
+   }
+
+   @Test
+   void changingTheSecretIdClearsTheUnavailableState() {
+      AbstractSecretsManager manager = createManager();
+      doReturn(null).when(manager).decryptPassword(anyString());
+      TestCloudCredential credential = new TestCloudCredential(manager, SECRET_ID);
+
+      credential.fetchCredential();
+      assertTrue(credential.isCredentialUnavailable());
+
+      // the state described the previous secret, it must not carry over to a different one
+      credential.setId("a-different-secret-id");
+      assertFalse(credential.isCredentialUnavailable());
+      assertTrue(credential.isFetchRetryDue());
+
+      // setting the same id again leaves the state alone
+      credential.fetchCredential();
+      assertTrue(credential.isCredentialUnavailable());
+      credential.setId("a-different-secret-id");
+      assertTrue(credential.isCredentialUnavailable());
+   }
+
+   @Test
+   void onlyOneThreadFetchesAtATime() {
+      AbstractSecretsManager manager = createManager();
+      doReturn(null).when(manager).decryptPassword(anyString());
+      TestCloudCredential credential = new TestCloudCredential(manager, SECRET_ID);
+      credential.fetchCredential();
+      reset(manager);
+      doReturn(null).when(manager).decryptPassword(anyString());
+
+      // a fetch already in flight makes the other callers return rather than pile up behind it
+      assertTrue(credential.beginFetchRetry());
+      assertFalse(credential.ensureCredentialAvailable());
+      verify(manager, never()).decryptPassword(anyString());
+
+      credential.endFetchRetry();
+      assertFalse(credential.ensureCredentialAvailable());
+      verify(manager, times(1)).decryptPassword(anyString());
+   }
+
+   @Test
+   void unavailableStateIsNotPartOfEquals() {
+      AbstractSecretsManager manager = createManager();
+      TestCloudCredential first = new TestCloudCredential(manager, SECRET_ID);
+      TestCloudCredential second = new TestCloudCredential(manager, SECRET_ID);
+      first.setCredentialUnavailable(true);
+
+      assertEquals(first, second);
+      assertEquals(second, first);
+   }
+
+   private static AbstractSecretsManager createManager() {
+      return Mockito.mock(AbstractSecretsManager.class, Mockito.CALLS_REAL_METHODS);
+   }
+
+   /**
+    * A cloud credential bound to a specific secrets manager instance, so that the test does not
+    * depend on the configured password encryption.
+    */
+   private static final class TestCloudCredential extends CloudPasswordCredential {
+      TestCloudCredential(AbstractSecretsManager manager, String id) {
+         this.manager = manager;
+         setId(id);
+      }
+
+      @Override
+      public AbstractSecretsManager getSecretsManager() {
+         return manager;
+      }
+
+      @Override
+      public boolean isFetchRetryDue() {
+         return retryDue;
+      }
+
+      private final AbstractSecretsManager manager;
+      // controlled by the test so that the retry interval does not make it time dependent
+      private boolean retryDue = true;
+   }
+
+   private static final String SECRET_ID = "6f1d0b8e-test-secret-id";
+   private static final String VALID_SECRET = "{\"user\":\"scott\",\"password\":\"tiger\"}";
+}


### PR DESCRIPTION
## Problem

`AbstractSecretsManager.getCredential()` wrapped the vault fetch *and* the Jackson parse in a single `catch(Exception)`, logged a context-free `"Failed to decrypt password"`, and returned `null`:

```
ERROR i.u.AbstractSecretsManager: Failed to decrypt password
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('p' (code 112)): was expecting double-quote to start field name
    at inetsoft.util.AbstractSecretsManager.getCredential(AbstractSecretsManager.java:66)
    at inetsoft.util.credential.CloudCredential.fetchCredential(CloudCredential.java:29)
    at inetsoft.util.credential.AbstractCloudCredential.parseXML(AbstractCloudCredential.java:131)
    at inetsoft.uql.jdbc.JDBCDataSource.parseXML(JDBCDataSource.java:928)
```

`CloudCredential.fetchCredential()` then dropped the `null` with no log at all, so `parseXML()` completed "successfully" with `user`/`password` left null. `DataSourceRegistry.getObject()` cached the data source in that broken state until the storage timestamp changed, and the authentication failure only surfaced much later at JDBC connect time with nothing tying it back to the vault content.

Three distinct failure modes were funnelled into that one catch, not just the reported malformed JSON:

1. **Malformed / non-JSON payload** — `readTree` throws (the reported stack).
2. **Fetch failure** — every provider's `decryptPassword()` logs and returns `null` (`AwsSecretsManagerPasswordEncryption:124`, and the Azure/Google/HCP equivalents), so `readTree(null)` threw inside the same catch. A vault outage was indistinguishable from a corrupt payload.
3. **Secret that parses but carries nothing usable** — `{}`, or fields that don't match the credential type (the deserializers ignore unknown keys). This produced a blank credential and was treated as success.

This is the community-core follow-up that inetsoft-technology/stylebi-enterprise#746 (Bug #76425) explicitly deferred.

## Changes

**`AbstractSecretsManager.getCredential()`** — the three failure modes are handled separately and each throws `SecretsUnavailableException`. Every message carries the secret id (a vault reference, safe to log), the credential class, the dbType and which secrets manager. The payload is never logged. The empty-value check runs *before* `setId`, so `isEmpty()` reports on the values the secret actually carried.

**`SecretsUnavailableException`** (new) — extends `MessageException` at `LogLevel.ERROR, dumpStack=false`, since the condition is already logged with full context at the source.

**`CloudCredential` / `AbstractCloudCredential`** — a "credential unavailable" state, distinct from an empty id, which means no credential is configured. It is `transient` (runtime-only; it must not reach XML, blob storage or cluster serialization, where it would go stale), is cleared when the secret id changes, and is excluded from `equals`/`isEmpty`/`writeXML` so it cannot cause spurious "modified" detection or connection-pool key churn. `fetchCredential()` never propagates, so the data source still loads and stays listable and editable in EM. `ensureCredentialAvailable()` re-fetches at most once per 30s, single-flighted **without blocking** the other callers — a hung vault must not pile every thread up behind it.

**`JDBCHandler`** — retry-then-fail-fast on both connect paths, which are disjoint (`connect0` for test-connection, private `getConnection` for pooled queries). Guarded by `isRequireLogin() && user/password empty`, so prompted logins, `VariableTable` params and `XPrincipal` parameters are unaffected. The retry runs on the *resolved* data source (an additional connection resolves to a different object with its own credential) and before the clone, since `clone()` deep-copies the credential.

**`connect()` was swallowing the exception** — its catch only retried for the Vault DB secrets engine and otherwise fell through returning `conn == null`, so `testDataSource` replaced the real cause with a generic `SQLException`. Without this, the new message never reached the UI. Narrowed to `MessageException` so ordinary SQL errors keep today's friendly "Failed to connect to datasource[X]!" message.

**Catalog** — `common.datasource.credentialUnavailable`, deliberately naming only the data source: the secret id can carry deployment detail (an ARN embeds the account id) and goes to the log instead. The wording avoids "username"/"password" because `DataSourceStatusService.getStatusModel():160` collapses any message containing those into a generic login error. The existing `XDataSource.Status` surface therefore renders it in the portal Data Sources browser with **no UI change**.

## Testing

New `AbstractSecretsManagerTest` (12) and `CloudCredentialTest` (9) — 21 cases, no live vault required, covering all three failure modes, the id-change reset, the retry throttle and the single-flight guard. There was previously **no** test anywhere for `getCredential`, `fetchCredential` or `AbstractCloudCredential.parseXML`.

```
Tests run: 21, Failures: 0, Errors: 0, Skipped: 0   (new tests)
Tests run: 121, Failures: 0, Errors: 0, Skipped: 0  (inetsoft.util + inetsoft.uql.jdbc)
BUILD SUCCESS
```

The enterprise `integration/` modules (AWS, Azure, Google) build clean against the changed signature.

## Not addressed here

- `GoogleSecretsManagerPasswordEncryption:174` is still missing the legacy `\aes` guard that AWS/Azure/HCP have — enterprise repo, flagged by #746 for separate triage.
- `AbstractCloudCredential.writeXML()`'s `isEncryptForceLocal()` branch silently exports an empty local credential when `Tool.decryptPasswordToCredential` returns null. Same class of bug, different path; making export throw would break asset export deployment-wide.
- Non-JDBC tabular connectors get no fail-fast check (per-connector `TabularHandler.testDataSource`). Unchanged from today; the improved log with the secret id is the win there.
- `AbstractSecretsManager.decryptPassword(String, String)` discards `encryptedKey` for every provider. Pre-existing, flagged by #746.
- The state is `transient`, so a data source Java-serialized to another cluster node arrives with the flag cleared and degrades to today's behavior on that node. Deriving it lazily would need a per-type notion of "resolved" that the generic `Credential` interface does not have.

Community only, no enterprise changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
