### PR TITLE
fix(#76449-wbs005): surface real driver error for RUNTIME_MODE worksheet-query failures

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuery.java
@@ -4069,6 +4069,15 @@ public abstract class AssetQuery extends PreAssetQuery {
          if(mode != AssetQuerySandbox.RUNTIME_MODE) {
             throw new ExpressionFailedException(-1, null, getTable().getName(), ex);
          }
+         else {
+            // RUNTIME_MODE returns a null table (see fixColumnHeaders(base, ...) below) instead
+            // of rethrowing, so leave the real cause behind for a caller (e.g.
+            // WorksheetPreviewService.preview) that needs to explain the null rather than report
+            // a generic "not found" message. Uses the same thread-local idiom as
+            // XSessionManager.getXNodeTableLens's writer / AssetQuery.getDesignTableLens's reader.
+            XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.set(
+               ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage());
+         }
       }
       finally {
          WSExecution.setAssetQuerySandbox(null);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPreviewService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPreviewService.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.worksheet;
 import inetsoft.report.TableLens;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.internal.XNodeMetaTable;
 import inetsoft.web.wiz.pairing.PairingException;
 import org.springframework.stereotype.Service;
 
@@ -83,6 +84,18 @@ public class WorksheetPreviewService {
       }
 
       if(lens == null) {
+         // RUNTIME_MODE execution of a SQL-bound table whose query fails leaves this thread-local
+         // set (AssetQuery.getPreBaseTableLens's catch(SQLExpressionFailedException) branch) rather
+         // than throwing, so lens == null here is ambiguous between "genuinely missing table" and
+         // "query executed and failed." Prefer the captured cause when present.
+         String cause = XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.get();
+
+         if(cause != null && !cause.isBlank()) {
+            XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.remove();
+            throw new PairingException("Failed to execute worksheet query for '"
+                                       + tableName + "': " + cause);
+         }
+
          throw new PairingException("Table not found or produced no data: " + tableName);
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPreviewServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPreviewServiceTest.java
@@ -20,8 +20,10 @@ package inetsoft.web.wiz.worksheet;
 import inetsoft.report.TableLens;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.internal.XNodeMetaTable;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +39,14 @@ import static org.mockito.Mockito.*;
 class WorksheetPreviewServiceTest {
 
    private final WorksheetPreviewService service = new WorksheetPreviewService();
+
+   @AfterEach
+   void clearFailedQueryMessage() {
+      // Guard against test-order pollution: LAST_FAILED_QUERY_MESSAGE is a real, shared
+      // ThreadLocal (production field, not a test double), and JUnit within a class typically
+      // reuses the same thread across tests.
+      XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.remove();
+   }
 
    // ---------------------------------------------------------------------------
    // Helpers
@@ -91,8 +101,46 @@ class WorksheetPreviewServiceTest {
       AssetQuerySandbox box = mock(AssetQuerySandbox.class);
       when(box.getTableLens(eq("T"), anyInt())).thenReturn(null);
 
-      assertThrows(PairingException.class,
-                   () -> service.preview(rws(box), "T", 10));
+      PairingException ex = assertThrows(PairingException.class,
+                                          () -> service.preview(rws(box), "T", 10));
+      assertEquals("Table not found or produced no data: T", ex.getMessage(),
+                   "with no captured query-failure cause, the generic message is unchanged");
+   }
+
+   // Bug #76449 (WBS-005): a SQL-bound table whose query fails during RUNTIME_MODE execution
+   // (e.g. a JDBC driver rejecting an unsupported SQL feature) is swallowed by
+   // AssetQuery.getPreBaseTableLens's catch(SQLExpressionFailedException) into a plain null
+   // TableLens - indistinguishable, at this layer, from a genuinely missing table - except that
+   // it leaves the real driver message behind in XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE. These
+   // tests exercise WorksheetPreviewService.preview's consumer side of that hand-off directly via
+   // the real (production) ThreadLocal field, since reproducing the producer side would require a
+   // live JDBC datasource whose driver rejects a specific SQL construct.
+   @Test
+   void surfacesCapturedQueryFailureCauseInsteadOfGenericMessage() throws Exception {
+      XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.set(
+         "[Vendor] window functions are not supported by this driver");
+
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(box.getTableLens(eq("T"), anyInt())).thenReturn(null);
+
+      PairingException ex = assertThrows(PairingException.class,
+                                          () -> service.preview(rws(box), "T", 10));
+      assertEquals("Failed to execute worksheet query for 'T': " +
+                   "[Vendor] window functions are not supported by this driver",
+                   ex.getMessage());
+   }
+
+   @Test
+   void consumesAndClearsCapturedQueryFailureCauseAfterSurfacingIt() throws Exception {
+      XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.set("driver says no");
+
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(box.getTableLens(eq("T"), anyInt())).thenReturn(null);
+
+      assertThrows(PairingException.class, () -> service.preview(rws(box), "T", 10));
+      assertNull(XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE.get(),
+                 "captured cause must be consumed (removed) once surfaced, matching " +
+                 "AssetQuery.getDesignTableLens's existing consume-and-clear reader");
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `AssetQuery.getPreBaseTableLens`'s `catch(SQLExpressionFailedException ex)` was a no-op for `RUNTIME_MODE`, silently dropping the real query-failure cause (e.g. a JDBC driver rejecting an unsupported SQL feature) and returning a null table lens.
- `WorksheetPreviewService.preview` (the endpoint behind the composer-chat MCP tool `preview_worksheet_data`) then reported the generic `"Table not found or produced no data"` message for both a genuinely missing table and a SQL-bound table whose query executed and failed - misleading a caller debugging bad SQL into thinking the table name itself was wrong.
- Fix: capture the cause into the existing `XNodeMetaTable.LAST_FAILED_QUERY_MESSAGE` thread-local (mirroring `XSessionManager.getXNodeTableLens`'s writer / `AssetQuery.getDesignTableLens`'s reader, an already-shipped instance of the same idiom for a different swallow point), and have `WorksheetPreviewService.preview` consume-and-clear it before falling back to the generic message.
- No control-flow change on any of `RUNTIME_MODE`'s ~49 call sites (viewsheet charts, scheduled reports, MV building, etc.) - every one still gets the identical `TableLens`/`null` it gets today.
- Uses `ex.getCause()` in preference to `ex.getMessage()`: `SQLExpressionFailedException`'s sole constructor is `SQLExpressionFailedException(Exception causedBy) { super(causedBy); }`, so bare `ex.getMessage()` would return a `"ClassName: "`-prefixed `cause.toString()`, not the bare driver text.
- Note: `LAST_FAILED_QUERY_MESSAGE` now has two independent writer/reader pairs (documented in code comments) - traced for cross-contamination on this bug's RUNTIME_MODE call path and found none, but worth knowing for whoever next touches either pair.

Companion plugin-side mitigation already merged in `stylebi-wiz` (PR #2191) added a disambiguating hint in `preview_worksheet_data`'s catch block using `get_query_plan` as an external SQL-bound discriminator. That mitigation guesses at the ambiguity from outside the JVM; this fix removes the ambiguity at the source, so that plugin-side hint may be simplifiable now that the real driver message is available directly in `preview_worksheet_data`'s response - flagging as a possible `stylebi-wiz`-repo follow-up, out of scope for this PR.

Full diagnosis/refute trail (two rounds each, both confirming the mechanism and fix location against source): `docs/teams/2026-09-03-bugs-composer-worksheet-entitlements-mcp/bug-76449-wbs005/{01-diagnosis,02-refute,03-fix}.md` in the `stylebi-wiz` repo.

## Test plan
- [x] `./mvnw test -pl core -Dtest=WorksheetPreviewServiceTest,AssetQueryTest` - 14/14 pass
- [x] Confirmed both new `WorksheetPreviewServiceTest` cases fail against pre-fix code (stashed the two production-code changes, reran, both failed with the expected pre-fix generic message / non-null thread-local), then re-verified passing after unstashing
- [x] Broader related suite (`WorksheetPreviewServiceTest`, `AssetQueryTest`, `AssetQueryCacheNormalizerTest`, `XNodeMetaTableTest`, `AssetQueryScopeTest`, all `WorksheetTableService*Test`, `WorksheetAgentControllerTest`) - 248/248 pass