### PR TITLE
fix(wiz): set an explicit font family on board PPTX export text runs (bug-76110)

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.report.io.viewsheet;
 
+import inetsoft.report.StyleFont;
 import inetsoft.web.wiz.service.MarkdownModel;
 import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
@@ -182,13 +183,20 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       return candidate + "…";
    }
 
-   /** Apply a uniform bold/size/color to every run in every paragraph of a text box. */
+   /** Apply a uniform bold/size/color to every run in every paragraph of a text box.
+    *  Also sets an explicit font family: without one, a run has no Latin-typeface element at
+    *  all and resolves purely by OOXML theme inheritance (the deck's theme font), which
+    *  {@link #appendBlock} and {@link #appendSpans} below rely on this same explicit-family
+    *  approach for too. This matches this codebase's other PPTX-export convention
+    *  ({@code PPTValueHelper}, bug #75992) of always writing a resolved family name rather than
+    *  leaving typeface resolution to the reader. */
    private void styleBox(XSLFTextBox box, boolean bold, double fontSize, Color color) {
       for(XSLFTextParagraph paragraph : box.getTextParagraphs()) {
          for(XSLFTextRun run : paragraph.getTextRuns()) {
             run.setBold(bold);
             run.setFontSize(fontSize);
             run.setFontColor(color);
+            run.setFontFamily(StyleFont.getDefaultFontFamily());
          }
       }
    }
@@ -299,6 +307,7 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
          bullet.setFontSize(bodySize);
          bullet.setFontColor(ACCENT);
          bullet.setBold(true);
+         bullet.setFontFamily(StyleFont.getDefaultFontFamily());
          appendSpans(p, block.spans(), bodySize, BODY_COLOR, false);
          break;
       default:
@@ -320,6 +329,7 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
          run.setFontColor(color);
          run.setBold(forceBold || span.bold());
          run.setItalic(span.italic());
+         run.setFontFamily(StyleFont.getDefaultFontFamily());
       }
    }
 

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -342,6 +342,72 @@ class PoiPptxDeckMergerTest {
       }
    }
 
+   /**
+    * bug-76110: an insight bullet whose text contained an emoji rendered as a missing-glyph box
+    * in the exported PPTX, because no run this merger creates ever set an explicit font family —
+    * without one, OOXML falls back to the deck's theme font (Calibri) by inheritance. The fix
+    * sets an explicit family ({@link inetsoft.report.StyleFont#getDefaultFontFamily()}, "Roboto"
+    * outside a live server context — same default the PDF export path resolves to) on every run,
+    * matching this codebase's own PPTX-export convention ({@code PPTValueHelper}, bug #75992) of
+    * never leaving typeface resolution to the reader. This does not by itself guarantee the
+    * emoji glyph renders (that depends on whether the resolved family has emoji coverage on the
+    * machine that opens the deck); it only guarantees every run carries an explicit,
+    * intentional typeface instead of an inherited one.
+    */
+   @Test
+   void everyRunCarriesAnExplicitFontFamilyInsteadOfThemeInheritance() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Revenue by Region", "cap", chart1, false,
+            "**Growth accelerating.**\n- 📈 Premium pricing drives most of the revenue.")
+      );
+
+      byte[] merged = merger.mergeSlides("Q39 Board", "Premium units run the business.", slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         // Title slide: exercises styleBox() (title box) and appendBlock()'s recap paragraph.
+         XSLFTextBox titleBox = result.getSlides().get(0).getShapes().stream()
+            .filter(sh -> sh instanceof XSLFTextBox tb && "Q39 Board".equals(tb.getText()))
+            .map(sh -> (XSLFTextBox) sh)
+            .findFirst().orElseThrow();
+         assertEquals("Roboto",
+            titleBox.getTextParagraphs().get(0).getTextRuns().get(0).getFontFamily(),
+            "styleBox() must set an explicit family instead of leaving the title run to theme "
+               + "inheritance");
+
+         // Insights slide: exercises appendBlock()'s bullet-marker run and appendSpans()'s span
+         // run (the run that would actually carry the emoji-containing text).
+         XSLFSlide insightsSlide = result.getSlides().get(2);
+         boolean sawBulletMarkerFamily = false;
+         boolean sawEmojiSpanFamily = false;
+
+         for(var shape : insightsSlide.getShapes()) {
+            if(shape instanceof XSLFTextBox tb) {
+               for(var paragraph : tb.getTextParagraphs()) {
+                  for(var run : paragraph.getTextRuns()) {
+                     String t = run.getRawText();
+
+                     if(t.contains("•")) {
+                        assertEquals("Roboto", run.getFontFamily(),
+                           "bullet-marker run in appendBlock() must set an explicit family");
+                        sawBulletMarkerFamily = true;
+                     }
+
+                     if(t.contains("Premium pricing")) {
+                        assertEquals("Roboto", run.getFontFamily(),
+                           "span run in appendSpans() must set an explicit family");
+                        sawEmojiSpanFamily = true;
+                     }
+                  }
+               }
+            }
+         }
+
+         assertTrue(sawBulletMarkerFamily, "expected to find the bullet-marker run");
+         assertTrue(sawEmojiSpanFamily, "expected to find the emoji-adjacent span run");
+      }
+   }
+
    @Test
    void continuationInsightsSlidesMarkedContd() throws Exception {
       byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");


### PR DESCRIPTION
## Bug

bug-76110: a board's PPTX export ("content not displayed well") showed a missing-glyph box
where an AI-generated insight bullet contained an emoji, while the same content in the PDF
export rendered correctly.

## Root cause

`PoiPptxDeckMerger` (the sole `PptxDeckMerger` implementation, wired via `PptxDeckMergerConfig`,
used by `WizViewsheetExportController.exportPptx()`) creates every `XSLFTextRun` for the title
slide, recap box, per-chart captions, and insights text (`styleBox()`, the bullet-marker run in
`appendBlock()`, and `appendSpans()`) with `{fontSize, fontColor, bold, italic}` but never called
`setFontFamily`. Per OOXML's inheritance model, a run with no explicit Latin-typeface element
resolves to the deck's theme font — confirmed "Calibri" in the reported PPTX's `theme1.xml`.

This is also an inconsistency with this codebase's own established PPTX-export convention:
`PPTValueHelper` (the generic, non-wiz PPTX export path, same POI/OOXML API) has always set an
explicit font family per run, with a comment citing a prior bug:

> bug #75992, write the font family, not the face name. getFontName() returns the face (e.g.
> "Roboto Bold"), which ppt cannot resolve as a typeface even when the family is installed, so it
> substitutes a font with different metrics and re-wraps the text.

## Fix

Set an explicit font family — `StyleFont.getDefaultFontFamily()` (resolves to
`SreeEnv.getProperty("default.font.family", "Roboto")`, "Roboto" by default) — on every run
created by `styleBox()`, the bullet-marker run in `appendBlock()`, and `appendSpans()`. This is
the same family the PDF export path resolves to for ordinary text
(`VSAssemblyInfo.getDefaultFont()` → `StyleFont(DEFAULT_FONT_FAMILY, ...)` →
`getDefaultFontFamily()`), so the two export paths are now consistent with each other, not just
each independently theme/property-driven.

Following the `PPTValueHelper`/bug #75992 precedent, this writes a plain resolved family name
(not a face/style-qualified name like "Roboto Bold") — bold/italic stay on the run's own
properties, as they already were.

## What this does NOT fix — please read before assuming "emoji now renders"

**This does not guarantee the emoji glyph itself renders instead of a missing-glyph box.** The
actual deployed Docker image (`community/docker/src/main/docker/Dockerfile`) installs only
`fonts-dejavu`, `fonts-liberation2`, `fonts-croscore`, `fonts-freefont-ttf`, and `fonts-roboto` —
none of which are confirmed emoji-capable. Whether any of these five families actually contains a
glyph for the reported pictograph could not be confirmed from source in this investigation (no
font-rendering tool or live target was available). This PR fixes a real, demonstrated
inconsistency (theme-inherited Calibri vs. an explicit, intentional family, matching this
codebase's own PPTX convention) — it is a plain-text/consistency fix, not a guaranteed emoji fix.
This was an explicit, informed product decision (font-only, not emoji-stripping or installing an
emoji font in the Docker image) made after the debugger and refuter both flagged the emoji
question as a product/UX call, not a fixer's call to make alone.

## Tests

Extended `PoiPptxDeckMergerTest` with
`everyRunCarriesAnExplicitFontFamilyInsteadOfThemeInheritance`: builds a `ChartSlide` with a
`**Growth accelerating.**` heading and a `- 📈 Premium pricing drives most of the revenue.`
bullet, merges, reopens the deck, and asserts `run.getFontFamily()` equals the resolved family
("Roboto" in this Spring-context-free unit test) for the title-slide run (`styleBox()`), the
bullet-marker run (`appendBlock()`), and the span run containing the emoji-adjacent text
(`appendSpans()`) — not just a non-null check, so an accidental future change shows as a diff.

```
mvn -pl utils/inetsoft-xml-formats -Dtest=PoiPptxDeckMergerTest test
Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
