### PR TITLE
fix(wiz): resolve worksheet table name for Text/Gauge output assemblies (bug 76368)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java
@@ -21,9 +21,8 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.cluster.*;
 import inetsoft.report.composition.*;
 import inetsoft.uql.asset.ColumnRef;
-import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.erm.DataRef;
-import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.BindableVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.drm.DataRefModel;
@@ -114,20 +113,21 @@ public class WizBrowseDataService {
     * Resolves the worksheet table name that {@code assemblyName} (the VS chart's own presentation
     * name, e.g. "Chart1") is bound to. {@link BrowseDataController#process} looks its {@code name}
     * up against the base WORKSHEET's own assemblies — a different namespace — so passing the chart
-    * name through unresolved always misses (silently: it returns null instead of erroring). Mirrors
-    * the same {@code DataVSAssembly} → {@code SourceInfo} → {@code getSource()} resolution
-    * {@code WizVsService} does for aggregate-condition handling. Package-private for unit testing.
+    * name through unresolved always misses (silently: it returns null instead of erroring). Gates on
+    * {@code BindableVSAssembly} (not {@code DataVSAssembly}) so Output assemblies (Text/Gauge — a
+    * sibling hierarchy that never {@code instanceof DataVSAssembly}) resolve too, mirroring the same
+    * widening {@code WizVsService} already applies for {@code applyConditionModel} and its own
+    * {@code wsTableName} lookup. Package-private for unit testing.
     */
    String resolveWorksheetTableName(Viewsheet vs, String assemblyName) {
       VSAssembly chartAssembly = vs != null ? vs.getAssembly(assemblyName) : null;
 
-      if(!(chartAssembly instanceof DataVSAssembly dataAssembly)) {
+      if(!(chartAssembly instanceof BindableVSAssembly bindableAssembly)) {
          throw new IllegalArgumentException(
             "No chart assembly named '" + assemblyName + "' found in the viewsheet");
       }
 
-      SourceInfo sourceInfo = dataAssembly.getSourceInfo();
-      String wsTableName = sourceInfo != null ? sourceInfo.getSource() : null;
+      String wsTableName = bindableAssembly.getTableName();
 
       if(wsTableName == null) {
          throw new IllegalStateException(

--- a/core/src/test/java/inetsoft/web/wiz/service/WizBrowseDataServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizBrowseDataServiceTest.java
@@ -1,8 +1,9 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
-import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.viewsheet.BindableVSAssembly;
 import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import org.junit.jupiter.api.Tag;
@@ -16,24 +17,38 @@ import static org.mockito.Mockito.*;
  * Regression coverage for {@link WizBrowseDataService#resolveWorksheetTableName}, extracted from
  * the {@code browseData} fix that stopped the endpoint from silently returning an empty value
  * list for every column on every chart (it was passing the VS chart's own presentation name where
- * a worksheet table name was expected).
+ * a worksheet table name was expected). Gates on {@code BindableVSAssembly} (not
+ * {@code DataVSAssembly}) so both Data assemblies (Chart/Table/Crosstab) and Output assemblies
+ * (Text/Gauge) resolve via their shared {@code getTableName()} accessor (bug 76368).
  */
 @Tag("core")
 class WizBrowseDataServiceTest {
    @Test
-   void resolvesWorksheetTableNameFromChartSourceInfo() {
+   void resolvesWorksheetTableNameFromDataAssembly() {
       ViewsheetService vsService = mock(ViewsheetService.class);
       Viewsheet vs = mock(Viewsheet.class);
       DataVSAssembly chartAssembly = mock(DataVSAssembly.class);
-      SourceInfo sourceInfo = mock(SourceInfo.class);
 
       when(vs.getAssembly("Chart1")).thenReturn(chartAssembly);
-      when(chartAssembly.getSourceInfo()).thenReturn(sourceInfo);
-      when(sourceInfo.getSource()).thenReturn("JOIN_SO_SOL");
+      when(chartAssembly.getTableName()).thenReturn("JOIN_SO_SOL");
 
       WizBrowseDataService service = new WizBrowseDataService(vsService);
 
       assertEquals("JOIN_SO_SOL", service.resolveWorksheetTableName(vs, "Chart1"));
+   }
+
+   @Test
+   void resolvesWorksheetTableNameFromOutputAssembly() {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      TextVSAssembly textAssembly = mock(TextVSAssembly.class);
+
+      when(vs.getAssembly("Text1")).thenReturn(textAssembly);
+      when(textAssembly.getTableName()).thenReturn("JOIN_SO_SOL");
+
+      WizBrowseDataService service = new WizBrowseDataService(vsService);
+
+      assertEquals("JOIN_SO_SOL", service.resolveWorksheetTableName(vs, "Text1"));
    }
 
    @Test
@@ -49,11 +64,11 @@ class WizBrowseDataServiceTest {
    }
 
    @Test
-   void throwsWhenChartAssemblyIsNotADataVSAssembly() {
+   void throwsWhenChartAssemblyIsNotBindable() {
       ViewsheetService vsService = mock(ViewsheetService.class);
       Viewsheet vs = mock(Viewsheet.class);
-      VSAssembly nonDataAssembly = mock(VSAssembly.class);
-      when(vs.getAssembly("Chart1")).thenReturn(nonDataAssembly);
+      VSAssembly nonBindableAssembly = mock(VSAssembly.class);
+      when(vs.getAssembly("Chart1")).thenReturn(nonBindableAssembly);
 
       WizBrowseDataService service = new WizBrowseDataService(vsService);
 
@@ -62,28 +77,12 @@ class WizBrowseDataServiceTest {
    }
 
    @Test
-   void throwsWhenSourceInfoMissing() {
+   void throwsWhenBindableAssemblyHasNoTableName() {
       ViewsheetService vsService = mock(ViewsheetService.class);
       Viewsheet vs = mock(Viewsheet.class);
-      DataVSAssembly chartAssembly = mock(DataVSAssembly.class);
+      BindableVSAssembly chartAssembly = mock(BindableVSAssembly.class);
       when(vs.getAssembly("Chart1")).thenReturn(chartAssembly);
-      when(chartAssembly.getSourceInfo()).thenReturn(null);
-
-      WizBrowseDataService service = new WizBrowseDataService(vsService);
-
-      assertThrows(IllegalStateException.class,
-                   () -> service.resolveWorksheetTableName(vs, "Chart1"));
-   }
-
-   @Test
-   void throwsWhenSourceInfoHasNoSource() {
-      ViewsheetService vsService = mock(ViewsheetService.class);
-      Viewsheet vs = mock(Viewsheet.class);
-      DataVSAssembly chartAssembly = mock(DataVSAssembly.class);
-      SourceInfo sourceInfo = mock(SourceInfo.class);
-      when(vs.getAssembly("Chart1")).thenReturn(chartAssembly);
-      when(chartAssembly.getSourceInfo()).thenReturn(sourceInfo);
-      when(sourceInfo.getSource()).thenReturn(null);
+      when(chartAssembly.getTableName()).thenReturn(null);
 
       WizBrowseDataService service = new WizBrowseDataService(vsService);
 


### PR DESCRIPTION
## Root cause

`WizBrowseDataService.resolveWorksheetTableName` (`core/src/main/java/inetsoft/web/wiz/service/WizBrowseDataService.java`) gated on `instanceof DataVSAssembly`, throwing `IllegalArgumentException("No chart assembly named 'X' found in the viewsheet")` for any assembly that isn't a `DataVSAssembly`. A `text`/`gauge` visualization is a `TextVSAssembly`/`GaugeVSAssembly extends OutputVSAssembly` — a sibling hierarchy that is never a `DataVSAssembly`.

This method is the runtime-value-browse call used by wiz's condition/filter agent to ground an LLM-guessed filter literal (e.g. "Eastern region of the United States") against the chart's real stored distinct values (e.g. "USA East"). A single-metric query with no dimension (e.g. "customer count in the Eastern region") recommends a `text` visualization, so this call failed 100% of the time for that query shape — not intermittently — leaving the wiz-side agent with no verified value to fall back on (Redmine #76368).

This is the third occurrence of an already-fixed class of defect in this same area:
- `WizVsService.applyConditionModel` (~line 5267-5311, comment "THE BUG THIS FIXES") was already widened from `DataVSAssembly` to `DynamicBindableVSAssembly`.
- `createViewsheetInternal`'s own `wsTableName` resolution for modification-only calls (~2077-2086) was already widened the same way, with a comment noting it was "broadened from DataVSAssembly alongside applyConditionModel's own widening."
- `WizBrowseDataService.resolveWorksheetTableName` was the one remaining call site never updated to match.

## Fix

Widen the type gate to `BindableVSAssembly` (the common interface both `DataVSAssembly` and `OutputVSAssembly` implement, declaring `getTableName()`), and resolve the worksheet table name via that shared accessor instead of reading `DataVSAssembly`'s `SourceInfo` directly. `BindableVSAssembly.getTableName()` is implemented consistently and null-safely on both hierarchies (`DataVSAssembly` derives it from `SourceInfo.getSource()`, `OutputVSAssembly` from its `ScalarBindingInfo`), so this reuses a resolution path `WizVsService` already prefers elsewhere — not a new one.

`resolveWorksheetTableName` has exactly one caller in the whole repo (`WizBrowseDataService.browseData`), confirmed by an exhaustive grep, so there's no other call site affected by widening the gate.

## Tests

Updated `WizBrowseDataServiceTest.java`:
- Existing `DataVSAssembly` coverage now stubs `getTableName()` directly (the resolution no longer reads `SourceInfo`).
- Added `resolvesWorksheetTableNameFromOutputAssembly`: a mocked `TextVSAssembly` with a bound `getTableName()` now resolves successfully instead of throwing — the regression case for this bug.
- Added `throwsWhenBindableAssemblyHasNoTableName`: a `BindableVSAssembly` whose `getTableName()` returns null still throws `IllegalStateException`.
- Renamed `throwsWhenChartAssemblyIsNotADataVSAssembly` to `throwsWhenChartAssemblyIsNotBindable` for accuracy under the widened gate (a bare `VSAssembly` mock is also not `BindableVSAssembly`, so it still throws, unchanged).

Ran `./mvnw -pl core test -Dtest=WizBrowseDataServiceTest`: 6/6 pass.

Redmine: #76368