### PR TITLE
fix(#76470): ranking n<=0 with groupOthers collapses to Others instead of no-op (CrossTabFilter)

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
@@ -1261,9 +1261,9 @@ public class CrossTabFilter extends AbstractTableLens
     */
    public void setRowTopN(int rcol, int dcol, int topn, boolean reverse, boolean others) {
       if(rcol >= 0 && rcol < rowtopns.length && dcol >= 0 &&
-         dcol < this.dcol.length && topn >= 1)
+         dcol < this.dcol.length)
       {
-         InnerTopNInfo info = new InnerTopNInfo(dcol, topn, reverse, others);
+         InnerTopNInfo info = new InnerTopNInfo(dcol, Math.max(topn, 0), reverse, others);
          rowtopns[rcol] = info;
       }
    }
@@ -1280,9 +1280,9 @@ public class CrossTabFilter extends AbstractTableLens
     */
    public void setColTopN(int ccol, int dcol, int topn, boolean reverse, boolean others) {
       if(ccol >= 0 && ccol < coltopns.length && dcol >= 0 &&
-         dcol < this.dcol.length && topn >= 1)
+         dcol < this.dcol.length)
       {
-         InnerTopNInfo info = new InnerTopNInfo(dcol, topn, reverse, others);
+         InnerTopNInfo info = new InnerTopNInfo(dcol, Math.max(topn, 0), reverse, others);
          coltopns[ccol] = info;
       }
    }
@@ -3902,7 +3902,7 @@ public class CrossTabFilter extends AbstractTableLens
 
    private boolean isOthers(InnerTopNInfo[] topNs) {
       for(InnerTopNInfo topn : topNs) {
-         if(topn == null || topn.n == 0 || topn.n == Integer.MAX_VALUE) {
+         if(topn == null || topn.n == Integer.MAX_VALUE) {
             continue;
          }
 
@@ -5484,7 +5484,7 @@ public class CrossTabFilter extends AbstractTableLens
       topNSections.sort(sc);
 
       assert info != null;
-      int n = (info.n > 0) ? Math.min(info.n, sections.size()) : sections.size();
+      int n = Math.min(Math.max(info.n, 0), sections.size());
 
       // @by billh, 'keep last equal' is not supported, but if we can edit it
       // in topn editor, we should support it

--- a/core/src/test/java/inetsoft/report/filter/CrossTabFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/CrossTabFilterTest.java
@@ -113,4 +113,114 @@ public class CrossTabFilterTest {
                               "Others should sum the merged NY+TX+WA rows (3+2+1=6), " +
                               "not just the last-processed row's raw value");
    }
+
+   /**
+    * Regression test for bug #76470: setRowTopN's registration guard used to require
+    * topn >= 1, silently dropping a ranking whose n resolves to 0 (e.g. via a bound
+    * variable) instead of treating n=0/groupOthers=true as "collapse everything into
+    * Others", the same semantics PC-002 established for SummaryFilter.setTopN.
+    */
+   @Test
+   public void rowTopNZeroWithOthers_collapsesAllRowsToOthers() {
+      Object[][] data = new Object[][]{
+         { "STATE", "CUSTOMER_COUNT" },
+         { "NJ", 6 },
+         { "CA", 4 },
+         { "MA", 4 },
+         { "NY", 3 },
+         { "TX", 2 },
+         { "WA", 1 },
+      };
+
+      int[] rowh = new int[]{ 0 };
+      int[] colh = new int[0];
+      int[] dcol = new int[]{ 1 };
+      Formula[] formulas = new Formula[]{ new NoneFormula() };
+
+      CrossTabFilter table = new CrossTabFilter(new DefaultTableLens(data), rowh, colh, dcol,
+                                                formulas);
+      table.setRowTopN(0, 0, 0, false, true);
+
+      int headerRows = table.getHeaderRowCount();
+      int dataRowCount = table.getRowCount() - headerRows;
+      Assertions.assertEquals(1, dataRowCount,
+                              "n=0 with groupOthers=true should collapse every row into a " +
+                              "single Others row, not keep any original rows");
+      Assertions.assertEquals("Others", table.getObject(headerRows, 0));
+      Assertions.assertEquals(20.0, ((Number) table.getObject(headerRows, 1)).doubleValue(),
+                              0.0001,
+                              "Others should sum all merged rows " +
+                              "(6+4+4+3+2+1=20), not come out blank/zero/stale");
+   }
+
+   /**
+    * Regression test for bug #76470: setRowTopN with n=0 and groupOthers=false should
+    * keep zero rows (mirrors the n>=1 semantics of "keep nothing outside the top N"),
+    * not silently no-op and keep every row.
+    */
+   @Test
+   public void rowTopNZeroWithoutOthers_keepsNoRows() {
+      Object[][] data = new Object[][]{
+         { "STATE", "CUSTOMER_COUNT" },
+         { "NJ", 6 },
+         { "CA", 4 },
+         { "MA", 4 },
+         { "NY", 3 },
+         { "TX", 2 },
+         { "WA", 1 },
+      };
+
+      int[] rowh = new int[]{ 0 };
+      int[] colh = new int[0];
+      int[] dcol = new int[]{ 1 };
+      Formula[] formulas = new Formula[]{ new NoneFormula() };
+
+      CrossTabFilter table = new CrossTabFilter(new DefaultTableLens(data), rowh, colh, dcol,
+                                                formulas);
+      table.setRowTopN(0, 0, 0, false, false);
+
+      Assertions.assertEquals(table.getHeaderRowCount(), table.getRowCount(),
+                              "n=0 with groupOthers=false should keep zero data rows");
+   }
+
+   /**
+    * Regression test for bug #76470: setColTopN mirror of
+    * rowTopNZeroWithOthers_collapsesAllRowsToOthers -- col-header ranking is a
+    * structurally separate array/guard (coltopns vs rowtopns) from row-header ranking
+    * and must not be assumed fixed just because the row-header case passes.
+    */
+   @Test
+   public void colTopNZeroWithOthers_collapsesAllColsToOthers() {
+      Object[][] data = new Object[][]{
+         { "GROUP", "STATE", "CUSTOMER_COUNT" },
+         { "ALL", "NJ", 6 },
+         { "ALL", "CA", 4 },
+         { "ALL", "MA", 4 },
+         { "ALL", "NY", 3 },
+         { "ALL", "TX", 2 },
+         { "ALL", "WA", 1 },
+      };
+
+      int[] rowh = new int[]{ 0 };
+      int[] colh = new int[]{ 1 };
+      int[] dcol = new int[]{ 2 };
+      Formula[] formulas = new Formula[]{ new NoneFormula() };
+
+      CrossTabFilter table = new CrossTabFilter(new DefaultTableLens(data), rowh, colh, dcol,
+                                                formulas);
+      table.setColTopN(0, 0, 0, false, true);
+
+      int headerCols = table.getHeaderColCount();
+      int headerRows = table.getHeaderRowCount();
+      int dataColCount = table.getColCount() - headerCols;
+      Assertions.assertEquals(1, dataColCount,
+                              "n=0 with groupOthers=true should collapse every column into " +
+                              "a single Others column, not keep any original columns");
+      Assertions.assertEquals("Others", table.getObject(headerRows - 1, headerCols));
+      Assertions.assertEquals(20.0,
+                              ((Number) table.getObject(headerRows, headerCols)).doubleValue(),
+                              0.0001,
+                              "Others should sum all merged columns " +
+                              "(6+4+4+3+2+1=20), not come out blank/zero/stale");
+   }
 }


### PR DESCRIPTION
## Summary
- `CrossTabFilter.setRowTopN`/`setColTopN` had the same `topn>=1` registration guard PC-002 (#4981) already fixed on `SummaryFilter.setTopN`: a row/col-header ranking whose `n` resolves to 0 (e.g. via a bound variable) silently no-op'd — no error, no Others row, table unchanged.
- Unlike `SummaryFilter`, registering `n=0` alone is not sufficient here: `calculateTopNSubSections()` had its own `info.n > 0` ternary that fell back to "keep everything" for `n=0`. That fallback is now replaced with the same unconditional `Math.min` the `SummaryFilter` fix relies on.
- Also drops the `topn.n == 0` disjunct from `isOthers(InnerTopNInfo[])`'s skip condition, so a genuinely-registered `n=0`/`groupOthers=true` entry is recognized as "has others" by `resetGrandTotal`'s Others-recompute gate and other `isOthers()` callers (e.g. the Others-sort-position re-sort in `process0`).

## Note on the 4th change (`isOthers`)
Confirmed via a live JUnit run (not just static trace) that in the canonical single-level, no-column-ranking repro, the Others cell's total is already independently safety-netted by `getMergedData0`'s own merged-tuple decomposition fallback (`CrossTabFilter.java:4343-4401`) even without this 4th change — so the included regression tests pass with or without it. It's kept anyway because it's the semantically correct fix for `isOthers()` itself and may matter for scenarios outside this ticket's regression coverage (nested grouping / sort-by-value).

## Test plan
- [x] `./mvnw test -pl core -Dtest=CrossTabFilterTest,CrossCalcFilterTest,CrosstabVSAQueryTest` — all pass
- [x] Confirmed all 3 new regression tests fail without any of the 4 changes
- [x] Confirmed `rowTopNZeroWithOthers_collapsesAllRowsToOthers`/`rowTopNZeroWithoutOthers_keepsNoRows` still fail with only changes 1-2 applied (registration alone, no `calculateTopNSubSections` clamp) — isolates change 3 as load-bearing
- [x] Existing `testTopNGroupOthersWithNoneFormulaSumsMergedRows` (n=3 case) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)