### PR TITLE
PSM-001: same-runtime co-occupancy count for wiz-agent joins

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -95,9 +95,14 @@ public class BindingAgentController {
     * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
     *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
     *                      could not be resolved
+    * @param concurrentSessionCount how many sessions (including this one) are live on the exact
+    *                      same runtime right now (PSM-001 Change B) — self-inclusive, so a solo
+    *                      join reports {@code 1}, never {@code 0}; advisory only, never a reason
+    *                      this join itself would be refused
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext, String sheetLabel) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel,
+                              Integer concurrentSessionCount) {}
 
    @PostMapping("/api/wiz/v1/agent/binding/join")
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
@@ -106,7 +111,7 @@ public class BindingAgentController {
       JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
-                              outcome.sheetLabel());
+                              outcome.sheetLabel(), outcome.concurrentSessionCount());
    }
 
    @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/fields")

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
@@ -70,17 +70,32 @@ public class SheetJoinService {
    }
 
    /**
-    * The result of a successful {@link #join}: the reusable session, plus a best-effort
-    * human-readable label for the sheet it joined (sourced from {@code AssetEntry.toView()}),
-    * for display alongside the raw {@code runtimeId}.
+    * The result of a successful {@link #join}: the reusable session, a best-effort human-readable
+    * label for the sheet it joined (sourced from {@code AssetEntry.toView()}, for display
+    * alongside the raw {@code runtimeId}), and how many sessions (including this one) are now
+    * live on the exact same runtime (PSM-001 Change B) -- self-inclusive, so a solo join reports
+    * {@code 1}, never {@code 0}.
     *
-    * <p>Kept as a join-time-only wrapper rather than a field on {@link JoinSession} itself:
+    * <p>Kept as a join-time-only wrapper rather than fields on {@link JoinSession} itself:
     * {@code JoinSession} is reconstructed at 8+ call sites across this file ({@code resolve()},
-    * {@code retarget()}, {@code withEditorContext}/{@code withFollowFocusEnabled}), and a rarely-
-    * changing display string would either need threading through every one of them or go stale
-    * forever after a rename. {@code sheetLabel} is computed once, at join, and never refreshed.
+    * {@code retarget()}, {@code withEditorContext}/{@code withFollowFocusEnabled}), and both of
+    * these values would either need threading through every one of them or go stale immediately
+    * (a co-occupancy count in particular is only meaningful at the instant of joining, not on
+    * every later refresh). Both are computed once, at join, and never refreshed.
     */
-   public record JoinOutcome(JoinSession session, String sheetLabel) {}
+   public record JoinOutcome(JoinSession session, String sheetLabel, int concurrentSessionCount) {
+      /**
+       * Back-compat constructor predating {@code concurrentSessionCount} (PSM-001) -- defaults it
+       * to {@code 1} (self-inclusive "just me", the same value a real solo join computes), so the
+       * existing hand-built {@code new JoinOutcome(session, label)} fixtures across the
+       * worksheet/viewsheet/script/binding controller test packages -- none of which exercise
+       * co-occupancy -- do not all need updating for one new field on a record none of them
+       * otherwise touch.
+       */
+      public JoinOutcome(JoinSession session, String sheetLabel) {
+         this(session, sheetLabel, 1);
+      }
+   }
 
    /**
     * Validate flag + code + same-logical-user, consume it, open and return a reusable JoinSession.
@@ -176,9 +191,16 @@ public class SheetJoinService {
 
       String sheetLabel = resolveSheetLabel(runtimeSheet, grant.runtimeId());
 
+      // Self-inclusive: session is already in SheetSessionService's map by this point (opened
+      // just above), so this counts itself plus any other live session already on this exact
+      // runtime -- a solo join reports 1, never 0. Advisory only, never a refusal (PSM-001 Change
+      // B) -- the co-occupant is a different, unrelated caller by construction, and refusing here
+      // would break legitimate concurrent/collaborative use.
+      int concurrentSessionCount = sessions.findAllOnRuntime(session.runtimeId()).size();
+
       LOG.info("Sheet agent pairing join granted (runtimeId={}, sheetType={}, agent={})",
                grant.runtimeId(), grant.sheetType(), agentUser.getName());
-      return new JoinOutcome(session, sheetLabel);
+      return new JoinOutcome(session, sheetLabel, concurrentSessionCount);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
@@ -249,6 +249,35 @@ public class SheetSessionService {
    }
 
    /**
+    * Returns every unexpired session bound to {@code runtimeId}, across every owner and token --
+    * advisory only (PSM-001 Change B), used to warn a joining agent when it has landed on a
+    * document someone (possibly the same agent, via a different session) already has open. Unlike
+    * {@link #findOpen}, which is scoped to one {@code (ownerIdentity, sheetType)} and used to
+    * refuse a silent replace, this scans by runtime alone and is never a refusal ground -- it
+    * exists purely to report a count.
+    *
+    * <p>Self-inclusive by construction: called from {@link SheetJoinService#join} right after
+    * {@link #open} has already put the new session into {@link #sessions}, so a solo join returns
+    * a list of size 1, not 0 -- there is no separate "am I the only one" branch to keep in sync.
+    */
+   public List<JoinSession> findAllOnRuntime(String runtimeId) {
+      if(runtimeId == null) {
+         return List.of();
+      }
+
+      long now = clock.getAsLong();
+      List<JoinSession> result = new ArrayList<>();
+
+      for(JoinSession s : sessions.values()) {
+         if(!s.isExpired(now) && runtimeId.equals(s.runtimeId())) {
+            result.add(s);
+         }
+      }
+
+      return result;
+   }
+
+   /**
     * Returns the unexpired session bound to both {@code socketSessionId} and {@code runtimeId},
     * or {@code null} if none is held.
     *

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -99,7 +99,7 @@ public class ViewsheetAgentController {
       JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
-                              outcome.sheetLabel());
+                              outcome.sheetLabel(), outcome.concurrentSessionCount());
    }
 
    /**
@@ -112,9 +112,14 @@ public class ViewsheetAgentController {
     * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
     *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
     *                      could not be resolved
+    * @param concurrentSessionCount how many sessions (including this one) are live on the exact
+    *                      same runtime right now (PSM-001 Change B) — self-inclusive, so a solo
+    *                      join reports {@code 1}, never {@code 0}; advisory only, never a reason
+    *                      this join itself would be refused
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext, String sheetLabel) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel,
+                              Integer concurrentSessionCount) {}
 
    /**
     * @param editorContext the session's CURRENT scope -- {@code null} for whole-sheet -- read

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -129,9 +129,19 @@ public class ViewsheetAssemblyAgentController {
     *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
     *                      could not be resolved (or, for {@link #openBaseWorksheet}, not resolved
     *                      at all — that path does not go through {@link SheetJoinService#join})
+    * @param concurrentSessionCount how many sessions (including this one) are live on the exact
+    *                      same runtime right now (PSM-001 Change B) — self-inclusive, so a solo
+    *                      join reports {@code 1}, never {@code 0}; advisory only, never a reason
+    *                      this join itself would be refused. {@code null} for
+    *                      {@link #openBaseWorksheet}/{@link #createViewsheet}, same as
+    *                      {@code sheetLabel} — those mint a brand-new runtime directly rather than
+    *                      going through {@link SheetJoinService#join}, so there is no co-occupancy
+    *                      computation to report (a freshly-minted runtime cannot yet have another
+    *                      session on it).
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext, String sheetLabel) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel,
+                              Integer concurrentSessionCount) {}
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/join")
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
@@ -140,7 +150,7 @@ public class ViewsheetAssemblyAgentController {
       JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
-                              outcome.sheetLabel());
+                              outcome.sheetLabel(), outcome.concurrentSessionCount());
    }
 
    /** {@code force} closes a worksheet session already held for this identity instead of
@@ -164,7 +174,8 @@ public class ViewsheetAssemblyAgentController {
       boolean force = body != null && Boolean.TRUE.equals(body.force());
       JoinSession session = openService.openBaseWorksheet(sessionToken, user, force);
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
-                              session.sheetType().name().toLowerCase(), session.editorContext(), null);
+                              session.sheetType().name().toLowerCase(), session.editorContext(), null,
+                              null);
    }
 
    /**
@@ -240,10 +251,11 @@ public class ViewsheetAssemblyAgentController {
       }
 
       // sheetLabel: null, same as openBaseWorksheet -- the newly-created viewsheet is untitled and
-      // unsaved, so there is no resolvable human-readable identity for it yet.
+      // unsaved, so there is no resolvable human-readable identity for it yet. concurrentSessionCount:
+      // null for the same reason as openBaseWorksheet's -- see the field's javadoc above.
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
-                              null);
+                              null, null);
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/model")

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -219,7 +219,7 @@ public class WorksheetAgentController {
 
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
-                              null);
+                              null, null);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -175,7 +175,7 @@ public class WorksheetAgentController {
       JoinSession session = outcome.session();
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase(), session.editorContext(),
-                              outcome.sheetLabel());
+                              outcome.sheetLabel(), outcome.concurrentSessionCount());
    }
 
    /**
@@ -3591,9 +3591,14 @@ public class WorksheetAgentController {
     * @param sheetLabel    best-effort human-readable label for the sheet (e.g. its Composer tab
     *                      title), sourced from {@code AssetEntry.toView()} — {@code null} if it
     *                      could not be resolved
+    * @param concurrentSessionCount how many sessions (including this one) are live on the exact
+    *                      same runtime right now (PSM-001 Change B) — self-inclusive, so a solo
+    *                      join reports {@code 1}, never {@code 0}; advisory only, never a reason
+    *                      this join itself would be refused
     */
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
-                              String sheetType, EditorContext editorContext, String sheetLabel) {}
+                              String sheetType, EditorContext editorContext, String sheetLabel,
+                              Integer concurrentSessionCount) {}
 
    // ---------------------------------------------------------------------------
    // Exception handling

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
@@ -72,6 +72,12 @@ import static org.mockito.Mockito.when;
  *                   absent, never fatal
  * [labelDegrades]   resolveSheetLabel degrades to null (not a thrown exception) when reading
  *                   the found runtime's label itself throws (e.g. AssetEntry.toView())
+ * [soloCount]       joining a runtime with no other live session reports concurrentSessionCount
+ *                   == 1 (self-inclusive, never 0) (PSM-001 Change B)
+ * [coOccupiedCount] joining a runtime that already has a live session on it reports the total
+ *                   count including the new joiner
+ * [neverRefuses]    a same-runtime double-join always succeeds -- the count is advisory only,
+ *                   never a refusal ground
  */
 @Tag("core")
 @ExtendWith(MockitoExtension.class)
@@ -554,5 +560,55 @@ class SheetJoinServiceTest {
 
       assertNotNull(outcome.session());
       assertNull(outcome.sheetLabel());
+   }
+
+   // ---------------------------------------------------------------------------
+   // concurrentSessionCount (PSM-001 Change B)
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void soloJoinReportsSelfInclusiveCountOfOneNeverZero() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String code = pairing.mint("Worksheet/solo-1", ALICE_KEY, "sock-solo", null,
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      SheetJoinService.JoinOutcome outcome = svc.join(code, alice);
+
+      assertEquals(1, outcome.concurrentSessionCount());
+   }
+
+   @Test
+   void secondJoinOnTheSameRuntimeReportsTheTotalCountIncludingTheNewJoiner() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String firstCode = pairing.mint("Worksheet/shared-1", ALICE_KEY, "sock-a", null,
+                                      SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+      svc.join(firstCode, alice);
+
+      // A second, independent pairing code for the SAME runtimeId (the G12 mechanism: a pairing
+      // code binds to whatever document is already open, not to a dedicated asset).
+      String secondCode = pairing.mint("Worksheet/shared-1", ALICE_KEY, "sock-b", null,
+                                       SheetType.WORKSHEET, null);
+      SheetJoinService.JoinOutcome secondOutcome = svc.join(secondCode, alice);
+
+      assertEquals(2, secondOutcome.concurrentSessionCount());
+   }
+
+   @Test
+   void aSameRuntimeDoubleJoinAlwaysSucceedsTheCountIsAdvisoryOnlyNeverARefusal() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String firstCode = pairing.mint("Worksheet/shared-2", ALICE_KEY, "sock-a", null,
+                                      SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+      svc.join(firstCode, alice);
+
+      String secondCode = pairing.mint("Worksheet/shared-2", ALICE_KEY, "sock-b", null,
+                                       SheetType.WORKSHEET, null);
+
+      // Must not throw -- a high concurrentSessionCount is a signal to surface, never a reason to
+      // refuse the join itself.
+      SheetJoinService.JoinOutcome secondOutcome = svc.join(secondCode, alice);
+      assertNotNull(secondOutcome.session());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -21,6 +21,8 @@ import inetsoft.web.wiz.script.PaneScopeService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -41,6 +43,9 @@ import static org.mockito.Mockito.verify;
  * [Socket close: pane]    socketClosed expires a pane-scoped session on that socket
  * [Socket close: toolbar] socketClosed leaves a whole-sheet session's TTL behaviour alone
  * [Detach]                detach ends the one session matching socket + editorContext
+ * [findAllOnRuntime]      returns every unexpired session on a runtimeId across owners/tokens,
+ *                         self-inclusive for a solo session, excludes expired ones, empty for an
+ *                         unknown runtime (PSM-001 Change B)
  *
  * Follow Focus (retarget/popFocus/setFollowFocus):
  * [Follow focus: default off]     a freshly opened session has followFocusEnabled == false
@@ -300,6 +305,51 @@ class SheetSessionServiceTest {
          () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
       assertNull(svcLater.findOpen("frank~;~org", SheetType.WORKSHEET),
                  "an expired session must not be reported as held");
+   }
+
+   // ---- findAllOnRuntime (PSM-001 Change B) ---------------------------------------------------
+
+   @Test
+   void findAllOnRuntimeReturnsEveryUnexpiredSessionOnThatRuntimeAcrossOwnersAndTokens() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession first = svc.open("vs-1", "alice~;~org", SheetType.VIEWSHEET, "sock-1", "alice", null);
+      JoinSession second = svc.open("vs-1", "bob~;~org", SheetType.VIEWSHEET, "sock-2", "bob", null);
+      // A different runtime must not be counted.
+      svc.open("vs-2", "carol~;~org", SheetType.VIEWSHEET, "sock-3", "carol", null);
+
+      List<JoinSession> found = svc.findAllOnRuntime("vs-1");
+
+      assertEquals(2, found.size());
+      assertTrue(found.stream().anyMatch(s -> s.sessionToken().equals(first.sessionToken())));
+      assertTrue(found.stream().anyMatch(s -> s.sessionToken().equals(second.sessionToken())));
+   }
+
+   @Test
+   void findAllOnRuntimeIsSelfInclusiveForASoloSession() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession solo = svc.open("vs-3", "dave~;~org", SheetType.VIEWSHEET, null, null, null);
+
+      List<JoinSession> found = svc.findAllOnRuntime("vs-3");
+
+      assertEquals(1, found.size(), "a solo join must report 1 (itself), never 0");
+      assertEquals(solo.sessionToken(), found.get(0).sessionToken());
+   }
+
+   @Test
+   void findAllOnRuntimeExcludesExpiredSessions() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      svc.open("vs-4", "erin~;~org", SheetType.VIEWSHEET, null, null, null);
+
+      SheetSessionService svcLater = new SheetSessionService(
+         () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
+
+      assertEquals(0, svcLater.findAllOnRuntime("vs-4").size());
+   }
+
+   @Test
+   void findAllOnRuntimeReturnsEmptyForARuntimeWithNoSessions() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      assertTrue(svc.findAllOnRuntime("no-such-runtime").isEmpty());
    }
 
    // ---- Follow Focus: retarget / popFocus / setFollowFocus -----------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -355,6 +355,30 @@ class WorksheetAgentControllerTest {
       assertEquals(ctx, resp.editorContext());
    }
 
+   /**
+    * PSM-001 Change B: the service-layer concurrentSessionCount must reach the actual HTTP-facing
+    * JoinResponse DTO, not just JoinOutcome -- this is the controller-level test §7 of the design
+    * calls for, since a unit test on SheetJoinService alone would not catch a field dropped while
+    * building the response.
+    */
+   @Test
+   void joinResponseCarriesTheConcurrentSessionCount() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = session("TOK-2");
+
+      SheetJoinService joinSvc = mock(SheetJoinService.class);
+      when(joinSvc.join(eq("CODE"), eq(agent)))
+         .thenReturn(new SheetJoinService.JoinOutcome(s, "Sales Analysis", 3));
+
+      WorksheetAgentController ctrl = controller(featureOn(), joinSvc,
+         mock(SheetSessionService.class), mock(WorksheetReadService.class),
+         mock(WorksheetEditService.class), mock(WorksheetService.class));
+
+      WorksheetAgentController.JoinResponse resp = ctrl.join(new WorksheetAgentController.JoinRequest("CODE"), agent);
+
+      assertEquals(3, resp.concurrentSessionCount());
+   }
+
    @Test
    void joinRejectsFlagOff() {
       WorksheetAgentController ctrl = controller(featureOff(),


### PR DESCRIPTION
## Summary
- `SheetSessionService.findAllOnRuntime(runtimeId)` -- returns every unexpired session bound to an exact runtime id, across owners/tokens (self-inclusive by construction when called post-open).
- `SheetJoinService.join()` computes a self-inclusive `concurrentSessionCount` right after opening a new session and threads it through `JoinOutcome` (not `JoinSession` -- it's a join-time-only value, following the same wrapper pattern `sheetLabel` already established, to avoid re-threading through `JoinSession`'s 8+ reconstruction call sites).
- All `JoinResponse` records across the four wiz-agent controllers (worksheet, binding, viewsheet-script, viewsheet-assembly) plus the newly-added `create_worksheet` endpoint gain an optional `concurrentSessionCount` field -- `null` for the two `SheetOpenService`-minted paths (`openBaseWorksheet`/`createViewsheet`/`createWorksheet`) that can't yet have a second session on a freshly-minted runtime, a real self-inclusive count for every `SheetJoinService.join()` path.

This is the server-side half of a same-runtime co-occupancy warning -- the plugin side (paired stylebi-wiz PR) surfaces it as a loud, never-refusing warning in `connect_sheet`'s response when the count is `>1`, silent when absent (older server) or `=1` (solo join). This addresses a real incident (two independent processes landing on the same document with no signal) without capping or refusing concurrent access.

Design, build, and 2 rounds of adversarial review are archived at `docs/teams/2026-09-04-feature-psm-001/` in the paired stylebi-wiz repo.

## Test plan
- [x] `SheetSessionServiceTest`: 41 tests (4 new -- cross-owner/token, self-inclusive-solo, excludes-expired, empty-for-unknown-runtime)
- [x] `SheetJoinServiceTest`: 24 tests (3 new -- solo reports 1 never 0, co-occupied reports correct total, double-join never refused)
- [x] `WorksheetAgentControllerTest`: 131 tests (4 new -- DTO threads the field correctly through the join path, plus 3 tests for the new `create_worksheet` endpoint's own JoinResponse construction, fixed to compile against this branch during rebase)
- [x] `BindingAgentControllerTest`/`ViewsheetAgentControllerTest`/`ViewsheetAssemblyAgentControllerTest`: unchanged, all still passing (17/14/55)
- Total: 282 tests, 0 failures, `BUILD SUCCESS`

🤖 Generated with a `/feature-workflow` run (Claude Code)