### PR TITLE
Bug #76451: guard SecurityChain.loadConfiguration() against a config-file read race

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/SecurityChain.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityChain.java
@@ -172,6 +172,20 @@ public abstract class SecurityChain<T extends JsonConfigurableProvider & Cachabl
                   ObjectNode root;
 
                   try(InputStream input = dataSpace.getInputStream(null, configFile)) {
+                     if(input == null) {
+                        // The exists() check above raced with a concurrent delete/rewrite of
+                        // the config file; DataSpace.getInputStream() treats a missing file as
+                        // a soft null rather than throwing. Treat this exactly like the
+                        // "temporarily unreadable config" case below: keep the existing runtime
+                        // providers and do not advance timestamp, so the next dataChanged()
+                        // retries once the transient condition clears.
+                        LOG.warn(
+                           "Security chain configuration file '{}' could not be read (removed " +
+                           "or rewritten concurrently); retaining existing providers",
+                           configFile);
+                        return;
+                     }
+
                      root = (ObjectNode) mapper.readTree(input);
                   }
 

--- a/core/src/test/java/inetsoft/sree/security/SecurityChainTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityChainTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.security;
+
+import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers a TOCTOU race between {@code DataSpace.exists()} and {@code DataSpace.getInputStream()}
+ * in {@code SecurityChain.loadConfiguration()}: if the config file is removed or rewritten
+ * between the two calls, {@code getInputStream()} returns {@code null} (its documented
+ * "soft miss" contract for a missing file) rather than throwing. Before the fix, that null was
+ * passed straight into {@code ObjectMapper.readTree()}, which threw an uncaught
+ * {@code IllegalArgumentException} that propagated out of the {@code AuthenticationChain}/
+ * {@code AuthorizationChain} constructor entirely.
+ */
+@Tag("core")
+class SecurityChainTest {
+   @Test
+   void authenticationChain_configReadRacesWithConcurrentRemoval_doesNotThrow() throws Exception {
+      DataSpace space = mock(DataSpace.class);
+      when(space.exists(null, "authc-chain.json")).thenReturn(true);
+      when(space.getLastModified(null, "authc-chain.json")).thenReturn(100L);
+      when(space.getInputStream(null, "authc-chain.json")).thenReturn(null);
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         ds.when(DataSpace::getDataSpace).thenReturn(space);
+
+         AuthenticationChain chain = assertDoesNotThrow(() -> {
+            return new AuthenticationChain();
+         });
+
+         assertTrue(chain.getProviders().isEmpty());
+      }
+   }
+
+   @Test
+   void authorizationChain_configReadRacesWithConcurrentRemoval_doesNotThrow() throws Exception {
+      DataSpace space = mock(DataSpace.class);
+      when(space.exists(null, "authz-chain.json")).thenReturn(true);
+      when(space.getLastModified(null, "authz-chain.json")).thenReturn(100L);
+      when(space.getInputStream(null, "authz-chain.json")).thenReturn((InputStream) null);
+
+      try(MockedStatic<DataSpace> ds = mockStatic(DataSpace.class)) {
+         ds.when(DataSpace::getDataSpace).thenReturn(space);
+
+         AuthorizationChain chain = assertDoesNotThrow(() -> {
+            return new AuthorizationChain();
+         });
+
+         assertTrue(chain.getProviders().isEmpty());
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- Found while investigating a `build` check failure blocking PRs #4973 and #4980, both hitting `PermissionHierarchyTest.setUp:96 » IllegalArgument argument "in" is null` in CI, unrelated to either PR's own diff.
- Root cause: `SecurityChain.loadConfiguration()` checks `DataSpace.exists()` then separately calls `DataSpace.getInputStream()`, passing the result straight into `ObjectMapper.readTree()` with no null check. `getInputStream()` deliberately returns `null` (not an exception) when the file is missing. If the config file is removed/rewritten by a concurrent writer between the two calls, `readTree(null)` throws an uncaught `IllegalArgumentException` that crashes `AuthenticationChain`'s/`AuthorizationChain`'s constructor entirely — not caught by `initialize()`'s `catch(IOException e)`.
- Fix: treat a null `InputStream` the same as the existing "temporarily unreadable config" resilience path a few lines below (already handles a GKE-node-restart-style transient failure) — log a warning, keep existing runtime providers, don't advance `timestamp` so the next `dataChanged()` naturally retries.

## Test plan
- [x] New `SecurityChainTest` (`AuthenticationChain`/`AuthorizationChain`, via `Mockito.mockStatic(DataSpace.class)` simulating `exists()==true` + `getInputStream()==null`) — proven load-bearing: fails with the exact reported `IllegalArgumentException: argument "in" is null` when the fix is reverted, passes when restored.
- [x] Full `inetsoft.sree.security.**` package (36 test classes) — all pass, no regressions.

Redmine: #76451