### PR TITLE
Bug #76468: elements.js/viewer-element.js gulp bundles not generated

### DIFF
--- a/web/gulp/elements.js
+++ b/web/gulp/elements.js
@@ -28,9 +28,9 @@ const { verifyClassicScriptBundle } = require("./verify-classic-script");
 const { rebundleMainForClassicScript } = require("./esbuild-classic-script-rebundle");
 
 // The esbuild @angular/build:application builder (in use for this project since the
-// Angular 17->18/esbuild migration) hashes output filenames as "<name>-<HASH>.js" and does
-// not emit a separate runtime chunk -- unlike the older Webpack builder's "<name>.<hash>.js"
-// convention these patterns used to target.
+// migration away from the older Webpack-based builder) hashes output filenames as
+// "<name>-<HASH>.js" and does not emit a separate runtime chunk -- unlike that older builder's
+// "<name>.<hash>.js" convention these patterns used to target.
 const ngOutputDir = "target/generated-resources/ng/inetsoft/web/resources/elements";
 const rebundleDir = "target/generated-resources/gulp/tmp/elements";
 const appDir = "target/generated-resources/gulp/inetsoft/web/resources/app";

--- a/web/gulp/viewer-element.js
+++ b/web/gulp/viewer-element.js
@@ -29,9 +29,9 @@ const { verifyClassicScriptBundle } = require("./verify-classic-script");
 const { rebundleMainForClassicScript } = require("./esbuild-classic-script-rebundle");
 
 // The esbuild @angular/build:application builder (in use for this project since the
-// Angular 17->18/esbuild migration) hashes output filenames as "<name>-<HASH>.js" and does
-// not emit a separate runtime chunk -- unlike the older Webpack builder's "<name>.<hash>.js"
-// convention these patterns used to target.
+// migration away from the older Webpack-based builder) hashes output filenames as
+// "<name>-<HASH>.js" and does not emit a separate runtime chunk -- unlike that older builder's
+// "<name>.<hash>.js" convention these patterns used to target.
 const ngOutputDir = "target/generated-resources/ng/inetsoft/web/resources/viewer-element";
 const rebundleDir = "target/generated-resources/gulp/tmp/viewer-element";
 const appDir = "target/generated-resources/gulp/inetsoft/web/resources/app";

--- a/web/projects/portal/src/app/embed/chart/embed-chart.routes-eager.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.routes-eager.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Route, Routes } from "@angular/router";
+import { Routes } from "@angular/router";
 import { canDeactivateGuard } from "../../common/services/can-deactivate-guard.service";
 import { EMBED_CHART_URL_MATCHER } from "./embed-chart-url-matcher";
 import { EMBED_CHART_ROUTE_PROVIDERS } from "./embed-chart.route-providers";
@@ -43,5 +43,5 @@ export const embedChartRoutesEager: Routes = [
       canDeactivate: [canDeactivateGuard],
       matcher: EMBED_CHART_URL_MATCHER,
       providers: EMBED_CHART_ROUTE_PROVIDERS
-   } as Route
+   }
 ];


### PR DESCRIPTION
## Summary

- The `elements`/`viewer-element` Angular projects use the esbuild `@angular/build:application` builder, which hashes output filenames as `<name>-<HASH>.js` (dash-delimited) and no longer emits a separate `runtime.*.js` chunk.
- `web/gulp/elements.js` and `web/gulp/viewer-element.js`'s `*:scripts` tasks still globbed for the old Webpack-era `<name>.<hash>.js` convention (a literal dot before the hash). None of the patterns matched, so `gulp-concat` received an empty stream and silently wrote nothing — `elements.js`/`viewer-element.js` were never produced, while the task still reported "Finished" in ~15-35ms with exit code 0. Broken on `main` for ~4 months since the esbuild migration, with no indication anything was wrong.
- Any page embedding the Web Components (`<inetsoft-chart>`, `<inetsoft-viewer>`) fails to load, since the referenced script doesn't exist on the server.

## Fix

- Update the glob patterns in both files to the real dash-hashed convention (`main-*.js`, `polyfills-*.js`, `scripts-*.js`), dropping the `runtime-*.js` pattern (never emitted by this builder for these projects).
- Add a `requireNonEmptyStream()` guard (new `gulp/require-non-empty-stream.js`, shared by both tasks) that fails the task loudly if its glob ever matches zero files again, instead of silently succeeding — this is exactly the failure mode that let the regression go undetected for 4 months across two subsequent Angular version bumps.

## Test plan

- [x] Ran a real `ng build elements --configuration production` / `ng build viewer-element --configuration production`, confirmed the real dash-hashed output filenames (`main-*.js`, `polyfills-*.js`, `scripts-*.js`, no `runtime*.js`).
- [x] Ran `gulp elements:scripts viewer-element:scripts` against that real output with the fix — both `elements.js` (2.7MB) and `viewer-element.js` (9.7MB) are now produced with real concatenated content.
- [x] Verified the new guard: with the `ng build` output directory removed (simulating a future zero-match glob), the task now fails loudly (`Error: Task 'elements:scripts' matched zero input files...`, exit code 1) instead of silently succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)