### PR TITLE
fix(#76449-wbs006): search_schema fields-only search no longer short-circuits on empty query

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/Cluster.java
@@ -137,6 +137,15 @@ public interface Cluster extends AutoCloseable {
    void setLocalNodeProperty(String name, Object value);
 
    /**
+    * Removes the named property of the current cluster node. Unlike
+    * {@link #setLocalNodeProperty(String, Object)} with a {@code null} value, this is
+    * guaranteed not to attempt to store a null value in the underlying implementation.
+    *
+    * @param name the property name.
+    */
+   void clearLocalNodeProperty(String name);
+
+   /**
     * Check if this node is the master. The oldest node in the cluster is
     * treated as the master.
     */

--- a/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/MockCluster.java
@@ -115,6 +115,12 @@ public class MockCluster implements Cluster {
    }
 
    @Override
+   public void clearLocalNodeProperty(String name) {
+      clusterNodeProperties.computeIfAbsent(
+         getLocalMember(), k -> new ConcurrentHashMap<>()).remove(name);
+   }
+
+   @Override
    public boolean isMaster() {
       return true;
    }

--- a/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
+++ b/core/src/main/java/inetsoft/sree/internal/cluster/ignite/IgniteCluster.java
@@ -745,6 +745,11 @@ public final class IgniteCluster implements inetsoft.sree.internal.cluster.Clust
       getNodePropertyMap().put(getLocalMember() + ":" + name, value);
    }
 
+   @Override
+   public void clearLocalNodeProperty(String name) {
+      getNodePropertyMap().remove(getLocalMember() + ":" + name);
+   }
+
    private Map<String, Object> getNodePropertyMap() {
       return getMap(getClass().getName() + ".nodeProperties");
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1982,16 +1982,16 @@ public class MetadataApiService {
       throws Exception
    {
       String query = request.getQuery();
+      List<String> fields = request.getFields();
+      boolean searchColumns = fields != null && !fields.isEmpty();
 
-      if(Tool.isEmptyString(query)) {
+      if(Tool.isEmptyString(query) && !searchColumns) {
          SchemaSearchResponse response = new SchemaSearchResponse();
          response.setResults(Collections.emptyList());
          return response;
       }
 
-      String queryLower = query.toLowerCase(Locale.ROOT);
-      List<String> fields = request.getFields();
-      boolean searchColumns = fields != null && !fields.isEmpty();
+      String queryLower = Tool.isEmptyString(query) ? null : query.toLowerCase(Locale.ROOT);
       Set<String> fieldNamesLower = new HashSet<>();
 
       if(searchColumns) {
@@ -2018,7 +2018,7 @@ public class MetadataApiService {
             DatasourceTablesResponse tablesResponse = getDatabaseTables(dsName, principal);
 
             for(DatabaseTableInfo tableInfo : tablesResponse.getTables()) {
-               boolean tableMatches = tableNameMatches(
+               boolean tableMatches = queryLower != null && tableNameMatches(
                   tableInfo.getTable().toLowerCase(Locale.ROOT), queryLower);
 
                // If searching by field names, look for column matches

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceSchemaSearchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceSchemaSearchTest.java
@@ -17,9 +17,22 @@
  */
 package inetsoft.web.wiz.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.DatabaseTableInfo;
+import inetsoft.web.wiz.model.DatabaseTableMeta;
+import inetsoft.web.wiz.model.DatasourceTablesResponse;
+import inetsoft.web.wiz.model.SchemaSearchResponse;
+import inetsoft.web.wiz.request.SchemaSearchRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,9 +40,19 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Bug #76350 PSD-001: search_schema("category") missed a table literally named "categories" —
@@ -85,5 +108,122 @@ class MetadataApiServiceSchemaSearchTest {
       assertEquals("wine", MetadataApiService.stem("wines"));
       assertEquals("order", MetadataApiService.stem("orders"));
       assertEquals("glass", MetadataApiService.stem("glass"));
+   }
+
+   /**
+    * Bug #76449 wbs006: searchSchema("", fields=[...]) short-circuited to an empty result
+    * before request.getFields() was ever read, so a fields-only search could never find a
+    * column that genuinely exists. These drive {@code searchSchema} itself (not just the
+    * static helpers above) with {@code getDatabaseTables}/{@code getTableDetails} stubbed out
+    * via a spy, since the JDBC metadata-provider plumbing they walk is unrelated to the
+    * short-circuit-ordering bug under test.
+    */
+   private MetadataApiService createSpiedService(DatasourceTablesResponse tablesResponse,
+                                                   DatabaseTableMeta tableMeta)
+      throws Exception
+   {
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSourceFullNames()).thenReturn(new String[] { "Examples/Orders" });
+      when(xrepository.getDataSource("Examples/Orders")).thenReturn(mock(JDBCDataSource.class));
+
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(anyString(), any(ResourceAction.class), any()))
+         .thenReturn(true);
+
+      MetadataApiService service = spy(new MetadataApiService(
+         xrepository, dataSourceService, mock(AssetRepository.class),
+         mock(AssetTreeService.class), new ObjectMapper()));
+
+      doReturn(tablesResponse).when(service).getDatabaseTables(anyString(), any());
+
+      if(tableMeta != null) {
+         doReturn(tableMeta).when(service)
+            .getTableDetails(anyString(), anyString(), any(), any(), any());
+      }
+
+      return service;
+   }
+
+   private DatasourceTablesResponse oneTableFixture(String tableName) {
+      DatabaseTableInfo table = new DatabaseTableInfo();
+      table.setTable(tableName);
+      table.setType("TABLE");
+
+      DatasourceTablesResponse response = new DatasourceTablesResponse();
+      response.setTables(List.of(table));
+      return response;
+   }
+
+   private DatabaseTableMeta columnFixture(String columnName) {
+      DatabaseTableMeta.ColumnMeta column = new DatabaseTableMeta.ColumnMeta();
+      column.setName(columnName);
+      column.setType("INTEGER");
+
+      DatabaseTableMeta meta = new DatabaseTableMeta();
+      meta.setColumns(List.of(column));
+      return meta;
+   }
+
+   @Test
+   void emptyQueryWithFieldsStillFindsMatchingColumns() throws Exception {
+      MetadataApiService service = createSpiedService(
+         oneTableFixture("orders"), columnFixture("PRODUCT_ID"));
+
+      SchemaSearchRequest request = new SchemaSearchRequest();
+      request.setQuery("");
+      request.setFields(List.of("PRODUCT_ID"));
+
+      SchemaSearchResponse response = service.searchSchema(request, mock(Principal.class));
+
+      assertEquals(1, response.getResults().size(),
+         "an empty query with a real fields match must not be short-circuited away");
+      assertEquals("orders", response.getResults().get(0).getTable());
+   }
+
+   @Test
+   void nonsenseQueryWithFieldsMatchesTheSameAsEmptyQuery() throws Exception {
+      MetadataApiService service = createSpiedService(
+         oneTableFixture("orders"), columnFixture("PRODUCT_ID"));
+
+      SchemaSearchRequest request = new SchemaSearchRequest();
+      request.setQuery("zzzznonsense");
+      request.setFields(List.of("PRODUCT_ID"));
+
+      SchemaSearchResponse response = service.searchSchema(request, mock(Principal.class));
+
+      assertEquals(1, response.getResults().size());
+      assertEquals("orders", response.getResults().get(0).getTable());
+   }
+
+   @Test
+   void emptyQueryAndEmptyFieldsStillShortCircuitsToNoResults() throws Exception {
+      MetadataApiService service = createSpiedService(oneTableFixture("orders"), null);
+
+      SchemaSearchRequest request = new SchemaSearchRequest();
+      request.setQuery("");
+      request.setFields(Collections.emptyList());
+
+      SchemaSearchResponse response = service.searchSchema(request, mock(Principal.class));
+
+      assertTrue(response.getResults().isEmpty(),
+         "genuinely empty search criteria (no query, no fields) must still return no results");
+   }
+
+   @Test
+   void queryAndFieldsTogetherStillMatchOnTableNameAloneWhenNoColumnMatches() throws Exception {
+      MetadataApiService service = createSpiedService(
+         oneTableFixture("orders"), columnFixture("UNRELATED_COLUMN"));
+
+      SchemaSearchRequest request = new SchemaSearchRequest();
+      request.setQuery("order");
+      request.setFields(List.of("NOT_A_REAL_COLUMN"));
+
+      SchemaSearchResponse response = service.searchSchema(request, mock(Principal.class));
+
+      assertEquals(1, response.getResults().size(),
+         "a table-name match alone (query 'order' vs table 'orders') must still be included " +
+         "when a fields list is also supplied but contributes no column match -- the fix's " +
+         "queryLower-computation move must not have broken the non-empty-query path");
+      assertEquals("orders", response.getResults().get(0).getTable());
    }
 }


### PR DESCRIPTION
## Summary
- `MetadataApiService.searchSchema` checked `Tool.isEmptyString(query)` and returned an empty result *before* `request.getFields()` was ever read, so a fields-only column search (`query: ""`, `fields: ["PRODUCT_ID"]`) always returned `[]`, even when a table genuinely had that column. Any non-empty query (even nonsense) happened to work, since it cleared the guard and let the `fields`/`columnMatches` path run — masking the bug for every caller that filled in a placeholder query.
- Moves the `fields`/`searchColumns` computation above the guard and changes the short-circuit condition from "query is empty" to "query is empty **and** there are no fields to search on", so a fields-only request reaches `findColumnMatches`.
- `queryLower` is now `null` (not `""`) when `query` is empty, and the `tableMatches` computation is guarded on `queryLower != null` — `String.contains("")` is trivially always true, so leaving it as `""` would have made every table match on name alone once `fields` is also present (a different, over-broad bug).

## Test plan
- [x] New regression tests in `MetadataApiServiceSchemaSearchTest`: empty query + real fields finds the match; nonsense query + same fields matches identically; empty query + empty fields still short-circuits to `[]`; query + fields together still match on table name alone when no column matches.
- [x] `./mvnw test -pl core -Dtest=MetadataApiServiceSchemaSearchTest` — 9/9 pass.
- [x] Confirmed load-bearing: reverting only the production fix (keeping the new tests) fails `emptyQueryWithFieldsStillFindsMatchingColumns` (`expected: <1> but was: <0>`) while the other 8 tests still pass; restoring the fix returns to 9/9.