### PR TITLE
fix(wiz): recompute numeric TimeSlider rangeSize once it no longer fits the live data range

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -1033,6 +1033,10 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
          double mind = ((Number) min).doubleValue();
          double maxd = ((Number) max).doubleValue();
          double curr = (minObj == null) ? mind : ((Number) minObj).doubleValue();
+         // the live data range, captured before either branch below overwrites mind/maxd with
+         // "niced" bounds -- used to detect a persisted rangeSize that no longer fits the
+         // current data (e.g. the bound column's range has shrunk since it was last persisted).
+         double rawSpan = maxd - mind;
 
          if(rangecol != null && rsize0 != 0) {
             Number gap = rangecol.getInterval();
@@ -1061,7 +1065,9 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
                rsize0 = gap.doubleValue();
             }
 
-            if(rsize0 > tinfo.getRangeSizeValue()) {
+            // also recompute (rather than replay the stale value) if the persisted step no
+            // longer fits the live data range at all
+            if(rsize0 > tinfo.getRangeSizeValue() || tinfo.getRangeSize() > rawSpan) {
                tinfo.setRangeSize(rsize0);
             }
             else {
@@ -1094,7 +1100,10 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
                rsize0 = numbers[2];
             }
 
-            if(rsize0 > tinfo.getRangeSizeValue()) {
+            // also recompute (rather than replay the stale value) if the persisted step no
+            // longer fits the live data range at all -- e.g. the bound column's range has
+            // shrunk since this rangeSize was last persisted
+            if(rsize0 > tinfo.getRangeSizeValue() || tinfo.getRangeSize() > rawSpan) {
                if(init) {
                   tinfo.setRangeSizeValue(rsize0);
                }

--- a/core/src/test/java/inetsoft/report/composition/execution/TimeSliderVSAQueryNumericRangeTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/TimeSliderVSAQueryNumericRangeTest.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * VSFILT-009 part 2: a real (non-mocked) execution of {@link TimeSliderVSAQuery#getData()} for
@@ -109,6 +110,88 @@ class TimeSliderVSAQueryNumericRangeTest {
       Object[] range = (Object[]) data;
       assertEquals(0.00, ((Number) range[0]).doubleValue(), 0.0001, "min");
       assertEquals(0.20, ((Number) range[1]).doubleValue(), 0.0001, "max");
+   }
+
+   /**
+    * VSFILT-009 (round 2): a numeric TimeSlider's {@code SingleTimeInfo.rangeSize} is persisted
+    * the first time it successfully computes a tick step (see
+    * {@code TimeSliderVSAQuery.refreshSingleSelectionValue}'s NUMBER branch). If the column's
+    * live data range later shrinks well below that persisted step size -- e.g. after a reload,
+    * once the bound column's real range no longer resembles the one that produced the original
+    * step -- the "only grow, never shrink" comparison at that branch's
+    * {@code if(rsize0 > tinfo.getRangeSizeValue())} check always keeps the stale, oversized
+    * step, collapsing {@code getPreferredTicks} down to its 2-point (min/max only) fallback --
+    * a slider with no real granularity to drag, i.e. exactly the reported "doesn't filter"
+    * symptom.
+    */
+   @Test
+   void staleRangeSizeIsRecomputedWhenDataRangeShrinks() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      TimeSliderVSAssembly slider = new TimeSliderVSAssembly(vs, "RangeSlider1");
+      slider.setTableName("Query1");
+
+      ColumnRef discountRef = new ColumnRef(new AttributeRef("DISCOUNT"));
+      discountRef.setDataType(XSchema.DOUBLE);
+      SingleTimeInfo tinfo = new SingleTimeInfo();
+      tinfo.setDataRef(discountRef);
+      tinfo.setRangeTypeValue(TimeInfo.NUMBER);
+      slider.setTimeInfo(tinfo);
+      vs.addAssembly(slider);
+
+      // Pass 1: a wide range lets the NUMBER branch auto-compute and persist a rangeSize
+      // (SingleTimeInfo.rangeSizeValue, the "D" value) sized for 0..20 -- this is what a real
+      // control does the first time it successfully renders.
+      Object[][] wideRows = new Object[][] {
+         { "DISCOUNT" },
+         { 0.0 }, { 5.0 }, { 10.0 }, { 15.0 }, { 20.0 },
+      };
+      runOnePass(vs, wideRows);
+      assertTrue(slider.getSelectionList().getSelectionValueCount() > 0,
+         "sanity: the first pass over the wide range must itself produce a non-empty " +
+         "selection list");
+      double persistedRangeSize = tinfo.getRangeSizeValue();
+      assertTrue(persistedRangeSize > 0, "first pass must persist a non-zero rangeSize");
+
+      // Pass 2: simulates a reload -- reuses the same assembly/tinfo, so the persisted
+      // rangeSize carries over exactly as SingleTimeInfo's D-value/R-value split makes it
+      // across a real save/reopen -- but the column's live data range has since shrunk well
+      // below the persisted step size.
+      Object[][] narrowRows = new Object[][] {
+         { "DISCOUNT" },
+         { 0.00 }, { 0.05 }, { 0.10 }, { 0.15 }, { 0.20 },
+      };
+      runOnePass(vs, narrowRows);
+
+      // With the bug, the persisted (too-large) rangeSize is kept unconditionally, so
+      // getPreferredTicks collapses to its 2-point (min/max only) fallback -- no usable
+      // granularity to drag. A correctly-recomputed step for a 0..0.20 range should produce
+      // several intermediate ticks.
+      assertTrue(slider.getSelectionList().getSelectionValueCount() > 2,
+         "a stale persisted rangeSize (" + persistedRangeSize + ") from a wider prior data " +
+         "range must not be kept once the live data range has shrunk below it -- got only " +
+         slider.getSelectionList().getSelectionValueCount() + " selection value(s)");
+   }
+
+   private static void runOnePass(Viewsheet vs, Object[][] rows) throws Exception {
+      Worksheet ws = new Worksheet();
+      buildEmbeddedTable(ws, "Query1", rows, true);
+      buildEmbeddedTable(ws, "S_Query1", rows, false);
+
+      Method setBaseWorksheet = Viewsheet.class.getDeclaredMethod("setBaseWorksheet", Worksheet.class);
+      setBaseWorksheet.setAccessible(true);
+      setBaseWorksheet.invoke(vs, ws);
+
+      ViewsheetSandbox box = new ViewsheetSandbox(vs, AbstractSheet.SHEET_RUNTIME_MODE, null, false, null);
+      AssetQuerySandbox wbox = new AssetQuerySandbox(ws, null, new VariableTable());
+      Field wboxField = ViewsheetSandbox.class.getDeclaredField("wbox");
+      wboxField.setAccessible(true);
+      wboxField.set(box, wbox);
+
+      TimeSliderVSAQuery query = new TimeSliderVSAQuery(box, "RangeSlider1");
+      Object data = query.getData();
+      assertNotNull(data, "getData() must resolve a real min/max range for a populated " +
+         "numeric column, not silently return null");
+      query.refreshSelectionValue(data);
    }
 
    private static void buildEmbeddedTable(


### PR DESCRIPTION
## Summary
- VSFILT-009 (visualizations-boards test corpus): a numeric TimeSlider (e.g. bound to DISCOUNT) rendered `undefined` min/max labels and didn't filter when dragged.
- Root cause (live-verified via JDWP against a running `wiz-stylebi` container, see internal diagnosis docs): `TimeSliderVSAQuery.refreshSingleSelectionValue`'s NUMBER branch persists the auto-computed tick step (`rangeSize`) the first time a control renders, but the persistence guard (`if(rsize0 > tinfo.getRangeSizeValue())`, present in both the MV and non-MV code paths) only ever lets that value **grow**. If the bound column's live data range later shrinks below the persisted step (real data change, or rebinding to a narrower column), the stale, oversized step is replayed unconditionally, and `getPreferredTicks` collapses to its 2-point (min/max-only) fallback — no usable drag granularity.
- Fix: capture the live data range width before it gets overwritten by "niced" bounds, and widen both persistence guards to `if(rsize0 > tinfo.getRangeSizeValue() || tinfo.getRangeSize() > rawSpan)` — i.e. also recompute when the persisted value no longer fits inside the live range at all, not just when a fresh auto-computation happens to be larger. This is deliberately conservative: it does not touch a composer user's explicitly-configured range size as long as it still fits the current data.
- Confirmed (by reading `SingleTimeInfo`'s D-value/R-value split) that a brand-new control's very first render is unaffected — there is no "stale" value to compare against on a fresh control.

## Test plan
- [x] Added `staleRangeSizeIsRecomputedWhenDataRangeShrinks` to `TimeSliderVSAQueryNumericRangeTest` (sibling of the existing PR #4988 test): persists a `rangeSize` against a wide 0..20 DISCOUNT fixture, then reuses the same `SingleTimeInfo` against a narrow 0.00..0.20 fixture and asserts the resulting `SelectionList` has more than the 2 degenerate endpoint values. Fails before the fix (`got only 2 selection value(s)`), passes after.
- [x] `TimeSliderVSAQueryTest` (pre-existing): 3/3 green.
- [x] `WizFilterLayoutTest`: 12/12, `WizFilterOperationTest`: 3/3, `WizVsServiceAddFiltersTest`: 14/14, `WizVisualizationServiceTest`: 22/22, plus 19 other `WizVsService*Test` classes — all green (27 test classes total, run via `./mvnw -o -pl core test -Dtest='WizVsService*Test,WizFilterLayoutTest,TimeSliderVSAQueryNumericRangeTest,WizFilterOperationTest'`).
- [ ] Live browser re-verification (rebuild/redeploy + reopen the saved `VizFiltersRun_r3_verify` fixture in the interactive viewer) not performed in this pass — recommend as a follow-up before closing out VSFILT-009 fully.