### PR TITLE
L7: Assembly & Viewsheet Properties, Hyperlinks -- wiz agent backend fixes

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogService.java
@@ -36,6 +36,8 @@ import org.springframework.stereotype.Service;
 
 import java.awt.*;
 import java.security.Principal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -314,6 +316,7 @@ public class CalendarPropertyDialogService {
       info.setDaySelectionValue(calendarAdvancedPaneModel.isDaySelection());
       info.setSingleSelectionValue(calendarAdvancedPaneModel.isSingleSelection());
       info.setSubmitOnChangeValue(calendarAdvancedPaneModel.isSubmitOnChange());
+      requireMinBeforeMax(calendarAdvancedPaneModel.getMin(), calendarAdvancedPaneModel.getMax());
       info.setMinValue(calendarAdvancedPaneModel.getMin().convertToValue());
       info.setMaxValue(calendarAdvancedPaneModel.getMax().convertToValue());
 
@@ -332,6 +335,43 @@ public class CalendarPropertyDialogService {
       return null;
    }
 
+
+   /**
+    * Mirrors {@code calendar-advanced-pane.component.ts}'s {@code minGreaterThanMaxValidator}:
+    * refuses a static min that is not strictly before a static max. Skipped -- same as the
+    * Angular validator -- when either side is a variable/expression (no static value to
+    * compare) or empty, and when a static value does not parse as a plain date: this check adds
+    * only the min/max ordering rule, not date well-formedness, which is out of scope here.
+    */
+   private void requireMinBeforeMax(DynamicValueModel min, DynamicValueModel max) {
+      if(min == null || max == null || !DynamicValueModel.VALUE.equals(min.getType()) ||
+         !DynamicValueModel.VALUE.equals(max.getType()))
+      {
+         return;
+      }
+
+      String minValue = min.convertToValue();
+      String maxValue = max.convertToValue();
+
+      if(minValue == null || minValue.isEmpty() || maxValue == null || maxValue.isEmpty()) {
+         return;
+      }
+
+      SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+
+      try {
+         if(!format.parse(minValue).before(format.parse(maxValue))) {
+            throw new IllegalArgumentException(
+               "Calendar 'min' (" + minValue + ") must be before 'max' (" + maxValue + "). " +
+               "The Composer UI refuses this the same way: a calendar cannot show a range that " +
+               "starts on or after its own end.");
+         }
+      }
+      catch(ParseException e) {
+         // Not a plain yyyy-MM-dd date -- leave it to the write itself, which is where date
+         // well-formedness is already handled.
+      }
+   }
 
    private final VSObjectPropertyService vsObjectPropertyService;
    private final VSOutputService vsOutputService;

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
@@ -372,8 +372,9 @@ public class ChartPropertyDialogService {
       ChartAdvancedPaneModel advancePaneCheck = value == null ? null : value.getChartAdvancedPaneModel();
 
       if(advancePaneCheck != null) {
-         if(advancePaneCheck.isGlossyEffect() && advancePaneCheck.isSparklineSupported() &&
-            advancePaneCheck.isSparkline())
+         if(advancePaneCheck.isGlossyEffect() &&
+            (!this.chartPropertyService.isSupported(vsChartInfo, "effectEnabled", false) ||
+               (advancePaneCheck.isSparklineSupported() && advancePaneCheck.isSparkline())))
          {
             advancePaneCheck.setGlossyEffect(false);
          }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
@@ -364,6 +364,25 @@ public class ChartPropertyDialogService {
          throw e;
       }
 
+      // Normalized before anything is applied. These mirror Angular disabled-checkbox
+      // conditions (chart-advanced-pane.component.html) whose bound model can still carry a
+      // stale "true" once disabled -- since a human can never actually express these
+      // combinations through the UI, silently correcting them (rather than throwing) matches
+      // what the disabled checkbox itself means: "this value doesn't apply here".
+      ChartAdvancedPaneModel advancePaneCheck = value == null ? null : value.getChartAdvancedPaneModel();
+
+      if(advancePaneCheck != null) {
+         if(advancePaneCheck.isGlossyEffect() && advancePaneCheck.isSparklineSupported() &&
+            advancePaneCheck.isSparkline())
+         {
+            advancePaneCheck.setGlossyEffect(false);
+         }
+
+         if(GraphTypes.isMekko(vsChartInfo.getChartType())) {
+            advancePaneCheck.setEnableDrilling(false);
+         }
+      }
+
       ChartGeneralPaneModel chartGeneralPaneModel = value.getChartGeneralPaneModel();
       GeneralPropPaneModel generalPropPaneModel = chartGeneralPaneModel.getGeneralPropPaneModel();
       BasicGeneralPaneModel basicGeneralPaneModel = generalPropPaneModel.getBasicGeneralPaneModel();

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogService.java
@@ -184,6 +184,19 @@ public class TableViewPropertyDialogService {
       TipPaneModel tipPaneModel = tableAdvancedPaneModel.getTipPaneModel();
       VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel = value.getVsAssemblyScriptPaneModel();
 
+      if(tableViewGeneralPaneModel.getMaxRows() < 0) {
+         throw new IllegalArgumentException(
+            "'maxRows' must be 0 or greater; " + tableViewGeneralPaneModel.getMaxRows() +
+            " is not a valid row limit.");
+      }
+
+      if(tableAdvancedPaneModel.isForm() && tableAdvancedPaneModel.isEnableAdhoc()) {
+         throw new IllegalArgumentException(
+            "'form' and 'enableAdhoc' cannot both be true on a table: enabling form input " +
+            "turns off ad hoc editing in the Composer UI, and enabling ad hoc editing turns " +
+            "off form input. Set at most one of them.");
+      }
+
       if(tableViewGeneralPaneModel.isShowSubmitOnChange()) {
          ((EmbeddedTableVSAssemblyInfo) tableAssemblyInfo).setSubmitOnChangeValue(
             tableViewGeneralPaneModel.isSubmitOnChange());

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
@@ -286,6 +286,19 @@ public class ViewsheetPropertyDialogService {
       ViewsheetInfo info = viewsheet.getViewsheetInfo();
       VSOptionsPaneModel vsOptionsPaneModel = value.vsOptionsPane();
 
+      // Validated before any info.setX(...) mutation below -- this service has no defensive
+      // clone (it mutates ViewsheetInfo live), so an invalid field must be caught before any
+      // other field is applied to avoid a partial write. Mirrors form-validators.ts's
+      // inSanpGridRangeOrNull (sic): a non-positive or non-multiple-of-5 grid size divides into
+      // the Composer's own live canvas drag math and produces NaN/Infinity assembly positions,
+      // so this is refused rather than silently applied.
+      if(vsOptionsPaneModel.getSnapGrid() <= 0 || vsOptionsPaneModel.getSnapGrid() % 5 != 0) {
+         throw new IllegalArgumentException(
+            "'snapGrid' must be a positive multiple of 5; " + vsOptionsPaneModel.getSnapGrid() +
+            " is not. The Composer's canvas drag math divides by this value, so an invalid " +
+            "grid size would corrupt assembly positions rather than merely look wrong.");
+      }
+
       boolean reset = info.isMetadata() != vsOptionsPaneModel.isUseMetaData() ||
          info.getDesignMaxRows() != vsOptionsPaneModel.getMaxRows();
 
@@ -304,6 +317,7 @@ public class ViewsheetPropertyDialogService {
       info.setUpdateEnabled(vsOptionsPaneModel.isServerSideUpdate());
       info.setTouchInterval(vsOptionsPaneModel.getTouchInterval());
       info.setDesignMaxRows(vsOptionsPaneModel.getMaxRows());
+
       info.setSnapGrid(vsOptionsPaneModel.getSnapGrid());
       info.setOnReport(vsOptionsPaneModel.isListOnPortalTree());
 

--- a/core/src/main/java/inetsoft/web/wiz/WizUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizUtil.java
@@ -28,6 +28,7 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
 import inetsoft.util.Tool;
+import inetsoft.web.wiz.pairing.PairingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -285,6 +286,33 @@ public class WizUtil {
       }
 
       return value;
+   }
+
+   /**
+    * Refuses a caret in a caller-supplied asset path/name, before it is used to build any
+    * {@link inetsoft.uql.asset.AssetEntry}.
+    *
+    * <p>{@code AssetEntry.toIdentifier()} joins its fields with a literal, unescaped
+    * {@code '^'} ({@code scope^type^user^path^orgID}). {@code AssetEntry.createAssetEntry(String)}
+    * recovers {@code path} correctly (it splits on the LAST {@code '^'} in the identifier), but
+    * recovers {@code orgID} using the FIRST {@code '^'} found after the user field -- which, when
+    * {@code path} itself contains a caret, is a caret embedded inside the path rather than the
+    * true path/orgID boundary. The recovered {@code orgID} then silently absorbs the remainder of
+    * the path plus the real orgID, corrupting it on any later round-trip through
+    * {@code createAssetEntry(identifier)}. Mirrors the same rule the Composer's own asset-picker
+    * dialogs (new-viewsheet-dialog, select-data-source-dialog, new-visualization-dialog) already
+    * enforce client-side.
+    *
+    * @param value the path/name to check; {@code null}/empty is not this method's concern.
+    * @param field the field name to name in the error, e.g. {@code "path"} or {@code "name"}.
+    */
+   public static void requireNoCaret(String value, String field) throws PairingException {
+      if(value != null && value.indexOf('^') >= 0) {
+         throw new PairingException(
+            "'" + field + "' must not contain '^'. AssetEntry.toIdentifier() joins its fields " +
+            "with a literal, unescaped '^', so a caret embedded in '" + field + "' corrupts the " +
+            "orgID recovered on any later round-trip through AssetEntry.createAssetEntry(identifier).");
+      }
    }
 
    public static final String ANNOTATION_RAW_DATA_MAX_ROW = "annotation.rawdata.maxrow";

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -66,7 +66,69 @@ public final class PropertyAliases {
     */
    private static final Set<String> CHART_READ_ONLY_FLAGS = Set.of(
       "gridLineVisible", "innerLineVisible", "trendLineVisible", "facetGridVisible",
-      "facetGridEnabled", "projectForwardEnabled", "lineTabVisible");
+      "facetGridEnabled", "projectForwardEnabled", "lineTabVisible",
+      // chartAdvancedPaneModel's own capability flags: recomputed from the chart type/embedding
+      // on every read (ChartAdvancedPaneModel's constructor and ChartPropertyDialogService's
+      // getChartPropertyDialogModel0), never consulted by updateChartAdvancedPaneModel. Same
+      // shape as the line-pane flags above -- a write reports success and changes nothing.
+      "adhocVisible", "glossyEffectSupported", "sortOthersLastEnabled",
+      // rankPerGroupLabel is a derived display string (ChartAdvancedPaneModel.getRankPerGroupLabel,
+      // computed in the constructor from the chart's ranking state) that
+      // updateChartAdvancedPaneModel never reads back -- same "readable, not writable" shape as
+      // projectForwardEnabled below.
+      "rankPerGroupLabel",
+      // chartPlotOptionsPaneModel's own capability/derived flags -- ChartPlotOptionsPaneModel's
+      // constructor computes each from the chart type, and updateChartPlotOptionsPaneModel never
+      // reads any of them back. Their real, writable siblings (showValues, stackValues, ...) are
+      // aliased above; only the derived flag for each is refused here.
+      "alphaEnabled", "showValuesVisible", "showValuesEnabled", "stackValuesVisible",
+      "stackValuesEnabled", "showReferenceLineVisible", "keepElementInPlotVisible",
+      "bandingXVisible", "bandingXColorEnabled", "bandingXSizeEnabled", "bandingYVisible",
+      "bandingYColorEnabled", "bandingYSizeEnabled", "backgroundEnabled", "showPointsVisible",
+      "showPointsLabel", "explodedPieVisible", "fillTimeVisible", "fillGapWithDashVisible",
+      "polygonColorVisible", "hasXDimension", "hasYDimension", "mapEmptyColorVisible",
+      "borderColorVisible", "paretoLineColorVisible", "webMapVisible", "mapPolygon",
+      "contourEnabled", "includeParentLabelsVisible", "applyAestheticsToSourceVisible",
+      "wordCloud", "barCornerRadiusVisible", "barRoundAllCornersVisible");
+
+   /**
+    * Table and crosstab fields with a getter/setter pair, populated on every GET, that the
+    * matching set*PropertyModel apply method never reads back. Confirmed by reading
+    * {@code TableViewPropertyDialogService}/{@code CrosstabPropertyDialogService}'s apply
+    * methods in full: {@code shadow}/{@code editable} (on the shared
+    * {@code basicGeneralPaneModel}, inherited from the outputGeneral() shape but never applied
+    * for a data assembly -- see {@link #dataGeneral}), {@code container} (VSDialogService's
+    * setAssemblySize/setAssemblyPosition never call isContainer()), and the type-specific
+    * capability flags below.
+    */
+   private static final Map<String, Set<String>> DEAD_FIELDS = Map.of(
+      "table", Set.of("shadow", "editable", "container", "shrinkEnabled", "formVisible"),
+      "crosstab", Set.of("shadow", "editable", "container", "crosstabInfoNull",
+                         "sortOthersLastEnabled", "dateComparisonSupport"));
+
+   /**
+    * {@code refresh} is aliased through the shared {@link #basicGeneral} helper because it is
+    * genuinely applied for the input assemblies (checkbox/combobox/radiobutton/slider/spinner/
+    * textinput, via {@code VSInputService}) and for submit (via
+    * {@code SubmitPropertyDialogService}). It is not applied at all for these four types --
+    * their apply methods never call {@code basicGeneralPaneModel.isRefresh()}. Refused here by
+    * type rather than removed from the shared helper, which would also remove it from the types
+    * where it is real.
+    */
+   private static final Set<String> REFRESH_DEAD_TYPES =
+      Set.of("table", "crosstab", "text", "selectionlist");
+
+   /**
+    * {@code locked} is aliased through the shared {@link #sizePosition} helper for every
+    * assembly type, but {@code SizePositionPaneModel.isLocked()} has zero consumers anywhere in
+    * {@code core/src/main/java} outside test/model code -- no {@code *PropertyDialogService}
+    * apply method ever reads it back, for any type. Image and Shape (line/oval/rectangle) are the
+    * sole exceptions: their own dialog services genuinely apply it. Everywhere else, a write
+    * through {@code set_assembly_properties} would report success and silently do nothing; the
+    * real way to lock/unlock any assembly is {@code edit(op:"set_lock")}, which mutates the live
+    * {@code LockableVSAssembly} state directly.
+    */
+   private static final Set<String> LOCKED_LIVE_TYPES = Set.of("image", "line", "oval", "rectangle");
 
    private static final Map<String, TypeAliases> REGISTRY = registry();
 
@@ -135,7 +197,51 @@ public final class PropertyAliases {
    private static String writeRefusal(String normalizedType, String pathOrKey) {
       String refusal = viewsheetWriteRefusal(normalizedType, pathOrKey);
 
-      return refusal != null ? refusal : chartWriteRefusal(normalizedType, pathOrKey);
+      if(refusal != null) {
+         return refusal;
+      }
+
+      refusal = chartWriteRefusal(normalizedType, pathOrKey);
+
+      return refusal != null ? refusal : deadFieldWriteRefusal(normalizedType, pathOrKey);
+   }
+
+   /**
+    * Refuses a write to one of the {@link #DEAD_FIELDS}/{@link #REFRESH_DEAD_TYPES} entries --
+    * fields with a getter/setter pair that this assembly type's apply method never reads back.
+    */
+   private static String deadFieldWriteRefusal(String normalizedType, String pathOrKey) {
+      if(pathOrKey == null) {
+         return null;
+      }
+
+      String leaf = pathOrKey.substring(pathOrKey.lastIndexOf('.') + 1);
+      Set<String> dead = DEAD_FIELDS.get(normalizedType);
+
+      if(dead != null && dead.contains(leaf)) {
+         return "'" + leaf + "' is read-only on " + normalizedType + ". It has a getter/setter " +
+            "pair on the dialog model, populated on every read, but this type's apply method " +
+            "never reads it back -- a write would report success and change nothing.";
+      }
+
+      if("refresh".equals(leaf) && REFRESH_DEAD_TYPES.contains(normalizedType)) {
+         return "'refresh' is read-only on " + normalizedType + ". It is real for the input " +
+            "assemblies and submit, but this type's own apply method never reads " +
+            "basicGeneralPaneModel.refresh back -- a write would report success and change " +
+            "nothing.";
+      }
+
+      if("locked".equals(leaf) && !SHEET.equals(normalizedType) &&
+         !LOCKED_LIVE_TYPES.contains(normalizedType))
+      {
+         return "'locked' is read-only on " + normalizedType + " through " +
+            "set_assembly_properties. It has a getter/setter pair on the dialog model, " +
+            "populated on every read, but this type's apply method never reads it back -- a " +
+            "write would report success and change nothing. Use edit(op:\"set_lock\") to " +
+            "lock/unlock this assembly instead.";
+      }
+
+      return null;
    }
 
    /**
@@ -301,11 +407,11 @@ public final class PropertyAliases {
       // Phase 3 batch a — the input assemblies, all on VSInputService, plus range slider,
       // calendar and tab.
       register(registry, "checkbox", CheckboxPropertyDialogModel.class,
-               listInput("checkboxGeneralPaneModel", true));
+               listInput("checkboxGeneralPaneModel", true, false));
       register(registry, "combobox", ComboboxPropertyDialogModel.class,
-               listInput("comboboxGeneralPaneModel", false));
+               listInput("comboboxGeneralPaneModel", false, true));
       register(registry, "radiobutton", RadioButtonPropertyDialogModel.class,
-               listInput("radioButtonGeneralPaneModel", true));
+               listInput("radioButtonGeneralPaneModel", true, false));
       register(registry, "slider", SliderPropertyDialogModel.class, slider());
       register(registry, "spinner", SpinnerPropertyDialogModel.class, spinner());
       register(registry, "textinput", TextInputPropertyDialogModel.class, textInput());
@@ -446,6 +552,16 @@ public final class PropertyAliases {
       aliases.put("majorIncrement", "gaugeGeneralPaneModel.numberRangePaneModel.majorIncrement");
       aliases.put("minorIncrement", "gaugeGeneralPaneModel.numberRangePaneModel.minorIncrement");
       aliases.put("showValue", "gaugeAdvancedPaneModel.showValue");
+      // Only "face" is applied on write -- setGaugePropertyDialogModel reads facePaneModel.face
+      // but never facePaneModel.faceType/.faceIds, despite both having a setter. Left unaliased
+      // (not added to a refusal list either, since they were never reachable by a short name
+      // before this batch) rather than aliased-then-refused.
+      aliases.put("face", "gaugeGeneralPaneModel.facePaneModel.face");
+      String range = "gaugeAdvancedPaneModel.rangePaneModel";
+      aliases.put("gradient", range + ".gradient");
+      aliases.put("rangeValues", range + ".rangeValues");
+      aliases.put("rangeColorValues", range + ".rangeColorValues");
+      aliases.put("targetValue", range + ".targetValue");
       dataOutput(aliases);
       return aliases;
    }
@@ -456,6 +572,8 @@ public final class PropertyAliases {
       sizePosition(aliases, "textGeneralPaneModel");
       aliases.put("alpha", "textGeneralPaneModel.alpha");
       aliases.put("popComponent", "textGeneralPaneModel.popComponent");
+      aliases.put("text", "textGeneralPaneModel.textPaneModel.text");
+      aliases.put("tipOption", "textGeneralPaneModel.tipPaneModel.tipOption");
       dataOutput(aliases);
       return aliases;
    }
@@ -481,6 +599,50 @@ public final class PropertyAliases {
       aliases.put("enableAdhocEditing", "chartAdvancedPaneModel.enableAdhocEditing");
       aliases.put("glossyEffect", "chartAdvancedPaneModel.glossyEffect");
       aliases.put("sparkline", "chartAdvancedPaneModel.sparkline");
+      aliases.put("sortOthersLast", "chartAdvancedPaneModel.sortOthersLast");
+      aliases.put("rankPerGroup", "chartAdvancedPaneModel.rankPerGroup");
+      // Readable so a caller can see why ranking-per-group applied the way it did; refused for
+      // write below (CHART_READ_ONLY_FLAGS) -- updateChartAdvancedPaneModel never reads it back,
+      // same "readable, not writable" shape as projectForwardEnabled further down.
+      aliases.put("rankPerGroupLabel", "chartAdvancedPaneModel.rankPerGroupLabel");
+
+      // The plot-options pane's own real, writable leaf fields -- updateChartPlotOptionsPaneModel
+      // applies each of these. Deliberately absent: every *Visible/*Enabled/*Supported capability
+      // flag, plus mapPolygon/contourEnabled/wordCloud/showPointsLabel/mapboxStyles, none of which
+      // updateChartPlotOptionsPaneModel ever reads back -- see CHART_READ_ONLY_FLAGS.
+      String plotOptions = "chartAdvancedPaneModel.chartPlotOptionsPaneModel";
+      aliases.put("alpha", plotOptions + ".alpha");
+      aliases.put("showValues", plotOptions + ".showValues");
+      aliases.put("stackValues", plotOptions + ".stackValues");
+      aliases.put("showReferenceLine", plotOptions + ".showReferenceLine");
+      aliases.put("keepElementInPlot", plotOptions + ".keepElementInPlot");
+      aliases.put("bandingXColor", plotOptions + ".bandingXColor");
+      aliases.put("bandingXSize", plotOptions + ".bandingXSize");
+      aliases.put("bandingYColor", plotOptions + ".bandingYColor");
+      aliases.put("bandingYSize", plotOptions + ".bandingYSize");
+      aliases.put("backgroundColor", plotOptions + ".backgroundColor");
+      aliases.put("showPoints", plotOptions + ".showPoints");
+      aliases.put("explodedPie", plotOptions + ".explodedPie");
+      aliases.put("fillTimeGap", plotOptions + ".fillTimeGap");
+      aliases.put("fillZero", plotOptions + ".fillZero");
+      aliases.put("fillGapWithDash", plotOptions + ".fillGapWithDash");
+      aliases.put("polygonColor", plotOptions + ".polygonColor");
+      aliases.put("mapEmptyColor", plotOptions + ".mapEmptyColor");
+      aliases.put("borderColor", plotOptions + ".borderColor");
+      aliases.put("paretoLineColor", plotOptions + ".paretoLineColor");
+      aliases.put("webMap", plotOptions + ".webMap");
+      aliases.put("webMapStyle", plotOptions + ".webMapStyle");
+      aliases.put("contourLevels", plotOptions + ".contourLevels");
+      aliases.put("contourBandwidth", plotOptions + ".contourBandwidth");
+      aliases.put("contourEdgeAlpha", plotOptions + ".contourEdgeAlpha");
+      aliases.put("contourCellSize", plotOptions + ".contourCellSize");
+      aliases.put("includeParentLabels", plotOptions + ".includeParentLabels");
+      aliases.put("applyAestheticsToSource", plotOptions + ".applyAestheticsToSource");
+      aliases.put("wordCloudFontScale", plotOptions + ".wordCloudFontScale");
+      aliases.put("pieRatio", plotOptions + ".pieRatio");
+      aliases.put("barCornerRadius", plotOptions + ".barCornerRadius");
+      aliases.put("barRoundAllCorners", plotOptions + ".barRoundAllCorners");
+      aliases.put("oneLine", plotOptions + ".oneLine");
 
       // The line pane — trend lines, grid lines, facet grid. What a user means by "add a trend
       // line" lives here, one pane below the general/advanced panes.
@@ -517,9 +679,14 @@ public final class PropertyAliases {
       title(aliases, "tableViewGeneralPaneModel");
       aliases.put("maxRows", "tableViewGeneralPaneModel.maxRows");
       aliases.put("submitOnChange", "tableViewGeneralPaneModel.submitOnChange");
+      aliases.put("tableStyle", "tableViewGeneralPaneModel.tableStylePaneModel.tableStyle");
       aliases.put("shrink", "tableAdvancedPaneModel.shrink");
       aliases.put("form", "tableAdvancedPaneModel.form");
       aliases.put("enableAdhoc", "tableAdvancedPaneModel.enableAdhoc");
+      aliases.put("insert", "tableAdvancedPaneModel.insert");
+      aliases.put("del", "tableAdvancedPaneModel.del");
+      aliases.put("edit", "tableAdvancedPaneModel.edit");
+      aliases.put("writeBack", "tableAdvancedPaneModel.writeBack");
       return aliases;
    }
 
@@ -529,11 +696,21 @@ public final class PropertyAliases {
       sizePosition(aliases, "tableViewGeneralPaneModel");
       title(aliases, "tableViewGeneralPaneModel");
       aliases.put("maxRows", "tableViewGeneralPaneModel.maxRows");
+      aliases.put("tableStyle", "tableViewGeneralPaneModel.tableStylePaneModel.tableStyle");
       aliases.put("fillBlankWithZero", "crosstabAdvancedPaneModel.fillBlankWithZero");
       aliases.put("summarySideBySide", "crosstabAdvancedPaneModel.summarySideBySide");
       aliases.put("mergeSpan", "crosstabAdvancedPaneModel.mergeSpan");
       aliases.put("shrink", "crosstabAdvancedPaneModel.shrink");
       aliases.put("drillEnabled", "crosstabAdvancedPaneModel.drillEnabled");
+      aliases.put("enableAdhoc", "crosstabAdvancedPaneModel.enableAdhoc");
+      aliases.put("sortOthersLast", "crosstabAdvancedPaneModel.sortOthersLast");
+      aliases.put("calculateTotal", "crosstabAdvancedPaneModel.calculateTotal");
+      aliases.put("tipOption", "crosstabAdvancedPaneModel.tipPaneModel.tipOption");
+      aliases.put("tipView", "crosstabAdvancedPaneModel.tipPaneModel.tipView");
+      aliases.put("alpha", "crosstabAdvancedPaneModel.tipPaneModel.alpha");
+      aliases.put("flyOverViews", "crosstabAdvancedPaneModel.tipPaneModel.flyOverViews");
+      aliases.put("flyOnClick", "crosstabAdvancedPaneModel.tipPaneModel.flyOnClick");
+      aliases.put("tipOnClick", "crosstabAdvancedPaneModel.tipPaneModel.tipOnClick");
       return aliases;
    }
 
@@ -543,6 +720,11 @@ public final class PropertyAliases {
       sizePosition(aliases, "selectionGeneralPaneModel");
       title(aliases, "selectionGeneralPaneModel");
       selectionGeneral(aliases);
+      String measure = "selectionListPaneModel.selectionMeasurePaneModel";
+      aliases.put("measure", measure + ".measure");
+      aliases.put("formula", measure + ".formula");
+      aliases.put("showText", measure + ".showText");
+      aliases.put("showBar", measure + ".showBar");
       return aliases;
    }
 
@@ -564,6 +746,8 @@ public final class PropertyAliases {
       aliases.put("singleSelection", "selectionGeneralPaneModel.singleSelection");
       aliases.put("submitOnChange", "selectionGeneralPaneModel.submitOnChange");
       aliases.put("suppressBlank", "selectionGeneralPaneModel.suppressBlank");
+      aliases.put("selectFirstItem", "selectionGeneralPaneModel.selectFirstItem");
+      aliases.put("quickSwitchAllowed", "selectionGeneralPaneModel.quickSwitchAllowed");
    }
 
    // ── Phase 3 batch a ───────────────────────────────────────────────────────
@@ -574,14 +758,26 @@ public final class PropertyAliases {
     * — distinct from combobox's separate top-level {@code dataInputPaneModel} (row/column
     * write-back target), which is deliberately not aliased here or via {@link #dataInput}; see
     * that method's doc for why the two must not collide under the same alias name.
+    *
+    * <p>{@code hasInputLabel} covers combobox's own top-level {@code inputLabelPaneModel}
+    * (the optional label shown next to the dropdown). Checkbox and radiobutton have no such
+    * field on their dialog model at all -- they show their own title bar instead -- so this is
+    * declared per caller rather than assumed from the shape the other two parameters share.
     */
-   private static Map<String, String> listInput(String prefix, boolean hasTitle) {
+   private static Map<String, String> listInput(String prefix, boolean hasTitle,
+                                                 boolean hasInputLabel)
+   {
       Map<String, String> aliases = new LinkedHashMap<>();
       dataGeneral(aliases, prefix);
       sizePosition(aliases, prefix);
 
       if(hasTitle) {
          title(aliases, prefix);
+      }
+
+      if(hasInputLabel) {
+         aliases.put("showLabel", "inputLabelPaneModel.showLabel");
+         aliases.put("labelText", "inputLabelPaneModel.labelText");
       }
 
       String editor = prefix + ".listValuesPaneModel.comboBoxEditorModel." +
@@ -598,6 +794,21 @@ public final class PropertyAliases {
       sizePosition(aliases, "sliderGeneralPaneModel");
       numericRange(aliases, "sliderGeneralPaneModel");
       aliases.put("snap", "sliderAdvancedPaneModel.snap");
+      // sliderLabelPaneModel's own "minimum"/"maximum" are visibility toggles for the min/max
+      // value labels -- a different field from numericRangePaneModel's "min"/"max" (the actual
+      // range values) aliased above by numericRange(). Named showMin/showMax to keep both
+      // reachable under distinct names. sliderLabelPaneModel.showLabel is deliberately NOT
+      // aliased here: setSliderPropertyDialogModel hardcodes it true on every read and never
+      // reads it back on write -- it is dead, unlike inputLabelPaneModel.showLabel below, which
+      // is real.
+      String sliderLabel = "sliderAdvancedPaneModel.sliderLabelPaneModel";
+      aliases.put("tick", sliderLabel + ".tick");
+      aliases.put("currentValue", sliderLabel + ".currentValue");
+      aliases.put("label", sliderLabel + ".label");
+      aliases.put("showMin", sliderLabel + ".minimum");
+      aliases.put("showMax", sliderLabel + ".maximum");
+      aliases.put("showLabel", "inputLabelPaneModel.showLabel");
+      aliases.put("labelText", "inputLabelPaneModel.labelText");
       dataInput(aliases);
       return aliases;
    }
@@ -607,6 +818,8 @@ public final class PropertyAliases {
       dataGeneral(aliases, "spinnerGeneralPaneModel");
       sizePosition(aliases, "spinnerGeneralPaneModel");
       numericRange(aliases, "spinnerGeneralPaneModel");
+      aliases.put("showLabel", "inputLabelPaneModel.showLabel");
+      aliases.put("labelText", "inputLabelPaneModel.labelText");
       dataInput(aliases);
       return aliases;
    }
@@ -615,6 +828,8 @@ public final class PropertyAliases {
       Map<String, String> aliases = new LinkedHashMap<>();
       dataGeneral(aliases, "textInputGeneralPaneModel");
       sizePosition(aliases, "textInputGeneralPaneModel");
+      aliases.put("showLabel", "inputLabelPaneModel.showLabel");
+      aliases.put("labelText", "inputLabelPaneModel.labelText");
       dataInput(aliases);
       return aliases;
    }
@@ -632,6 +847,23 @@ public final class PropertyAliases {
       dataGeneral(aliases, "calendarGeneralPaneModel");
       sizePosition(aliases, "calendarGeneralPaneModel");
       title(aliases, "calendarGeneralPaneModel");
+      aliases.put("showType", "calendarAdvancedPaneModel.showType");
+      aliases.put("viewMode", "calendarAdvancedPaneModel.viewMode");
+      aliases.put("daySelection", "calendarAdvancedPaneModel.daySelection");
+      aliases.put("singleSelection", "calendarAdvancedPaneModel.singleSelection");
+      aliases.put("submitOnChange", "calendarAdvancedPaneModel.submitOnChange");
+      // min/max are deliberately NOT aliased: CalendarAdvancedPaneModel.min/max are
+      // DynamicValueModel objects (value/type/dataType), not plain scalars -- the short-name
+      // alias contract here is "a leaf value", and PropertyPath's JSON coercion has no way to
+      // build the right nested shape from a bare value. Reachable via the raw dotted path with
+      // the full object shape; see CalendarPropertyDialogService's min/max ordering check for
+      // the validation this still gets on write.
+      //
+      // calendarDataPaneModel.selectedTable/selectedColumn are also deliberately absent: the
+      // parity audit flagged a possible overlap with the set_calendar_display/
+      // set_calendar_dates tool's own write path, and this pass could not confirm from this
+      // repo alone whether the two would end up writing the same underlying setter. Left out
+      // rather than guessed at -- see the handoff report for this specific gap.
       return aliases;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -38,6 +38,8 @@ import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.MessageException;
+import inetsoft.web.composer.ws.dialog.WorksheetPropertyDialogService;
 import inetsoft.web.wiz.script.ScriptImageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1068,9 +1070,9 @@ public class ViewsheetAssemblyAgentController {
          ? name.substring(name.lastIndexOf('/') + 1) : name;
 
       try {
-         inetsoft.web.composer.ws.dialog.WorksheetPropertyDialogService.requireValidAlias(leaf);
+         WorksheetPropertyDialogService.requireValidAlias(leaf);
       }
-      catch(inetsoft.util.MessageException e) {
+      catch(MessageException e) {
          throw new PairingException(e.getMessage());
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -19,7 +19,9 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
+import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
@@ -1042,13 +1044,39 @@ public class ViewsheetAssemblyAgentController {
    {
       requireEnabled();
       RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
-      AssetEntry entry = rvs.getEntry();
+      AssetEntry oldEntry = rvs.getEntry();
+      AssetEntry entry = oldEntry;
       String name = body != null && body.name() != null ? body.name().trim() : null;
 
-      if(entry.getScope() == AssetRepository.TEMPORARY_SCOPE) {
+      // Mirrors save-viewsheet-dialog.component.ts's own client-only validators
+      // (FormValidators.assetEntryBannedCharacters / assetNameStartWithCharDigit) -- a
+      // pre-existing gap on both the UI's own Java submit path and this agent path, since
+      // neither validator exists server-side anywhere. Validated before the runtime is touched,
+      // like every other check in this class.
+      //
+      // Only the LAST path segment is validated: unlike the dialog's own leaf-only alias field
+      // (the folder is chosen separately there via selectFolder()), this endpoint's 'name' is
+      // documented to accept a full "My Folder/agent_vs_1" path, where '/' is a legal separator
+      // rather than a banned character. Reuses WorksheetPropertyDialogService.requireValidAlias
+      // rather than a second drifting copy of the same regexes (see its own javadoc); that method
+      // already treats null/empty as "not this check's concern", so the more helpful
+      // "Viewsheet is unsaved... Provide a 'name'" message below still fires first for that case.
+      String leaf = name != null && name.contains("/")
+         ? name.substring(name.lastIndexOf('/') + 1) : name;
+
+      try {
+         inetsoft.web.composer.ws.dialog.WorksheetPropertyDialogService.requireValidAlias(leaf);
+      }
+      catch(inetsoft.util.MessageException e) {
+         throw new PairingException(e.getMessage());
+      }
+
+      boolean wasTemporary = oldEntry.getScope() == AssetRepository.TEMPORARY_SCOPE;
+
+      if(wasTemporary) {
          if(name == null || name.isEmpty()) {
             throw new PairingException(
-               "Viewsheet is unsaved (\"" + entry.toView() + "\"). Provide a 'name' to save it " +
+               "Viewsheet is unsaved (\"" + oldEntry.toView() + "\"). Provide a 'name' to save it " +
                "(e.g. \"agent_vs_1\").");
          }
       }
@@ -1071,6 +1099,12 @@ public class ViewsheetAssemblyAgentController {
          viewsheetService.setViewsheet(rvs.getViewsheet(), entry, xp, true, true);
          rvs.setEntry(entry);
          rvs.setSavePoint(rvs.getCurrent());
+
+         // Mirrors SaveViewsheetDialogService.saveViewsheet(): the old entry's autosave draft is
+         // orphaned once this (its first real save) lands, since nothing else ever cleans it up.
+         if(wasTemporary) {
+            AutoSaveUtils.deleteAutoSaveFile(oldEntry, user);
+         }
       }
       catch(Exception e) {
          throw new PairingException("Failed to save viewsheet: " + e.getMessage(), e);
@@ -1114,6 +1148,11 @@ public class ViewsheetAssemblyAgentController {
     * type. Shared by {@link #attachBaseWorksheet} and {@code create_viewsheet} — do not duplicate
     * this resolution logic elsewhere.
     *
+    * <p>A caller-supplied {@code path} (the {@code worksheet}/{@code logicalModel} branches) is
+    * refused if it contains a caret, right after that branch's own null/empty check — see
+    * {@link WizUtil#requireNoCaret}. The {@code physicalTable} branch does not take a raw path
+    * (it resolves by {@code datasource}/{@code table} name instead), so it needs no such check.
+    *
     * @throws PairingException naming the specific missing/invalid field or resolution failure —
     *                          never a generic message.
     */
@@ -1131,6 +1170,8 @@ public class ViewsheetAssemblyAgentController {
                "Provide a 'path' naming the worksheet asset to attach " +
                "(e.g. \"Sample Queries/customers\").");
          }
+
+         WizUtil.requireNoCaret(path, "path");
 
          int assetScope = "user".equalsIgnoreCase(scope)
             ? AssetRepository.USER_SCOPE : AssetRepository.GLOBAL_SCOPE;
@@ -1175,6 +1216,8 @@ public class ViewsheetAssemblyAgentController {
             throw new PairingException(
                "Provide a 'path' naming the logical model, e.g. \"MyDataSource/MyModel\".");
          }
+
+         WizUtil.requireNoCaret(path, "path");
 
          AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
                                            path.trim(), null, uname.orgID);
@@ -1333,14 +1376,19 @@ public class ViewsheetAssemblyAgentController {
                                     "XPrincipal (" + user.getClass().getName() + ")");
       }
 
-      AssetRepository rep = rvs.getAssetRepository();
+      // The caret check on 'path' lives in resolveDataSourceEntry itself (shared with
+      // create_viewsheet), not here -- see that method's javadoc. rep is resolved lazily
+      // (only once resolveDataSourceEntry's own field checks pass) so a refusal on a bad field
+      // never triggers a real getAssetRepository() call, matching create_viewsheet's own supplier
+      // contract for this same shared method.
+      AssetRepository[] repHolder = new AssetRepository[1];
       AssetEntry entry;
 
       try {
          entry = resolveDataSourceEntry(body == null ? null : body.type(),
             body == null ? null : body.path(), body == null ? null : body.scope(),
             body == null ? null : body.datasource(), body == null ? null : body.table(), xp,
-            () -> rep);
+            () -> repHolder[0] = rvs.getAssetRepository());
       }
       catch(PairingException e) {
          throw e;
@@ -1348,6 +1396,8 @@ public class ViewsheetAssemblyAgentController {
       catch(Exception e) {
          throw new PairingException("Failed to attach base worksheet: " + e.getMessage(), e);
       }
+
+      AssetRepository rep = repHolder[0];
 
       try {
          vs.setBaseEntry(entry);

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -388,14 +388,17 @@ public class ViewsheetAssemblyAgentController {
                                            @RequestParam(required = false) Integer row,
                                            @RequestParam(required = false) Integer col,
                                            @RequestParam(required = false) String colName,
+                                           @RequestParam(required = false) boolean axis,
                                            @RequestParam(required = false) boolean titleLink,
+                                           @RequestParam(required = false) boolean emptyPlotLink,
                                            Principal user)
       throws Exception
    {
       requireEnabled();
       return hyperlinkService.read(
          sessionToken, user, assembly,
-         new AssemblyHyperlinkService.Region(row, col, colName, false, false, titleLink, false));
+         new AssemblyHyperlinkService.Region(
+            row, col, colName, axis, false, titleLink, emptyPlotLink));
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/hyperlink/types")

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.LockableVSAssembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
 import inetsoft.uql.viewsheet.TabVSAssembly;
 import inetsoft.uql.viewsheet.TitledVSAssembly;
@@ -215,8 +216,11 @@ public class ViewsheetEditService {
             "Edit op 'resize_title' requires 'height' — the new title-bar height in pixels.");
       }
 
+      requirePositive(request.op(), "height", request.height());
+
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          AssemblyNode current = requireExisting(rvs, request.assembly());
+         requireTitled(rvs, request.assembly(), request.op());
 
          ResizeVSObjectTitleEvent event = new ResizeVSObjectTitleEvent();
          event.setName(request.assembly());
@@ -403,6 +407,7 @@ public class ViewsheetEditService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          requireExisting(rvs, request.assembly());
+         requireLockable(rvs, request.assembly());
 
          LockVSObjectEvent event = new LockVSObjectEvent();
          event.setName(request.assembly());
@@ -422,7 +427,7 @@ public class ViewsheetEditService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          requireExisting(rvs, request.assembly());
-         requireTitled(rvs, request.assembly());
+         requireTitled(rvs, request.assembly(), request.op());
 
          ChangeVSObjectTextEvent event = new ChangeVSObjectTextEvent();
          event.setName(request.assembly());
@@ -631,9 +636,43 @@ public class ViewsheetEditService {
             targets.add(node);
          }
 
+         // Mirrors composer-toolbar.component.ts's layoutAlign/layoutDistribute, which filter
+         // out `locked === true` objects AND objects with a non-null `container` (a Tab/
+         // GroupContainer member) BEFORE computing the reference edge (align's base position,
+         // distribute's topLeft/bottomRight bounds) from what remains -- so a locked or
+         // grouped/tabbed assembly is excluded from both the moved set and the target the others
+         // align/distribute against, not merely left unmoved while still anchoring everyone else.
+         Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+         List<AssemblyNode> unlocked = new ArrayList<>();
+
+         for(AssemblyNode node : targets) {
+            VSAssembly assembly = vs == null ? null : vs.getAssembly(node.name());
+
+            boolean locked = assembly instanceof LockableVSAssembly lockable &&
+               Boolean.TRUE.equals(lockable.islocked());
+            boolean inContainer = assembly != null && assembly.getContainer() != null;
+
+            if(!locked && !inContainer) {
+               unlocked.add(node);
+            }
+         }
+
+         // composer-toolbar.component.ts's own enablement getters require align at >= 2 but
+         // distribute at > 2 (i.e. >= 3) -- at exactly 2, the UI's Distribute button is disabled,
+         // since "evenly distribute" between exactly two items is a degenerate, UI-forbidden
+         // operation.
+         int required = "distribute".equals(op) ? 3 : 2;
+
+         if(unlocked.size() < required) {
+            throw new IllegalArgumentException(
+               "Edit op '" + op + "' needs at least " + required + " unlocked, non-grouped " +
+               "assemblies among " + names + ", but only " + unlocked.size() + " of " +
+               targets.size() + " qualify.");
+         }
+
          MoveVSObjectEvent[] moves = "align".equals(op)
-            ? alignMoves(targets, axis)
-            : distributeMoves(targets, axis);
+            ? alignMoves(unlocked, axis)
+            : distributeMoves(unlocked, axis);
 
          // Same two-step contract as move(): moveObject actually repositions each assembly,
          // moveObjects afterwards only fixes up anchored lines. Calling the fix-up alone made
@@ -752,26 +791,53 @@ public class ViewsheetEditService {
     * "ok" on every op. Nothing downstream will ever complain, so we complain here.
     */
    /**
-    * Refuses set_title on an assembly that has no title bar.
+    * Refuses an op that needs a title bar (currently {@code set_title} and {@code resize_title})
+    * on an assembly that has none.
     *
     * <p>{@code ComposerObjectService.changeTitle} casts to {@code TitledVSAssembly}, so a Text or
     * a shape produced a raw {@code ClassCastException} as a bare 500 — an internal type name, with
-    * no hint that the op simply does not apply here.
+    * no hint that the op simply does not apply here. {@code resizeObjectTitle} does not cast, but
+    * silently no-ops the title-height write for the same assemblies, which is just as misleading
+    * since the op still reports success.
     *
     * <p>Tested with {@code instanceof} rather than a list of type names so it cannot drift from
     * whatever actually implements the interface. Charts, tables, crosstabs, selections and
     * calendars have titles; text, images and shapes do not — they ARE their content, so what
     * looks like a title on a Text is set through its own value, not this op.
     */
-   private void requireTitled(RuntimeViewsheet rvs, String name) {
+   private void requireTitled(RuntimeViewsheet rvs, String name, String op) {
       Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
       VSAssembly assembly = vs == null ? null : vs.getAssembly(name);
 
       if(assembly != null && !(assembly instanceof TitledVSAssembly)) {
          throw new IllegalArgumentException(
-            "'" + name + "' has no title bar, so 'set_title' does not apply to it. Charts, " +
+            "'" + name + "' has no title bar, so '" + op + "' does not apply to it. Charts, " +
             "tables, crosstabs, selections and calendars have titles; text, images and shapes " +
             "do not — a text assembly's visible text is its own content, not a title.");
+      }
+   }
+
+   /**
+    * Refuses set_lock on an assembly that cannot actually be locked.
+    *
+    * <p>{@code ComposerObjectService.changeLockState} tests {@code instanceof ImageVSAssembly} /
+    * {@code instanceof ShapeVSAssembly} with no {@code else} branch, so a Chart, Table, Crosstab,
+    * Text, Gauge, CalcTable, etc. fell through every check and the lock write was silently
+    * dropped while the op still reported success.
+    *
+    * <p>Tested against {@code LockableVSAssembly}, the marker interface both
+    * {@code ImageVSAssembly} and {@code ShapeVSAssembly} implement, so this cannot drift from
+    * whichever types the Composer's own lock control actually applies to.
+    */
+   private void requireLockable(RuntimeViewsheet rvs, String name) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(name);
+
+      if(assembly != null && !(assembly instanceof LockableVSAssembly)) {
+         throw new IllegalArgumentException(
+            "'" + name + "' is a " + assembly.getClass().getSimpleName() + ", so 'set_lock' " +
+            "does not apply to it. Locking only applies to images and shapes (lines, " +
+            "rectangles, ovals).");
       }
    }
 
@@ -805,6 +871,15 @@ public class ViewsheetEditService {
             "Edit op '" + op + "' requires '" + firstName + "' and '" + secondName +
             "' to be greater than zero — got " + first + " and " + second +
             ". Non-positive sizes are clamped to 1x1 rather than refused.");
+      }
+   }
+
+   /** Single-value sibling of the pair check above, for ops like resize_title with one field. */
+   private static void requirePositive(String op, String fieldName, Integer value) {
+      if(value != null && value <= 0) {
+         throw new IllegalArgumentException(
+            "Edit op '" + op + "' requires '" + fieldName + "' to be greater than zero — got " +
+            value + ". Non-positive sizes are clamped to 1x1 rather than refused.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -72,6 +72,7 @@ import inetsoft.web.composer.ws.command.WSCollectVariablesCommand;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.composer.ws.service.SaveWorksheetService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.service.RenderWaitSupport;
 import inetsoft.web.wiz.service.TabularEndpointBindingSupport;
@@ -1063,6 +1064,8 @@ public class WorksheetAgentController {
       // trimmed surrounding whitespace, so an embedded control character (e.g. a literal tab)
       // passed straight through into the saved asset's name.
       String name = body.name() != null ? SUtil.removeControlChars(body.name().trim()) : null;
+
+      WizUtil.requireNoCaret(name, "name");
 
       if(entry.getScope() == AssetRepository.TEMPORARY_SCOPE) {
          if(name == null || name.isEmpty()) {

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogServiceTest.java
@@ -113,6 +113,57 @@ class CalendarPropertyDialogServiceTest {
       assertEquals(390, result.getPixelOffset().y);
    }
 
+   // ── min/max ordering validation (parity audit L7) ──────────────────────────
+
+   @Test
+   void refusesAMinThatIsNotBeforeMax() throws Exception {
+      CalendarVSAssemblyInfo info = new CalendarVSAssemblyInfo();
+
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(calendarAssembly);
+      when(calendarAssembly.getVSAssemblyInfo()).thenReturn(info);
+
+      CalendarPropertyDialogModel model = new CalendarPropertyDialogModel();
+      model.getCalendarAdvancedPaneModel().setMin(
+         new inetsoft.web.composer.model.vs.DynamicValueModel("2024-01-10"));
+      model.getCalendarAdvancedPaneModel().setMax(
+         new inetsoft.web.composer.model.vs.DynamicValueModel("2024-01-01"));
+
+      Exception thrown = org.junit.jupiter.api.Assertions.assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setCalendarPropertyModel(
+            "Viewsheet1", "Calendar1", model, "", null, commandDispatcher));
+
+      org.junit.jupiter.api.Assertions.assertTrue(thrown.getMessage().contains("min"));
+      org.junit.jupiter.api.Assertions.assertTrue(thrown.getMessage().contains("max"));
+      org.mockito.Mockito.verifyNoInteractions(vsObjectPropertyService);
+   }
+
+   @Test
+   void acceptsAMinThatIsBeforeMax() throws Exception {
+      CalendarVSAssemblyInfo info = new CalendarVSAssemblyInfo();
+
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(calendarAssembly);
+      when(calendarAssembly.getVSAssemblyInfo()).thenReturn(info);
+
+      CalendarPropertyDialogModel model = new CalendarPropertyDialogModel();
+      model.getCalendarAdvancedPaneModel().setMin(
+         new inetsoft.web.composer.model.vs.DynamicValueModel("2024-01-01"));
+      model.getCalendarAdvancedPaneModel().setMax(
+         new inetsoft.web.composer.model.vs.DynamicValueModel("2024-01-10"));
+
+      service.setCalendarPropertyModel(
+         "Viewsheet1", "Calendar1", model, "", null, commandDispatcher);
+
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), any(CalendarVSAssemblyInfo.class), any(String.class),
+         any(String.class), any(String.class), nullable(Principal.class),
+         any(CommandDispatcher.class), eq(true), nullable(Integer.class));
+   }
+
    @Mock VSObjectPropertyService vsObjectPropertyService;
    @Mock VSOutputService vsOutputService;
    @Mock RuntimeViewsheetRef runtimeViewsheetRef;

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogServiceTest.java
@@ -1,0 +1,224 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.dialog;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSChartHandler;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.composer.model.vs.ChartAdvancedPaneModel;
+import inetsoft.web.composer.model.vs.ChartPropertyDialogModel;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import inetsoft.web.composer.vs.objects.controller.VSTrapService;
+import inetsoft.web.viewsheet.service.ChartPropertyService;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.VSDialogService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+/**
+ * The glossyEffect+sparkline mutual exclusion and enableDrilling-on-Mekko gate (parity audit L7,
+ * mirroring chart-advanced-pane.component.html/.ts). Both are normalized -- not refused -- right
+ * after the try block that resolves {@code vsChartInfo}, before anything else in the patch is
+ * applied: a human can never actually express either combination through the Composer UI (both
+ * are disabled-checkbox states), so a stale value that got POSTed back is silently corrected
+ * rather than rejected. Because the checks mutate the same {@code ChartAdvancedPaneModel}
+ * instance that was passed in, the tests below can observe normalization directly on
+ * {@code advancedPane} even though the rest of the (heavy) apply path isn't fully mocked here and
+ * may itself throw further down -- that's caught and ignored since it's out of scope.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class ChartPropertyDialogServiceTest {
+   @BeforeEach
+   void setup() {
+      service = new ChartPropertyDialogService(
+         vsObjectPropertyService, chartPropertyService, vsChartHandler, dialogService,
+         viewsheetService, vsBindingService, assemblyInfoHandler, trapService);
+   }
+
+   @Test
+   void normalizesGlossyEffectWhenSparklineSupportedAndOn() throws Exception {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setVSChartInfo(new VSChartInfo());
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
+      when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
+      // Match ChartDescriptor's own defaults (both true) so the unrelated
+      // sortOthersLast/rankPerGroup 'clear shared frames' branch does not fire.
+      advancedPane.setSortOthersLast(true);
+      advancedPane.setRankPerGroup(true);
+      advancedPane.setGlossyEffect(true);
+      advancedPane.setSparklineSupported(true);
+      advancedPane.setSparkline(true);
+      model.setChartAdvancedPaneModel(advancedPane);
+
+      try {
+         service.setChartPropertyModel("Viewsheet1", "Chart1", model, "", null, commandDispatcher);
+      }
+      catch(Exception ignoredUnrelatedApplyPathFailure) {
+         // Setup here is intentionally minimal -- only enough to reach the normalization check
+         // under test. Anything past it is out of scope for this test.
+      }
+
+      assertFalse(advancedPane.isGlossyEffect(),
+                   "glossyEffect must be normalized to false when sparkline wins the gate");
+      assertTrue(advancedPane.isSparkline(), "sparkline itself must be left untouched");
+   }
+
+   /** Guards against over-normalization: when sparkline isn't supported, its value never applies -- so glossyEffect should not be cleared either. */
+   @Test
+   void doesNotNormalizeGlossyEffectWhenSparklineIsNotSupported() throws Exception {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setVSChartInfo(new VSChartInfo());
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
+      when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
+      advancedPane.setSortOthersLast(true);
+      advancedPane.setRankPerGroup(true);
+      advancedPane.setGlossyEffect(true);
+      advancedPane.setSparklineSupported(false);
+      advancedPane.setSparkline(true);
+      model.setChartAdvancedPaneModel(advancedPane);
+
+      try {
+         service.setChartPropertyModel("Viewsheet1", "Chart1", model, "", null, commandDispatcher);
+      }
+      catch(Exception ignoredUnrelatedApplyPathFailure) {
+         // Out of scope for this test; see class javadoc.
+      }
+
+      assertTrue(advancedPane.isGlossyEffect(),
+                  "glossyEffect must not be normalized when sparklineSupported is false");
+   }
+
+   @Test
+   void normalizesEnableDrillingOnAMekkoChart() throws Exception {
+      VSChartInfo chartInfo = new VSChartInfo();
+      chartInfo.setChartType(GraphTypes.CHART_MEKKO);
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setVSChartInfo(chartInfo);
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
+      when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
+      // Match ChartDescriptor's own defaults (both true) so the unrelated
+      // sortOthersLast/rankPerGroup 'clear shared frames' branch does not fire.
+      advancedPane.setSortOthersLast(true);
+      advancedPane.setRankPerGroup(true);
+      advancedPane.setEnableDrilling(true);
+      model.setChartAdvancedPaneModel(advancedPane);
+
+      try {
+         service.setChartPropertyModel("Viewsheet1", "Chart1", model, "", null, commandDispatcher);
+      }
+      catch(Exception ignoredUnrelatedApplyPathFailure) {
+         // Out of scope for this test; see class javadoc.
+      }
+
+      assertFalse(advancedPane.isEnableDrilling(),
+                   "enableDrilling must be normalized to false on a Mekko chart");
+   }
+
+   /** Guards against over-normalization: drilling stays settable on a non-Mekko chart type. */
+   @Test
+   void enableDrillingAloneIsNotNormalizedOnANonMekkoChart() throws Exception {
+      VSChartInfo chartInfo = new VSChartInfo();
+      chartInfo.setChartType(GraphTypes.CHART_BAR);
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setVSChartInfo(chartInfo);
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
+      when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
+      // Match ChartDescriptor's own defaults (both true) so the unrelated
+      // sortOthersLast/rankPerGroup 'clear shared frames' branch does not fire.
+      advancedPane.setSortOthersLast(true);
+      advancedPane.setRankPerGroup(true);
+      advancedPane.setEnableDrilling(true);
+      model.setChartAdvancedPaneModel(advancedPane);
+
+      try {
+         service.setChartPropertyModel("Viewsheet1", "Chart1", model, "", null, commandDispatcher);
+      }
+      catch(Exception ignoredUnrelatedApplyPathFailure) {
+         // Out of scope for this test; see class javadoc.
+      }
+
+      assertTrue(advancedPane.isEnableDrilling(),
+                  "enableDrilling must not be normalized on a bar chart");
+   }
+
+   @Mock VSObjectPropertyService vsObjectPropertyService;
+   @Mock ChartPropertyService chartPropertyService;
+   @Mock VSChartHandler vsChartHandler;
+   @Mock VSDialogService dialogService;
+   @Mock ViewsheetService viewsheetService;
+   @Mock VSBindingService vsBindingService;
+   @Mock VSAssemblyInfoHandler assemblyInfoHandler;
+   @Mock VSTrapService trapService;
+   @Mock CommandDispatcher commandDispatcher;
+   @Mock RuntimeViewsheet rvs;
+   @Mock Viewsheet viewsheet;
+   @Mock ChartVSAssembly chartAssembly;
+
+   private ChartPropertyDialogService service;
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogServiceTest.java
@@ -48,7 +48,9 @@ import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
@@ -86,6 +88,10 @@ class ChartPropertyDialogServiceTest {
       when(rvs.getViewsheet()).thenReturn(viewsheet);
       when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
       when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+      // Isolate the sparkline clause under test: glossyEffectSupported=true so the sibling
+      // !glossyEffectSupported clause (added later, see normalizesGlossyEffectWhenNotSupported
+      // below) never fires here.
+      when(chartPropertyService.isSupported(any(), eq("effectEnabled"), eq(false))).thenReturn(true);
 
       ChartPropertyDialogModel model = new ChartPropertyDialogModel();
       ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
@@ -121,6 +127,9 @@ class ChartPropertyDialogServiceTest {
       when(rvs.getViewsheet()).thenReturn(viewsheet);
       when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
       when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+      // Isolate the sparkline clause: glossyEffectSupported=true so this test's negative result
+      // is actually exercising the sparkline gate, not the sibling !glossyEffectSupported clause.
+      when(chartPropertyService.isSupported(any(), eq("effectEnabled"), eq(false))).thenReturn(true);
 
       ChartPropertyDialogModel model = new ChartPropertyDialogModel();
       ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
@@ -140,6 +149,45 @@ class ChartPropertyDialogServiceTest {
 
       assertTrue(advancedPane.isGlossyEffect(),
                   "glossyEffect must not be normalized when sparklineSupported is false");
+   }
+
+   /**
+    * Mirrors the other half of chart-advanced-pane.component.html's disabled condition:
+    * {@code [disabled]="!model.glossyEffectSupported || (model.sparklineSupported && model.sparkline)"}.
+    * A stale glossyEffect=true left over from a chart-type change that dropped support (e.g.
+    * effectEnabled no longer applicable to the new chart style) must be normalized even when the
+    * sparkline clause never fires.
+    */
+   @Test
+   void normalizesGlossyEffectWhenNotSupported() throws Exception {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setVSChartInfo(new VSChartInfo());
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(chartAssembly);
+      when(chartAssembly.getVSAssemblyInfo()).thenReturn(info);
+      when(chartPropertyService.isSupported(any(), eq("effectEnabled"), eq(false))).thenReturn(false);
+
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      ChartAdvancedPaneModel advancedPane = new ChartAdvancedPaneModel();
+      advancedPane.setSortOthersLast(true);
+      advancedPane.setRankPerGroup(true);
+      advancedPane.setGlossyEffect(true);
+      advancedPane.setSparklineSupported(false);
+      advancedPane.setSparkline(false);
+      model.setChartAdvancedPaneModel(advancedPane);
+
+      try {
+         service.setChartPropertyModel("Viewsheet1", "Chart1", model, "", null, commandDispatcher);
+      }
+      catch(Exception ignoredUnrelatedApplyPathFailure) {
+         // Out of scope for this test; see class javadoc.
+      }
+
+      assertFalse(advancedPane.isGlossyEffect(),
+                   "glossyEffect must be normalized to false when glossyEffectSupported is false, " +
+                   "even with the sparkline clause never firing");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogServiceTest.java
@@ -40,6 +40,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -98,6 +99,73 @@ class TableViewPropertyDialogServiceTest {
          service.getTableViewPropertyDialogModel("Viewsheet1", "Table1", null);
 
       assertEquals(7, result.getRevision());
+   }
+
+   // ── maxRows / form+enableAdhoc validation (parity audit L7) ────────────────
+
+   @Test
+   void refusesANegativeMaxRows() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(tableAssembly);
+      when(tableAssembly.getVSAssemblyInfo()).thenReturn(new TableVSAssemblyInfo());
+
+      TableViewPropertyDialogModel model = new TableViewPropertyDialogModel();
+      model.getTableViewGeneralPaneModel().setMaxRows(-1);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().scriptEnabled(false).expression("").build());
+
+      Exception thrown = org.junit.jupiter.api.Assertions.assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setTablePropertyModel(
+            "Viewsheet1", "Table1", model, "", null, commandDispatcher));
+
+      assertTrue(thrown.getMessage().contains("maxRows"));
+      org.mockito.Mockito.verifyNoInteractions(vsObjectPropertyService);
+   }
+
+   @Test
+   void refusesFormAndEnableAdhocBothTrue() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(tableAssembly);
+      when(tableAssembly.getVSAssemblyInfo()).thenReturn(new TableVSAssemblyInfo());
+
+      TableViewPropertyDialogModel model = new TableViewPropertyDialogModel();
+      model.getTableAdvancedPaneModel().setForm(true);
+      model.getTableAdvancedPaneModel().setEnableAdhoc(true);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().scriptEnabled(false).expression("").build());
+
+      Exception thrown = org.junit.jupiter.api.Assertions.assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setTablePropertyModel(
+            "Viewsheet1", "Table1", model, "", null, commandDispatcher));
+
+      assertTrue(thrown.getMessage().contains("form"));
+      assertTrue(thrown.getMessage().contains("enableAdhoc"));
+      org.mockito.Mockito.verifyNoInteractions(vsObjectPropertyService);
+   }
+
+   @Test
+   void acceptsFormAloneWithoutEnableAdhoc() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(tableAssembly);
+      when(tableAssembly.getVSAssemblyInfo()).thenReturn(new TableVSAssemblyInfo());
+
+      TableViewPropertyDialogModel model = new TableViewPropertyDialogModel();
+      model.getTableAdvancedPaneModel().setForm(true);
+      model.getTableAdvancedPaneModel().setEnableAdhoc(false);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().scriptEnabled(false).expression("").build());
+
+      service.setTablePropertyModel("Viewsheet1", "Table1", model, "", null, commandDispatcher);
+
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), any(TableVSAssemblyInfo.class), eq("Table1"),
+         nullable(String.class), any(String.class), nullable(Principal.class),
+         any(CommandDispatcher.class), eq(true), any());
    }
 
    @Mock VSObjectPropertyService vsObjectPropertyService;

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
@@ -244,6 +244,71 @@ public class ViewsheetPropertyDialogServiceTest {
       assertEquals(11.0, result.screensPane().getPrintLayout().getCustomHeight(), 1e-9);
    }
 
+   // ── snapGrid validation (parity audit L7) ───────────────────────────────────
+   //
+   // A non-positive or non-multiple-of-5 snapGrid divides into the Composer's own live canvas
+   // drag math and produces NaN/Infinity assembly positions -- the one validation in this batch
+   // with a confirmed corruption hazard if skipped. The accepting case is already covered by
+   // layoutIsUpdated() above, which exercises the full write path at VSOptionsPaneModel's
+   // default snapGrid of 20 (a legal multiple of 5) without hitting this check.
+
+   @Test
+   public void refusesAZeroSnapGrid() throws Exception {
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getViewsheetInfo()).thenReturn(new ViewsheetInfo());
+
+      ViewsheetPropertyDialogModel model = ViewsheetPropertyDialogModel.builder().build();
+      model.vsOptionsPane().setSnapGrid(0);
+
+      Exception thrown = org.junit.jupiter.api.Assertions.assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setViewsheetInfo("Viewsheet1", model, null, commandDispatcher, null, null));
+
+      org.junit.jupiter.api.Assertions.assertTrue(thrown.getMessage().contains("snapGrid"));
+   }
+
+   @Test
+   public void refusesASnapGridThatIsNotAMultipleOfFive() throws Exception {
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getViewsheetInfo()).thenReturn(new ViewsheetInfo());
+
+      ViewsheetPropertyDialogModel model = ViewsheetPropertyDialogModel.builder().build();
+      model.vsOptionsPane().setSnapGrid(7);
+
+      Exception thrown = org.junit.jupiter.api.Assertions.assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setViewsheetInfo("Viewsheet1", model, null, commandDispatcher, null, null));
+
+      org.junit.jupiter.api.Assertions.assertTrue(thrown.getMessage().contains("snapGrid"));
+   }
+
+   /**
+    * This service has no defensive clone (it mutates ViewsheetInfo live), so an illegal snapGrid
+    * arriving alongside other legal fields must be caught before any of those other fields are
+    * applied -- otherwise a refused patch would still leave a silent partial write behind.
+    */
+   @Test
+   public void refusesASnapGridBeforeMutatingAnyOtherField() throws Exception {
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      ViewsheetInfo info = new ViewsheetInfo();
+      when(viewsheet.getViewsheetInfo()).thenReturn(info);
+
+      ViewsheetPropertyDialogModel model = ViewsheetPropertyDialogModel.builder().build();
+      model.vsOptionsPane().setSnapGrid(7);
+      model.vsOptionsPane().setDesc("a distinctive description that must not be written");
+
+      org.junit.jupiter.api.Assertions.assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setViewsheetInfo("Viewsheet1", model, null, commandDispatcher, null, null));
+
+      org.junit.jupiter.api.Assertions.assertNotEquals(
+         "a distinctive description that must not be written", info.getDescription(),
+         "snapGrid validation must run before other fields are mutated");
+   }
+
    @Mock ViewsheetService viewsheetService;
    @Mock ViewsheetSettingsService viewsheetSettingsService;
    @Mock CoreLifecycleService coreLifecycleService;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -18,11 +18,16 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
 import java.util.LinkedHashMap;
@@ -32,6 +37,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+// gauge's "face" alias (parity audit L7) reads GaugeGeneralPaneModel.facePaneModel, whose lazy
+// construction runs VSGauge.getPrefixIDs() -> VSFaceUtil's static init -> a Spring-bean lookup.
+// listsTheAliasVocabularyWithCurrentValues below reads every declared alias's current value, so
+// this class needs the same running context TableViewPropertyDialogServiceTest and friends set
+// up for the same reason -- a bare Mockito-only test does not have a Spring context for that
+// static init to find.
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
 @Tag("core")
 class AssemblyPropertyServiceTest {
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -511,4 +511,165 @@ class PropertyAliasesTest {
       assertFalse(resolved.equals("dataInputPaneModel.table"),
                   "combobox's 'table' alias must not point at the row/column write-back target");
    }
+
+   // ── parity audit L7: new aliases round-trip ────────────────────────────────
+
+   @Test
+   void newChartAliasesResolveAndRoundTrip() {
+      assertEquals("chartAdvancedPaneModel.sortOthersLast",
+                   PropertyAliases.resolveForWrite("chart", "sortOthersLast"));
+      assertEquals("chartAdvancedPaneModel.chartPlotOptionsPaneModel.showValues",
+                   PropertyAliases.resolveForWrite("chart", "showValues"));
+
+      inetsoft.web.composer.model.vs.ChartPropertyDialogModel model =
+         new inetsoft.web.composer.model.vs.ChartPropertyDialogModel();
+      inetsoft.web.composer.model.vs.ChartAdvancedPaneModel advancedPane =
+         new inetsoft.web.composer.model.vs.ChartAdvancedPaneModel();
+      advancedPane.setChartPlotOptionsPaneModel(
+         new inetsoft.web.graph.model.dialog.ChartPlotOptionsPaneModel());
+      model.setChartAdvancedPaneModel(advancedPane);
+      String path = PropertyAliases.resolve("chart", "showValues");
+      Object result = PropertyPath.set(model, path, true);
+
+      assertEquals(true, PropertyPath.get(result, path));
+   }
+
+   @Test
+   void newTableAndCrosstabAliasesRoundTrip() {
+      assertEquals("tableAdvancedPaneModel.insert",
+                   PropertyAliases.resolveForWrite("table", "insert"));
+      assertEquals("crosstabAdvancedPaneModel.enableAdhoc",
+                   PropertyAliases.resolveForWrite("crosstab", "enableAdhoc"));
+
+      inetsoft.web.composer.model.vs.TableViewPropertyDialogModel model =
+         new inetsoft.web.composer.model.vs.TableViewPropertyDialogModel();
+      String path = PropertyAliases.resolve("table", "insert");
+      Object result = PropertyPath.set(model, path, true);
+
+      assertEquals(true, PropertyPath.get(result, path));
+   }
+
+   // ── parity audit L7: dead-field refusals ────────────────────────────────────
+
+   @Test
+   void refusesTableDeadFields() {
+      for(String field : java.util.List.of("shadow", "editable")) {
+         assertThrows(
+            IllegalArgumentException.class,
+            () -> PropertyAliases.resolveForWrite("table",
+               "tableViewGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel." + field),
+            field + " has no effect on write for table");
+      }
+
+      // shrinkEnabled/formVisible sit directly on tableAdvancedPaneModel, not the basic pane.
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("table",
+                      "tableAdvancedPaneModel.shrinkEnabled"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("table",
+                      "tableAdvancedPaneModel.formVisible"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("table",
+                      "tableViewGeneralPaneModel.sizePositionPaneModel.container"));
+   }
+
+   @Test
+   void refusesCrosstabDeadFields() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("crosstab",
+                      "crosstabAdvancedPaneModel.crosstabInfoNull"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("crosstab",
+                      "crosstabAdvancedPaneModel.sortOthersLastEnabled"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("crosstab",
+                      "crosstabAdvancedPaneModel.dateComparisonSupport"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("crosstab",
+                      "tableViewGeneralPaneModel.sizePositionPaneModel.container"));
+   }
+
+   /**
+    * {@code refresh} is real for the input assemblies/submit (aliased through the same shared
+    * {@code basicGeneral()} helper) but dead for these four -- their apply methods never read
+    * {@code basicGeneralPaneModel.refresh} back.
+    */
+   @Test
+   void refusesRefreshOnlyOnTheTypesWhereItIsDead() {
+      for(String type : java.util.List.of("table", "crosstab", "text", "selectionlist")) {
+         assertTrue(PropertyAliases.forType(type).aliases().containsKey("refresh"),
+                    type + " should still list 'refresh' as readable");
+         assertThrows(IllegalArgumentException.class,
+                      () -> PropertyAliases.resolveForWrite(type, "refresh"),
+                      "refresh has no effect on write for " + type);
+      }
+
+      assertEquals("comboboxGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.refresh",
+                   PropertyAliases.resolveForWrite("combobox", "refresh"),
+                   "refresh is real for combobox and must stay writable");
+   }
+
+   @Test
+   void refusesTheNewChartDerivedFlags() {
+      for(String flag : java.util.List.of("adhocVisible", "glossyEffectSupported",
+                                          "sortOthersLastEnabled", "rankPerGroupLabel"))
+      {
+         assertThrows(IllegalArgumentException.class,
+                      () -> PropertyAliases.resolveForWrite("chart",
+                         "chartAdvancedPaneModel." + flag),
+                      flag + " should be refused if reachable as a raw path");
+      }
+
+      for(String flag : java.util.List.of("showValuesVisible", "hasXDimension", "wordCloud")) {
+         assertThrows(IllegalArgumentException.class,
+                      () -> PropertyAliases.resolveForWrite("chart",
+                         "chartAdvancedPaneModel.chartPlotOptionsPaneModel." + flag),
+                      flag + " should be refused if reachable as a raw path");
+      }
+
+      // rankPerGroupLabel is readable, like projectForwardEnabled.
+      assertEquals("chartAdvancedPaneModel.rankPerGroupLabel",
+                   PropertyAliases.resolve("chart", "rankPerGroupLabel"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("chart", "rankPerGroupLabel"));
+   }
+
+   /**
+    * Regression: {@code SizePositionPaneModel.isLocked()} has zero consumers anywhere in
+    * {@code core/src/main/java} outside test/model code -- no {@code *PropertyDialogService}
+    * apply method ever reads it back on write, for any type. Before this fix,
+    * {@code set_assembly_properties({locked:true})} on a non-Image/Shape type returned
+    * {@code ok:true} and silently changed nothing; it must now be refused like the other dead
+    * fields, pointing the caller at {@code edit(op:"set_lock")} instead.
+    */
+   @Test
+   void refusesLockedOnTypesWhereItIsDead() {
+      for(String type : java.util.List.of("table", "crosstab", "chart", "gauge", "text",
+                                          "selectionlist", "selectiontree", "checkbox",
+                                          "combobox", "radiobutton", "slider", "spinner",
+                                          "textinput", "timeslider", "calendar", "tab",
+                                          "calctable", "groupcontainer", "selectioncontainer",
+                                          "submit"))
+      {
+         assertTrue(PropertyAliases.forType(type).aliases().containsKey("locked"),
+                    type + " should still list 'locked' as readable");
+         assertThrows(IllegalArgumentException.class,
+                      () -> PropertyAliases.resolveForWrite(type, "locked"),
+                      "'locked' has no effect on write for " + type);
+      }
+   }
+
+   /**
+    * Image and the three Shape types (line/oval/rectangle) are deliberately excluded from the
+    * {@code locked} dead-field refusal -- they are the types {@code edit(op:"set_lock")} (the
+    * real lock mechanism, gated on {@code LockableVSAssembly}) actually applies to, unlike every
+    * other type covered above.
+    */
+   @Test
+   void doesNotRefuseLockedOnImageOrShapeTypes() {
+      for(String type : java.util.List.of("image", "line", "oval", "rectangle")) {
+         assertDoesNotThrow(() -> PropertyAliases.resolveForWrite(type, "locked"),
+                            "'locked' must stay writable for " + type);
+      }
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -323,6 +323,27 @@ class ViewsheetAssemblyAgentControllerTest {
    }
 
    /**
+    * {@code get_hyperlink}'s {@code axis}/{@code emptyPlotLink} query params reach the
+    * {@code Region} the service reads with — the same two fields {@code set_hyperlink}'s
+    * {@code HyperlinkRequest.region()} already threads through, previously missing only from this
+    * GET mapping (parity audit L7, Group F).
+    */
+   @Test
+   void getHyperlinkThreadsAxisAndEmptyPlotLinkIntoTheRegion() throws Exception {
+      AssemblyHyperlinkService hyperlinkService = mock(AssemblyHyperlinkService.class);
+      Map<String, Object> expected = Map.of("linkType", "web");
+      when(hyperlinkService.read(eq("tok"), any(Principal.class), eq("Chart1"),
+         eq(new AssemblyHyperlinkService.Region(
+            null, null, null, true, false, false, true))))
+         .thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(hyperlinkService);
+
+      assertSame(expected, controller.getHyperlink(
+         "tok", "Chart1", null, null, null, true, false, true, principal()));
+   }
+
+   /**
     * A refused patch (a bad key, or the {@code vsScriptPane} refusal) must surface as the same
     * named-field {@code IllegalArgumentException} the global {@code WizControllerErrorHandler}
     * turns into a 400 — never a bare 500 that reads as a server bug.

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -894,6 +894,30 @@ class ViewsheetAssemblyAgentControllerTest {
       verifyNoInteractions(openService);
    }
 
+   /**
+    * Regression: the caret check on {@code path} lives in resolveDataSourceEntry() itself
+    * (shared by both endpoints) precisely so create_viewsheet also gets it -- it used to be
+    * checked only inside attach_base_worksheet's own body, leaving this sibling endpoint able to
+    * build an AssetEntry whose orgID would be corrupted on any later
+    * AssetEntry.createAssetEntry(identifier) round-trip. See the caret test alongside
+    * attach_base_worksheet's own tests for the corruption mechanism.
+    */
+   @Test
+   void createViewsheetRefusesAPathContainingACaretBeforeCallingSheetOpenService() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SheetOpenService openService = mock(SheetOpenService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.createViewsheet(
+            new ViewsheetAssemblyAgentController.CreateViewsheetRequest(
+               "tok-acting", "Sample^WS", null, "worksheet", null, null),
+            agent));
+      assertTrue(ex.getMessage().contains("path"));
+      verifyNoInteractions(openService);
+   }
+
    @Test
    void createViewsheetWrapsAnIllegalArgumentExceptionFromSheetOpenServiceAsPairingException()
       throws Exception
@@ -946,17 +970,89 @@ class ViewsheetAssemblyAgentControllerTest {
       ViewsheetAssemblyAgentController controller =
          controllerWith(sessions, viewsheetService, broadcast);
 
-      controller.save("tok",
-         new ViewsheetAssemblyAgentController.SaveRequest("agent_vs_1", null), agent);
+      try(org.mockito.MockedStatic<inetsoft.web.AutoSaveUtils> autoSave =
+             mockStatic(inetsoft.web.AutoSaveUtils.class))
+      {
+         controller.save("tok",
+            new ViewsheetAssemblyAgentController.SaveRequest("agent_vs_1", null), agent);
 
-      ArgumentCaptor<AssetEntry> captor = ArgumentCaptor.forClass(AssetEntry.class);
-      verify(viewsheetService).setViewsheet(any(), captor.capture(), any(), eq(true), eq(true));
-      assertEquals(AssetRepository.GLOBAL_SCOPE, captor.getValue().getScope());
-      assertEquals(AssetEntry.Type.VIEWSHEET, captor.getValue().getType());
-      assertEquals("agent_vs_1", captor.getValue().getPath());
-      verify(rvs).setEntry(captor.getValue());
-      verify(rvs).setSavePoint(3);
-      verify(broadcast).broadcastSave(eq(rvs), eq("rt-vs-1"), eq(agent));
+         ArgumentCaptor<AssetEntry> captor = ArgumentCaptor.forClass(AssetEntry.class);
+         verify(viewsheetService).setViewsheet(any(), captor.capture(), any(), eq(true), eq(true));
+         assertEquals(AssetRepository.GLOBAL_SCOPE, captor.getValue().getScope());
+         assertEquals(AssetEntry.Type.VIEWSHEET, captor.getValue().getType());
+         assertEquals("agent_vs_1", captor.getValue().getPath());
+         verify(rvs).setEntry(captor.getValue());
+         verify(rvs).setSavePoint(3);
+         verify(broadcast).broadcastSave(eq(rvs), eq("rt-vs-1"), eq(agent));
+      }
+   }
+
+   /**
+    * Regression for the autosave-orphan gap the audit flagged: {@code SaveViewsheetDialogService
+    * .saveViewsheet} (the UI's own commit path) deletes the pre-save entry's autosave draft
+    * whenever that entry was still {@code TEMPORARY_SCOPE} -- this agent path never did, leaving
+    * an orphaned draft file behind on every first save.
+    */
+   @Test
+   void saveOutOfTemporaryScopeDeletesTheOldEntrysAutosaveDraft() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.VIEWSHEET, "__TEMPORARY__/vs-1", null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEntry()).thenReturn(tempEntry);
+      when(rvs.getCurrent()).thenReturn(3);
+      when(rvs.getID()).thenReturn("rt-vs-1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions, viewsheetService,
+         mock(SheetAgentBroadcastService.class));
+
+      try(org.mockito.MockedStatic<inetsoft.web.AutoSaveUtils> autoSave =
+             mockStatic(inetsoft.web.AutoSaveUtils.class))
+      {
+         controller.save("tok",
+            new ViewsheetAssemblyAgentController.SaveRequest("agent_vs_1", null), agent);
+
+         autoSave.verify(() -> inetsoft.web.AutoSaveUtils.deleteAutoSaveFile(tempEntry, agent));
+      }
+   }
+
+   /** Companion negative case: an ordinary re-save of an already-permanent entry must not touch
+    *  the autosave draft -- there is no first-save transition to clean up after. */
+   @Test
+   void saveOnAnAlreadyPermanentEntryDoesNotDeleteAnAutosaveDraft() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry savedEntry = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
+         AssetEntry.Type.VIEWSHEET, "Existing VS", null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEntry()).thenReturn(savedEntry);
+      when(rvs.getCurrent()).thenReturn(1);
+      when(rvs.getID()).thenReturn("rt-vs-2");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions, viewsheetService,
+         mock(SheetAgentBroadcastService.class));
+
+      try(org.mockito.MockedStatic<inetsoft.web.AutoSaveUtils> autoSave =
+             mockStatic(inetsoft.web.AutoSaveUtils.class))
+      {
+         controller.save("tok",
+            new ViewsheetAssemblyAgentController.SaveRequest(null, null), agent);
+
+         autoSave.verifyNoInteractions();
+      }
    }
 
    /** Companion negative case: the original refusal must survive when no name is supplied. */
@@ -1006,6 +1102,140 @@ class ViewsheetAssemblyAgentControllerTest {
 
       verify(viewsheetService).setViewsheet(any(), eq(savedEntry), any(), eq(true), eq(true));
       verify(rvs).setEntry(savedEntry);
+   }
+
+   /**
+    * Regression: {@code name} is documented (this class's own javadoc, and the plugin's
+    * {@code viewsheetTools.ts} description) to accept a full folder path like
+    * {@code "My Folder/agent_vs_1"} -- {@code '/'} is a legal, expected separator here, unlike
+    * the Composer's own save dialog, whose alias field only ever sees the LEAF name (the folder
+    * is chosen separately there via {@code selectFolder()}). Only the leaf segment is validated
+    * for banned characters/start character; the path separator itself must not be refused.
+    */
+   @Test
+   void saveAcceptsALegalFolderPath() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.VIEWSHEET, "__TEMPORARY__/vs-1", null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEntry()).thenReturn(tempEntry);
+      when(rvs.getCurrent()).thenReturn(3);
+      when(rvs.getID()).thenReturn("rt-vs-1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions, viewsheetService,
+         mock(SheetAgentBroadcastService.class));
+
+      try(org.mockito.MockedStatic<inetsoft.web.AutoSaveUtils> autoSave =
+             mockStatic(inetsoft.web.AutoSaveUtils.class))
+      {
+         controller.save("tok",
+            new ViewsheetAssemblyAgentController.SaveRequest("My Folder/agent_vs_1", null), agent);
+
+         ArgumentCaptor<AssetEntry> captor = ArgumentCaptor.forClass(AssetEntry.class);
+         verify(viewsheetService).setViewsheet(any(), captor.capture(), any(), eq(true), eq(true));
+         assertEquals("My Folder/agent_vs_1", captor.getValue().getPath());
+      }
+   }
+
+   /**
+    * Regression for the missing-server-side-validation gap the audit flagged:
+    * {@code save-viewsheet-dialog.component.ts} applies {@code FormValidators
+    * .assetEntryBannedCharacters} client-side, but nothing enforced it server-side on this agent
+    * path (or on the UI's own Java submit path either -- a pre-existing, StyleBI-wide gap). Only
+    * the leaf segment is checked, so the banned character must be in the leaf, not the folder.
+    */
+   @Test
+   void saveRefusesANameWhoseLeafContainsABannedCharacter() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.VIEWSHEET, "__TEMPORARY__/vs-1", null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEntry()).thenReturn(tempEntry);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions, viewsheetService,
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> controller.save("tok",
+         new ViewsheetAssemblyAgentController.SaveRequest("My Folder/bad<name", null), agent));
+      assertTrue(ex.getMessage().contains("name"));
+
+      verifyNoInteractions(viewsheetService);
+   }
+
+   /**
+    * Regression for the missing-server-side-validation gap the audit flagged:
+    * {@code save-viewsheet-dialog.component.ts} also applies {@code FormValidators
+    * .assetNameStartWithCharDigit} client-side (the name must START with an alphanumeric or CJK
+    * character) -- likewise never enforced server-side.
+    */
+   @Test
+   void saveRefusesANameNotStartingWithAnAlnumOrCjkCharacter() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.VIEWSHEET, "__TEMPORARY__/vs-1", null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEntry()).thenReturn(tempEntry);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions, viewsheetService,
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> controller.save("tok",
+         new ViewsheetAssemblyAgentController.SaveRequest("-agent_vs_1", null), agent));
+      assertTrue(ex.getMessage().contains("start with a letter or digit"));
+
+      verifyNoInteractions(viewsheetService);
+   }
+
+   /** A name starting with a letter/digit is accepted -- companion positive case. */
+   @Test
+   void saveAcceptsANameStartingWithALetterOrDigit() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.VIEWSHEET, "__TEMPORARY__/vs-1", null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getEntry()).thenReturn(tempEntry);
+      when(rvs.getCurrent()).thenReturn(3);
+      when(rvs.getID()).thenReturn("rt-vs-1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      inetsoft.analytic.composition.ViewsheetService viewsheetService =
+         mock(inetsoft.analytic.composition.ViewsheetService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions, viewsheetService,
+         mock(SheetAgentBroadcastService.class));
+
+      try(org.mockito.MockedStatic<inetsoft.web.AutoSaveUtils> autoSave =
+             mockStatic(inetsoft.web.AutoSaveUtils.class))
+      {
+         controller.save("tok",
+            new ViewsheetAssemblyAgentController.SaveRequest("agent_vs_1", null), agent);
+
+         verify(viewsheetService).setViewsheet(any(), any(), any(), eq(true), eq(true));
+      }
    }
 
    // ---------------------------------------------------------------------------
@@ -1256,6 +1486,41 @@ class ViewsheetAssemblyAgentControllerTest {
       assertThrows(PairingException.class, () ->
          controller.attachBaseWorksheet("tok",
             new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("  ", null), agent));
+   }
+
+   /**
+    * Regression: {@code AssetEntry.toIdentifier()} joins its fields with a literal, unescaped
+    * '^', and {@code createAssetEntry(identifier)} recovers {@code orgID} using the FIRST '^'
+    * after the user field rather than the last -- so a caret embedded in {@code path} corrupts
+    * the orgID recovered on any later round-trip. Refused before any {@link AssetEntry} is built
+    * or the repository is touched, mirroring the Composer's own asset-picker dialogs
+    * (new-viewsheet-dialog, select-data-source-dialog, new-visualization-dialog), which reject
+    * the same character client-side.
+    */
+   @Test
+   void attachBaseWorksheetRefusesAPathContainingACaret() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), eq(agent))).thenReturn(rvs);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(sessions,
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         controller.attachBaseWorksheet("tok",
+            new ViewsheetAssemblyAgentController.AttachBaseWorksheetRequest("Sample^WS", null),
+            agent));
+      assertTrue(ex.getMessage().contains("path"));
+
+      verify(vs, never()).setBaseEntry(any());
+      verify(rvs, never()).getAssetRepository();
    }
 
    /** Still behaves exactly as before when type is omitted -- backward compatible default. */

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -33,6 +33,8 @@ import inetsoft.web.viewsheet.controller.VSRefreshService;
 import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.ImageVSAssembly;
+import inetsoft.uql.viewsheet.ShapeVSAssembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
 import inetsoft.uql.viewsheet.TabVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
@@ -589,6 +591,242 @@ class ViewsheetEditServiceTest {
       assertTrue(captor.getValue().isLocked());
    }
 
+   /**
+    * {@code ComposerObjectService.changeLockState} tests {@code instanceof ImageVSAssembly} /
+    * {@code instanceof ShapeVSAssembly} with no {@code else} branch -- a Chart (or Table,
+    * Crosstab, Text, Gauge, CalcTable, ...) fell through both checks, so the lock write was
+    * silently dropped while set_lock still reported success.
+    */
+   @Test
+   void setLockOnANonLockableAssemblyFailsLoud() {
+      RuntimeViewsheet rvs = runtimeWith("Chart1", mock(ChartVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true)));
+
+      EditRequest request = new EditRequest("set_lock", "Chart1", null, null, null, null, null,
+                                            null, Boolean.TRUE, null, null, null, null, null);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request, ""));
+      assertTrue(thrown.getMessage().contains("Chart1"));
+   }
+
+   /** An Image assembly -- one of the two lockable types -- still goes through. */
+   @Test
+   void setLockStillWorksOnAnImageAssembly() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      RuntimeViewsheet rvs = runtimeWith("Image1", mock(ImageVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Image1", "Image", 10, 10, 80, 40, 0, null, true)), objects);
+
+      EditRequest request = new EditRequest("set_lock", "Image1", null, null, null, null, null,
+                                            null, Boolean.TRUE, null, null, null, null, null);
+      service.apply("tok", principal(), request, "");
+
+      verify(objects).changeLockState(eq("rt1"), any(), any(Principal.class), any());
+   }
+
+   /** A Shape assembly -- the other lockable type -- still goes through. */
+   @Test
+   void setLockStillWorksOnAShapeAssembly() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      RuntimeViewsheet rvs = runtimeWith("Rect1", mock(ShapeVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Rect1", "Rectangle", 10, 10, 80, 40, 0, null, true)), objects);
+
+      EditRequest request = new EditRequest("set_lock", "Rect1", null, null, null, null, null,
+                                            null, Boolean.TRUE, null, null, null, null, null);
+      service.apply("tok", principal(), request, "");
+
+      verify(objects).changeLockState(eq("rt1"), any(), any(Principal.class), any());
+   }
+
+   /**
+    * Mirrors composer-toolbar.component.ts's layoutAlign, which filters {@code locked === true}
+    * assemblies out BEFORE computing the reference edge from what's left -- so a locked assembly
+    * is excluded from the moved set AND cannot skew where the unlocked ones land, even though its
+    * own position (x=5) would otherwise be the leftmost edge.
+    */
+   @Test
+   void alignExcludesALockedAssemblyFromBothTheMovedSetAndTheReferenceEdge() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 50, 10, 100, 20, 0, null, true),
+         new AssemblyNode("B", "Rectangle", 5, 60, 100, 20, 0, null, true),
+         new AssemblyNode("C", "Text", 20, 110, 100, 20, 0, null, true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly a = mock(TextVSAssembly.class);
+      ShapeVSAssembly lockedB = mock(ShapeVSAssembly.class);
+      VSAssembly c = mock(TextVSAssembly.class);
+      when(lockedB.islocked()).thenReturn(true);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(lockedB);
+      when(vs.getAssembly("C")).thenReturn(c);
+
+      ViewsheetEditService service = serviceWithRuntime(rvs, reader, objects);
+
+      service.apply("tok", principal(), arrange("align", List.of("A", "B", "C"), "left"), "");
+
+      ArgumentCaptor<MoveVSObjectEvent> captor = ArgumentCaptor.forClass(MoveVSObjectEvent.class);
+      verify(objects, times(2)).moveObject(eq("rt1"), captor.capture(), any(Principal.class),
+                                           any(), anyString());
+      List<MoveVSObjectEvent> moves = captor.getAllValues();
+      assertTrue(moves.stream().noneMatch(m -> "B".equals(m.getName())),
+                 "the locked assembly must not move");
+      assertTrue(moves.stream().allMatch(m -> m.getxOffset() == 20),
+                 "the reference edge must be A/C's own leftmost (20), not B's x=5 -- a locked " +
+                 "assembly must not skew the edge the others align to");
+   }
+
+   /**
+    * Same exclusion for distribute's bounding box (topLeft/bottomRight/totalSize). Uses four
+    * assemblies (one locked) so the three remaining unlocked ones still satisfy distribute's own
+    * minimum of 3 -- see {@link #distributeRejectsWhenOnlyTwoUnlockedAssembliesRemain}.
+    */
+   @Test
+   void distributeExcludesALockedAssemblyFromBothTheMovedSetAndTheBoundingBox() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 0, 0, 10, 10, 0, null, true),
+         new AssemblyNode("B", "Rectangle", 100, 0, 10, 10, 0, null, true),
+         new AssemblyNode("C", "Text", 40, 0, 10, 10, 0, null, true),
+         new AssemblyNode("D", "Text", 70, 0, 10, 10, 0, null, true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly a = mock(TextVSAssembly.class);
+      ShapeVSAssembly lockedB = mock(ShapeVSAssembly.class);
+      VSAssembly c = mock(TextVSAssembly.class);
+      VSAssembly d = mock(TextVSAssembly.class);
+      when(lockedB.islocked()).thenReturn(true);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(lockedB);
+      when(vs.getAssembly("C")).thenReturn(c);
+      when(vs.getAssembly("D")).thenReturn(d);
+
+      ViewsheetEditService service = serviceWithRuntime(rvs, reader, objects);
+
+      service.apply("tok", principal(),
+                    arrange("distribute", List.of("A", "B", "C", "D"), "horizontal"), "");
+
+      ArgumentCaptor<MoveVSObjectEvent> captor = ArgumentCaptor.forClass(MoveVSObjectEvent.class);
+      verify(objects, times(3)).moveObject(eq("rt1"), captor.capture(), any(Principal.class),
+                                           any(), anyString());
+      List<MoveVSObjectEvent> moves = captor.getAllValues();
+      assertTrue(moves.stream().noneMatch(m -> "B".equals(m.getName())),
+                 "the locked assembly must not move");
+      assertTrue(moves.stream().anyMatch(m -> "A".equals(m.getName()) && m.getxOffset() == 0));
+      assertTrue(moves.stream().anyMatch(m -> "D".equals(m.getName()) && m.getxOffset() == 70),
+                 "with B excluded, D is the last (rightmost) unlocked assembly and stays put " +
+                 "at its own edge (70), not B's x=100");
+   }
+
+   /** Excluding locked assemblies must not silently proceed with fewer than 2 to arrange. */
+   @Test
+   void alignRejectsWhenLockingLeavesFewerThanTwoUnlockedAssemblies() {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 50, 10, 100, 20, 0, null, true),
+         new AssemblyNode("B", "Rectangle", 5, 60, 100, 20, 0, null, true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly a = mock(TextVSAssembly.class);
+      ShapeVSAssembly lockedB = mock(ShapeVSAssembly.class);
+      when(lockedB.islocked()).thenReturn(true);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(lockedB);
+
+      ViewsheetEditService service =
+         serviceWithRuntime(rvs, reader, mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), arrange("align", List.of("A", "B"), "left"), ""));
+      assertTrue(thrown.getMessage().contains("unlocked"), thrown.getMessage());
+   }
+
+   /**
+    * Regression: composer-toolbar.component.ts's own layoutDistributeEnabled getter requires
+    * MORE than 2 qualifying objects (i.e. >= 3) -- unlike layoutAlignEnabled/layoutResizeEnabled,
+    * which only require >= 2. At exactly 2 unlocked assemblies, the UI's Distribute button is
+    * disabled; the agent path must refuse the same "evenly distribute between exactly two items"
+    * request rather than silently allowing it.
+    */
+   @Test
+   void distributeRejectsWhenOnlyTwoUnlockedAssembliesRemain() {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 0, 0, 10, 10, 0, null, true),
+         new AssemblyNode("B", "Rectangle", 100, 0, 10, 10, 0, null, true),
+         new AssemblyNode("C", "Text", 40, 0, 10, 10, 0, null, true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly a = mock(TextVSAssembly.class);
+      ShapeVSAssembly lockedB = mock(ShapeVSAssembly.class);
+      VSAssembly c = mock(TextVSAssembly.class);
+      when(lockedB.islocked()).thenReturn(true);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(lockedB);
+      when(vs.getAssembly("C")).thenReturn(c);
+
+      ViewsheetEditService service =
+         serviceWithRuntime(rvs, reader, mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(),
+                             arrange("distribute", List.of("A", "B", "C"), "horizontal"), ""));
+      assertTrue(thrown.getMessage().contains("3"), thrown.getMessage());
+   }
+
+   /**
+    * Regression: composer-toolbar.component.ts's alignObjects filter is
+    * {@code (obj) => !obj.container && obj.locked !== true} -- it excludes a Tab/GroupContainer
+    * member the same way it excludes a locked assembly, not merely the locked ones. Before this
+    * fix, a grouped/tabbed assembly still participated in align/distribute via the agent path.
+    */
+   @Test
+   void alignExcludesAContainerMemberFromBothTheMovedSetAndTheReferenceEdge() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 50, 10, 100, 20, 0, null, true),
+         new AssemblyNode("B", "Text", 5, 60, 100, 20, 0, "Tab1", true),
+         new AssemblyNode("C", "Text", 20, 110, 100, 20, 0, null, true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      VSAssembly a = mock(TextVSAssembly.class);
+      VSAssembly groupedB = mock(TextVSAssembly.class);
+      VSAssembly c = mock(TextVSAssembly.class);
+      TabVSAssembly tab = mock(TabVSAssembly.class);
+      when(groupedB.getContainer()).thenReturn(tab);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(groupedB);
+      when(vs.getAssembly("C")).thenReturn(c);
+
+      ViewsheetEditService service = serviceWithRuntime(rvs, reader, objects);
+
+      service.apply("tok", principal(), arrange("align", List.of("A", "B", "C"), "left"), "");
+
+      ArgumentCaptor<MoveVSObjectEvent> captor = ArgumentCaptor.forClass(MoveVSObjectEvent.class);
+      verify(objects, times(2)).moveObject(eq("rt1"), captor.capture(), any(Principal.class),
+                                           any(), anyString());
+      List<MoveVSObjectEvent> moves = captor.getAllValues();
+      assertTrue(moves.stream().noneMatch(m -> "B".equals(m.getName())),
+                 "the container-member assembly must not move");
+      assertTrue(moves.stream().allMatch(m -> m.getxOffset() == 20),
+                 "the reference edge must be A/C's own leftmost (20), not B's x=5 -- a " +
+                 "container-member assembly must not skew the edge the others align to");
+   }
+
    @Test
    void ungroupDelegatesTheContainerName() throws Exception {
       ComposerGroupService groups = mock(ComposerGroupService.class);
@@ -746,6 +984,65 @@ class ViewsheetEditServiceTest {
       assertEquals(240, captor.getValue().getHeight(), "resize_title must preserve height");
       assertEquals(240, captor.getValue().getxOffset(), "resize_title must preserve x");
       assertEquals(100, captor.getValue().getyOffset(), "resize_title must preserve y");
+   }
+
+   /**
+    * {@code resizeObjectTitle} delegates to {@code resizeObject}, which silently no-ops the
+    * title-height write for a non-titled assembly (Text/Image/Shape) rather than casting -- so
+    * the op reported success while quietly doing an ordinary geometric resize instead of the
+    * title-bar resize the caller actually asked for. Mirrors set_title's own
+    * ClassCastException-turned-clear-error guard.
+    */
+   @Test
+   void resizeTitleOnANonTitledAssemblyFailsLoud() {
+      RuntimeViewsheet rvs = runtimeWith("Text1", mock(TextVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Text1", "Text", 140, 440, 100, 20, 0, null, true)));
+
+      EditRequest request = new EditRequest("resize_title", "Text1", null, null, null, 40, null,
+                                            null, null, null, null, null, null, null);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request, ""));
+      assertTrue(thrown.getMessage().contains("Text1"));
+      assertTrue(thrown.getMessage().contains("resize_title"),
+                 "the error should name the actual op, got: " + thrown.getMessage());
+   }
+
+   /** A titled assembly still goes through resize_title. */
+   @Test
+   void resizeTitleStillWorksOnATitledAssembly() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      RuntimeViewsheet rvs = runtimeWith("Chart1", mock(ChartVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true)), objects);
+
+      EditRequest request = new EditRequest("resize_title", "Chart1", null, null, null, 40, null,
+                                            null, null, null, null, null, null, null);
+      service.apply("tok", principal(), request, "");
+
+      verify(objects).resizeObjectTitle(eq("rt1"), any(), any(Principal.class), any(),
+                                        anyString());
+   }
+
+   /**
+    * Only {@code height == null} was rejected -- {@code resize -50} on the title bar clamped to
+    * 1x1 like resize()'s own bug, and reported success. Mirrors resize()'s requirePositive guard.
+    */
+   @Test
+   void resizeTitleRejectsNonPositiveHeightRatherThanCollapsingTheAssembly() {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true));
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), reader);
+
+      EditRequest request = new EditRequest("resize_title", "Chart1", null, null, null, -10,
+                                            null, null, null, null, null, null, null, null);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request, ""));
+      assertTrue(thrown.getMessage().contains("height"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -4207,6 +4207,41 @@ class WorksheetAgentControllerTest {
          "the control character must be stripped from the saved name");
    }
 
+   /**
+    * Regression: {@code AssetEntry.toIdentifier()} joins its fields with a literal, unescaped
+    * '^', and {@code createAssetEntry(identifier)} recovers {@code orgID} using the FIRST '^'
+    * after the user field rather than the last -- so a caret embedded in {@code name} corrupts
+    * the orgID recovered on any later round-trip. Refused before any {@link AssetEntry} is built
+    * or the repository is touched, mirroring the identical fix in
+    * {@code ViewsheetAssemblyAgentController.attachBaseWorksheet}.
+    */
+   @Test
+   void saveRefusesANameContainingACaret() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.WORKSHEET, "__TEMPORARY__/ws-1", null);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getEntry()).thenReturn(tempEntry);
+      when(rws.getWorksheet()).thenReturn(new Worksheet());
+
+      WorksheetEditService edit = mock(WorksheetEditService.class);
+      when(edit.resolveWithSession(eq("TOK-SAVE-CARET"), eq(agent)))
+         .thenReturn(new WorksheetEditService.ResolvedSession(rws, "rt-ws-caret"));
+
+      WorksheetService ws = mock(WorksheetService.class);
+
+      WorksheetAgentController ctrl = controller(featureOn(), mock(SheetJoinService.class),
+         mock(SheetSessionService.class), mock(WorksheetReadService.class), edit, ws);
+
+      PairingException ex = assertThrows(PairingException.class, () -> ctrl.save("TOK-SAVE-CARET",
+         new WorksheetAgentController.SaveRequest("Sample^WS", null), agent));
+      assertTrue(ex.getMessage().contains("name"));
+
+      verifyNoInteractions(ws);
+   }
+
    // ---------------------------------------------------------------------------
    // save -- PVA-002: a plain re-save must proactively invalidate a connected viewsheet's
    // stale bindable-fields cache instead of relying on the lazy timestamp check


### PR DESCRIPTION
## Summary
- StyleBI backend side of the L7 parity audit (Assembly & Viewsheet Properties, Hyperlinks) mechanical fix batch.
- `PropertyAliases.java`: expose already-wired assembly/viewsheet properties, mirror Angular validations (~30 new aliases, dead-field write refusal generalized).
- `ViewsheetEditService.java`: `resize_title`/`set_lock`/`align`/`distribute` guards -- including a repair-review correction so the Mekko-chart and glossyEffect+sparkline checks normalize instead of throwing, since they sit on the native UI's own shared commit path.
- `WizUtil`/`ViewsheetAssemblyAgentController`/`WorksheetAgentController`: asset-name/caret validation on save/attach_base_worksheet/create_viewsheet, autosave cleanup on rename.
- `get_hyperlink` GET mapping: accept `axis`/`emptyPlotLink` params.
- Live-verified against a real running instance after landing -- see companion PR's report (`docs/parity/L7-assembly-viewsheet-properties-hyperlinks/` in `stylebi-wiz`) for per-finding evidence. All fixes here confirmed clean with both-arms evidence; nothing in this repo needed reverting (the one revert from this batch was plugin-side only, in the `set_format` tool's schema documentation, not touching `ViewsheetFormatService`/`FormatPainterService`).

## Companion PR
Plugin (`stylebi-wiz`): inetsoft-technology/stylebi-wiz#2187

## Test plan
- [x] Full compile clean
- [x] 427 StyleBI tests green (pre-live-verification batch)
- [x] Live-verified against a running StyleBI instance via the plugin's own MCP tools -- see companion PR's report for per-finding evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)