### PR TITLE
Bug #76438, fix swapped arguments in SSOTypeChangedMessage construction

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/SSOSettingsService.java
@@ -261,7 +261,7 @@ public class SSOSettingsService {
 
          if(ssoType != activeFilterType) {
             try {
-               cluster.sendMessage(new SSOTypeChangedMessage(activeFilterType, ssoType));
+               cluster.sendMessage(new SSOTypeChangedMessage(ssoType, activeFilterType));
             }
             catch(Exception ex) {
                LOG.debug("Failed to send sso type changed message", ex);


### PR DESCRIPTION
## Problem

`SSOSettingsService.updateSSOSettings()` built the cluster broadcast as:

```java
cluster.sendMessage(new SSOTypeChangedMessage(activeFilterType, ssoType));
```

`activeFilterType` is the **old** SSO type (read via `getActiveFilterType()` at line 191, before `sso.protocol.type` is overwritten later in the method) and `ssoType` is the **new** type from the request model. But the constructor signature is `SSOTypeChangedMessage(SSOType newType, SSOType oldType)`, so the arguments were reversed: `getNewType()` returned the old type and `getOldType()` returned the new one.

## Impact

The only current consumer, `ScheduleUsersChangeService.messageReceived()`, guards with

```java
message.getNewType() != message.getOldType() &&
   (message.getOldType() == SSOType.NONE || message.getNewType() == SSOType.NONE)
```

Both clauses are symmetric under swapping the two values, so this consumer behaves identically before and after the fix and no incorrect behavior has been observed. The bug is latent: any future consumer that reads the two values individually (logging "switched from X to Y", or distinguishing "SSO just turned on" from "just turned off") would get them backwards.

## Fix

Swap the arguments at the call site.

## Side effects

`SSOTypeChangedMessage` has no other construction sites, its getters have no other readers, and the sole consumer's guard is swap-invariant — so this is behavior-preserving today and correct for future consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)