### PR TITLE
Bug #76453: Bookmark-delete Confirm dialog hidden behind Bookmark panel

### DIFF
--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.risk.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.risk.tl.spec.ts
@@ -141,6 +141,25 @@ describe("ViewerAppComponent — deleteBookmark()", () => {
       expect(MODAL_MOCK.open).toHaveBeenCalledOnce();
    });
 
+   // Bug #76453: the still-open Bookmark panel (.fixed-dropdown, z-index 999900) painted
+   // over this Confirm dialog (.modal, z-index 10500 by default), hiding its "Yes" button.
+   // Fix: open it with windowClass/backdropClass that carry a z-index above 999900 (mirrors
+   // the pre-existing .remove-bookmarks-dialog override for the batch-delete path).
+   it("should open the confirm dialog with a z-index above the Bookmark panel's", async () => {
+      const { comp } = await renderComponent();
+      const bk: any = { name: "TestBK", readOnly: false };
+
+      comp.deleteBookmark(bk);
+
+      expect(MODAL_MOCK.open).toHaveBeenCalledWith(
+         expect.anything(),
+         expect.objectContaining({
+            windowClass: "delete-bookmark-confirm-dialog",
+            backdropClass: "delete-bookmark-confirm-dialog-backdrop",
+         }),
+      );
+   });
+
    // 🔁 Regression-sensitive: clicking "yes" MUST send the STOMP delete event.
    // If the dialog result is not awaited or the event URI is wrong, bookmarks
    // are never removed server-side.

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -1984,8 +1984,17 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
 
       const message = Tool.formatCatalogString("_#(js:viewer.viewsheet.bookmark.deleteSelected)", [bookmark.name])
 
+      // Bug #76453: the Bookmark panel dropdown (.fixed-dropdown, z-index 999900) stays open
+      // until "Yes" is clicked, so the generic Confirm modal (.modal, z-index 10500) rendered
+      // underneath it. Raise this dialog's z-index above the panel's, mirroring the same fix
+      // already applied to the "Remove Bookmarks" batch-delete dialog below.
       ComponentTool.showConfirmDialog(this.modalService, "_#(js:Confirm)", message,
-         {"yes": "_#(js:Yes)", "no": "_#(js:No)"})
+         {"yes": "_#(js:Yes)", "no": "_#(js:No)"},
+         <NgbModalOptions> {
+            backdrop: "static",
+            windowClass: "delete-bookmark-confirm-dialog",
+            backdropClass: "delete-bookmark-confirm-dialog-backdrop"
+         })
          .then((buttonClicked) => {
             if(buttonClicked === "yes") {
                this.bookmarkDropdownBtn?.close();

--- a/web/projects/portal/src/scss/internal/_dialog.scss
+++ b/web/projects/portal/src/scss/internal/_dialog.scss
@@ -237,6 +237,18 @@ div.ws-grouping-property-dialog.slide-out-content-container {
   z-index: 999901!important;
 }
 
+// Bug #76453: the single-bookmark delete Confirm dialog is opened from inside the still-open
+// Bookmark panel (.fixed-dropdown, z-index 999900 -- see scss/internal/_directives.scss),
+// which otherwise paints over the generic .modal (z-index 10500). Same fix as
+// .remove-bookmarks-dialog above, for the single-delete path.
+.delete-bookmark-confirm-dialog {
+  z-index: 999902!important;
+}
+
+.delete-bookmark-confirm-dialog-backdrop {
+  z-index: 999901!important;
+}
+
 .data-auto-drill-dialog.modal-content {
   height: 750px;
 }


### PR DESCRIPTION
## Summary

- The single-bookmark delete Confirm dialog (opened by `deleteBookmark()` in `viewer-app.component.ts`) rendered underneath the still-open Bookmark panel, covering its "Yes" button — a deterministic CSS z-index mismatch, not a race condition: `.fixed-dropdown` (the Bookmark panel's dropdown host) is `z-index: 999900`, while the generic `.modal` used by `ComponentTool.showConfirmDialog()` defaults to `z-index: 10500`. The Bookmark panel isn't closed until after the user clicks "Yes", so both elements are on-screen simultaneously as `document.body` siblings.
- This exact problem was already solved once for the sibling "Remove Bookmarks" batch-delete dialog (`.remove-bookmarks-dialog` / `-backdrop`, z-index 999902/999901) — the single-delete path just never got the same treatment.
- Fix: pass a `windowClass`/`backdropClass` into the `showConfirmDialog()` call at this one call site, with a z-index override above 999900, matching the existing pattern.

## Test plan

- [x] Extended `viewer-app.component.risk.tl.spec.ts`'s existing `deleteBookmark()` test group with a new test asserting the modal is opened with the new `windowClass`/`backdropClass`.
- [x] Confirmed the new test fails against the pre-fix code (`git stash` the fix only, rerun — exactly 1 failure, the new test; the other 47 unaffected) and passes with the fix restored.
- [x] Full `viewer-app.component.*.tl.spec.ts` suite (184 tests across 3 files) passes — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)