### PR TITLE
feat(tabular): add TabularDatasetSchema.description for the annotation LLM

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/TabularDatasetSchema.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularDatasetSchema.java
@@ -44,10 +44,38 @@ import java.util.Map;
  *                  dataset-level fact, not a per-column one: every column returned by one
  *                  {@code describeDataset} call comes from the same scan and shares the same trust
  *                  level.
+ * @param description the dataset's own description, as the source declares it, verbatim — the
+ *                  same contract {@link TabularColumn#description()} carries at column level,
+ *                  applied to the dataset as a whole. Null means the connector said nothing about
+ *                  this dataset — a different statement from an empty string, which would claim
+ *                  the source declared a description and it happened to be empty. Never invented:
+ *                  a connector must not compose a sentence describing the dataset itself, only pass
+ *                  through words the source already published. Worth filling when the source has
+ *                  them, because unlike {@code TabularColumn}'s own {@code description}, this one
+ *                  reaches wiz's annotation LLM as durable table-level context: wiz's
+ *                  {@code applyAnnotationToDoc} (in
+ *                  {@code reconstructFullTableDoc.ts}) only ever overwrites {@code ai_context},
+ *                  {@code isDimension}, {@code dimensionPrevalence}, {@code additive},
+ *                  {@code preserved} and {@code state} on a table, carrying every other field
+ *                  through unchanged — so a description supplied here is input the LLM reads and
+ *                  never output the LLM replaces.
  */
 public record TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
                                    List<String> keyColumns, Map<String, String> params,
-                                   boolean columnsMayBeIncomplete) {
+                                   boolean columnsMayBeIncomplete, String description) {
+   /**
+    * Compatibility constructor for callers written before {@code description} existed — every
+    * existing connector's construction site. Defaults to {@code null}: "the connector said
+    * nothing", which is the true state of every one of them until they opt in, not a placeholder
+    * value standing in for an empty string.
+    */
+   public TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
+                               List<String> keyColumns, Map<String, String> params,
+                               boolean columnsMayBeIncomplete)
+   {
+      this(datasetId, columns, keyColumns, params, columnsMayBeIncomplete, null);
+   }
+
    /**
     * Compatibility constructor for callers written before {@code columnsMayBeIncomplete} existed —
     * every existing connector's construction site. Defaults to {@code false}: Cassandra, Hive,

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -369,6 +369,11 @@ public class TabularCatalogService {
       OsiDataset dataset = new OsiDataset();
       dataset.setName(schema.datasetId());
       dataset.setSource(schema.datasetId());
+
+      if(schema.description() != null && !schema.description().isBlank()) {
+         dataset.setDescription(schema.description());
+      }
+
       dataset.setPrimaryKey(schema.keyColumns() == null || schema.keyColumns().isEmpty() ?
          null : schema.keyColumns());
       dataset.setFields(fields);

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogDatasetExtensionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogDatasetExtensionTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -129,5 +130,71 @@ class TabularCatalogDatasetExtensionTest {
       JsonNode data = new ObjectMapper().readTree(ext.getData());
       assertTrue(data.get("columnsMayBeIncomplete").asBoolean(),
          "columnsMayBeIncomplete must be written as a JSON boolean, not a string");
+   }
+
+   /**
+    * B3: unlike {@code params}/{@code columnsMayBeIncomplete} above, {@code description} is a
+    * top-level {@link OsiDataset} field, not a COMMON-extension key — this reads it directly off
+    * the returned dataset rather than parsing the extension JSON.
+    */
+   @Test
+   void toDatasetWritesDescriptionWhenPresent() {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"), Map.of(), false,
+         "Order line items from the Northwind sample database.");
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Rest/Northwind", "OData", schema, new ObjectMapper());
+
+      assertEquals("Order line items from the Northwind sample database.",
+         dataset.getDescription());
+   }
+
+   /**
+    * Two absence cases, not one: a single null case would still pass against a guard that only
+    * checked null and let a blank/whitespace-only string through — the same reasoning
+    * {@code column.description()}'s existing guard at the field level was written to satisfy.
+    */
+   @Test
+   void toDatasetOmitsDescriptionWhenNull() {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"), Map.of(), false, null);
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Rest/Northwind", "OData", schema, new ObjectMapper());
+
+      assertNull(dataset.getDescription());
+   }
+
+   @Test
+   void toDatasetOmitsDescriptionWhenBlank() {
+      TabularDatasetSchema schema = new TabularDatasetSchema("Products",
+         List.of(new TabularColumn("ID", XSchema.LONG)), List.of("ID"), Map.of(), false, "   ");
+
+      OsiDataset dataset =
+         TabularCatalogService.toDataset("Rest/Northwind", "OData", schema, new ObjectMapper());
+
+      assertNull(dataset.getDescription());
+   }
+
+   /**
+    * The 3/4/5-arg compatibility constructors all predate {@code description} and must leave it
+    * null -- "the connector said nothing" is the true state of every existing construction site
+    * until it opts in, not a value this schema invents on their behalf.
+    */
+   @Test
+   void compatibilityConstructorsLeaveDescriptionNull() {
+      TabularColumn column = new TabularColumn("ID", XSchema.LONG);
+
+      TabularDatasetSchema threeArg = new TabularDatasetSchema("Products", List.of(column),
+         List.of("ID"));
+      TabularDatasetSchema fourArg = new TabularDatasetSchema("Products", List.of(column),
+         List.of("ID"), Map.of("entity", "Products"));
+      TabularDatasetSchema fiveArg = new TabularDatasetSchema("Products", List.of(column),
+         List.of("ID"), Map.of("entity", "Products"), true);
+
+      assertNull(threeArg.description());
+      assertNull(fourArg.description());
+      assertNull(fiveArg.description());
    }
 }


### PR DESCRIPTION
Gives `TabularDatasetSchema` a `description` component, so a tabular connector can say what a
dataset *is* — not just what columns it has.

## Why

`OsiDataset.description` already has **11 production read sites** in wiz, and the tabular path
leaves every one of them empty:

- `agents/annotateDatasource/annotateDatabase/index.ts:92` — the annotation LLM's table context
  (`getDatasetAnnotation(t.dataset) || t.dataset.description || "(no description)"`)
- `agents/knowledge/tools/searchTableFields.ts` and `searchTableDefinition.ts` — retrieval
- `agents/suggestion/nodes/generateSuggestions.ts:168` — suggestion generation
  (`dataset.ai_context?.instructions || dataset.description || ""`)

The read side is fully wired. Neither `new OsiDataset()` site sets it —
`MetadataApiService.java:164` (JDBC) or `TabularCatalogService.java` (tabular) — so every tabular
dataset reaches the annotation LLM with `"(no description)"`.

## Why `description` and not `ai_context`

The JDBC path pre-fills `ai_context` (`MetadataApiService.java:178-186`), but
`reconstructFullTableDoc.ts:111` replaces it wholesale as soon as the LLM returns anything
non-empty — the guard only catches an all-empty result. `description`, by contrast, rides through
`applyAnnotationToDoc` in `...rest`: that function writes only `ai_context`, `isDimension`,
`dimensionPrevalence`, `additive`, `preserved` and `state`.

So `description` is **durable input** to the annotation LLM and is never overwritten by it, while
`ai_context` is the LLM's own output slot. That asymmetry is the whole reason this component
belongs on `description`.

## The change

Three files.

**`TabularDatasetSchema`** gains a 6th component, appended rather than inserted:

```java
public record TabularDatasetSchema(String datasetId, List<TabularColumn> columns,
                                   List<String> keyColumns, Map<String, String> params,
                                   boolean columnsMayBeIncomplete, String description)
```

The previous 5-arg form becomes a compatibility constructor delegating `description = null`, so
the chain is now 3 → 4 → 5 → 6. `null` means **the connector said nothing about this dataset as a
whole** — deliberately a different statement from an empty string, and `toDataset` treats both the
same way (the key is omitted, not written blank).

Backward compatibility was checked rather than assumed: 28 `new TabularDatasetSchema(...)`
construction sites across this tree and the enterprise connectors tree, and **no record
deconstruction patterns anywhere** (no `case TabularDatasetSchema(...)`, no
`instanceof TabularDatasetSchema(...)`), so appending a component cannot break a pattern match.
`GDataCatalog.java:192` is the only site on what was the canonical 5-arg form and keeps compiling
unchanged.

**`TabularCatalogService.toDataset`** gains one guarded write, placed between `setSource` and
`setPrimaryKey` and shaped identically to the field-level `description` write a few lines above:

```java
if(schema.description() != null && !schema.description().isBlank()) {
   dataset.setDescription(schema.description());
}
```

**No new validation.** `validateParams`/`validateColumnNames` are untouched: free text has nothing
to check, and `validateColumnNames`' own javadoc warns that inventing a rule there risks rejecting
a correct connector rather than only a broken one. No length cap either — nothing downstream
imposes one, and a cap invented here would silently truncate a connector's own words.

## Tests

Four cases added to `TabularCatalogDatasetExtensionTest`, which already covered `toDataset`'s
other keys:

- the description is written when present;
- omitted when `null`;
- omitted when blank/whitespace — a **separate** case, because a single null case passes against
  a guard that only checks null;
- all three compatibility constructors leave it null.

`TabularCatalogDatasetExtensionTest` 9 run / 0 failures. The Facebook Ad Insights connector, the
first consumer, still passes its own 56 / 0 / 2 against the appended record.

## Merge order

**This PR must merge before** the Facebook Ad Insights connector PR in the `stylebi` enterprise
tree, which supplies the first real description and compiles against `inetsoft-core`.

## Known unrelated failure in this module

`inetsoft.uql.ConditionTest$RegressionTests.toSqlConditionSilentlyDefaultsOnAnUnmatchedName`
fails on this branch and on its base — it is not caused by this change and is not fixed here.
`Condition.toNullSqlCondition` builds its default dates with `Calendar.set(int,int,int)`, which
does not reset the time-of-day fields, so the two `java.sql.Date` values the test compares are
equal only when both calls land inside the same millisecond. `ConditionTest` has zero references
to anything this PR touches, and `Condition.java` is not in the diff. Flagging it for whoever
owns `inetsoft.uql.Condition`; it currently makes any `-am` build of a downstream module red.
