### PR TITLE
fix(wiz/binding): expose calc-table cell naming, validate cross-table column binding

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -104,7 +104,7 @@ public final class CalcCellVocabulary {
                "'" + rejected.getKey() + "' is not a calc-table cell key — it means something " +
                "else elsewhere in this plugin, which is exactly why it is refused here. Use '" +
                rejected.getValue() + "'. Cell keys are: content, grouping, expand, field, " +
-               "value, formula.");
+               "value, formula, name.");
          }
       }
 
@@ -160,6 +160,7 @@ public final class CalcCellVocabulary {
       out.put("mergeCells", info.getMergeCells());
       out.put("rowGroup", info.getRowGroup());
       out.put("colGroup", info.getColGroup());
+      out.put("name", info.getName());
       out.put("runtimeName", info.getRuntimeName());
       return out;
    }

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -48,8 +48,11 @@ import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
 import inetsoft.web.binding.model.table.CellBindingInfo;
 import inetsoft.web.binding.model.table.TableCell;
+import inetsoft.web.wiz.binding.model.BindableTable;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -75,11 +78,13 @@ import java.util.List;
 public class CalcTableService {
    @Autowired
    public CalcTableService(ViewsheetSessionService sessions, VSTableLayoutService layoutService,
-                           DataRefModelFactoryService refModelService)
+                           DataRefModelFactoryService refModelService,
+                           BindableFieldsService fieldsService)
    {
       this.sessions = sessions;
       this.layoutService = layoutService;
       this.refModelService = refModelService;
+      this.fieldsService = fieldsService;
    }
 
    /**
@@ -271,6 +276,11 @@ public class CalcTableService {
          requireInGrid(layoutOf(assembly), row, col);
 
          CellBindingInfo cellBindingInfo = toCellBindingInfo(binding);
+
+         if(cellBindingInfo.getType() == CellBinding.BIND_COLUMN) {
+            requireBindableColumn(runtimeId, user, assemblyName, cellBindingInfo.getValue());
+         }
+
          String namedGroup = cellBindingInfo.getType() == CellBinding.BIND_COLUMN
             ? namedGroupOf(binding.get("field")) : null;
 
@@ -286,6 +296,34 @@ public class CalcTableService {
          event.setBinding(cellBindingInfo);
          layoutService.setCellBinding(runtimeId, event, user, dispatcher);
       });
+   }
+
+   /**
+    * Checks that a column cell's {@code field.column} is actually reachable from the calc
+    * table's current {@code set_table_source} target, the same check
+    * {@code BindingAgentController.resolveSourceTable} already makes for chart/table/crosstab
+    * writes via {@link BindableColumns#require}. Without it, a column that is a real column —
+    * just on a different table than this assembly's source — bound cleanly and rendered a
+    * silently blank cell (CLAUDE.md's tool-misuse-accepted-silently class).
+    *
+    * <p>A listing failure is logged and skipped rather than propagated, matching
+    * {@code resolveSourceTable}'s own reasoning: not being able to read the tree is a different
+    * fault than a bad column, and refusing the write on the strength of it would turn a read
+    * problem into a write problem.
+    */
+   private void requireBindableColumn(String runtimeId, Principal user, String assemblyName,
+                                      String column)
+   {
+      try {
+         List<BindableTable> tables = fieldsService.list(runtimeId, assemblyName, user);
+         BindableColumns.require(tables, assemblyName, new FieldRef(column, null, null, null, null));
+      }
+      catch(IllegalArgumentException e) {
+         throw e;
+      }
+      catch(Exception e) {
+         LOG.debug("Could not list bindable columns for {}; skipping the check", assemblyName, e);
+      }
    }
 
    /**
@@ -570,6 +608,12 @@ public class CalcTableService {
       int type = CalcCellVocabulary.content(str(binding, "content"));
       info.setType(type);
 
+      String name = str(binding, "name");
+
+      if(name != null) {
+         info.setName(name);
+      }
+
       if(binding.get("grouping") != null) {
          info.setBtype(CalcCellVocabulary.grouping(str(binding, "grouping")));
       }
@@ -738,7 +782,10 @@ public class CalcTableService {
       return text.isEmpty() ? null : text;
    }
 
+   private static final Logger LOG = LoggerFactory.getLogger(CalcTableService.class);
+
    private final ViewsheetSessionService sessions;
    private final VSTableLayoutService layoutService;
    private final DataRefModelFactoryService refModelService;
+   private final BindableFieldsService fieldsService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -51,6 +51,8 @@ import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
 import inetsoft.web.binding.model.table.CellBindingInfo;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.wiz.binding.model.BindableField;
+import inetsoft.web.wiz.binding.model.BindableTable;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -112,6 +114,42 @@ class CalcTableServiceTest {
       assertEquals("group", binding.get("grouping"));
       assertEquals("vertical", binding.get("expand"));
       assertEquals("SomeName", binding.get("runtimeName"));
+   }
+
+   /**
+    * Regression test for the cross-cell-formula gap: {@code CellBindingInfo} already round-trips
+    * a cell's explicit {@code name} ({@code setName}/{@code getName}) into
+    * {@code TableCellBinding.cellName}, which {@code CalcTableScope.initRuntimeReferences}
+    * registers at runtime as {@code "$" + name} so another formula cell can reference this one's
+    * computed value. Before this fix, {@code CalcTableService.toCellBindingInfo} never called
+    * {@code setName}, so there was no way to name a cell through this tool at all.
+    */
+   @Test
+   void readsCellNameBackAfterDescribing() {
+      CellBindingInfo info = new CellBindingInfo();
+      info.setType(CellBinding.BIND_COLUMN);
+      info.setName("OrderTotal");
+
+      Map<String, Object> described = CalcCellVocabulary.describe(info);
+
+      assertEquals("OrderTotal", described.get("name"));
+   }
+
+   /** @see #readsCellNameBackAfterDescribing() -- the write side of the same gap. */
+   @Test
+   void namesACellSoAnotherFormulaCellCanReferenceItAsADollarName() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 1,
+                               spec("content", "column", "grouping", "summary", "expand", "none",
+                                    "formula", "Sum", "name", "OrderTotal",
+                                    "field", Map.of("column", "PAID", "type", "measure")));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      assertEquals("OrderTotal", captor.getValue().getBinding().getName());
    }
 
    @Test
@@ -197,6 +235,35 @@ class CalcTableServiceTest {
                                              "field", Map.of("column", "PAID",
                                                              "type", "measure"))));
       assertTrue(thrown.getMessage().contains("formula"));
+   }
+
+   /**
+    * Regression test for the secondary finding: a {@code field.column} that is a real column --
+    * just on a different table than the calc table's current {@code set_table_source} target --
+    * used to be accepted without error and rendered a silently blank cell
+    * (CLAUDE.md's tool-misuse-accepted-silently class). {@code BindableColumns.require} is the
+    * same check {@code BindingAgentController.resolveSourceTable} already applies to
+    * chart/table/crosstab writes; this is the first time a calc-table cell write applies it too.
+    */
+   @Test
+   void refusesAColumnNotOnTheAssemblysCurrentSource() throws Exception {
+      Harness h = harness(3, 3);
+      when(h.fieldsService().list(anyString(), anyString(), any(Principal.class))).thenReturn(
+         List.of(new BindableTable("OrderAmountTotal", true,
+                                   List.of(new BindableField("TOTAL_ORDER_AMOUNT", "double",
+                                                             "measure")))));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.setCellBinding(
+            "tok", principal(), "Calc1", 1, 1,
+            spec("content", "column", "grouping", "summary", "expand", "none", "formula", "Sum",
+                 "field", Map.of("column", "TOTAL_RETURN_AMOUNT", "type", "measure"))));
+
+      assertTrue(thrown.getMessage().contains("TOTAL_RETURN_AMOUNT"));
+      assertTrue(thrown.getMessage().contains("OrderAmountTotal"));
+      verify(h.layoutService, never()).setCellBinding(anyString(), any(), any(Principal.class),
+                                                       any());
    }
 
    @Test
@@ -329,7 +396,8 @@ class CalcTableServiceTest {
    private record Harness(CalcTableService service, ViewsheetSessionService sessions,
                           VSTableLayoutService layoutService, Viewsheet viewsheet,
                           CalcTableVSAssemblyInfo assemblyInfo,
-                          DataRefModelFactoryService refModelService) {}
+                          DataRefModelFactoryService refModelService,
+                          BindableFieldsService fieldsService) {}
 
    private static Harness harness(int rows, int cols) {
       CalcTableVSAssembly assembly = mock(CalcTableVSAssembly.class);
@@ -387,8 +455,26 @@ class CalcTableServiceTest {
       VSTableLayoutService layoutService = mock(VSTableLayoutService.class);
       DataRefModelFactoryService refModelService = mock(DataRefModelFactoryService.class);
       when(refModelService.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
-      return new Harness(new CalcTableService(sessions, layoutService, refModelService), sessions,
-                         layoutService, vs, info, refModelService);
+
+      // Default fixture: a single "current" source table carrying every column the existing
+      // test suite binds. Individual tests that need to exercise the column-existence check
+      // itself stub fieldsService.list(...) again with a narrower fixture.
+      BindableFieldsService fieldsService = mock(BindableFieldsService.class);
+
+      try {
+         when(fieldsService.list(anyString(), anyString(), any(Principal.class))).thenReturn(
+            List.of(new BindableTable("Query1", true, List.of(
+               new BindableField("Region", "string", "dimension"),
+               new BindableField("REGION", "string", "dimension"),
+               new BindableField("PAID", "double", "measure")))));
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new Harness(
+         new CalcTableService(sessions, layoutService, refModelService, fieldsService), sessions,
+         layoutService, vs, info, refModelService, fieldsService);
    }
 
    private static Principal principal() {


### PR DESCRIPTION
## Summary

Fixes two gaps in the wiz-agent calc (freehand) table cell-binding surface, found while testing the `stylebi-wiz` composer-chat plugin's cross-cell formula support (see `stylebi-wiz` case doc `docs/teams/2026-09-04-test-composer-plugin-calc-tables/case-freehand-cross-cell-formula/`).

**1. Cell naming (`CellBindingInfo.name`) was never written.** Calc tables already support a real named-cell reference mechanism: `TableLayoutInfo.setCellName(row, col, name)` stores a name on `TableCellBinding.cellName`, and at runtime `CalcTableScope.initRuntimeReferences` registers it as `"$" + name` so another formula cell can reference that cell's *computed* value (e.g. `$OrderTotal - $ReturnTotal`) — the exact mechanism the Composer's own Formula Editor generates when a user clicks a named cell. `CellBindingInfo` already has `setName`/`getName` and correctly round-trips to `TableCellBinding.cellName`, but `CalcTableService.toCellBindingInfo` never called `setName`, so there was no write path for it at all through this agent surface. `toCellBindingInfo` now sets the name when supplied, and `CalcCellVocabulary.describe` reports it back (alongside the existing auto-generated `runtimeName`, which is a different, non-referenceable name).

**2. A column cell's `field.column` was never validated against the calc table's actual bound source.** `CalcTableService.columnOf` only checked the column was non-blank and had a valid `type` — never that it actually exists on the table named via `set_table_source`. A column belonging to a *different* table was accepted silently and rendered a blank cell, with no error anywhere. `setCellBinding` now validates a `BIND_COLUMN` cell's column via `BindableFieldsService` + `BindableColumns.require` — the identical check `BindingAgentController.resolveSourceTable` already applies to chart/table/crosstab writes — so an invalid column now throws, naming the column and the assembly's actual current source.

## Changes

- `core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java`
  - `toCellBindingInfo`: sets `CellBindingInfo.name` when `binding.name` is supplied.
  - `setCellBinding`: injects `BindableFieldsService` and validates a `BIND_COLUMN` cell's `field.column` against the assembly's current bindable columns before writing, mirroring `BindingAgentController.resolveSourceTable`'s existing pattern (a listing failure is logged and skipped, not propagated — matching that method's own reasoning).
- `core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java`
  - `describe`: reports `name` alongside `runtimeName`.
  - `validate`: lists `name` among the accepted cell keys in its error message.

## Test plan

- [x] `CalcTableServiceTest` (extended): name round-trips through `toCellBindingInfo`/`describe`; a column on a different table than the assembly's current source is refused, naming the column and the source; all existing tests still pass with the new `BindableFieldsService` dependency wired into the harness.
- [x] `mvn -pl core test -Dtest=CalcTableServiceTest` — 43/43 pass.
- [x] `mvn -pl core test -Dtest=CalcCellVocabularyTest,BindingAgentControllerTest,BindableColumnsTest,BindableFieldsServiceTest,ChartBindingServiceTest,...` (surrounding `wiz.binding` package) — all pass, no collateral regressions from the constructor/vocabulary changes.

## Companion PR

Paired with `stylebi-wiz` PR (plugin-side `set_cell_binding`/`set_calc_cell_script` changes that expose this through the MCP tool surface) — will link once opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)