### PR TITLE
fix(cluster): add Cluster.clearLocalNodeProperty to avoid null-value cache put (bug 76460)

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
@@ -137,6 +137,15 @@ public interface Cluster extends AutoCloseable {
    void setLocalNodeProperty(String name, Object value);
 
    /**
+    * Removes the named property of the current cluster node. Unlike
+    * {@link #setLocalNodeProperty(String, Object)} with a {@code null} value, this is
+    * guaranteed not to attempt to store a null value in the underlying implementation.
+    *
+    * @param name the property name.
+    */
+   void clearLocalNodeProperty(String name);
+
+   /**
     * Check if this node is the master. The oldest node in the cluster is
     * treated as the master.
     */

--- a/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
@@ -115,6 +115,12 @@ public class MockCluster implements Cluster {
    }
 
    @Override
+   public void clearLocalNodeProperty(String name) {
+      clusterNodeProperties.computeIfAbsent(
+         getLocalMember(), k -> new ConcurrentHashMap<>()).remove(name);
+   }
+
+   @Override
    public boolean isMaster() {
       return true;
    }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -745,6 +745,11 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       getNodePropertyMap().put(getLocalMember() + ":" + name, value);
    }
 
+   @Override
+   public void clearLocalNodeProperty(String name) {
+      getNodePropertyMap().remove(getLocalMember() + ":" + name);
+   }
+
    private Map<String, Object> getNodePropertyMap() {
       return getMap(getClass().getName() + ".nodeProperties");
    }


### PR DESCRIPTION
## Summary

- `Cluster.setLocalNodeProperty(name, null)` was being used as a "clear this property" convention by one caller (`EnterpriseLicenseStrategy.setClaimedLicense`, in the sibling `stylebi-enterprise` PR), but the interface never actually supported a null value: Ignite's `IgniteCache.put(key, val)` throws an uncaught `NullPointerException: Ouch! Argument cannot be null: val` on a null value, and `MockCluster`'s plain `ConcurrentHashMap`-backed implementation throws its own NPE on `put(key, null)` too.
- Adds a dedicated `Cluster.clearLocalNodeProperty(String name)` method with real key-removal semantics, implemented in both `Cluster` implementors:
  - `IgniteCluster`: removes the entry from the underlying `IgniteDistributedMap`/`IgniteCache`-backed node-property map.
  - `MockCluster`: removes the entry from its `ConcurrentHashMap`-backed per-node property map.
- Confirmed (via grep across `community/core` and `enterprise`) that `EnterpriseLicenseStrategy.java:953` is the only call site of `setLocalNodeProperty` that could ever pass a null value; the other two call sites pass hardcoded non-null literals and are unaffected.

This is the `community` half of the fix for Redmine bug #76460 ("`apply_license_changes` status unreliable for a key removal"). See the companion `stylebi-enterprise` PR for the actual license-claim call site fix and regression tests.

## Test plan

- [x] `./mvnw -o -pl community/core,enterprise -am test -Dtest="EnterpriseLicenseStrategyTest,LicenseChangesetApplyServiceTest,LicenseKeySettingsServiceTest,LicenseChangePlanServiceTest"` — 35/35 passing (2 new + 33 pre-existing).
- [x] `./mvnw -o -pl community/core,enterprise -am test-compile` — full test-compile of both modules (~2600 + 99 test source files) succeeds, confirming `IgniteCluster`/`MockCluster` are the only two `Cluster` implementors and nothing else broke.

Ref: Redmine #76460.