### PR TITLE
L6 Calc Tables: parity audit fixes + sort/rank-by-value + inline named groups

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/handler/TableLayoutHandler.java
+++ b/core/src/main/java/inetsoft/web/binding/handler/TableLayoutHandler.java
@@ -37,8 +37,25 @@ import java.util.Map;
 
 @Component
 public class TableLayoutHandler {
+   /**
+    * The Composer's own Insert Rows/Columns dialog caps its own count field at this many
+    * ({@code insert-row-col-dialog.component.ts} / {@code b-calctable-action-handler.directive.ts}
+    * silently falls back to 1 above it) -- enforced only in that one Angular directive until now,
+    * so any other caller of this shared handler (the wiz agent path among them) could grow a
+    * table's row/column count without bound in a single call.
+    */
+   private static final int MAX_INSERT_COUNT = 1000;
+
    /** TableTool insertrow/column */
    public void doOperation(CalcTableVSAssemblyInfo info, String op, Rectangle rect, int n) {
+      if(("insertRow".equals(op) || "appendRow".equals(op) || "insertCol".equals(op) ||
+          "appendCol".equals(op)) && n > MAX_INSERT_COUNT)
+      {
+         throw new IllegalArgumentException(
+            "Cannot insert " + n + " row(s)/column(s) in one operation -- the limit is " +
+            MAX_INSERT_COUNT + ".");
+      }
+
       int r = (int) rect.getY();
       int c = (int) rect.getX();
       int w = (int) rect.getWidth();

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -291,7 +291,6 @@ public final class CalcCellVocabulary {
       out.put("colGroup", info.getColGroup());
       out.put("name", info.getName());
       out.put("runtimeName", info.getRuntimeName());
-      out.put("name", info.getName());
       out.put("mergeRowGroup", info.getMergeRowGroup());
       out.put("mergeColGroup", info.getMergeColGroup());
       out.put("timeSeries", info.isTimeSeries());

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -22,6 +22,7 @@ import inetsoft.report.GroupableCellBinding;
 import inetsoft.report.TableCellBinding;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.AggregateRef;
 import inetsoft.web.binding.model.table.CellBindingInfo;
 import inetsoft.web.binding.model.table.OrderModel;
 import inetsoft.web.binding.model.table.TopNModel;
@@ -69,16 +70,20 @@ public final class CalcCellVocabulary {
 
    /**
     * A group cell's sort direction ({@code OrderModel.type}). {@code "manual"} requires
-    * {@code manualOrder} alongside it. Sorting by a specific aggregate's value
-    * ({@code XConstants.SORT_VALUE_ASC}/{@code SORT_VALUE_DESC}) is not exposed here yet -- it
-    * needs the same in-scope-aggregate resolution {@link #TOPN_MODE} deliberately does not
-    * expose either; see the note on {@code topn.mode}.
+    * {@code manualOrder} alongside it. {@code "value_asc"}/{@code "value_desc"} sort by a
+    * specific in-scope summary cell's value rather than the group's own label, and require
+    * {@code rankBy} alongside them -- resolved to {@code OrderModel.sortByCol} by
+    * {@code CalcTableService}, which has the runtime access this stateless vocabulary does not.
+    * Token spelling matches {@code DimensionSortRanking} (the equivalent for chart/crosstab
+    * dimensions), so an agent that has driven that surface does not have to relearn it here.
     */
    private static final Map<String, Integer> SORT_DIRECTION = Map.of(
       "none", XConstants.SORT_NONE,
       "asc", XConstants.SORT_ASC,
       "desc", XConstants.SORT_DESC,
-      "manual", XConstants.SORT_SPECIFIC);
+      "manual", XConstants.SORT_SPECIFIC,
+      "value_asc", XConstants.SORT_VALUE_ASC,
+      "value_desc", XConstants.SORT_VALUE_DESC);
 
    /**
     * A group cell's ranking mode ({@code TopNModel.type}). Values match {@code StyleConstants}
@@ -202,12 +207,14 @@ public final class CalcCellVocabulary {
    }
 
    /**
-    * A group cell's sort direction. Deliberately narrower than {@code OrderModel}: sorting by a
-    * specific aggregate's value ({@code SORT_VALUE_ASC}/{@code SORT_VALUE_DESC}) needs the same
-    * in-scope-aggregate resolution {@code topn.mode: "top"/"bottom"} would need for
-    * {@code rankBy} and neither is exposed yet — see the class-level note on {@code TOPN_MODE}.
-    * {@code manual} requires {@code manualOrder} alongside it, since a manual order with nothing
-    * to order is not meaningfully different from no order at all.
+    * A group cell's sort direction. {@code manual} requires {@code manualOrder} alongside it,
+    * since a manual order with nothing to order is not meaningfully different from no order at
+    * all. {@code value_asc}/{@code value_desc} require {@code rankBy} -- {@code {column,
+    * formula}} naming one of this table's summary cells -- since sorting "by value" with nothing
+    * to sort by would otherwise silently fall back to sorting by the label, which looks like the
+    * request was honoured. This only checks the shape; resolving {@code rankBy} against the
+    * table's actual summary cells happens in {@code CalcTableService}, which has the runtime
+    * access this stateless vocabulary does not.
     */
    private static void validateSort(Map<String, Object> sort) {
       if(sort == null) {
@@ -232,15 +239,19 @@ public final class CalcCellVocabulary {
                "otherwise there is nothing to order by.");
          }
       }
+
+      if(resolved == XConstants.SORT_VALUE_ASC || resolved == XConstants.SORT_VALUE_DESC) {
+         requireRankBy(sort.get("rankBy"), "sort.direction '" + direction + "'");
+      }
    }
 
    /**
-    * A group cell's ranking. {@code rankBy} (choosing a specific aggregate to rank by, when a
-    * group has more than one) is not exposed yet: the UI resolves it against a server-pushed,
-    * cell-selection-scoped aggregate list this seam does not have access to, and guessing an
-    * index wrong would silently rank by the wrong column rather than fail loud. With exactly one
-    * aggregate in scope -- the common case -- StyleBI's own default (index 0) applies, matching
-    * what the Composer's own "Aggregate" dropdown defaults to when nothing else is selected.
+    * A group cell's ranking. {@code rankBy} ({@code {column, formula}}, naming the summary cell
+    * to rank by) is optional: with exactly one summary cell in scope -- the common case --
+    * {@code CalcTableService} defaults to it, matching what the Composer's own Top-N pane falls
+    * back to. With more than one, {@code CalcTableService} refuses rather than guessing, since a
+    * wrong guess would silently rank by the wrong column instead of failing loud. This only
+    * checks the shape of a given {@code rankBy}; resolving it happens in {@code CalcTableService}.
     */
    private static void validateTopn(Map<String, Object> topn) {
       if(topn == null) {
@@ -259,6 +270,32 @@ public final class CalcCellVocabulary {
       if(n != null && (!(n instanceof Number) || ((Number) n).intValue() < 1)) {
          throw new IllegalArgumentException("'topn.n' must be a positive integer, got " + n + ".");
       }
+
+      if(topn.get("rankBy") != null) {
+         requireRankBy(topn.get("rankBy"), "'topn.rankBy'");
+      }
+   }
+
+   /** The {@code {column, formula}} shape both {@code sort.rankBy} and {@code topn.rankBy} use. */
+   private static void requireRankBy(Object rankBy, String forWhat) {
+      if(!(rankBy instanceof Map)) {
+         throw new IllegalArgumentException(
+            forWhat + " needs a 'rankBy' of {column, formula} -- naming the summary cell to " +
+            "rank by. Without it the sort/ranking would silently fall back to a default column " +
+            "instead of failing loud.");
+      }
+
+      Map<?, ?> map = (Map<?, ?>) rankBy;
+
+      if(!(map.get("column") instanceof String text) || text.isBlank()) {
+         throw new IllegalArgumentException(forWhat + "'s 'rankBy' needs a non-blank 'column'.");
+      }
+
+      if(!(map.get("formula") instanceof String formulaText) || formulaText.isBlank()) {
+         throw new IllegalArgumentException(
+            forWhat + "'s 'rankBy' needs a non-blank 'formula' (e.g. \"Sum\") -- " +
+            "list_cell_vocabulary's 'aggregateFormulas' lists the accepted names.");
+      }
    }
 
    @SuppressWarnings("unchecked")
@@ -276,6 +313,19 @@ public final class CalcCellVocabulary {
 
    /** Renders a cell binding back in tokens. Never emits an integer constant or an alias key. */
    public static Map<String, Object> describe(CellBindingInfo info) {
+      return describe(info, null);
+   }
+
+   /**
+    * Same as {@link #describe(CellBindingInfo)}, additionally resolving a {@code value_asc}/
+    * {@code value_desc} sort's or a ranking's {@code sortByCol}/{@code sumCol} index back to the
+    * {@code {column, formula}} it names. {@code aggregates} is the same in-scope summary-cell
+    * list {@code CalcTableService} resolved {@code rankBy} against on write -- pass {@code null}
+    * only when that context is unavailable (the index is then omitted rather than reported bare,
+    * since a bare index is exactly the brittle-under-reorder shape this vocabulary avoids
+    * elsewhere).
+    */
+   public static Map<String, Object> describe(CellBindingInfo info, AggregateRef[] aggregates) {
       if(info == null) {
          return null;
       }
@@ -306,6 +356,11 @@ public final class CalcCellVocabulary {
          if(order.getType() == XConstants.SORT_SPECIFIC) {
             sort.put("manualOrder", order.getManualOrder());
          }
+         else if(order.getType() == XConstants.SORT_VALUE_ASC ||
+                 order.getType() == XConstants.SORT_VALUE_DESC)
+         {
+            sort.put("rankBy", rankByOf(aggregates, order.getSortCol()));
+         }
 
          out.put("sort", sort);
          // DateLevels.name() takes the STORED numeric-string form; a group cell whose field
@@ -322,11 +377,25 @@ public final class CalcCellVocabulary {
 
          if(topn.getType() != XCondition.NONE) {
             topnOut.put("n", topn.getTopn());
+            topnOut.put("rankBy", rankByOf(aggregates, topn.getSumCol()));
          }
 
          out.put("topn", topnOut);
       }
 
+      return out;
+   }
+
+   /** Resolves a {@code sortByCol}/{@code sumCol} index back to the summary cell it names. */
+   private static Map<String, Object> rankByOf(AggregateRef[] aggregates, int index) {
+      if(aggregates == null || index < 0 || index >= aggregates.length) {
+         return null;
+      }
+
+      AggregateRef agg = aggregates[index];
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("column", agg.getDataRef() == null ? null : agg.getDataRef().getName());
+      out.put("formula", agg.getFormulaName());
       return out;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -19,7 +19,12 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.report.CellBinding;
 import inetsoft.report.GroupableCellBinding;
+import inetsoft.report.TableCellBinding;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.XCondition;
 import inetsoft.web.binding.model.table.CellBindingInfo;
+import inetsoft.web.binding.model.table.OrderModel;
+import inetsoft.web.binding.model.table.TopNModel;
 
 import java.util.*;
 
@@ -62,6 +67,29 @@ public final class CalcCellVocabulary {
       "horizontal", GroupableCellBinding.EXPAND_H,
       "h", GroupableCellBinding.EXPAND_H);
 
+   /**
+    * A group cell's sort direction ({@code OrderModel.type}). {@code "manual"} requires
+    * {@code manualOrder} alongside it. Sorting by a specific aggregate's value
+    * ({@code XConstants.SORT_VALUE_ASC}/{@code SORT_VALUE_DESC}) is not exposed here yet -- it
+    * needs the same in-scope-aggregate resolution {@link #TOPN_MODE} deliberately does not
+    * expose either; see the note on {@code topn.mode}.
+    */
+   private static final Map<String, Integer> SORT_DIRECTION = Map.of(
+      "none", XConstants.SORT_NONE,
+      "asc", XConstants.SORT_ASC,
+      "desc", XConstants.SORT_DESC,
+      "manual", XConstants.SORT_SPECIFIC);
+
+   /**
+    * A group cell's ranking mode ({@code TopNModel.type}). Values match {@code StyleConstants}
+    * exactly (confirmed identical to {@code XCondition.NONE}/{@code TOP_N}/{@code BOTTOM_N}: 0,
+    * 9, 10) -- the UI's own dropdown and this vocabulary resolve to the same wire values.
+    */
+   private static final Map<String, Integer> TOPN_MODE = Map.of(
+      "none", XCondition.NONE,
+      "top", XCondition.TOP_N,
+      "bottom", XCondition.BOTTOM_N);
+
    /** Keys that mean something else here, mapped to the key the caller meant. */
    private static final Map<String, String> REJECTED = Map.of(
       "type", "content",
@@ -82,6 +110,14 @@ public final class CalcCellVocabulary {
 
    public static int expand(String token) {
       return resolve(EXPAND, token, "expand");
+   }
+
+   public static int sortDirection(String token) {
+      return resolve(SORT_DIRECTION, token, "sort.direction");
+   }
+
+   public static int topnMode(String token) {
+      return resolve(TOPN_MODE, token, "topn.mode");
    }
 
    /** Whether a resolved grouping constant is the aggregating one. */
@@ -143,6 +179,99 @@ public final class CalcCellVocabulary {
          throw new IllegalArgumentException(
             "A cell with content 'text' needs a 'value' — the literal text to show.");
       }
+
+      if(cell.get("name") != null && !(cell.get("name") instanceof String)) {
+         throw new IllegalArgumentException("'name' must be a string — the cell's own name.");
+      }
+
+      validateSort(asMap(cell.get("sort")));
+      validateTopn(asMap(cell.get("topn")));
+
+      for(String key : List.of("mergeRowGroup", "mergeColGroup")) {
+         if(cell.get(key) != null && !(cell.get(key) instanceof String)) {
+            throw new IllegalArgumentException(
+               "'" + key + "' must be a string (another group cell's name), '" +
+               TableCellBinding.DEFAULT_GROUP + "' to inherit the nearest enclosing group, or " +
+               "null for the grand total.");
+         }
+      }
+
+      if(cell.get("timeSeries") != null && !(cell.get("timeSeries") instanceof Boolean)) {
+         throw new IllegalArgumentException("'timeSeries' must be true or false.");
+      }
+   }
+
+   /**
+    * A group cell's sort direction. Deliberately narrower than {@code OrderModel}: sorting by a
+    * specific aggregate's value ({@code SORT_VALUE_ASC}/{@code SORT_VALUE_DESC}) needs the same
+    * in-scope-aggregate resolution {@code topn.mode: "top"/"bottom"} would need for
+    * {@code rankBy} and neither is exposed yet — see the class-level note on {@code TOPN_MODE}.
+    * {@code manual} requires {@code manualOrder} alongside it, since a manual order with nothing
+    * to order is not meaningfully different from no order at all.
+    */
+   private static void validateSort(Map<String, Object> sort) {
+      if(sort == null) {
+         return;
+      }
+
+      String direction = str(sort, "direction");
+
+      if(direction == null) {
+         throw new IllegalArgumentException(
+            "'sort' needs a 'direction' of " + tokens(SORT_DIRECTION) + ".");
+      }
+
+      int resolved = sortDirection(direction);
+
+      if(resolved == XConstants.SORT_SPECIFIC) {
+         Object manual = sort.get("manualOrder");
+
+         if(!(manual instanceof List) || ((List<?>) manual).isEmpty()) {
+            throw new IllegalArgumentException(
+               "sort.direction 'manual' needs a non-empty 'manualOrder' array of values — " +
+               "otherwise there is nothing to order by.");
+         }
+      }
+   }
+
+   /**
+    * A group cell's ranking. {@code rankBy} (choosing a specific aggregate to rank by, when a
+    * group has more than one) is not exposed yet: the UI resolves it against a server-pushed,
+    * cell-selection-scoped aggregate list this seam does not have access to, and guessing an
+    * index wrong would silently rank by the wrong column rather than fail loud. With exactly one
+    * aggregate in scope -- the common case -- StyleBI's own default (index 0) applies, matching
+    * what the Composer's own "Aggregate" dropdown defaults to when nothing else is selected.
+    */
+   private static void validateTopn(Map<String, Object> topn) {
+      if(topn == null) {
+         return;
+      }
+
+      String mode = str(topn, "mode");
+
+      if(mode == null) {
+         throw new IllegalArgumentException("'topn' needs a 'mode' of " + tokens(TOPN_MODE) + ".");
+      }
+
+      topnMode(mode);
+      Object n = topn.get("n");
+
+      if(n != null && (!(n instanceof Number) || ((Number) n).intValue() < 1)) {
+         throw new IllegalArgumentException("'topn.n' must be a positive integer, got " + n + ".");
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> asMap(Object value) {
+      if(value == null) {
+         return null;
+      }
+
+      if(!(value instanceof Map)) {
+         throw new IllegalArgumentException("expected an object, got " + value);
+      }
+
+      return (Map<String, Object>) value;
    }
 
    /** Renders a cell binding back in tokens. Never emits an integer constant or an alias key. */
@@ -162,6 +291,43 @@ public final class CalcCellVocabulary {
       out.put("colGroup", info.getColGroup());
       out.put("name", info.getName());
       out.put("runtimeName", info.getRuntimeName());
+      out.put("name", info.getName());
+      out.put("mergeRowGroup", info.getMergeRowGroup());
+      out.put("mergeColGroup", info.getMergeColGroup());
+      out.put("timeSeries", info.isTimeSeries());
+
+      // sort/topn/dateLevel only mean something on a group cell -- reporting OrderModel's
+      // default (SORT_ASC, option YEAR_DATE_GROUP) on every detail/summary/text cell as well
+      // would read as "this cell is sorted/date-grouped" when nothing was ever set on it.
+      if(info.getBtype() == CellBinding.GROUP) {
+         OrderModel order = info.getOrder();
+         Map<String, Object> sort = new LinkedHashMap<>();
+         sort.put("direction", tokenOf(SORT_DIRECTION, order.getType()));
+
+         if(order.getType() == XConstants.SORT_SPECIFIC) {
+            sort.put("manualOrder", order.getManualOrder());
+         }
+
+         out.put("sort", sort);
+         // DateLevels.name() takes the STORED numeric-string form; a group cell whose field
+         // isn't a date/time column simply carries the unused OrderModel default (YEAR_DATE_GROUP)
+         // here, same as the write side leaves it unless the caller sets 'field.dateLevel' -- so a
+         // caller should read this as meaningful only when the bound field is itself a date/time
+         // column.
+         out.put("dateLevel", DateLevels.name(String.valueOf(order.getOption())));
+         out.put("dateInterval", order.getInterval());
+
+         TopNModel topn = info.getTopn();
+         Map<String, Object> topnOut = new LinkedHashMap<>();
+         topnOut.put("mode", tokenOf(TOPN_MODE, topn.getType()));
+
+         if(topn.getType() != XCondition.NONE) {
+            topnOut.put("n", topn.getTopn());
+         }
+
+         out.put("topn", topnOut);
+      }
+
       return out;
    }
 
@@ -175,6 +341,14 @@ public final class CalcCellVocabulary {
 
    public static List<String> expandTokens() {
       return List.of("none", "vertical", "horizontal");
+   }
+
+   public static List<String> sortDirectionTokens() {
+      return sorted(SORT_DIRECTION);
+   }
+
+   public static List<String> topnModeTokens() {
+      return sorted(TOPN_MODE);
    }
 
    // ── helpers ───────────────────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -172,6 +172,10 @@ public final class CalcCellVocabulary {
             "nothing renders blank, which reads as missing data rather than a binding error.");
       }
 
+      if(type == CellBinding.BIND_COLUMN && cell.get("field") instanceof Map<?, ?> fieldMap) {
+         validateInlineNamedGroup(fieldMap);
+      }
+
       if(type == CellBinding.BIND_FORMULA && str(cell, "formula") == null &&
          str(cell, "value") == null)
       {
@@ -273,6 +277,79 @@ public final class CalcCellVocabulary {
 
       if(topn.get("rankBy") != null) {
          requireRankBy(topn.get("rankBy"), "'topn.rankBy'");
+      }
+   }
+
+   /**
+    * The shape of an inline ('Customize') {@code field.namedGroup} -- {@code {groups: [{name,
+    * conditions}], others?}} -- checked here, before the runtime is touched, for the same reason
+    * {@link #validateSort}/{@link #validateTopn} are: an invalid shape costs nothing to reject
+    * before {@code sessions.mutate} opens a checkpoint the caller then has to undo. A string
+    * {@code namedGroup} (the by-name form) is untouched -- resolving whether that name exists is
+    * {@code CalcTableService}'s job, since it needs runtime session state this stateless
+    * vocabulary does not have. Building the actual {@code ConditionVocabulary.Clause} list is
+    * likewise left to {@code CalcTableService.applyInlineNamedGroup}; this only checks the shape
+    * is well-formed enough that building it cannot fail on a null/malformed input.
+    */
+   @SuppressWarnings("unchecked")
+   private static void validateInlineNamedGroup(Map<?, ?> field) {
+      Object namedGroup = field.get("namedGroup");
+
+      if(!(namedGroup instanceof Map)) {
+         return;
+      }
+
+      Map<String, Object> spec = (Map<String, Object>) namedGroup;
+      Object rawGroups = spec.get("groups");
+
+      if(!(rawGroups instanceof List<?> groups) || groups.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'field.namedGroup.groups' needs at least one {name, conditions} group -- a named " +
+            "group with no groups in it buckets nothing.");
+      }
+
+      String column = str((Map<String, Object>) field, "column");
+
+      for(int i = 0; i < groups.size(); i++) {
+         Object g = groups.get(i);
+
+         if(!(g instanceof Map<?, ?> groupSpec)) {
+            throw new IllegalArgumentException(
+               "'field.namedGroup.groups[" + i + "]' must be an object.");
+         }
+
+         Object name = groupSpec.get("name");
+
+         if(!(name instanceof String text) || text.isBlank()) {
+            throw new IllegalArgumentException(
+               "Every group in 'field.namedGroup.groups' needs a non-blank 'name'.");
+         }
+
+         Object rawConditions = groupSpec.get("conditions");
+
+         if(!(rawConditions instanceof List<?> conditions) || conditions.isEmpty()) {
+            throw new IllegalArgumentException(
+               "Every group in 'field.namedGroup.groups' needs at least one condition.");
+         }
+
+         for(int c = 0; c < conditions.size(); c++) {
+            Object condition = conditions.get(c);
+
+            if(!(condition instanceof Map<?, ?> clause)) {
+               throw new IllegalArgumentException(
+                  "Every condition in 'field.namedGroup.groups[].conditions' must be an object " +
+                  "such as {operator: \"one_of\", values: [...]}, got " + condition + ".");
+            }
+
+            Object conditionField = clause.get("field");
+
+            if(conditionField != null && column != null && !column.equals(String.valueOf(conditionField))) {
+               throw new IllegalArgumentException(
+                  "'field.namedGroup.groups[" + i + "].conditions[" + c + "]' names field '" +
+                  conditionField + "', but a named group only conditions on the column it is " +
+                  "grouping ('" + column + "'). Omit 'field' or set it to '" + column + "'.");
+            }
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -21,11 +21,13 @@ import inetsoft.report.CellBinding;
 import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.XCondition;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import inetsoft.uql.viewsheet.DataVSAssembly;
@@ -36,8 +38,10 @@ import inetsoft.report.internal.binding.AssetNamedGroupInfo;
 import inetsoft.web.binding.command.GetCellScriptCommand;
 import inetsoft.web.binding.command.GetPredefinedNamedGroupCommand;
 import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.event.GetCellScriptEvent;
 import inetsoft.web.binding.event.GetPredefinedNamedGroupEvent;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.binding.model.NamedGroupInfoModel;
 import inetsoft.web.binding.model.table.OrderModel;
 import inetsoft.web.binding.model.table.TopNModel;
@@ -52,6 +56,7 @@ import inetsoft.web.binding.model.table.CellBindingInfo;
 import inetsoft.web.binding.model.table.TableCell;
 import inetsoft.web.wiz.binding.model.BindableTable;
 import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ConditionVocabulary;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,12 +86,14 @@ public class CalcTableService {
    @Autowired
    public CalcTableService(ViewsheetSessionService sessions, VSTableLayoutService layoutService,
                            DataRefModelFactoryService refModelService,
-                           BindableFieldsService fieldsService)
+                           BindableFieldsService fieldsService,
+                           VSColumnHandler columnsHandler)
    {
       this.sessions = sessions;
       this.layoutService = layoutService;
       this.refModelService = refModelService;
       this.fieldsService = fieldsService;
+      this.columnsHandler = columnsHandler;
    }
 
    /**
@@ -273,17 +280,6 @@ public class CalcTableService {
       // reject here, and opens no checkpoint the caller then has to undo.
       CalcCellVocabulary.validate(binding);
 
-      // Both 'sort' and a resolved 'field.namedGroup' end up setting the same OrderModel --
-      // namedGroup forces SORT_SPECIFIC with the group's own conditions as the order. Accepting
-      // both silently would mean one wins and the caller never learns which; refusing is cheap
-      // and this runs before the runtime is touched, so it costs no checkpoint to reject.
-      if(binding.get("sort") != null && namedGroupOf(binding.get("field")) != null) {
-         throw new IllegalArgumentException(
-            "A cell can't have both 'sort' and 'field.namedGroup' -- resolving a named group " +
-            "sets its own order (SORT_SPECIFIC, ordered by the group's own conditions), which " +
-            "would silently override whatever 'sort' asked for. Send one or the other.");
-      }
-
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
          requireInGrid(layoutOf(assembly), row, col);
@@ -294,13 +290,39 @@ public class CalcTableService {
             requireBindableColumn(runtimeId, user, assemblyName, cellBindingInfo.getValue());
          }
 
+         Object field = binding.get("field");
          String namedGroup = cellBindingInfo.getType() == CellBinding.BIND_COLUMN
-            ? namedGroupOf(binding.get("field")) : null;
+            ? namedGroupOf(field) : null;
+         Map<String, Object> inlineNamedGroup = cellBindingInfo.getType() == CellBinding.BIND_COLUMN
+            ? inlineNamedGroupOf(field) : null;
 
+         // 'sort' and 'field.namedGroup' are independent: a named group only changes which raw
+         // values collapse into which labelled bucket (OrderModel.info), while 'sort' (any
+         // direction, including manual) orders the resulting labels same as any other value
+         // (see LayoutTool.createGroupExpression -- it reads order.info and order.type/asc
+         // separately when building the cell's mapList()/toList() expression). So this only
+         // adds the group's own conditions onto whatever OrderModel 'sort' already built above,
+         // rather than replacing it.
          if(namedGroup != null) {
-            cellBindingInfo.setOrder(resolveNamedGroupOrder(
+            resolveNamedGroupOrder(cellBindingInfo.getOrder(),
                rvs, assembly, runtimeId, user, dispatcher, cellBindingInfo.getValue(),
-               namedGroup));
+               namedGroup);
+         }
+         else if(inlineNamedGroup != null) {
+            applyInlineNamedGroup(cellBindingInfo.getOrder(), inlineNamedGroup, rvs, assembly,
+               cellBindingInfo.getValue());
+         }
+         else {
+            // toCellBindingInfo builds a brand-new OrderModel every call, whose 'info' defaults
+            // to an empty-but-non-null NamedGroupInfoModel (type 0) -- VSTableLayoutService
+            // .setNamedGroupInfo only clears the persisted named group for an explicit null,
+            // not for that default object, so omitting 'field.namedGroup' silently left a prior
+            // write's named group in place (live-confirmed: set one, then write the same cell
+            // without 'namedGroup', and the old group kept rendering). The Composer's own UI
+            // never hits this branch: it loads the real OrderModel once and mutates it in
+            // place, so clearing there always means an explicit null. Explicit null here makes
+            // this match this tool's own documented contract -- 'field' is not preserved.
+            cellBindingInfo.getOrder().setInfo(null);
          }
 
          SetCellBindingEvent event = new SetCellBindingEvent();
@@ -385,22 +407,28 @@ public class CalcTableService {
    }
 
    /**
-    * Resolves a cell's {@code field.namedGroup} to the {@code OrderModel}
-    * {@code VSTableLayoutService.setNamedGroupInfo} actually knows how to apply -- worksheet-local
-    * first (an {@code EXPERT_NAMEDGROUP_INFO} built from the assembly's own per-group
-    * conditions), then the repository-registered asset kind. Neither matching is a hard failure:
-    * a name that resolves to nothing would otherwise silently render without any grouping at
-    * all, which is the defect this fixes.
+    * Resolves a cell's {@code field.namedGroup} onto the given {@code OrderModel}'s {@code info}
+    * -- worksheet-local first (an {@code EXPERT_NAMEDGROUP_INFO} built from the assembly's own
+    * per-group conditions), then the repository-registered asset kind. Neither matching is a
+    * hard failure: a name that resolves to nothing would otherwise silently render without any
+    * grouping at all, which is the defect this fixes.
+    *
+    * <p>Only {@code order.info} is touched here -- {@code order.type} (sort direction/manual
+    * order) is whatever 'sort' already set it to (or the default, if 'sort' was omitted). The
+    * two are independent inputs to the same {@code mapList()}/{@code toList()} expression
+    * {@code LayoutTool.createGroupExpression} builds; forcing a direction here would silently
+    * discard what 'sort' asked for.
     */
-   private OrderModel resolveNamedGroupOrder(RuntimeViewsheet rvs, CalcTableVSAssembly assembly,
-                                             String runtimeId, Principal user,
-                                             CapturingCommandDispatcher dispatcher,
-                                             String column, String namedGroup)
+   private void resolveNamedGroupOrder(OrderModel order, RuntimeViewsheet rvs,
+                                       CalcTableVSAssembly assembly, String runtimeId,
+                                       Principal user, CapturingCommandDispatcher dispatcher,
+                                       String column, String namedGroup)
       throws Exception
    {
       for(DefaultNamedGroupAssembly ngAssembly : worksheetNamedGroups(rvs, assembly, column)) {
          if(namedGroup.equals(ngAssembly.getName())) {
-            return worksheetLocalOrder(ngAssembly);
+            worksheetLocalOrder(order, ngAssembly);
+            return;
          }
       }
 
@@ -411,10 +439,8 @@ public class CalcTableService {
          NamedGroupInfoModel ngInfoModel = new NamedGroupInfoModel();
          ngInfoModel.setType(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO);
          ngInfoModel.setName(namedGroup);
-         OrderModel orderModel = new OrderModel();
-         orderModel.setType(XConstants.SORT_SPECIFIC);
-         orderModel.setInfo(ngInfoModel);
-         return orderModel;
+         order.setInfo(ngInfoModel);
+         return;
       }
 
       throw new IllegalArgumentException(
@@ -426,7 +452,7 @@ public class CalcTableService {
    /**
     * Converts a worksheet-local {@code DefaultNamedGroupAssembly}'s per-group conditions into
     * the {@code EXPERT_NAMEDGROUP_INFO} shape {@code VSTableLayoutService.setNamedGroupInfo}
-    * consumes.
+    * consumes, and sets it onto the given {@code OrderModel}'s {@code info}.
     *
     * <p>This cannot reuse {@code NamedGroupInfoModel.fixNamedGroupInfoModel} -- that method skips
     * anything whose {@code getType()} isn't {@code EXPERT}/{@code SIMPLE}, and a worksheet-local
@@ -434,12 +460,16 @@ public class CalcTableService {
     * though it holds inline per-group {@code ConditionList}s. The conversion itself is the same
     * technique that method uses.
     *
-    * <p>{@code SORT_SPECIFIC} on the order is not optional decoration: {@code OrderInfo.isSpecific()}
-    * -- which reads this exact bit -- gates whether {@code OrderInfo.createSortOrder} ever folds
-    * the named-group conditions into the {@code SortOrder} StyleBI actually groups by. Without
-    * it the named group is attached but never takes effect.
+    * <p>Only {@code order.info} is set here, deliberately -- {@code order.type} is not touched.
+    * {@code LayoutTool.createGroupExpression} reads {@code order.getRealNamedGroupInfo()} (the
+    * group mapping) and {@code order.getType()}/{@code isAsc()} (the resulting sort) as two
+    * independent inputs to the same generated {@code mapList()} expression; the Composer's own
+    * {@code CalcNamedGroupDialog.apply()} likewise only ever assigns {@code order.info}/
+    * {@code order.others}, never {@code order.type}.
     */
-   private OrderModel worksheetLocalOrder(DefaultNamedGroupAssembly ngAssembly) throws Exception {
+   private void worksheetLocalOrder(OrderModel order, DefaultNamedGroupAssembly ngAssembly)
+      throws Exception
+   {
       NamedGroupInfoModel ngInfoModel = new NamedGroupInfoModel();
       ngInfoModel.setType(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO);
 
@@ -452,10 +482,124 @@ public class CalcTableService {
          ngInfoModel.addCondition(conditionExpression);
       }
 
-      OrderModel orderModel = new OrderModel();
-      orderModel.setType(XConstants.SORT_SPECIFIC);
-      orderModel.setInfo(ngInfoModel);
-      return orderModel;
+      order.setInfo(ngInfoModel);
+   }
+
+   /**
+    * Builds an inline ('Customize') named group straight from the caller's own conditions --
+    * {@code {groups: [{name, conditions}], others?}} -- rather than looking one up by name. This
+    * is the mechanism most calc-table named groups actually use: the Composer's own Named Group
+    * Definition dialog ({@code ExpertNamedGroupDialog}) always builds one of these, on the fly,
+    * scoped to the one cell being edited -- unlike {@link #resolveNamedGroupOrder}'s two lookups,
+    * neither of which is what "Customize" itself is.
+    *
+    * <p>Each group's {@code conditions} reuses {@link ConditionVocabulary}'s own flat,
+    * junction-chained vocabulary -- the same one {@code set_condition} uses -- so this does not
+    * grow a second condition-shape for an agent to learn.
+    *
+    * <p>Sets both {@code order.info} and {@code order.others}, matching
+    * {@code CalcNamedGroupDialog.apply()} exactly: {@code order.type} is untouched, for the same
+    * reason {@link #worksheetLocalOrder} leaves it alone.
+    */
+   private void applyInlineNamedGroup(OrderModel order, Map<String, Object> spec,
+                                      RuntimeViewsheet rvs, CalcTableVSAssembly assembly,
+                                      String column) throws Exception
+   {
+      Object rawGroups = spec.get("groups");
+      List<?> groups = rawGroups instanceof List<?> list ? list : List.of();
+
+      if(groups.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'field.namedGroup.groups' needs at least one {name, conditions} group -- a named " +
+            "group with no groups in it buckets nothing.");
+      }
+
+      DataRefModel fieldModel = refModelService.createDataRefModel(columnRef(rvs, assembly, column));
+      NamedGroupInfoModel ngInfoModel = new NamedGroupInfoModel();
+      ngInfoModel.setType(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO);
+
+      for(Object g : groups) {
+         Map<?, ?> groupSpec = g instanceof Map<?, ?> map ? map : Map.of();
+         Object name = groupSpec.get("name");
+
+         if(!(name instanceof String text) || text.isBlank()) {
+            throw new IllegalArgumentException(
+               "Every group in 'field.namedGroup.groups' needs a non-blank 'name'.");
+         }
+
+         Object[] conditionArray = ConditionVocabulary.toConditionList(
+            clausesOf(groupSpec.get("conditions"), column), new DataRefModel[]{ fieldModel });
+         ConditionExpression expr = new ConditionExpression();
+         expr.setName(text);
+         expr.setList(conditionArray);
+         ngInfoModel.addCondition(expr);
+      }
+
+      order.setInfo(ngInfoModel);
+      order.setOthers(!"leave".equals(spec.get("others")));
+   }
+
+   /**
+    * The real, properly-typed {@code DataRef} for a bound column -- needed so
+    * {@link ConditionVocabulary#toConditionList} parses each condition's values against the
+    * column's actual data type (a date column's values need {@code dataType}, or they parse as
+    * plain strings and never match). Mirrors {@code VSTableLayoutService.getPredefinedNamedGroup}'s
+    * own column resolution.
+    */
+   private DataRef columnRef(RuntimeViewsheet rvs, CalcTableVSAssembly assembly, String column)
+      throws Exception
+   {
+      SourceInfo source = assembly.getSourceInfo();
+      ColumnSelection cols = columnsHandler.getColumnSelection(
+         rvs, assembly.getAbsoluteName(), source == null ? null : source.getSource(),
+         null, false, true, false, false, false, false);
+      DataRef field = cols == null ? null : cols.getAttribute(column);
+
+      if(field == null) {
+         throw new IllegalArgumentException(
+            "'" + column + "' is not a bindable column on this table -- list_bindable_fields " +
+            "reports what is available.");
+      }
+
+      return field;
+   }
+
+   /**
+    * One named group's conditions, in {@link ConditionVocabulary}'s flat clause shape. A
+    * condition's own {@code field} defaults to the column being grouped -- the only one a named
+    * group can meaningfully condition on -- and naming a different one is refused rather than
+    * silently ignored.
+    */
+   @SuppressWarnings("unchecked")
+   private static List<ConditionVocabulary.Clause> clausesOf(Object rawConditions, String column) {
+      if(!(rawConditions instanceof List<?> list) || list.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Every group in 'field.namedGroup.groups' needs at least one condition.");
+      }
+
+      List<ConditionVocabulary.Clause> clauses = new ArrayList<>();
+
+      for(Object c : list) {
+         Map<String, Object> clause = (Map<String, Object>) c;
+         Object field = clause.get("field");
+
+         if(field != null && !column.equals(String.valueOf(field))) {
+            throw new IllegalArgumentException(
+               "A named-group condition's 'field' must be the column being grouped ('" + column +
+               "'), got '" + field + "'. Omit 'field' or set it to '" + column + "'.");
+         }
+
+         Object rawValues = clause.get("values");
+         List<Object> values = rawValues instanceof List<?> valueList
+            ? new ArrayList<>(valueList) : List.of();
+         Object junction = clause.get("junction");
+         clauses.add(new ConditionVocabulary.Clause(
+            column, String.valueOf(clause.get("operator")), values,
+            junction == null ? null : String.valueOf(junction),
+            Boolean.TRUE.equals(clause.get("negated"))));
+      }
+
+      return clauses;
    }
 
    /**
@@ -709,12 +853,6 @@ public class CalcTableService {
       info.setMergeColGroup(binding.containsKey("mergeColGroup") ?
                              mergeColGroup : TableCellBinding.DEFAULT_GROUP);
 
-      String name = str(binding, "name");
-
-      if(name != null) {
-         info.setName(name);
-      }
-
       if(binding.get("timeSeries") instanceof Boolean timeSeries) {
          info.setTimeSeries(timeSeries);
       }
@@ -843,12 +981,32 @@ public class CalcTableService {
          "A cell's 'field' must be an object such as {column: \"Region\", type: \"dimension\"}.");
    }
 
-   /** A field's named-group name, if it carries one. {@code null} means none was given. */
+   /**
+    * A field's by-name named-group reference, if it carries one. {@code null} means none was
+    * given, or it was given inline (a {@code Map} -- see {@link #inlineNamedGroupOf}) rather
+    * than by name.
+    */
    private static String namedGroupOf(Object field) {
       Object namedGroup = field instanceof FieldRef ref ? ref.namedGroup()
          : field instanceof Map<?, ?> map ? map.get("namedGroup") : null;
+
+      if(namedGroup instanceof Map<?, ?>) {
+         return null;
+      }
+
       String text = namedGroup == null ? "" : String.valueOf(namedGroup).trim();
       return text.isEmpty() ? null : text;
+   }
+
+   /**
+    * A field's inline ('Customize') named-group definition, if it carries one --
+    * {@code {groups: [{name, conditions}], others?}}. {@code null} means none was given, or it
+    * was given by name (a plain string -- see {@link #namedGroupOf}) instead.
+    */
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> inlineNamedGroupOf(Object field) {
+      Object namedGroup = field instanceof Map<?, ?> map ? map.get("namedGroup") : null;
+      return namedGroup instanceof Map<?, ?> ? (Map<String, Object>) namedGroup : null;
    }
 
    private static TableCell cellAt(int row, int col) {
@@ -930,4 +1088,5 @@ public class CalcTableService {
    private final VSTableLayoutService layoutService;
    private final DataRefModelFactoryService refModelService;
    private final BindableFieldsService fieldsService;
+   private final VSColumnHandler columnsHandler;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -22,6 +22,7 @@ import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
+import inetsoft.uql.XCondition;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
@@ -39,6 +40,7 @@ import inetsoft.web.binding.event.GetCellScriptEvent;
 import inetsoft.web.binding.event.GetPredefinedNamedGroupEvent;
 import inetsoft.web.binding.model.NamedGroupInfoModel;
 import inetsoft.web.binding.model.table.OrderModel;
+import inetsoft.web.binding.model.table.TopNModel;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.composer.model.condition.ConditionExpression;
 import inetsoft.web.composer.model.condition.ConditionUtil;
@@ -270,6 +272,17 @@ public class CalcTableService {
       // Validated before the runtime is touched: an incomplete binding costs nothing to
       // reject here, and opens no checkpoint the caller then has to undo.
       CalcCellVocabulary.validate(binding);
+
+      // Both 'sort' and a resolved 'field.namedGroup' end up setting the same OrderModel --
+      // namedGroup forces SORT_SPECIFIC with the group's own conditions as the order. Accepting
+      // both silently would mean one wins and the caller never learns which; refusing is cheap
+      // and this runs before the runtime is touched, so it costs no checkpoint to reject.
+      if(binding.get("sort") != null && namedGroupOf(binding.get("field")) != null) {
+         throw new IllegalArgumentException(
+            "A cell can't have both 'sort' and 'field.namedGroup' -- resolving a named group " +
+            "sets its own order (SORT_SPECIFIC, ordered by the group's own conditions), which " +
+            "would silently override whatever 'sort' asked for. Send one or the other.");
+      }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
@@ -593,12 +606,30 @@ public class CalcTableService {
 
    /** The tokens this build accepts, so an agent can discover rather than guess. */
    public Map<String, Object> vocabulary() {
-      return Map.of(
-         "content", CalcCellVocabulary.contentTokens(),
-         "grouping", CalcCellVocabulary.groupingTokens(),
-         "expand", CalcCellVocabulary.expandTokens(),
-         "layoutOps", new TreeSet<>(LAYOUT_OPS.values()),
-         "copyOps", List.of("copy", "cut", "remove"));
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("content", CalcCellVocabulary.contentTokens());
+      out.put("grouping", CalcCellVocabulary.groupingTokens());
+      out.put("expand", CalcCellVocabulary.expandTokens());
+      out.put("layoutOps", new TreeSet<>(LAYOUT_OPS.values()));
+      out.put("copyOps", List.of("copy", "cut", "remove"));
+      out.put("sortDirections", CalcCellVocabulary.sortDirectionTokens());
+      out.put("topnModes", CalcCellVocabulary.topnModeTokens());
+      // The names a 'summary' cell's 'formula' accepts. The string itself can also carry a
+      // percentage-of-group mode (append '<N>', N = one of the PERCENTAGE_* values a caller
+      // would otherwise have to read off StyleConstants), a second column for a two-column
+      // formula (append '(ColumnName)' -- Correlation/Covariance/WeightedAverage/First/Last), or
+      // an Nth/Pth parameter for the formulas that take one (append '(N)') -- exactly the syntax
+      // the Composer's own aggregate-option pane builds. Neither the percentage encoding nor
+      // which formulas take an N/second-column argument is enumerated here yet.
+      List<String> aggregateFormulas = new ArrayList<>();
+
+      for(inetsoft.uql.asset.AggregateFormula formula : inetsoft.uql.asset.AggregateFormula.getFormulas()) {
+         aggregateFormulas.add(formula.getFormulaName());
+      }
+
+      out.put("aggregateFormulas", aggregateFormulas);
+      out.put("dateLevels", DateLevels.names());
+      return out;
    }
 
    // ── conversions ───────────────────────────────────────────────────────────
@@ -667,9 +698,120 @@ public class CalcTableService {
       info.setRowGroup(rowGroup != null ? rowGroup : TableCellBinding.DEFAULT_GROUP);
       String colGroup = str(binding, "colGroup");
       info.setColGroup(colGroup != null ? colGroup : TableCellBinding.DEFAULT_GROUP);
-      info.setMergeRowGroup(TableCellBinding.DEFAULT_GROUP);
-      info.setMergeColGroup(TableCellBinding.DEFAULT_GROUP);
+
+      // Same "inherit by default" reasoning as rowGroup/colGroup above, extended to the merge-
+      // specific pair: a caller who never mentions these means "leave the default ancestor",
+      // not "clear it" -- so the sentinel, not null, is what an omitted key produces.
+      String mergeRowGroup = str(binding, "mergeRowGroup");
+      info.setMergeRowGroup(binding.containsKey("mergeRowGroup") ?
+                             mergeRowGroup : TableCellBinding.DEFAULT_GROUP);
+      String mergeColGroup = str(binding, "mergeColGroup");
+      info.setMergeColGroup(binding.containsKey("mergeColGroup") ?
+                             mergeColGroup : TableCellBinding.DEFAULT_GROUP);
+
+      String name = str(binding, "name");
+
+      if(name != null) {
+         info.setName(name);
+      }
+
+      if(binding.get("timeSeries") instanceof Boolean timeSeries) {
+         info.setTimeSeries(timeSeries);
+      }
+
+      applySort(info, asMap(binding.get("sort")));
+      applyTopn(info, asMap(binding.get("topn")));
+
+      if(type == CellBinding.BIND_COLUMN) {
+         applyDateGroup(info, asMap(binding.get("field")));
+      }
+
       return info;
+   }
+
+   /**
+    * A group cell's sort direction/manual order. Deliberately does not touch
+    * {@code sortByCol}/{@code sortByValue} (sort-by-a-specific-aggregate's-value) -- see
+    * {@link CalcCellVocabulary#validateSort} for why that is not exposed yet.
+    */
+   private static void applySort(CellBindingInfo info, Map<String, Object> sort) {
+      if(sort == null) {
+         return;
+      }
+
+      OrderModel order = info.getOrder();
+      order.setType(CalcCellVocabulary.sortDirection(str(sort, "direction")));
+
+      if(order.getType() == XConstants.SORT_SPECIFIC) {
+         List<?> manual = (List<?>) sort.get("manualOrder");
+         List<String> values = new ArrayList<>();
+
+         for(Object value : manual) {
+            values.add(value == null ? null : String.valueOf(value));
+         }
+
+         order.setManualOrder(values);
+      }
+   }
+
+   /**
+    * A group cell's ranking. {@code sumCol} defaults to 0 -- the same default the Composer's own
+    * Top-N pane falls back to when exactly one aggregate is in scope (see
+    * {@code CalcGroupOption.changeTopnType}) -- since choosing a specific aggregate by name needs
+    * the same in-scope-aggregate resolution {@link CalcCellVocabulary#validateTopn} does not
+    * expose yet.
+    */
+   private static void applyTopn(CellBindingInfo info, Map<String, Object> topn) {
+      if(topn == null) {
+         return;
+      }
+
+      TopNModel model = info.getTopn();
+      model.setType(CalcCellVocabulary.topnMode(str(topn, "mode")));
+
+      if(model.getType() != XCondition.NONE) {
+         Object n = topn.get("n");
+         model.setTopn(n == null ? 3 : ((Number) n).intValue());
+         model.setSumCol(0);
+      }
+   }
+
+   /**
+    * Wires {@code field.dateLevel}/{@code field.dateInterval} into the OrderModel that actually
+    * drives calc-table date grouping ({@code order.option}/{@code order.interval} --
+    * {@code CalcGroupOption.levelChanged} on the UI side). Earlier, 'field.dateLevel' was declared
+    * on this tool's schema and forwarded over the wire, but nothing on this path ever read it back
+    * off the map -- it validated cleanly and was silently discarded. Fixed here rather than left
+    * as a validated-but-inert field, per this plugin's stated position on a declared parameter
+    * that does not do what its description says.
+    */
+   private static void applyDateGroup(CellBindingInfo info, Map<String, Object> field) {
+      if(field == null) {
+         return;
+      }
+
+      String dateLevel = str(field, "dateLevel");
+
+      if(dateLevel != null) {
+         String normalized = DateLevels.normalize(dateLevel);
+         info.getOrder().setOption(Integer.parseInt(normalized));
+      }
+
+      Object interval = field.get("dateInterval");
+
+      if(interval != null) {
+         if(!(interval instanceof Number) || ((Number) interval).intValue() < 1) {
+            throw new IllegalArgumentException(
+               "'field.dateInterval' must be a positive integer, got " + interval + ".");
+         }
+
+         info.getOrder().setInterval(((Number) interval).intValue());
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> asMap(Object value) {
+      return value instanceof Map ? (Map<String, Object>) value : null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -542,7 +542,20 @@ public class CalcTableService {
       }
 
       order.setInfo(ngInfoModel);
-      order.setOthers(!"leave".equals(spec.get("others")));
+      order.setOthers(!isLeaveOthers(spec.get("others")));
+   }
+
+   /**
+    * {@code field.namedGroup.others} in the tool's own string vocabulary ({@code "group"}/
+    * {@code "leave"}), but also accepts the plain {@code Boolean} this same concept uses
+    * elsewhere in {@code inetsoft.web.wiz} ({@code DimensionSortRanking.Ranking.others},
+    * {@code EditRequest.groupOthers} -- both {@code true} = group, {@code false} = leave). A
+    * caller reasonably following that sibling convention and sending {@code others: false} here
+    * would otherwise silently get {@code GROUP_OTHERS} instead of the requested "leave ungrouped"
+    * behavior, since only the exact string {@code "leave"} was ever recognized.
+    */
+   private static boolean isLeaveOthers(Object others) {
+      return Boolean.FALSE.equals(others) || "leave".equalsIgnoreCase(String.valueOf(others));
    }
 
    /**
@@ -676,6 +689,12 @@ public class CalcTableService {
       List<ConditionVocabulary.Clause> clauses = new ArrayList<>();
 
       for(Object c : list) {
+         if(!(c instanceof Map<?, ?>)) {
+            throw new IllegalArgumentException(
+               "Every condition in 'field.namedGroup.groups[].conditions' must be an object " +
+               "such as {operator: \"one_of\", values: [...]}, got " + c + ".");
+         }
+
          Map<String, Object> clause = (Map<String, Object>) c;
          Object field = clause.get("field");
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -24,6 +24,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.AggregateRef;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
@@ -35,12 +36,14 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.uql.erm.CalcAggregate;
 import inetsoft.web.binding.command.GetCellScriptCommand;
 import inetsoft.web.binding.command.GetPredefinedNamedGroupCommand;
 import inetsoft.web.binding.controller.VSTableLayoutService;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.event.GetCellScriptEvent;
 import inetsoft.web.binding.event.GetPredefinedNamedGroupEvent;
+import inetsoft.web.binding.handler.TableLayoutHandler;
 import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.binding.model.NamedGroupInfoModel;
 import inetsoft.web.binding.model.table.OrderModel;
@@ -87,13 +90,14 @@ public class CalcTableService {
    public CalcTableService(ViewsheetSessionService sessions, VSTableLayoutService layoutService,
                            DataRefModelFactoryService refModelService,
                            BindableFieldsService fieldsService,
-                           VSColumnHandler columnsHandler)
+                           VSColumnHandler columnsHandler, TableLayoutHandler layoutHandler)
    {
       this.sessions = sessions;
       this.layoutService = layoutService;
       this.refModelService = refModelService;
       this.fieldsService = fieldsService;
       this.columnsHandler = columnsHandler;
+      this.layoutHandler = layoutHandler;
    }
 
    /**
@@ -109,6 +113,7 @@ public class CalcTableService {
       RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
       CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
       TableLayout layout = layoutOf(assembly);
+      AggregateRef[] aggregates = aggregatesOf(rvs, assembly);
       List<Map<String, Object>> cells = new ArrayList<>();
 
       for(int row = 0; row < layout.getRowCount(); row++) {
@@ -125,7 +130,7 @@ public class CalcTableService {
 
             cell.put("binding",
                      CalcCellVocabulary.describe(
-                        layoutService.getCellBindingInfo(assembly, row, col)));
+                        layoutService.getCellBindingInfo(assembly, row, col), aggregates));
             cells.add(cell);
          }
       }
@@ -151,7 +156,8 @@ public class CalcTableService {
       out.put("row", row);
       out.put("col", col);
       out.put("binding",
-              CalcCellVocabulary.describe(layoutService.getCellBindingInfo(assembly, row, col)));
+              CalcCellVocabulary.describe(layoutService.getCellBindingInfo(assembly, row, col),
+                                          aggregatesOf(rvs, assembly)));
       return out;
    }
 
@@ -284,7 +290,7 @@ public class CalcTableService {
          CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
          requireInGrid(layoutOf(assembly), row, col);
 
-         CellBindingInfo cellBindingInfo = toCellBindingInfo(binding);
+         CellBindingInfo cellBindingInfo = toCellBindingInfo(binding, rvs, assembly);
 
          if(cellBindingInfo.getType() == CellBinding.BIND_COLUMN) {
             requireBindableColumn(runtimeId, user, assemblyName, cellBindingInfo.getValue());
@@ -549,10 +555,7 @@ public class CalcTableService {
    private DataRef columnRef(RuntimeViewsheet rvs, CalcTableVSAssembly assembly, String column)
       throws Exception
    {
-      SourceInfo source = assembly.getSourceInfo();
-      ColumnSelection cols = columnsHandler.getColumnSelection(
-         rvs, assembly.getAbsoluteName(), source == null ? null : source.getSource(),
-         null, false, true, false, false, false, false);
+      ColumnSelection cols = columnSelectionOf(rvs, assembly);
       DataRef field = cols == null ? null : cols.getAttribute(column);
 
       if(field == null) {
@@ -562,6 +565,99 @@ public class CalcTableService {
       }
 
       return field;
+   }
+
+   private ColumnSelection columnSelectionOf(RuntimeViewsheet rvs, CalcTableVSAssembly assembly)
+      throws Exception
+   {
+      SourceInfo source = assembly.getSourceInfo();
+      return columnsHandler.getColumnSelection(
+         rvs, assembly.getAbsoluteName(), source == null ? null : source.getSource(),
+         null, false, true, false, false, false, false);
+   }
+
+   /**
+    * Every distinct summary ({@code grouping: "summary"}) cell in this calc table, deduplicated
+    * by column+formula identity -- the same list {@code sort.rankBy}/{@code topn.rankBy} are
+    * resolved against on write, and the read side reports {@code rankBy} from
+    * ({@link CalcCellVocabulary#describe(CellBindingInfo, AggregateRef[])}). Order matters: it is
+    * the same order {@code OrderModel.sortByCol}/{@code TopNModel.sumCol} index into, mirroring
+    * {@code VSTableLayoutService.getAggregates}.
+    */
+   private AggregateRef[] aggregatesOf(RuntimeViewsheet rvs, CalcTableVSAssembly assembly)
+      throws Exception
+   {
+      ColumnSelection cols = columnSelectionOf(rvs, assembly);
+      CalcAggregate[] aggs = layoutHandler.getCalcAggregateFields(assembly, cols);
+      AggregateRef[] out = new AggregateRef[aggs.length];
+
+      for(int i = 0; i < aggs.length; i++) {
+         out[i] = (AggregateRef) aggs[i];
+      }
+
+      return out;
+   }
+
+   /**
+    * Resolves a {@code {column, formula}} rank-by reference to its index in
+    * {@link #aggregatesOf}'s list -- the same index {@code OrderModel.sortByCol}/
+    * {@code TopNModel.sumCol} actually store. {@code rankBy == null} is only valid with exactly
+    * one summary cell in scope, matching what the Composer's own Top-N pane defaults to; with
+    * zero or more than one, guessing would silently rank by the wrong column, so this refuses
+    * instead.
+    */
+   private int resolveRankBy(RuntimeViewsheet rvs, CalcTableVSAssembly assembly,
+                             Map<String, Object> rankBy, String forWhat) throws Exception
+   {
+      AggregateRef[] aggs = aggregatesOf(rvs, assembly);
+
+      if(rankBy == null) {
+         if(aggs.length == 1) {
+            return 0;
+         }
+
+         throw new IllegalArgumentException(
+            forWhat + " needs a 'rankBy' of {column, formula} -- this table has " + aggs.length +
+            " summary cell(s) in scope (" + describeAggs(aggs) + "), so which one to use is " +
+            "ambiguous." + (aggs.length == 0 ?
+               " Add a summary cell first." : " Name one with 'rankBy'."));
+      }
+
+      String column = str(rankBy, "column");
+      String formula = str(rankBy, "formula");
+
+      for(int i = 0; i < aggs.length; i++) {
+         AggregateRef agg = aggs[i];
+         String aggColumn = agg.getDataRef() == null ? null : agg.getDataRef().getName();
+
+         if(Objects.equals(aggColumn, column) && Objects.equals(agg.getFormulaName(), formula)) {
+            return i;
+         }
+      }
+
+      throw new IllegalArgumentException(
+         forWhat + "'s 'rankBy' names " + formula + "(" + column + "), which isn't one of this " +
+         "table's summary cells (" + describeAggs(aggs) + ").");
+   }
+
+   private static String describeAggs(AggregateRef[] aggs) {
+      if(aggs.length == 0) {
+         return "none";
+      }
+
+      StringBuilder out = new StringBuilder();
+
+      for(int i = 0; i < aggs.length; i++) {
+         if(i > 0) {
+            out.append(", ");
+         }
+
+         AggregateRef agg = aggs[i];
+         out.append(agg.getFormulaName()).append("(")
+            .append(agg.getDataRef() == null ? "?" : agg.getDataRef().getName()).append(")");
+      }
+
+      return out.toString();
    }
 
    /**
@@ -778,7 +874,9 @@ public class CalcTableService {
 
    // ── conversions ───────────────────────────────────────────────────────────
 
-   static CellBindingInfo toCellBindingInfo(Map<String, Object> binding) {
+   private CellBindingInfo toCellBindingInfo(Map<String, Object> binding, RuntimeViewsheet rvs,
+                                             CalcTableVSAssembly assembly) throws Exception
+   {
       CellBindingInfo info = new CellBindingInfo();
       int type = CalcCellVocabulary.content(str(binding, "content"));
       info.setType(type);
@@ -857,8 +955,8 @@ public class CalcTableService {
          info.setTimeSeries(timeSeries);
       }
 
-      applySort(info, asMap(binding.get("sort")));
-      applyTopn(info, asMap(binding.get("topn")));
+      applySort(info, asMap(binding.get("sort")), rvs, assembly);
+      applyTopn(info, asMap(binding.get("topn")), rvs, assembly);
 
       if(type == CellBinding.BIND_COLUMN) {
          applyDateGroup(info, asMap(binding.get("field")));
@@ -868,11 +966,14 @@ public class CalcTableService {
    }
 
    /**
-    * A group cell's sort direction/manual order. Deliberately does not touch
-    * {@code sortByCol}/{@code sortByValue} (sort-by-a-specific-aggregate's-value) -- see
-    * {@link CalcCellVocabulary#validateSort} for why that is not exposed yet.
+    * A group cell's sort direction/manual order, or -- for {@code value_asc}/{@code value_desc}
+    * -- which summary cell to sort by. {@code sort.rankBy} is resolved against
+    * {@link #aggregatesOf} at write time, the same list the Composer's own Sort dropdown resolves
+    * its selection against when the human clicks save.
     */
-   private static void applySort(CellBindingInfo info, Map<String, Object> sort) {
+   private void applySort(CellBindingInfo info, Map<String, Object> sort, RuntimeViewsheet rvs,
+                          CalcTableVSAssembly assembly) throws Exception
+   {
       if(sort == null) {
          return;
       }
@@ -890,16 +991,23 @@ public class CalcTableService {
 
          order.setManualOrder(values);
       }
+      else if(order.getType() == XConstants.SORT_VALUE_ASC ||
+              order.getType() == XConstants.SORT_VALUE_DESC)
+      {
+         order.setSortCol(resolveRankBy(rvs, assembly, asMap(sort.get("rankBy")),
+                                        "sort.direction '" + str(sort, "direction") + "'"));
+      }
    }
 
    /**
-    * A group cell's ranking. {@code sumCol} defaults to 0 -- the same default the Composer's own
-    * Top-N pane falls back to when exactly one aggregate is in scope (see
-    * {@code CalcGroupOption.changeTopnType}) -- since choosing a specific aggregate by name needs
-    * the same in-scope-aggregate resolution {@link CalcCellVocabulary#validateTopn} does not
-    * expose yet.
+    * A group cell's ranking, including which summary cell to rank by. {@code topn.rankBy} is
+    * resolved against {@link #aggregatesOf} at write time; omitted, it defaults to the sole
+    * in-scope summary cell (matching the Composer's own Top-N pane) or refuses when that is
+    * ambiguous.
     */
-   private static void applyTopn(CellBindingInfo info, Map<String, Object> topn) {
+   private void applyTopn(CellBindingInfo info, Map<String, Object> topn, RuntimeViewsheet rvs,
+                          CalcTableVSAssembly assembly) throws Exception
+   {
       if(topn == null) {
          return;
       }
@@ -910,7 +1018,7 @@ public class CalcTableService {
       if(model.getType() != XCondition.NONE) {
          Object n = topn.get("n");
          model.setTopn(n == null ? 3 : ((Number) n).intValue());
-         model.setSumCol(0);
+         model.setSumCol(resolveRankBy(rvs, assembly, asMap(topn.get("rankBy")), "'topn'"));
       }
    }
 
@@ -1089,4 +1197,5 @@ public class CalcTableService {
    private final DataRefModelFactoryService refModelService;
    private final BindableFieldsService fieldsService;
    private final VSColumnHandler columnsHandler;
+   private final TableLayoutHandler layoutHandler;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -861,10 +861,22 @@ public class CalcTableService {
       // an Nth/Pth parameter for the formulas that take one (append '(N)') -- exactly the syntax
       // the Composer's own aggregate-option pane builds. Neither the percentage encoding nor
       // which formulas take an N/second-column argument is enumerated here yet.
+      //
+      // AggregateFormula's static initializer reads a property via SreeEnv, which throws
+      // ShutdownException outside a running Spring context (server startup/shutdown, or a unit
+      // test with no Spring context at all) -- degrade this one enrichment to an empty list
+      // rather than losing the rest of vocabulary()'s response over it.
       List<String> aggregateFormulas = new ArrayList<>();
 
-      for(inetsoft.uql.asset.AggregateFormula formula : inetsoft.uql.asset.AggregateFormula.getFormulas()) {
-         aggregateFormulas.add(formula.getFormulaName());
+      try {
+         for(inetsoft.uql.asset.AggregateFormula formula :
+            inetsoft.uql.asset.AggregateFormula.getFormulas())
+         {
+            aggregateFormulas.add(formula.getFormulaName());
+         }
+      }
+      catch(Throwable e) {
+         LOG.debug("Could not list aggregate formulas; reporting none", e);
       }
 
       out.put("aggregateFormulas", aggregateFormulas);

--- a/core/src/main/java/inetsoft/web/wiz/binding/DateLevels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/DateLevels.java
@@ -107,6 +107,11 @@ public final class DateLevels {
       return token;
    }
 
+   /** The accepted names, for a vocabulary listing — not the numbers they resolve to. */
+   public static List<String> names() {
+      return new ArrayList<>(BY_NAME.keySet());
+   }
+
    /** StyleBI's sentinel for an unset level — see {@code VSDimensionRef.setDateLevel}. */
    private static final String UNSET = "-1";
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcCellVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcCellVocabularyTest.java
@@ -19,14 +19,20 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.report.CellBinding;
 import inetsoft.report.GroupableCellBinding;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AggregateRef;
+import inetsoft.uql.erm.AttributeRef;
 import inetsoft.web.binding.model.table.CellBindingInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Tag("core")
 class CalcCellVocabularyTest {
@@ -239,5 +245,185 @@ class CalcCellVocabularyTest {
    void acceptsValueAsAnAliasForFormulaContent() {
       assertDoesNotThrow(
          () -> CalcCellVocabulary.validate(spec("content", "formula", "value", "Sum(Sales)")));
+   }
+
+   // ── sort.rankBy / topn.rankBy shape ──────────────────────────────────────────
+
+   @Test
+   void mapsValueAscAndValueDescSortTokens() {
+      assertEquals(XConstants.SORT_VALUE_ASC, CalcCellVocabulary.sortDirection("value_asc"));
+      assertEquals(XConstants.SORT_VALUE_DESC, CalcCellVocabulary.sortDirection("value_desc"));
+   }
+
+   @Test
+   void refusesValueAscSortWithNoRankBy() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "text", "value", "x",
+            "sort", spec("direction", "value_asc"))));
+
+      assertTrue(thrown.getMessage().contains("rankBy"));
+   }
+
+   @Test
+   void acceptsValueDescSortWithRankBy() {
+      assertDoesNotThrow(() -> CalcCellVocabulary.validate(spec(
+         "content", "text", "value", "x",
+         "sort", spec("direction", "value_desc",
+                      "rankBy", spec("column", "Revenue", "formula", "Sum")))));
+   }
+
+   @Test
+   void refusesTopnRankByMissingColumn() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "text", "value", "x",
+            "topn", spec("mode", "top", "rankBy", spec("formula", "Sum")))));
+
+      assertTrue(thrown.getMessage().contains("column"));
+   }
+
+   // ── field.namedGroup inline ('Customize') shape ──────────────────────────────
+   //
+   // Checked eagerly in validate() (before sessions.mutate opens a checkpoint the caller then
+   // has to undo), same as sort/topn -- the actual condition-list-building for a valid shape is
+   // CalcTableService.applyInlineNamedGroup's job, not this stateless vocabulary's.
+
+   @Test
+   void refusesInlineNamedGroupWithNoGroups() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "column", "grouping", "group", "expand", "vertical",
+            "field", spec("column", "Region", "type", "dimension",
+                          "namedGroup", spec("groups", List.of())))));
+
+      assertTrue(thrown.getMessage().contains("groups"));
+   }
+
+   @Test
+   void refusesInlineNamedGroupGroupWithBlankName() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "column", "grouping", "group", "expand", "vertical",
+            "field", spec("column", "Region", "type", "dimension",
+                          "namedGroup", spec("groups", List.of(
+                             spec("name", " ",
+                                  "conditions", List.of(spec("operator", "one_of",
+                                                             "values", List.of("CA"))))))))));
+
+      assertTrue(thrown.getMessage().contains("name"));
+   }
+
+   @Test
+   void refusesInlineNamedGroupGroupWithNoConditions() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "column", "grouping", "group", "expand", "vertical",
+            "field", spec("column", "Region", "type", "dimension",
+                          "namedGroup", spec("groups", List.of(
+                             spec("name", "West", "conditions", List.of())))))));
+
+      assertTrue(thrown.getMessage().contains("condition"));
+   }
+
+   @Test
+   void refusesInlineNamedGroupConditionThatIsNotAnObject() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "column", "grouping", "group", "expand", "vertical",
+            "field", spec("column", "Region", "type", "dimension",
+                          "namedGroup", spec("groups", List.of(
+                             spec("name", "West", "conditions", List.of("not-an-object"))))))));
+
+      assertTrue(thrown.getMessage().contains("object"));
+   }
+
+   @Test
+   void refusesInlineNamedGroupConditionNamingADifferentField() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec(
+            "content", "column", "grouping", "group", "expand", "vertical",
+            "field", spec("column", "Region", "type", "dimension",
+                          "namedGroup", spec("groups", List.of(
+                             spec("name", "West",
+                                  "conditions", List.of(spec("field", "State",
+                                                             "operator", "one_of",
+                                                             "values", List.of("CA"))))))))));
+
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void acceptsAWellFormedInlineNamedGroup() {
+      assertDoesNotThrow(() -> CalcCellVocabulary.validate(spec(
+         "content", "column", "grouping", "group", "expand", "vertical",
+         "field", spec("column", "Region", "type", "dimension",
+                       "namedGroup", spec("groups", List.of(
+                          spec("name", "West",
+                               "conditions", List.of(spec("operator", "one_of",
+                                                          "values", List.of("CA"))))),
+                                          "others", "leave")))));
+   }
+
+   @Test
+   void ignoresByNameNamedGroupStringsEntirely() {
+      // The by-name form ("a predefined group's name") needs runtime session state to resolve --
+      // not this stateless vocabulary's job. A plain string must pass through untouched here.
+      assertDoesNotThrow(() -> CalcCellVocabulary.validate(spec(
+         "content", "column", "grouping", "group", "expand", "vertical",
+         "field", spec("column", "Region", "type", "dimension", "namedGroup", "Coastal"))));
+   }
+
+   // ── describe(info, aggregates): resolving sortByCol/sumCol back to {column, formula} ────────
+
+   @Test
+   void describeResolvesSortByColBackToRankBy() {
+      CellBindingInfo info = new CellBindingInfo();
+      info.setType(CellBinding.BIND_COLUMN);
+      info.setBtype(CellBinding.GROUP);
+      info.getOrder().setType(XConstants.SORT_VALUE_DESC);
+      info.getOrder().setSortCol(1);
+
+      AggregateRef sum = mock(AggregateRef.class);
+      when(sum.getDataRef()).thenReturn(new AttributeRef(null, "PAID"));
+      when(sum.getFormulaName()).thenReturn("Sum");
+      AggregateRef avg = mock(AggregateRef.class);
+      when(avg.getDataRef()).thenReturn(new AttributeRef(null, "PAID"));
+      when(avg.getFormulaName()).thenReturn("Average");
+
+      Map<String, Object> described =
+         CalcCellVocabulary.describe(info, new AggregateRef[]{ sum, avg });
+      @SuppressWarnings("unchecked")
+      Map<String, Object> sort = (Map<String, Object>) described.get("sort");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> rankBy = (Map<String, Object>) sort.get("rankBy");
+
+      assertEquals("value_desc", sort.get("direction"));
+      assertEquals("PAID", rankBy.get("column"));
+      assertEquals("Average", rankBy.get("formula"));
+   }
+
+   @Test
+   void describeOmitsRankByWhenAggregatesAreUnavailable() {
+      CellBindingInfo info = new CellBindingInfo();
+      info.setType(CellBinding.BIND_COLUMN);
+      info.setBtype(CellBinding.GROUP);
+      info.getOrder().setType(XConstants.SORT_VALUE_ASC);
+      info.getOrder().setSortCol(0);
+
+      // The single-argument overload -- no aggregate context available -- must not report a
+      // bare index under 'rankBy' (exactly the brittle-under-reorder shape this vocabulary
+      // avoids everywhere else); it omits the key instead.
+      @SuppressWarnings("unchecked")
+      Map<String, Object> sort = (Map<String, Object>) CalcCellVocabulary.describe(info).get("sort");
+
+      assertNull(sort.get("rankBy"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -46,6 +46,8 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.web.binding.controller.VSTableLayoutService;
 import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.handler.TableLayoutHandler;
+import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.binding.event.CopyCutCalcCellEvent;
 import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
@@ -472,9 +474,20 @@ class CalcTableServiceTest {
          throw new IllegalStateException(e);
       }
 
+      VSColumnHandler columnsHandler = mock(VSColumnHandler.class);
+      TableLayoutHandler layoutHandler = mock(TableLayoutHandler.class);
+
+      // Default fixture: no summary cells in scope. Mockito's default answer for an array
+      // return type is null, not empty -- aggregatesOf()'s "new AggregateRef[aggs.length]" NPEs
+      // on that for every test that never bound a summary cell, not just the ones that care
+      // about rankBy/sort-by-value.
+      when(layoutHandler.getCalcAggregateFields(any(), any()))
+         .thenReturn(new inetsoft.uql.erm.CalcAggregate[0]);
+
       return new Harness(
-         new CalcTableService(sessions, layoutService, refModelService, fieldsService), sessions,
-         layoutService, vs, info, refModelService, fieldsService);
+         new CalcTableService(sessions, layoutService, refModelService, fieldsService,
+                              columnsHandler, layoutHandler),
+         sessions, layoutService, vs, info, refModelService, fieldsService);
    }
 
    private static Principal principal() {
@@ -669,9 +682,13 @@ class CalcTableServiceTest {
    /**
     * The confirmed silent-drop defect: {@code field.namedGroup} naming a worksheet-local group
     * created via {@code add_named_group} must land on {@code CellBindingInfo.order} as an
-    * {@code EXPERT_NAMEDGROUP_INFO} built from that assembly's own per-group conditions, with
-    * {@code order.type == SORT_SPECIFIC} -- the bit {@code OrderInfo.isSpecific()} gates before
-    * a named group's conditions are ever folded into the actual grouping order.
+    * {@code EXPERT_NAMEDGROUP_INFO} built from that assembly's own per-group conditions --
+    * {@code order.info} only. {@code order.type} is untouched (stays at {@code OrderModel}'s
+    * default) when the call gives no {@code sort}: a named group and a sort direction are
+    * independent settings on a real cell (confirmed live -- a Composer cell can carry
+    * {@code Sort: Manual} or even {@code Sort: By Value (Asc)} together with a named group), and
+    * {@code CalcNamedGroupDialog.apply()}, the Composer's own commit path for a named group,
+    * never assigns {@code order.type} either.
     */
    @Test
    void bindsAWorksheetLocalNamedGroupAsAnExpertOrder() throws Exception {
@@ -709,7 +726,10 @@ class CalcTableServiceTest {
       verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
                                              any());
       inetsoft.web.binding.model.table.OrderModel order = captor.getValue().getBinding().getOrder();
-      assertEquals(XConstants.SORT_SPECIFIC, order.getType());
+      // No 'sort' was given, so order.type stays at its OrderModel default (SORT_ASC) --
+      // resolving a named group only ever sets order.info, never order.type (see the class
+      // comment above).
+      assertEquals(XConstants.SORT_ASC, order.getType());
       assertEquals(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO, order.getInfo().getType());
       List<inetsoft.web.composer.model.condition.ConditionExpression> conds =
          order.getInfo().getConditions();
@@ -748,7 +768,9 @@ class CalcTableServiceTest {
       verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
                                              any());
       inetsoft.web.binding.model.table.OrderModel order = captor.getValue().getBinding().getOrder();
-      assertEquals(XConstants.SORT_SPECIFIC, order.getType());
+      // Same reasoning as bindsAWorksheetLocalNamedGroupAsAnExpertOrder above: no 'sort' was
+      // given, so order.type stays at its default rather than being forced by the named group.
+      assertEquals(XConstants.SORT_ASC, order.getType());
       assertEquals(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO, order.getInfo().getType());
       assertEquals("Tiers", order.getInfo().getName());
    }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -29,10 +29,12 @@ import inetsoft.report.GroupableCellBinding;
 import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.Condition;
 import inetsoft.uql.ConditionItem;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AggregateRef;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
@@ -41,6 +43,7 @@ import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.AbstractTableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
@@ -393,13 +396,163 @@ class CalcTableServiceTest {
       assertTrue(String.valueOf(vocabulary.get("expand")).contains("vertical"));
    }
 
+   // ── sort.rankBy / topn.rankBy resolution ─────────────────────────────────────
+
+   private static AggregateRef aggregate(String column, String formulaName) {
+      // A real AggregateFormula constant would work here too, but its static initializer reads
+      // a property via SreeEnv, which throws outside a running Spring context -- exactly the
+      // trap CalcTableService.vocabulary()'s own try/catch exists for. Mocking AggregateRef
+      // directly avoids ever touching that class in this pure-Mockito suite.
+      AggregateRef agg = mock(AggregateRef.class);
+      when(agg.getDataRef()).thenReturn(new AttributeRef(null, column));
+      when(agg.getFormulaName()).thenReturn(formulaName);
+      return agg;
+   }
+
+   @Test
+   void resolvesSortRankByToTheMatchingSummaryCellsIndex() throws Exception {
+      Harness h = harness(3, 3);
+      AggregateRef avg = aggregate("PAID", "Average");
+      AggregateRef sum = aggregate("PAID", "Sum");
+      when(h.layoutHandler().getCalcAggregateFields(any(), any()))
+         .thenReturn(new inetsoft.uql.erm.CalcAggregate[]{ avg, sum });
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension"),
+              "sort", spec("direction", "value_desc",
+                           "rankBy", spec("column", "PAID", "formula", "Sum"))));
+
+      ArgumentCaptor<SetCellBindingEvent> captor = ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      inetsoft.web.binding.model.table.OrderModel order = captor.getValue().getBinding().getOrder();
+      assertEquals(XConstants.SORT_VALUE_DESC, order.getType());
+      // Index 1 ("Sum"), not 0 ("Average") -- proves the match is by {column, formula}, not by
+      // first-in-scope-aggregate.
+      assertEquals(1, order.getSortCol());
+   }
+
+   @Test
+   void refusesTopnWithNoRankByWhenMultipleSummaryCellsAreInScope() throws Exception {
+      Harness h = harness(3, 3);
+      AggregateRef avg = aggregate("PAID", "Average");
+      AggregateRef sum = aggregate("PAID", "Sum");
+      when(h.layoutHandler().getCalcAggregateFields(any(), any()))
+         .thenReturn(new inetsoft.uql.erm.CalcAggregate[]{ avg, sum });
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.setCellBinding(
+         "tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension"),
+              "topn", spec("mode", "top", "n", 3))));
+
+      assertTrue(thrown.getMessage().contains("ambiguous"));
+      assertTrue(thrown.getMessage().contains("Sum"));
+      assertTrue(thrown.getMessage().contains("Average"));
+   }
+
+   @Test
+   void defaultsTopnRankByToTheSoleSummaryCellInScope() throws Exception {
+      Harness h = harness(3, 3);
+      AggregateRef sum = aggregate("PAID", "Sum");
+      when(h.layoutHandler().getCalcAggregateFields(any(), any()))
+         .thenReturn(new inetsoft.uql.erm.CalcAggregate[]{ sum });
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension"),
+              "topn", spec("mode", "top", "n", 3)));
+
+      ArgumentCaptor<SetCellBindingEvent> captor = ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      assertEquals(0, captor.getValue().getBinding().getTopn().getSumCol());
+   }
+
+   // ── field.namedGroup.others (boolean and string forms) ───────────────────────
+
+   @Test
+   void inlineNamedGroupOthersFalseMeansLeaveOthersInTheirOwnGroup() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension",
+                            "namedGroup", spec(
+                               "groups", List.of(spec("name", "West",
+                                  "conditions", List.of(spec("operator", "one_of",
+                                                             "values", List.of("CA"))))),
+                               "others", false))));
+
+      ArgumentCaptor<SetCellBindingEvent> captor = ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      // false must mean "leave" -- inverted, this would silently group instead (the exact
+      // opposite of what the natural Boolean convention used elsewhere in inetsoft.web.wiz,
+      // e.g. DimensionSortRanking.Ranking.others, means).
+      assertFalse(captor.getValue().getBinding().getOrder().isOthers());
+   }
+
+   @Test
+   void inlineNamedGroupOthersLeaveStringMeansLeaveOthersInTheirOwnGroup() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension",
+                            "namedGroup", spec(
+                               "groups", List.of(spec("name", "West",
+                                  "conditions", List.of(spec("operator", "one_of",
+                                                             "values", List.of("CA"))))),
+                               "others", "leave"))));
+
+      ArgumentCaptor<SetCellBindingEvent> captor = ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      assertFalse(captor.getValue().getBinding().getOrder().isOthers());
+   }
+
+   @Test
+   void inlineNamedGroupOthersOmittedDefaultsToGroupingThemTogether() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension",
+                            "namedGroup", spec(
+                               "groups", List.of(spec("name", "West",
+                                  "conditions", List.of(spec("operator", "one_of",
+                                                             "values", List.of("CA")))))))));
+
+      ArgumentCaptor<SetCellBindingEvent> captor = ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      assertTrue(captor.getValue().getBinding().getOrder().isOthers());
+   }
+
+   // ── mergeRowGroup / mergeColGroup / timeSeries wiring ─────────────────────────
+
+   @Test
+   void wiresMergeRowGroupMergeColGroupAndTimeSeriesOntoTheBinding() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", spec("column", "REGION", "type", "dimension"),
+              "mergeRowGroup", "TotalsRow", "mergeColGroup", null, "timeSeries", true));
+
+      ArgumentCaptor<SetCellBindingEvent> captor = ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      CellBindingInfo bound = captor.getValue().getBinding();
+      assertEquals("TotalsRow", bound.getMergeRowGroup());
+      assertNull(bound.getMergeColGroup());
+      assertTrue(bound.isTimeSeries());
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private record Harness(CalcTableService service, ViewsheetSessionService sessions,
                           VSTableLayoutService layoutService, Viewsheet viewsheet,
                           CalcTableVSAssemblyInfo assemblyInfo,
                           DataRefModelFactoryService refModelService,
-                          BindableFieldsService fieldsService) {}
+                          BindableFieldsService fieldsService,
+                          VSColumnHandler columnsHandler, TableLayoutHandler layoutHandler) {}
 
    private static Harness harness(int rows, int cols) {
       CalcTableVSAssembly assembly = mock(CalcTableVSAssembly.class);
@@ -456,7 +609,15 @@ class CalcTableServiceTest {
 
       VSTableLayoutService layoutService = mock(VSTableLayoutService.class);
       DataRefModelFactoryService refModelService = mock(DataRefModelFactoryService.class);
-      when(refModelService.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
+      // ConditionVocabulary.toConditionList matches conditions to fields by name, so the
+      // stub must echo the real DataRef's name rather than a bare, unstubbed mock (whose
+      // getName() would default to null and make every field lookup fail).
+      when(refModelService.createDataRefModel(any())).thenAnswer(invocation -> {
+         DataRef ref = invocation.getArgument(0);
+         DataRefModel model = mock(DataRefModel.class);
+         when(model.getName()).thenReturn(ref.getName());
+         return model;
+      });
 
       // Default fixture: a single "current" source table carrying every column the existing
       // test suite binds. Individual tests that need to exercise the column-existence check
@@ -477,6 +638,25 @@ class CalcTableServiceTest {
       VSColumnHandler columnsHandler = mock(VSColumnHandler.class);
       TableLayoutHandler layoutHandler = mock(TableLayoutHandler.class);
 
+      // Default fixture: the same columns fieldsService.list() above already carries, so
+      // CalcTableService.columnRef() (the inline named-group path's own column resolution,
+      // separate from BindableFieldsService's column-existence check) also finds "REGION"/
+      // "PAID" out of the box, the same way a fresh test doesn't have to stub fieldsService
+      // again unless it needs a narrower fixture.
+      try {
+         ColumnSelection bindableCols = new ColumnSelection();
+         bindableCols.addAttribute(new AttributeRef(null, "Region"));
+         bindableCols.addAttribute(new AttributeRef(null, "REGION"));
+         bindableCols.addAttribute(new AttributeRef(null, "PAID"));
+         when(columnsHandler.getColumnSelection(any(), any(), any(), any(),
+                                                anyBoolean(), anyBoolean(), anyBoolean(),
+                                                anyBoolean(), anyBoolean(), anyBoolean()))
+            .thenReturn(bindableCols);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
       // Default fixture: no summary cells in scope. Mockito's default answer for an array
       // return type is null, not empty -- aggregatesOf()'s "new AggregateRef[aggs.length]" NPEs
       // on that for every test that never bound a summary cell, not just the ones that care
@@ -487,7 +667,8 @@ class CalcTableServiceTest {
       return new Harness(
          new CalcTableService(sessions, layoutService, refModelService, fieldsService,
                               columnsHandler, layoutHandler),
-         sessions, layoutService, vs, info, refModelService, fieldsService);
+         sessions, layoutService, vs, info, refModelService, fieldsService,
+         columnsHandler, layoutHandler);
    }
 
    private static Principal principal() {


### PR DESCRIPTION
## Summary
- Fixes L6 (Calc Tables) parity audit findings: `CalcTableService.toCellBindingInfo`/`applySort`/`applyTopn` now actually wire cell `name`, `sort`, `topn`, `mergeRowGroup`/`mergeColGroup`, `timeSeries`, and `field.dateLevel`/`dateInterval` through to `CellBindingInfo`/`OrderModel`/`TopNModel` (previously silently dropped); `CalcCellVocabulary.vocabulary()` reports `aggregateFormulas`/`dateLevels`/`sortDirections`/`topnModes`; `TableLayoutHandler.doOperation` caps insert/append row/column counts at 1000. All live-verified against a redeployed build.
- Removes an incorrect `sort` + `field.namedGroup` mutual-exclusivity refusal drafted earlier in this same lane. Live UI inspection (a real Composer cell with `Sort: Manual` + `Named Group: Customize`, or `Sort: By Value (Asc)` + a named group, both rendering correctly) and source (`calc-named-group-dialog.component.ts`'s `apply()`, `LayoutTool.createGroupExpression`) both confirm a named group and a sort direction are independent settings — `resolveNamedGroupOrder`/`worksheetLocalOrder` now mutate the already-built `OrderModel` (setting only `.info`) instead of replacing it wholesale forced to `SORT_SPECIFIC`.
- Adds `sort.rankBy`/`topn.rankBy: {column, formula}` — sort or rank a group cell by a specific summary cell's value, resolved against `TableLayoutHandler.getCalcAggregateFields` (the same table-wide, deduplicated summary-cell list `VSTableLayoutService.getAggregates` already builds for the UI). Closes a gap this lane originally declared out of scope.
- Adds inline ("Customize") named-group authoring on `field.namedGroup` — `{groups: [{name, conditions}], others?}` — the mechanism most calc-table named groups actually use in practice (the pre-existing by-name form only ever resolved a worksheet-local `add_named_group` assembly or a repository-registered asset, neither of which is what "Customize" itself is). Reuses `ConditionVocabulary`'s existing flat clause vocabulary. Live-verified for string dimensions; date-typed columns are a known, deferred gap traced to `LayoutTool.quoteValue()` only rendering an actual `Date` object as `new Date(millis)`, not a `dataType`-coerced string.
- Fixes a related bug surfaced while live-testing the above: omitting `field.namedGroup` on a rewrite didn't clear a previously-set named group, because `toCellBindingInfo` builds a fresh `OrderModel` per call whose default `NamedGroupInfoModel` (`type=0`) matches neither of `VSTableLayoutService.setNamedGroupInfo`'s recognized branches. Fixed with an explicit `order.setInfo(null)`.
- Reconciles with #4997 (merged to this branch the same day, independently adding overlapping cell-naming work): fixed a duplicate `String name` declaration `toCellBindingInfo` that neither PR's diff alone would have caught, and corrected two of #4997's own `CalcTableServiceTest` assertions that encoded the exact `order.type == SORT_SPECIFIC` premise this PR disproves.
- Full narrative, evidence, and verdicts: see the companion stylebi-wiz PR's `docs/parity/L6-calc-tables/L6-parity-report.md`.

Companion plugin-side PR: inetsoft-technology/stylebi-wiz#2182 (same lane, same live-verification pass).

## Test plan
- [x] `mvn -pl core -am compile -o` clean
- [x] `CalcTableServiceTest`, `CalcCellVocabularyTest`: all passing
- [x] Live-verified against a redeployed build via the plugin's own MCP tools — see the parity report's "Live session, third pass" section
- [ ] Gate 0 (independent refuter) / repair review — not yet done, tracked in the report's "What's next"

🤖 Generated with [Claude Code](https://claude.com/claude-code)