### PR TITLE
Add create_worksheet agent endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,7 @@ terraform.rc
 # is a review artifact, never applied automatically. Same reasoning as docs/properties/properties.json
 # in the stylebi-enterprise superproject: untracked rather than committed-and-stale.
 core/tools/admin-property-catalog/catalog-promotion-proposals.json
+
+# Local git worktrees created for isolated feature branches (using-git-worktrees convention) --
+# lives at the repo root, sibling to the checkouts it holds; never meant to be tracked.
+.worktrees/

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -323,6 +323,96 @@ public class SheetOpenService {
       return vsSession;
    }
 
+   /**
+    * {@code create_worksheet}. Mints a brand-new, BLANK worksheet runtime, and pairs the caller
+    * to it directly by reusing the ACTING session's already-live browser socket -- the exact
+    * mechanism {@link #createViewsheet} already uses in the reverse direction (worksheet/
+    * viewsheet -> new viewsheet), applied here to worksheet/viewsheet -> new worksheet.
+    *
+    * <p>Unlike {@link #openBaseWorksheet}, which always follows a viewsheet down to ITS OWN base
+    * (never an arbitrary target), the acting session here may be EITHER sheet type, exactly like
+    * {@link #createViewsheet} -- resolved through the generic, type-agnostic
+    * {@link SheetSessionService#resolve}, not {@link ViewsheetSessionService}.
+    *
+    * <p>Unlike {@link #createViewsheet}, there is no data source to resolve: the new worksheet is
+    * always blank. Callers design it with the add_table/add_join/add_calc_field family of tools,
+    * then save_worksheet to persist it. If the acting session is a viewsheet with no source of
+    * its own, attach_base_worksheet is the tool that connects the saved worksheet back to it.
+    *
+    * @param fromSessionToken the already-paired session (worksheet or viewsheet) whose browser
+    *                         connection the new session reuses
+    * @throws IllegalArgumentException on every refusal, with a message naming the specific
+    *                                  problem and, where there is one, the next tool to call.
+    */
+   public JoinSession createWorksheet(String fromSessionToken, Principal user) throws Exception {
+      JoinSession actingSession = sheetSessions.resolve(fromSessionToken, agentKey(user));
+
+      if(actingSession == null) {
+         throw new IllegalArgumentException(
+            "Invalid or expired session: " + fromSessionToken + ". Ask the user for a fresh " +
+            "pairing code and run connect_sheet again.");
+      }
+
+      // Same class of bug openBaseWorksheet/createViewsheet guard against: a pane-scoped session
+      // is a write handle for ONE script location, and minting a new whole-sheet
+      // (editorContext = null) session from it would launder that narrow grant into unscoped
+      // whole-sheet authority on a runtime the pane's grant never named. Must come before the
+      // runtime is touched or any grant is minted.
+      if(actingSession.editorContext() != null) {
+         throw new IllegalArgumentException(
+            "This session is scoped to one script location, not to the whole sheet, so it " +
+            "cannot create a new worksheet: doing so would turn a single-expression grant into " +
+            "a whole-sheet write handle. Ask the user to re-pair from the sheet toolbar " +
+            "('Connect to Claude') and call create_worksheet from that session.");
+      }
+
+      if(actingSession.socketSessionId() == null) {
+         throw new IllegalArgumentException(
+            "The connected session has no active browser connection to create a worksheet in; " +
+            "ask the user to re-pair (run connect_sheet again) before calling create_worksheet.");
+      }
+
+      boolean canCreate = securityProvider.checkPermission(
+         user, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS);
+
+      if(!canCreate) {
+         throw new IllegalArgumentException(
+            "You do not have permission to create a Data Worksheet in Visual Composer.");
+      }
+
+      String runtimeId = viewsheetService.openTemporaryWorksheet(user, null);
+
+      // The acting session's own socket/owner, exactly like createViewsheet mints in the reverse
+      // direction -- no new pairing code, and the new session is opened whole-sheet (null
+      // editorContext), matching how a freshly-created worksheet has always been opened.
+      JoinSession wsSession = sheetSessions.open(runtimeId, actingSession.ownerIdentity(),
+                                                  SheetType.WORKSHEET,
+                                                  actingSession.socketSessionId(),
+                                                  actingSession.socketUserName(), null);
+
+      // Tells the Composer tab bar an agent is now attached to this runtime -- the same
+      // best-effort notification openBaseWorksheet/createViewsheet send for their own attach
+      // paths; create_worksheet is a fourth real entry point that attaches a session, so it needs
+      // the same call for the tab-bar indicator to be consistent across all of them.
+      try {
+         broadcast.sendAgentActive(wsSession);
+      }
+      catch(Exception ex) {
+         LOG.warn("Worksheet created, but notifying the tab bar failed (runtimeId={})",
+                  runtimeId, ex);
+      }
+
+      OpenComposerAssetCommand command = OpenComposerAssetCommand.builder()
+         .assetId(null)          // unsaved, blank worksheet -- there is no asset path yet
+         .viewsheet(false)
+         .runtimeId(runtimeId)
+         .build();
+
+      broadcast.sendToComposer(actingSession.socketSessionId(), command);
+
+      return wsSession;
+   }
+
    private static String agentKey(Principal agent) {
       if(agent instanceof XPrincipal p) {
          IdentityID id = IdentityID.getIdentityIDFromKey(p.getName());

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -76,6 +76,7 @@ import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.service.RenderWaitSupport;
 import inetsoft.web.wiz.service.TabularEndpointBindingSupport;
 import inetsoft.web.wiz.script.PaneScopeService;
+import inetsoft.web.wiz.viewsheet.SheetOpenService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.slf4j.Logger;
@@ -128,7 +129,8 @@ public class WorksheetAgentController {
                                    LayoutGraphService layoutGraphService,
                                    DataSourceService dataSourceService,
                                    SecurityEngine securityEngine,
-                                   RenameTransformHandler renameTransformHandler)
+                                   RenameTransformHandler renameTransformHandler,
+                                   SheetOpenService openService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -146,6 +148,7 @@ public class WorksheetAgentController {
       this.dataSourceService = dataSourceService;
       this.securityEngine = securityEngine;
       this.renameTransformHandler = renameTransformHandler;
+      this.openService = openService;
    }
 
    // ---------------------------------------------------------------------------
@@ -173,6 +176,50 @@ public class WorksheetAgentController {
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
                               outcome.sheetLabel());
+   }
+
+   /**
+    * Request body for the create-worksheet endpoint.
+    *
+    * @param fromSessionToken the already-paired session (worksheet or viewsheet) whose browser
+    *                         connection the new session reuses
+    */
+   public record CreateWorksheetRequest(String fromSessionToken) {}
+
+   /**
+    * {@code create_worksheet}. Mints a brand-new, blank worksheet runtime and pairs the caller to
+    * it directly -- no new pairing code needed, and the browser visually follows along in the
+    * currently-open Composer window -- by reusing the ALREADY-PAIRED session named by
+    * {@code fromSessionToken} (worksheet or viewsheet, either is accepted). {@link SheetOpenService}
+    * performs every guard and the browser broadcast; this endpoint only translates its
+    * {@link JoinSession} into the same join shape {@link #join} returns.
+    *
+    * <p>The worksheet this mints is always blank -- no table, no source. Design it with the
+    * existing add_table/add_join/add_calc_field family of tools, then save_worksheet to persist
+    * it. If the acting session is a viewsheet with no source of its own, attach_base_worksheet is
+    * the tool that connects the saved worksheet back to it.
+    *
+    * @throws PairingException naming the specific problem: no acting session, no live browser
+    *                          connection on it, or a permission failure.
+    */
+   @PostMapping("/api/wiz/v1/agent/worksheet/create")
+   public JoinResponse createWorksheet(@RequestBody CreateWorksheetRequest body, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      JoinSession session;
+
+      try {
+         session = openService.createWorksheet(body == null ? null : body.fromSessionToken(), user);
+      }
+      catch(IllegalArgumentException e) {
+         throw new PairingException(e.getMessage(), e);
+      }
+
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase(), session.editorContext(),
+                              null);
    }
 
    /**
@@ -3606,6 +3653,7 @@ public class WorksheetAgentController {
    private final DataSourceService dataSourceService;
    private final SecurityEngine securityEngine;
    private final RenameTransformHandler renameTransformHandler;
+   private final SheetOpenService openService;
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetAgentController.class);
 
    // Mirrors ViewsheetEditService.TABLE_WARM_MAX_ATTEMPTS/TABLE_WARM_RETRY_SLEEP_MS: the same

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -551,6 +551,225 @@ class SheetOpenServiceTest {
       assertTrue(thrown.getMessage().toLowerCase().contains("permission"), thrown.getMessage());
    }
 
+   // ── createWorksheet ──────────────────────────────────────────────────────
+   // create_worksheet: mints a brand-new, BLANK worksheet runtime and pairs the caller to it
+   // directly, by reusing the ACTING session's (worksheet or viewsheet) already-live browser
+   // socket -- the exact mechanism createViewsheet already uses in the reverse direction
+   // (worksheet/viewsheet -> new viewsheet), applied here to worksheet/viewsheet -> new worksheet.
+
+   @Test
+   void createWorksheetMintsABlankWorksheetRuntimeFromAWorksheetActingSession() throws Exception {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+
+      JoinSession created = service.createWorksheet("tok-acting", principal());
+
+      assertEquals(SheetType.WORKSHEET, created.sheetType());
+      assertEquals("ws-runtime-new", created.runtimeId());
+   }
+
+   /** Proves the acting session may be EITHER sheet type, exactly like createViewsheet. */
+   @Test
+   void createWorksheetMintsABlankWorksheetRuntimeFromAViewsheetActingSession() throws Exception {
+      SheetOpenService service = createWorksheetService(SheetType.VIEWSHEET, true);
+
+      JoinSession created = service.createWorksheet("tok-acting", principal());
+
+      assertEquals(SheetType.WORKSHEET, created.sheetType());
+      assertEquals("ws-runtime-new", created.runtimeId());
+   }
+
+   /** The whole point of create_worksheet vs. createViewsheet(dataSource): no asset to point at. */
+   @Test
+   void createWorksheetOpensATemporaryWorksheetWithNoAssetEntry() throws Exception {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+
+      service.createWorksheet("tok-acting", principal());
+
+      verify(viewsheetService).openTemporaryWorksheet(any(Principal.class), isNull());
+   }
+
+   @Test
+   void theNewWorksheetSessionCarriesTheActingSessionsSocketIdentifiers() throws Exception {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+
+      JoinSession created = service.createWorksheet("tok-acting", principal());
+
+      assertEquals("sock-1", created.socketSessionId());
+      assertEquals(SOCKET_USER, created.socketUserName());
+   }
+
+   @Test
+   void pushesAnOpenCommandMarkedAsAWorksheetCarryingTheServerCreatedRuntimeId() throws Exception {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+
+      service.createWorksheet("tok-acting", principal());
+
+      ArgumentCaptor<Object> command = ArgumentCaptor.forClass(Object.class);
+      verify(broadcast).sendToComposer(eq("sock-1"), command.capture());
+
+      OpenComposerAssetCommand sent = (OpenComposerAssetCommand) command.getValue();
+      assertEquals("ws-runtime-new", sent.runtimeId());
+      assertFalse(sent.viewsheet());
+   }
+
+   /**
+    * agent-sheet-visibility: create_worksheet is another real entry point that attaches a
+    * session, alongside SheetJoinService.join, openBaseWorksheet, and createViewsheet, so it
+    * needs the same sendAgentActive notification for the Composer tab-bar "agent connected"
+    * indicator to be consistent across all of them.
+    */
+   @Test
+   void notifiesTheTabBarThatAnAgentIsNowAttachedToTheNewWorksheetFromCreateWorksheet()
+      throws Exception
+   {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+
+      JoinSession created = service.createWorksheet("tok-acting", principal());
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendAgentActive(sent.capture());
+      assertEquals(created.runtimeId(), sent.getValue().runtimeId());
+   }
+
+   /** A broken tab-bar notification must not fail the create -- best-effort, independent try/catch. */
+   @Test
+   void tabBarNotifyFailureDoesNotFailTheCreateWorksheet() throws Exception {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+      doThrow(new RuntimeException("socket gone")).when(broadcast).sendAgentActive(any());
+
+      JoinSession created = service.createWorksheet("tok-acting", principal());
+
+      assertNotNull(created);
+      assertEquals("ws-runtime-new", created.runtimeId());
+   }
+
+   @Test
+   void createWorksheetRefusesWhenActingSessionIsUnresolvable() {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createWorksheet("not-a-real-token", principal()));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("invalid or expired"),
+                thrown.getMessage());
+   }
+
+   @Test
+   void createWorksheetRefusesWhenActingSessionHasNoSocket() {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, true, null, null);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createWorksheet("tok-acting", principal()));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("browser connection"),
+                thrown.getMessage());
+   }
+
+   /**
+    * Mirrors createViewsheetRefusesAPaneScopedActingSessionRatherThanMintingAWholeSheetOne: a
+    * pane-scoped session is a write handle for ONE script location, and minting a new whole-sheet
+    * (editorContext = null) session from it would launder that narrow grant into unscoped
+    * whole-sheet authority on a runtime the pane's grant never named.
+    *
+    * <p>The four never() assertions are the substance: refusing with a message while still
+    * opening the runtime, or still minting the session, would leave the hole open.
+    */
+   @Test
+   void createWorksheetRefusesAPaneScopedActingSessionRatherThanMintingAWholeSheetOne()
+      throws Exception
+   {
+      SheetOpenService service = createWorksheetService(
+         SheetType.WORKSHEET, true, "sock-1",
+         new inetsoft.web.wiz.pairing.EditorContext("assemblyMain", "Chart1", null, null));
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createWorksheet("tok-acting", principal()));
+
+      assertTrue(thrown.getMessage().contains("scoped to one script location"),
+                thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("create_worksheet"), thrown.getMessage());
+
+      verify(viewsheetService, never()).openTemporaryWorksheet(any(Principal.class), any());
+      verify(sheetSessions, never()).open(anyString(), anyString(), any(SheetType.class),
+                                          any(), any(), any());
+      verify(broadcast, never()).sendAgentActive(any());
+      verify(broadcast, never()).sendToComposer(anyString(), any());
+   }
+
+   @Test
+   void createWorksheetRefusesWhenTheAgentLacksWorksheetPermission() {
+      SheetOpenService service = createWorksheetService(SheetType.WORKSHEET, false);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.createWorksheet("tok-acting", principal()));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("permission"), thrown.getMessage());
+   }
+
+   /**
+    * Purpose-built harness for {@code createWorksheet} -- mirrors {@code createViewsheetService}'s
+    * shape but with no data-source concept at all: create_worksheet always mints a BLANK
+    * worksheet, so there is no "defaults to acting worksheet" / "explicit data source" split to
+    * parameterize.
+    *
+    * @param actingType    the acting session's own sheet type (worksheet or viewsheet -- either
+    *                      is valid, unlike openBaseWorksheet which only ever follows a viewsheet)
+    * @param hasPermission whether the agent has {@code ResourceType.WORKSHEET} ACCESS
+    */
+   private SheetOpenService createWorksheetService(SheetType actingType, boolean hasPermission) {
+      return createWorksheetService(actingType, hasPermission, "sock-1", null);
+   }
+
+   /**
+    * @param editorContext the acting session's own scope -- {@code null} for the ordinary
+    *                      whole-sheet session every other test here uses, non-null for the
+    *                      pane-scoped session createWorksheet must refuse.
+    */
+   private SheetOpenService createWorksheetService(SheetType actingType, boolean hasPermission,
+                                                    String socketSessionId,
+                                                    inetsoft.web.wiz.pairing.EditorContext editorContext)
+   {
+      try {
+         JoinSession actingSession = new JoinSession(
+            "tok-acting", "acting-runtime-1", OWNER, actingType, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+            socketSessionId, SOCKET_USER, editorContext);
+
+         SheetSessionService sheetSessions = mock(SheetSessionService.class);
+         this.sheetSessions = sheetSessions;
+         when(sheetSessions.resolve(eq("tok-acting"), eq(OWNER))).thenReturn(actingSession);
+
+         JoinSession newWsSession = new JoinSession(
+            "tok-ws-new", "ws-runtime-new", OWNER, SheetType.WORKSHEET, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+            socketSessionId, SOCKET_USER, null);
+         when(sheetSessions.open(eq("ws-runtime-new"), eq(OWNER), eq(SheetType.WORKSHEET),
+                                 eq(socketSessionId), eq(SOCKET_USER), isNull()))
+            .thenReturn(newWsSession);
+
+         runtimeAccess = mock(inetsoft.web.wiz.pairing.SheetRuntimeAccess.class);
+
+         viewsheetService = mock(inetsoft.analytic.composition.ViewsheetService.class);
+         when(viewsheetService.openTemporaryWorksheet(any(Principal.class), isNull()))
+            .thenReturn("ws-runtime-new");
+
+         SecurityProvider securityProvider = mock(SecurityProvider.class);
+         when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.WORKSHEET),
+                                               eq("*"), eq(ResourceAction.ACCESS)))
+            .thenReturn(hasPermission);
+
+         broadcast = mock(SheetAgentBroadcastService.class);
+         worksheetService = mock(WorksheetService.class);
+
+         return new SheetOpenService(mock(ViewsheetSessionService.class), sheetSessions,
+                                     worksheetService, securityProvider, broadcast,
+                                     viewsheetService, runtimeAccess);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
    /**
     * Purpose-built harness for {@code createViewsheet} -- {@code openBaseWorksheet}'s own
     * {@code serviceWithBase} is tailored to that method's very different fixture shape

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -135,7 +135,8 @@ class WorksheetAgentControllerTest {
                                           mock(inetsoft.web.composer.ws.LayoutGraphService.class),
                                           mock(inetsoft.web.portal.controller.database.DataSourceService.class),
                                           mock(inetsoft.sree.security.SecurityEngine.class),
-                                          renameTransformHandler);
+                                          renameTransformHandler,
+                                          mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class));
    }
 
    /** Like the 6-arg {@code controller}, but lets a {@code dependents} test control the
@@ -158,7 +159,8 @@ class WorksheetAgentControllerTest {
                                           mock(inetsoft.web.composer.ws.LayoutGraphService.class),
                                           mock(inetsoft.web.portal.controller.database.DataSourceService.class),
                                           mock(inetsoft.sree.security.SecurityEngine.class),
-                                          mock(inetsoft.uql.asset.sync.RenameTransformHandler.class));
+                                          mock(inetsoft.uql.asset.sync.RenameTransformHandler.class),
+                                          mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class));
    }
 
    private static SheetAgentFeature featureOn() {
@@ -192,7 +194,8 @@ class WorksheetAgentControllerTest {
          xrepository, mock(AssetRepository.class), metadataApiService,
          queryManagerService, mock(LayoutGraphService.class),
          dataSourceService, securityEngine,
-         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class));
+         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class),
+         mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class));
    }
 
    /** Builds an {@code add_table} EditRequest that routes to addBoundTable() (no logicalModel). */
@@ -2689,11 +2692,98 @@ class WorksheetAgentControllerTest {
          mock(inetsoft.web.composer.ws.LayoutGraphService.class),
          mock(inetsoft.web.portal.controller.database.DataSourceService.class),
          mock(inetsoft.sree.security.SecurityEngine.class),
-         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class));
+         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class),
+         mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class));
 
       ctrl.detach("TOK-D", agent);
 
       verify(broadcast).sendAgentInactive(s);
+   }
+
+   // ---------------------------------------------------------------------------
+   // create_worksheet -- mints a blank worksheet runtime by reusing an already-paired
+   // session's browser connection. Symmetric to
+   // ViewsheetAssemblyAgentController.createViewsheet; SheetOpenService.createWorksheet performs
+   // every guard, this endpoint only translates its result into the same JoinResponse shape join
+   // already returns.
+   // ---------------------------------------------------------------------------
+
+   /** Feature enabled, only {@code openService} wired -- for the create_worksheet tests. */
+   private static WorksheetAgentController controllerWithOpenService(
+      inetsoft.web.wiz.viewsheet.SheetOpenService openService)
+   {
+      return controllerWithOpenService(featureOn(), openService);
+   }
+
+   private static WorksheetAgentController controllerWithOpenService(
+      SheetAgentFeature feature, inetsoft.web.wiz.viewsheet.SheetOpenService openService)
+   {
+      return new WorksheetAgentController(feature,
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class), mock(WorksheetPreviewService.class),
+         mock(SheetAgentBroadcastService.class), mock(inetsoft.uql.XRepository.class),
+         mock(inetsoft.uql.asset.AssetRepository.class),
+         mock(inetsoft.web.wiz.service.MetadataApiService.class),
+         mock(inetsoft.web.portal.controller.database.QueryManagerService.class),
+         mock(inetsoft.web.composer.ws.LayoutGraphService.class),
+         mock(inetsoft.web.portal.controller.database.DataSourceService.class),
+         mock(inetsoft.sree.security.SecurityEngine.class),
+         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class),
+         openService);
+   }
+
+   @Test
+   void createWorksheetReturnsTheNewlyMintedWorksheetSession() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      JoinSession created = new JoinSession("tok-ws-new", "ws-runtime-new", "alice~;~host-org",
+         SheetType.WORKSHEET, 0L, SheetSessionService.TTL_MILLIS,
+         JoinSession.ConnectionMode.PAIRED, "sock-1", "alice-browser", null);
+
+      inetsoft.web.wiz.viewsheet.SheetOpenService openService =
+         mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class);
+      when(openService.createWorksheet(eq("tok-acting"), eq(agent))).thenReturn(created);
+
+      WorksheetAgentController ctrl = controllerWithOpenService(openService);
+
+      WorksheetAgentController.JoinResponse response = ctrl.createWorksheet(
+         new WorksheetAgentController.CreateWorksheetRequest("tok-acting"), agent);
+
+      assertEquals("worksheet", response.sheetType());
+      assertEquals("ws-runtime-new", response.runtimeId());
+      verify(openService).createWorksheet(eq("tok-acting"), eq(agent));
+   }
+
+   @Test
+   void createWorksheetWrapsAnIllegalArgumentExceptionFromSheetOpenServiceAsPairingException()
+      throws Exception
+   {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      inetsoft.web.wiz.viewsheet.SheetOpenService openService =
+         mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class);
+      when(openService.createWorksheet(any(), any()))
+         .thenThrow(new IllegalArgumentException("invalid or expired session"));
+
+      WorksheetAgentController ctrl = controllerWithOpenService(openService);
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         ctrl.createWorksheet(
+            new WorksheetAgentController.CreateWorksheetRequest("tok-acting"), agent));
+      assertTrue(ex.getMessage().contains("invalid or expired session"));
+   }
+
+   @Test
+   void createWorksheetRefusesWhenTheFeatureIsDisabled() {
+      inetsoft.web.wiz.viewsheet.SheetOpenService openService =
+         mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class);
+      WorksheetAgentController ctrl = controllerWithOpenService(featureOff(), openService);
+
+      assertThrows(org.springframework.web.server.ResponseStatusException.class, () ->
+         ctrl.createWorksheet(new WorksheetAgentController.CreateWorksheetRequest("tok-acting"),
+            TestPrincipals.user("alice", "host-org")));
+      verifyNoInteractions(openService);
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetScriptControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetScriptControllerTest.java
@@ -134,7 +134,8 @@ class WorksheetScriptControllerTest {
          mock(inetsoft.web.wiz.service.MetadataApiService.class),
          mock(QueryManagerService.class), mock(LayoutGraphService.class),
          mock(DataSourceService.class), securityEngine,
-         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class));
+         mock(inetsoft.uql.asset.sync.RenameTransformHandler.class),
+         mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class));
 
       WorksheetScriptService scriptService =
          new WorksheetScriptService(editService, worksheetController);


### PR DESCRIPTION
## Summary
- Add `SheetOpenService.createWorksheet(fromSessionToken, user)`: mints a brand-new, blank worksheet runtime by reusing an already-paired session's live browser socket, symmetric to the existing `createViewsheet`.
- Expose it via `POST /api/wiz/v1/agent/worksheet/create` on `WorksheetAgentController`, returning the same `JoinResponse` shape every other agent endpoint uses.
- This closes the gap where the wiz agent plugin could mint a new *viewsheet* (`create_viewsheet`) or attach an existing worksheet as a viewsheet's base (`attach_base_worksheet`), but had no way to build a brand-new, multi-table/joined worksheet from scratch.

## Design
Full design/rationale: see `docs/superpowers/specs/2026-09-04-create-worksheet-tool-design.md` and `docs/superpowers/plans/2026-09-04-create-worksheet-community-backend.md` in the `stylebi-wiz` repo (not part of this PR).

`createWorksheet` mirrors `createViewsheet`'s three guards exactly (valid acting session, not pane-scoped, has a live socket) plus the same permission check pattern, then mints via `openTemporaryWorksheet(user, null)` — the same call `OpenWorksheetController`'s own "New Worksheet" button and `WorksheetTableService.openProbeWorksheet` already use for a pure, asset-less runtime.

The plugin-side `create_worksheet` MCP tool (in `stylebi-wiz`) is a separate, later PR that will call this endpoint.

## Test plan
- [x] `./mvnw test -pl core -Dtest=SheetOpenServiceTest` — 38 tests, 0 failures (11 new)
- [x] `./mvnw test -pl core -Dtest=WorksheetAgentControllerTest` — 130 tests, 0 failures (3 new)
- [x] `./mvnw test -pl core -Dtest=WorksheetScriptControllerTest` — 7 tests, 0 failures (constructor call-site fix)
- [x] Full `./mvnw test -pl core` — 8736 tests, 0 failures, 0 errors, BUILD SUCCESS
- [x] Independent code review (no findings)