### PR TITLE
Bug #75686, animate pie slice borders with their slices

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -532,6 +532,12 @@ public class SVGAnimationDOMInjector {
          return;
       }
 
+      // Pair each fill path with the wedge-border path(s) Batik emits alongside it when the pie
+      // has a slice border, so the outline sweeps in with its slice instead of showing the pie's
+      // whole group structure from the first paint.  Built here, before any "d" is rewritten,
+      // because "d" is the pairing key.
+      Map<Element, List<Element>> companions = buildSliceCompanions(slices);
+
       // Detect and reclassify donut center-hole overlays; a faceted donut has one per panel.
       List<double[]> holes = preprocessDonutHoles(svgRoot);
 
@@ -560,7 +566,7 @@ public class SVGAnimationDOMInjector {
          // that, so fall back to the opacity fade.  All panels begin at t=0 (facets in parallel).
          boolean tiled = isPanelTiled(panel, viewport);
          double endTime = animatePiePanel(panel.slices, panel.center, hole, tiled,
-                                          cssKeyframes, kfCounter);
+                                          cssKeyframes, kfCounter, companions);
          maxEndTime = Math.max(maxEndTime, endTime);
       }
 
@@ -665,11 +671,17 @@ public class SVGAnimationDOMInjector {
     * <p>@keyframes rules are appended to the shared {@code cssKeyframes} buffer (flushed once by
     * the caller) and named via the shared {@code kfCounter} so names stay unique across panels.
     *
+    * <p>{@code slices} holds only the fill paths, so all the grouping and timing below sees the
+    * same input it always has.  A slice's border path, if it has one, rides along via
+    * {@code companions} — see {@link #buildSliceCompanions}.
+    *
+    * @param companions slice -&gt; border path(s) to animate in lockstep with it.
     * @return the time (seconds) at which this panel's last slice finishes animating.
     */
    private static double animatePiePanel(List<Element> slices, double[] pieCenter,
                                          double[] holeParams, boolean tiled,
-                                         StringBuilder cssKeyframes, int[] kfCounter)
+                                         StringBuilder cssKeyframes, int[] kfCounter,
+                                         Map<Element, List<Element>> companions)
    {
       final double SLICE_DUR = AnimationConstants.PIE_SLICE_DURATION;
       // Tolerance (radians, ~0.06°) for treating two arc start angles as the same logical slice.
@@ -729,9 +741,10 @@ public class SVGAnimationDOMInjector {
       // the pie is clipped across tiles where the sweep's rewritten "d" would not survive.
       if(numArcGroups == 0 || tiled) {
          for(int si = 0; si < slices.size(); si++) {
-            mergeStyle(slices.get(si), String.format(java.util.Locale.US,
+            styleSlice(slices.get(si), String.format(java.util.Locale.US,
                "opacity:0;animation:inetsoft-pie-fade %.2fs %s %.2fs both",
-               AnimationConstants.PIE_FADE_DURATION, AnimationConstants.PIE_FADE_EASING, si * SLICE_DUR));
+               AnimationConstants.PIE_FADE_DURATION, AnimationConstants.PIE_FADE_EASING, si * SLICE_DUR),
+               companions);
          }
 
          return slices.size() * SLICE_DUR;
@@ -808,9 +821,9 @@ public class SVGAnimationDOMInjector {
                ? groupBegin[myArcIdx]
                : findDepthFaceDelay(d, groupKeys, groupBegin);
             if(snapDelay >= 0) {
-               mergeStyle(slice, String.format(java.util.Locale.US,
+               styleSlice(slice, String.format(java.util.Locale.US,
                   "opacity:0;animation:inetsoft-pie-fade 0.001s steps(1,start) %.3fs both",
-                  snapDelay));
+                  snapDelay), companions);
             }
             continue;
          }
@@ -836,9 +849,9 @@ public class SVGAnimationDOMInjector {
 
                if(isDepthFace) {
                   // Arc depth face: snap to full opacity when this slice's sweep begins.
-                  mergeStyle(slice, String.format(java.util.Locale.US,
+                  styleSlice(slice, String.format(java.util.Locale.US,
                      "opacity:0;animation:inetsoft-pie-fade 0.001s steps(1,start) %.3fs both",
-                     delay));
+                     delay), companions);
                   continue;
                }
 
@@ -908,7 +921,7 @@ public class SVGAnimationDOMInjector {
                   : String.format(java.util.Locale.US,
                      "M%.4f %.4f A%.4f %.4f %.0f 0 %.0f %.4f %.4f L%.4f %.4f Z",
                      sx, sy, rx, ry, xrot, sw, sx, sy, cx, cy);
-               slice.setAttribute("d", fromD);
+               setSliceD(slice, fromD, companions);
 
                // Build a unique @keyframes rule for this slice's sweep path sequence.
                // CSS d-property animation requires path() wrapper around each SVG path string.
@@ -925,16 +938,16 @@ public class SVGAnimationDOMInjector {
                }
 
                cssKeyframes.append("}");
-               mergeStyle(slice, String.format(java.util.Locale.US,
-                  "animation:%s %.3fs linear %.3fs forwards", kfName, sliceDur, delay));
+               styleSliceSweep(slice, kfName, sliceDur, delay, companions);
                continue;
             }
          }
 
          // No center available: opacity fade.
-         mergeStyle(slice, String.format(java.util.Locale.US,
+         styleSlice(slice, String.format(java.util.Locale.US,
             "opacity:0;animation:inetsoft-pie-fade %.2fs %s %.2fs both",
-            AnimationConstants.PIE_FADE_DURATION, AnimationConstants.PIE_FADE_EASING, delay));
+            AnimationConstants.PIE_FADE_DURATION, AnimationConstants.PIE_FADE_EASING, delay),
+            companions);
       }
 
       return totalAnimEndTime;
@@ -1748,15 +1761,191 @@ public class SVGAnimationDOMInjector {
             // are never treated as pie slices.
             textGroups.add(c);
          }
-         // Pie slices from Batik are rendered with stroke="none" by default.
-         // If a chart is configured with a visible slice border/stroke, getAttribute("stroke")
-         // won't return "none" and those slices will be silently skipped (no animation).
+         // Batik writes stroke="none" on the path it emits for a fill() call, so this predicate
+         // picks out the filled wedge and skips the separate stroked path that BarVO.paintLine
+         // draws over the same shape when the slice has a border.  Those border paths are paired
+         // back to their fill by buildSliceCompanions() and animated alongside it.
          else if("path".equals(c.getLocalName()) && "none".equals(c.getAttribute("stroke"))) {
             slices.add(c);
          }
          else {
             collectSlicesAndText(c, slices, textGroups);
          }
+      }
+   }
+
+   /**
+    * Pair each collected pie slice fill path with the border path(s) that trace the same geometry.
+    *
+    * <p>A pie whose binding has a group dimension gets a slice border: {@code GraphGenerator}
+    * gives the IntervalElement a {@code StaticLineFrame(new GLine(1))} so adjacent slices stay
+    * distinguishable.  {@code BarVO.paintBar} then fills the wedge and strokes the SAME
+    * {@code Shape}, so Batik writes two sibling {@code <path>} elements with an identical
+    * {@code d} inside the one {@code <g class="inetsoft-bar">} annotation group:
+    *
+    * <pre>
+    * &lt;g class="inetsoft-bar" data-row=".." data-col=".."&gt;
+    *   &lt;g fill="red" stroke="red"&gt;
+    *     &lt;path d="M93.3 25 A50 50 0 0 0 25 6.7L 50 50 Z" stroke="none"/&gt;   &lt;!-- fill   --&gt;
+    *     &lt;path fill="none" d="M93.3 25 A50 50 0 0 0 25 6.7L 50 50 Z" stroke="black"/&gt; &lt;!-- border --&gt;
+    *   &lt;/g&gt;
+    * &lt;/g&gt;
+    * </pre>
+    *
+    * {@link #collectSlicesAndText} takes the fill (it carries {@code stroke="none"}) and skips the
+    * border (it carries {@code fill="none"}), so before this pairing the complete set of wedge
+    * outlines — the pie's group boundaries — was painted at full geometry in the very first frame
+    * while only the fills swept in.
+    *
+    * <p>Matching on the identical {@code d} within the enclosing annotation group is exact and is
+    * robust against Batik hoisting fill/stroke onto an intermediate {@code <g>} (see
+    * {@link #firstDescendantPath}) and against a group holding more than one wedge geometry.  A
+    * slice with no enclosing {@code inetsoft-bar} group simply has no companions, which preserves
+    * the previous behaviour.
+    *
+    * <p>A border is claimed by the first slice that matches it.  With the "apply effect" (shine)
+    * option {@code BarVO.applyEffect} fills the very same wedge path twice more with gradients,
+    * and those two extra paths also carry {@code stroke="none"} and so are collected as slices
+    * too — without the claim check the one border would accumulate three stacked
+    * {@code animation} declarations and only the last would take effect.
+    *
+    * <p>Only {@code inetsoft-bar} groups are considered, which is all a pie needs: a 3D pie
+    * ({@code Pie3DVO}, which annotates with {@code inetsoft-pie} instead) never reaches here at
+    * all, because {@code VGraphPair.hasPieVO} skips {@code Pie3DVO} and so no animation hint is
+    * ever set for it.
+    *
+    * <p>Must be called BEFORE any {@code d} is rewritten, since {@code d} is the pairing key.
+    *
+    * @param slices the collected fill paths, in DOM order.
+    * @return slice -&gt; its border path(s); slices with no companion are absent from the map.
+    */
+   private static Map<Element, List<Element>> buildSliceCompanions(List<Element> slices) {
+      Set<Element> sliceSet = Collections.newSetFromMap(new IdentityHashMap<>());
+      sliceSet.addAll(slices);
+      // Borders already paired to an earlier slice, so a duplicated fill cannot re-claim them.
+      Set<Element> claimed = Collections.newSetFromMap(new IdentityHashMap<>());
+      Map<Element, List<Element>> companions = new IdentityHashMap<>();
+
+      for(Element slice : slices) {
+         Element annot = enclosingAnnotationGroup(slice, SVGSupport.ANNOTATION_BAR);
+         String d = slice.getAttribute("d");
+
+         if(annot == null || d.isEmpty()) {
+            continue;
+         }
+
+         List<Element> paths = new ArrayList<>();
+         collectDescendantPaths(annot, paths);
+         List<Element> borders = paths.stream()
+            .filter(p -> !sliceSet.contains(p) && !claimed.contains(p)
+               && d.equals(p.getAttribute("d")))
+            .collect(Collectors.toList());
+
+         if(!borders.isEmpty()) {
+            claimed.addAll(borders);
+            companions.put(slice, borders);
+         }
+      }
+
+      return companions;
+   }
+
+   /** The nearest ancestor-or-self {@code <g class="cssClass">} of {@code el}, or null. */
+   private static Element enclosingAnnotationGroup(Element el, String cssClass) {
+      for(Node n = el; n instanceof Element e; n = n.getParentNode()) {
+         if(cssClass.equals(e.getAttribute("class"))) {
+            return e;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Collect the {@code <path>} descendants of {@code root}, in DOM order.
+    *
+    * <p>Only {@code <g>} children are descended into — the same restriction
+    * {@link #firstDescendantPath} uses, since Batik's only nesting inside an annotation group is
+    * the intermediate {@code <g>} it emits for a fill/stroke state change.  This keeps
+    * {@code <defs>}, {@code <clipPath>} and {@code <pattern>} content out of the results, so a
+    * referenced shape can never be mistaken for a wedge outline and have its geometry rewritten.
+    */
+   private static void collectDescendantPaths(Element root, List<Element> out) {
+      NodeList children = root.getChildNodes();
+
+      for(int i = 0; i < children.getLength(); i++) {
+         if(!(children.item(i) instanceof Element c)) {
+            continue;
+         }
+
+         if("path".equals(c.getLocalName())) {
+            out.add(c);
+         }
+         else if("g".equals(c.getLocalName())) {
+            collectDescendantPaths(c, out);
+         }
+      }
+   }
+
+   /** Set the {@code d} attribute on a slice and, in lockstep, on each of its border companions. */
+   private static void setSliceD(Element slice, String d,
+                                 Map<Element, List<Element>> companions)
+   {
+      slice.setAttribute("d", d);
+
+      for(Element border : companions.getOrDefault(slice, List.of())) {
+         border.setAttribute("d", d);
+      }
+   }
+
+   /**
+    * Merge {@code style} into a slice and, in lockstep, into each of its border companions.
+    *
+    * <p>Used for every styling outcome whose style already gates opacity
+    * ({@code opacity:0;animation:inetsoft-pie-fade ... both}): the staggered fade fallback, the 3D
+    * depth-face snap and the no-center fade.  The border is then hidden for exactly the same
+    * interval and revealed on exactly the same timeline as its fill.
+    */
+   private static void styleSlice(Element slice, String style,
+                                  Map<Element, List<Element>> companions)
+   {
+      mergeStyle(slice, style);
+
+      for(Element border : companions.getOrDefault(slice, List.of())) {
+         mergeStyle(border, style);
+      }
+   }
+
+   /**
+    * Apply the arc-sweep animation to a slice and, in lockstep, to its border companions.
+    *
+    * <p>The fill gets the sweep alone: its from-state {@code d} encloses zero area, so it is
+    * invisible throughout the delay without any opacity handling and {@code forwards} suffices.
+    *
+    * <p>A border cannot rely on that.  The from-state {@code M sx sy A ... sx sy L cx cy Z} is a
+    * degenerate arc, which SVG treats as omitted (SVG 1.1 §8.3.8), leaving
+    * {@code moveto -> lineto(hub) -> closepath}: zero area when filled, but a 1px radial hairline
+    * from the rim to the hub when STROKED.  Ungated, every slice's border would draw a visible
+    * spoke at t=0 — an asterisk across the whole pie.  So a companion also gets
+    * {@code inetsoft-pie-fade} as a {@code steps(1,start)} snap at the same delay: the backwards
+    * fill holds {@code opacity:0} through the delay and flips it to 1 exactly when the sweep
+    * begins.  Same idiom as the 3D depth faces below.
+    *
+    * <p>The sweep keyframes themselves are shared rather than duplicated: {@code @keyframes} have
+    * no element affinity, and identical geometry means the fill and its outline interpolate
+    * identically with no chance of drift.
+    */
+   private static void styleSliceSweep(Element slice, String kfName, double sliceDur,
+                                       double delay, Map<Element, List<Element>> companions)
+   {
+      mergeStyle(slice, String.format(java.util.Locale.US,
+         "animation:%s %.3fs linear %.3fs forwards", kfName, sliceDur, delay));
+
+      for(Element border : companions.getOrDefault(slice, List.of())) {
+         mergeStyle(border, String.format(java.util.Locale.US,
+            "opacity:0;animation:%s %.3fs linear %.3fs forwards,"
+               + "inetsoft-pie-fade 0.001s steps(1,start) %.3fs both",
+            kfName, sliceDur, delay, delay));
       }
    }
 

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -2471,6 +2471,423 @@ class SVGAnimationDOMInjectorTest {
    }
 
    // -------------------------------------------------------------------------
+   // Bordered (grouped) pie animation tests
+   //
+   // A pie whose binding has a group dimension gets a 1px slice border (GraphGenerator gives the
+   // IntervalElement a StaticLineFrame), so BarVO.paintBar fills the wedge and then strokes the
+   // same Shape.  Batik writes the two as sibling <path> elements with an identical "d" inside
+   // one <g class="inetsoft-bar">, and only the fill carries stroke="none".  The border used to
+   // be skipped entirely, painting the pie's whole group structure in the first frame while the
+   // fills swept in behind it.
+   // -------------------------------------------------------------------------
+
+   /**
+    * Re-parents {@code slice} into a {@code <g class="inetsoft-bar">} annotation group holding a
+    * Batik style-wrapper {@code <g>}, and adds the border path that {@code BarVO.paintLine} draws
+    * over the same shape — {@code fill="none"}, its own stroke, and an identical {@code d}:
+    *
+    * <pre>
+    * &lt;g class="inetsoft-bar"&gt;&lt;g fill="red" stroke="red"&gt;
+    *   &lt;path d="M.. A.. L.. Z" stroke="none"/&gt;
+    *   &lt;path fill="none" d="M.. A.. L.. Z" stroke="black"/&gt;
+    * &lt;/g&gt;&lt;/g&gt;
+    * </pre>
+    *
+    * <p>Batik may instead put the draw pass in a second sibling {@code <g>}, and may omit the
+    * border's own {@code stroke} when it matches the inherited one.  Pairing is by {@code d}
+    * within the annotation group, so both shapes behave identically; this one nests the two paths
+    * together to also cover the deeper-than-direct-child case.
+    *
+    * @return the border path element.
+    */
+   private static Element addSliceBorder(Document doc, Element slice) {
+      Element parent = (Element) slice.getParentNode();
+      Element annot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      annot.setAttribute("class", SVGSupport.ANNOTATION_BAR);
+      Element wrapper = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
+      wrapper.setAttribute("fill", "red");
+      wrapper.setAttribute("stroke", "red");
+      annot.appendChild(wrapper);
+      parent.replaceChild(annot, slice);
+      wrapper.appendChild(slice);
+      return appendBorderPath(doc, wrapper, slice.getAttribute("d"));
+   }
+
+   /** Appends a Batik draw-pass path ({@code fill="none"}, stroked) with the given geometry. */
+   private static Element appendBorderPath(Document doc, Element parent, String d) {
+      Element border = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      border.setAttribute("fill", "none");
+      border.setAttribute("stroke", "black");
+      border.setAttribute("d", d);
+      parent.appendChild(border);
+      return border;
+   }
+
+   /** Extracts the delay (as formatted) from an {@code inetsoft-pie-sweep-N} animation style. */
+   private static String sweepDelay(String style) {
+      Matcher m = Pattern.compile("inetsoft-pie-sweep-\\d+ [\\d.]+s linear ([\\d.]+)s")
+         .matcher(style);
+      return m.find() ? m.group(1) : null;
+   }
+
+   /**
+    * The wedge outline must sweep in on exactly its own slice's timeline: same keyframes rule,
+    * same duration, same delay, same rewritten from-state geometry.
+    */
+   @Test
+   void groupedPie_borderSweepsWithItsOwnFill() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element b = addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      Element borderA = addSliceBorder(doc, a);
+      Element borderB = addSliceBorder(doc, b);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      for(Element[] pair : List.of(new Element[]{ a, borderA }, new Element[]{ b, borderB })) {
+         String fillStyle = pair[0].getAttribute("style");
+         String borderStyle = pair[1].getAttribute("style");
+
+         assertNotNull(sweepKeyframeName(fillStyle), "fill must sweep");
+         assertEquals(sweepKeyframeName(fillStyle), sweepKeyframeName(borderStyle),
+                      "border must reference its own slice's sweep keyframes, not another's");
+         // The fill's whole animation string appears verbatim as the border's first animation,
+         // which pins duration and delay as well as the keyframes name.
+         assertTrue(borderStyle.contains(fillStyle),
+                    "border must run the identical sweep as its fill: " + borderStyle);
+         assertEquals(pair[0].getAttribute("d"), pair[1].getAttribute("d"),
+                      "border must be rewritten to the same zero-arc from-state as its fill");
+      }
+
+      assertNotEquals(sweepKeyframeName(borderA.getAttribute("style")),
+                      sweepKeyframeName(borderB.getAttribute("style")),
+                      "each slice keeps its own sweep, so the two borders must differ");
+   }
+
+   /**
+    * The zero-length-arc from-state is invisible when filled (it encloses no area) but draws a
+    * radial hairline from the rim to the hub when STROKED.  So the border must be held at
+    * {@code opacity:0} until its own sweep begins, otherwise every slice's spoke shows at t=0 —
+    * an asterisk across the pie, which is the same defect in a different costume.
+    */
+   @Test
+   void groupedPie_borderHiddenUntilItsSweepBegins() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element b = addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      Element borderA = addSliceBorder(doc, a);
+      Element borderB = addSliceBorder(doc, b);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      for(Element[] pair : List.of(new Element[]{ a, borderA }, new Element[]{ b, borderB })) {
+         String delay = sweepDelay(pair[0].getAttribute("style"));
+         String borderStyle = pair[1].getAttribute("style");
+
+         assertNotNull(delay, "fill must carry a sweep delay");
+         assertTrue(borderStyle.startsWith("opacity:0"),
+                    "border must start hidden: " + borderStyle);
+         // steps(1,start) + both: the backwards fill holds opacity 0 through the delay, then it
+         // snaps to 1 exactly when the sweep starts.
+         assertTrue(borderStyle.contains(
+                       "inetsoft-pie-fade 0.001s steps(1,start) " + delay + "s both"),
+                    "border must be revealed at its own sweep delay (" + delay + "s): "
+                       + borderStyle);
+      }
+   }
+
+   /**
+    * The load-bearing no-regression test: pairing the border in must not perturb the fill's
+    * geometry, timing or the generated CSS by so much as a character.  {@code slices} still
+    * holds only fill paths, so the grouping and duration math sees identical input.
+    */
+   @Test
+   void groupedPie_fillStyleIdenticalToUngroupedPie() throws Exception {
+      Document plain = newDocument();
+      Element pa = addPieSlice(plain, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element pb = addPieSlice(plain, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+
+      Document bordered = newDocument();
+      Element ba = addPieSlice(bordered, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element bb = addPieSlice(bordered, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      addSliceBorder(bordered, ba);
+      addSliceBorder(bordered, bb);
+
+      SVGAnimationDOMInjector.injectAnimation(plain.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+      SVGAnimationDOMInjector.injectAnimation(bordered.getDocumentElement(),
+                                              SVGSupport.ANIMATION_PIE);
+
+      assertEquals(pa.getAttribute("style"), ba.getAttribute("style"),
+                   "border pairing must not change the fill's animation");
+      assertEquals(pb.getAttribute("style"), bb.getAttribute("style"),
+                   "border pairing must not change the fill's animation");
+      assertEquals(pa.getAttribute("d"), ba.getAttribute("d"),
+                   "border pairing must not change the fill's from-state");
+      assertEquals(allStyleContent(plain.getDocumentElement()),
+                   allStyleContent(bordered.getDocumentElement()),
+                   "border pairing must not change the generated CSS");
+   }
+
+   /** Borders share their slice's keyframes rule rather than duplicating the sweep CSS. */
+   @Test
+   void groupedPie_sweepKeyframesNotDuplicated() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element b = addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      addSliceBorder(doc, a);
+      addSliceBorder(doc, b);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertEquals(2, countOccurrences(allStyleContent(doc.getDocumentElement()),
+                                       "@keyframes inetsoft-pie-sweep-"),
+                   "one sweep rule per fill slice — borders share, they do not duplicate");
+   }
+
+   /**
+    * Bezier donut rings have no arc command, so the whole panel falls back to the staggered
+    * opacity fade.  That style already gates opacity, so the border gets it verbatim and is
+    * hidden and revealed on exactly its slice's timeline.
+    */
+   @Test
+   void groupedBezierDonut_borderFadesWithFill() throws Exception {
+      Document doc = newDocument();
+      Element r1 = addRingSlice(doc, 100, 100, 0, 120);
+      Element r2 = addRingSlice(doc, 100, 100, 120, 120);
+      Element border1 = addSliceBorder(doc, r1);
+      Element border2 = addSliceBorder(doc, r2);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      for(Element[] pair : List.of(new Element[]{ r1, border1 }, new Element[]{ r2, border2 })) {
+         String fillStyle = pair[0].getAttribute("style");
+
+         assertTrue(fillStyle.contains("inetsoft-pie-fade"), "bezier ring must use the fade");
+         assertEquals(fillStyle, pair[1].getAttribute("style"),
+                      "border must fade on exactly its slice's timeline");
+      }
+
+      assertNotEquals(r1.getAttribute("style"), r2.getAttribute("style"),
+                      "the fade is staggered per slice, so the two must differ");
+   }
+
+   /**
+    * An arc donut (hole detected) rewrites slices to a two-arc ring from-state, which likewise
+    * collapses to a radial spoke when stroked.  The border must get the same ring geometry, the
+    * same ring keyframes, and the opacity gate.
+    */
+   @Test
+   void groupedArcDonut_borderGetsRingFromState() throws Exception {
+      Document doc = newDocument();
+      addHoleOverlay(doc, 100, 100, 30);
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element border = addSliceBorder(doc, a);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      String d = a.getAttribute("d");
+      assertEquals(2, countOccurrences(d, "A"), "donut from-state must be a ring (two arcs)");
+      assertEquals(d, border.getAttribute("d"), "border must get the same ring from-state");
+      assertEquals(sweepKeyframeName(a.getAttribute("style")),
+                   sweepKeyframeName(border.getAttribute("style")),
+                   "border must share its slice's ring keyframes");
+      assertTrue(border.getAttribute("style").startsWith("opacity:0"),
+                 "the ring from-state is a stroked spoke, so the border must start hidden");
+   }
+
+   /**
+    * On a grouped donut the center-hole overlay picks up a border too — a second stroked
+    * {@code <circle>}, not a {@code <path>} — so hole detection (which requires a circle and no
+    * path) must still fire and keep the overlay pinned opaque.
+    */
+   @Test
+   void groupedDonut_holeOverlayStillReclassified() throws Exception {
+      Document doc = newDocument();
+      Element hole = addHoleOverlay(doc, 100, 100, 30);
+      Element holeBorder = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "circle");
+      holeBorder.setAttribute("fill", "none");
+      holeBorder.setAttribute("stroke", "black");
+      holeBorder.setAttribute("cx", "100");
+      holeBorder.setAttribute("cy", "100");
+      holeBorder.setAttribute("r", "30");
+      hole.appendChild(holeBorder);
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      addSliceBorder(doc, a);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertEquals(SVGSupport.ANNOTATION_DONUT_HOLE, hole.getAttribute("class"),
+                   "a bordered hole overlay must still be reclassified");
+      assertTrue(hole.getAttribute("style").contains("opacity:1!important"),
+                 "hole overlay must stay pinned opaque");
+      assertTrue(a.getAttribute("style").contains("inetsoft-pie-sweep"),
+                 "the hole must still be recognised so slices sweep as a ring");
+   }
+
+   /**
+    * Companion matching is scoped to the enclosing annotation group, so an unrelated stroked path
+    * that merely happens to share a slice's geometry is never touched.  This also locks in the
+    * no-op for a 3D pie, whose faces have no {@code inetsoft-bar} group at all.
+    */
+   @Test
+   void pieSliceOutsideAnnotationGroup_getsNoCompanion() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      // Same geometry, stroked, but not inside any annotation group.
+      Element stray = appendBorderPath(doc, doc.getDocumentElement(), a.getAttribute("d"));
+      String origStrayD = stray.getAttribute("d");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertTrue(a.getAttribute("style").contains("inetsoft-pie-sweep"), "the slice must sweep");
+      assertEquals("", stray.getAttribute("style"),
+                   "a path outside the slice's annotation group must not be animated");
+      assertEquals(origStrayD, stray.getAttribute("d"),
+                   "a path outside the slice's annotation group must keep its geometry");
+   }
+
+   /**
+    * A collected path with no arc command alongside slices that do have one (a mixed donut, or a
+    * 3D depth quad) snaps to opaque when the matching slice's sweep begins rather than sweeping
+    * itself.  Its border must snap on the same beat.
+    *
+    * <p>Note this covers the non-arc snap branch generically, not a real 3D pie: a 3D pie is
+    * drawn by {@code Pie3DVO}, which {@code VGraphPair.hasPieVO} skips, so it never receives an
+    * animation hint and never reaches this code at all.
+    */
+   @Test
+   void nonArcSlice_borderSnapsWithItsFace() throws Exception {
+      Document doc = newDocument();
+      Element top = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 160, 100, 100);
+      addSliceBorder(doc, top);
+      Element depth = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      depth.setAttribute("stroke", "none");
+      depth.setAttribute("d", "M100 160 L180 100 L180 120 L100 180 Z");
+      doc.getDocumentElement().appendChild(depth);
+      Element depthBorder = addSliceBorder(doc, depth);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      String depthStyle = depth.getAttribute("style");
+      assertTrue(depthStyle.contains("steps(1,start)"), "depth quad must snap, not sweep");
+      assertEquals(depthStyle, depthBorder.getAttribute("style"),
+                   "depth-face border must snap on the same beat as its face");
+   }
+
+   /** A pie clipped across tiles falls back to the fade; the border must follow it there too. */
+   @Test
+   void tiledGroupedPie_borderFadesWithFill() throws Exception {
+      Document doc = newDocument();   // viewBox 0 0 800 600
+      // Pie center (600,300), r=500 → bbox width 1000 > 800: larger than the tile.
+      Element a = addPieSlice(doc, 1100, 300, 500, 0, 1, 600, 800, 600, 300);
+      Element b = addPieSlice(doc, 600, 800, 500, 0, 1, 100, 300, 600, 300);
+      Element borderA = addSliceBorder(doc, a);
+      addSliceBorder(doc, b);
+      String origBorderD = borderA.getAttribute("d");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertTrue(a.getAttribute("style").contains("inetsoft-pie-fade"), "tiled pie must fade");
+      assertEquals(a.getAttribute("style"), borderA.getAttribute("style"),
+                   "border must fade with its slice");
+      assertEquals(origBorderD, borderA.getAttribute("d"),
+                   "the fade must not rewrite the border's geometry either");
+   }
+
+   /**
+    * {@code GShape} can emit an outline pass on top of the fill in addition to the line frame's
+    * border, so one annotation group may hold more than one companion.  Every one must animate.
+    */
+   @Test
+   void groupedPie_multipleCompanionsAllAnimated() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      Element border1 = addSliceBorder(doc, a);
+      Element border2 = appendBorderPath(doc, (Element) border1.getParentNode(),
+                                         a.getAttribute("d"));
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      String kf = sweepKeyframeName(a.getAttribute("style"));
+
+      for(Element border : List.of(border1, border2)) {
+         assertEquals(kf, sweepKeyframeName(border.getAttribute("style")),
+                      "every companion must share the slice's sweep");
+         assertEquals(a.getAttribute("d"), border.getAttribute("d"),
+                      "every companion must get the slice's from-state");
+      }
+   }
+
+   /**
+    * With the "apply effect" (shine) chart option, {@code BarVO.applyEffect} fills the very same
+    * wedge path twice more with gradients.  Those extra paths also carry {@code stroke="none"},
+    * so they are collected as slices too — and the one border must be claimed by only the first
+    * of them, or it accumulates a stack of {@code animation} declarations of which only the last
+    * has any effect.
+    */
+   @Test
+   void groupedPie_duplicateShineFillsClaimBorderOnce() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      Element border = addSliceBorder(doc, a);
+      Element wrapper = (Element) border.getParentNode();
+      // The two gradient overlay fills applyEffect draws over the same wedge.
+      for(int i = 0; i < 2; i++) {
+         Element shine = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+         shine.setAttribute("stroke", "none");
+         shine.setAttribute("fill", "url(#gradient" + i + ")");
+         shine.setAttribute("d", a.getAttribute("d"));
+         wrapper.appendChild(shine);
+      }
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      String borderStyle = border.getAttribute("style");
+      assertEquals(1, countOccurrences(borderStyle, "animation:"),
+                   "border must be claimed once, not once per duplicated fill: " + borderStyle);
+      assertEquals(1, countOccurrences(borderStyle, "opacity:0"),
+                   "border must carry a single opacity gate: " + borderStyle);
+      assertEquals(sweepKeyframeName(a.getAttribute("style")),
+                   sweepKeyframeName(borderStyle),
+                   "border must follow the slice that claimed it");
+   }
+
+   /**
+    * Referenced geometry ({@code <defs>}/{@code <clipPath>}) can share a slice's {@code d} without
+    * being a wedge outline.  Rewriting it would corrupt the reference, so the companion search
+    * descends only into {@code <g>}.
+    */
+   @Test
+   void groupedPie_defsContentNotTreatedAsBorder() throws Exception {
+      Document doc = newDocument();
+      Element a = addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      addPieSlice(doc, 100, 180, 80, 0, 1, 20, 100, 100, 100);
+      Element border = addSliceBorder(doc, a);
+      Element annot = (Element) border.getParentNode().getParentNode();
+      Element defs = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "defs");
+      Element clip = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "clipPath");
+      clip.setAttribute("id", "clip1");
+      Element clipPath = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
+      clipPath.setAttribute("d", a.getAttribute("d"));
+      clip.appendChild(clipPath);
+      defs.appendChild(clip);
+      annot.appendChild(defs);
+      String origClipD = clipPath.getAttribute("d");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_PIE);
+
+      assertTrue(border.getAttribute("style").contains("inetsoft-pie-sweep"),
+                 "the real border must still be animated");
+      assertEquals(origClipD, clipPath.getAttribute("d"),
+                   "clip-path geometry must never be rewritten");
+      assertEquals("", clipPath.getAttribute("style"),
+                   "clip-path geometry must never be animated");
+   }
+
+   // -------------------------------------------------------------------------
    // Relation / tree / network chart tests
    // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Open viewsheet `pie` in the portal. When the pie chart's binding contains a **Group** dimension, the pie's full wedge outlines are already painted in the first frame — the group structure is visible before the animation starts. Only the slice *fills* sweep in.

## Root cause

Three things line up, which is why it only reproduces when a group exists:

1. `GraphGenerator.java:4894-4899` — when a chart has group fields and at least one group *dimension*, the `IntervalElement` gets `setLineFrame(new StaticLineFrame(new GLine(1)))`: *"add border around each piece otherwise it's not distinguishable."* This gate is exactly the "when pie chart exist group" condition.

2. `BarVO.paintBar()` fills the wedge and then strokes the **same `Shape`**, so Batik emits two sibling `<path>` elements with an identical `d` inside one `<g class="inetsoft-bar">` — the fill carrying `stroke="none"`, the border carrying `fill="none"`:

```
<g class="inetsoft-bar" data-row=".." data-col="..">
  <g fill="red" stroke="red">
    <path d="M100 50 A50 50 0 0 0 25 6.7 L50 50 Z" stroke="none"/>
    <path fill="none" d="M100 50 A50 50 0 0 0 25 6.7 L50 50 Z" stroke="black"/>
  </g>
</g>
```

3. `SVGAnimationDOMInjector.collectSlicesAndText()` collects only paths whose own `stroke` is `"none"`. The border path was never collected, never given a from-state and never animated, so it rendered at full geometry and full opacity from frame 0.

Pie is the only chart type affected — every other `inject*Animation` styles the whole annotation `<g>`, which covers the border for free. Pie has to style individual paths because it rewrites `d` for the arc sweep.

## Fix

`SVGAnimationDOMInjector` only. No change to `GraphGenerator` or `BarVO`: the border itself is intended and correct at rest, only its entrance was wrong.

`buildSliceCompanions()` pairs each fill path with the border path(s) sharing its `d` within the enclosing annotation group, and all six per-slice styling outcomes now route through `setSliceD` / `styleSlice` / `styleSliceSweep`. `slices` still holds only fill paths, so panel partitioning, angle grouping, durations and stagger see identical input — the existing animation's timing is untouched.

One subtlety worth calling out: the sweep's from-state is a *degenerate* arc, which SVG treats as omitted, leaving `moveto -> lineto(hub) -> closepath`. That encloses no area when filled (which is why the fill needs no opacity handling and `forwards` suffices), but draws a **radial hairline when stroked**. Copying just the `d` would have traded "full outline at load" for "an asterisk at load", so each border also gets an `inetsoft-pie-fade 0.001s steps(1,start) <delay>s both` gate — the same idiom already used for 3D depth faces.

A border is claimed by the first slice that matches it. With the apply-effect (shine) option, `BarVO.applyEffect` fills the same wedge twice more with gradients and those paths are collected as slices too, so without the claim check the one border would accumulate three stacked `animation` declarations of which only the last took effect.

3D pie never reaches this code: `VGraphPair.hasPieVO` skips `Pie3DVO`, so no animation hint is ever set for it.

## Verification

- **Batik DOM probe** (throwaway, not committed) confirmed the assumed structure exactly: identical `d`, `stroke="none"` on the fill, `fill="none"` on the border, both under the `inetsoft-bar` group.
- **End-to-end through real Batik + the injector** (throwaway, not committed): a 3-wedge bordered pie produced, per slice, a fill on `inetsoft-pie-sweep-N` and its border on the *same* rule plus the opacity gate at the *same* delay — durations proportional to sweep angle (0.250/0.188/0.313s for 120°/90°/150°), 3 keyframe rules for 3 slices, no duplication.
- **102/102 tests pass** in `inetsoft-xml-formats` (86 in `SVGAnimationDOMInjectorTest`, 13 new).
- **Negative check**: stashing the production change makes 7 of the new tests fail with exactly the expected messages (empty border style, `null` keyframe name, wrong from-state). The remaining new tests are no-regression guards and correctly pass either way — notably `groupedPie_fillStyleIdenticalToUngroupedPie`, which asserts the fill's `d`, `style` and the whole generated CSS are byte-identical with and without borders.
- **Visually confirmed** in the portal on the `pie` viewsheet: the plot starts blank and each wedge's outline grows with its fill; no outlines and no radial hairlines before the sweep. Regression-checked ungrouped pie, donut, faceted pie, and composer/binding (`:noanim`) rendering.

## Notes

Community-only change; no enterprise counterpart.

Two unrelated latent defects were found while tracing this and deliberately left out of scope — happy to file them separately:

- `@keyframes` names are not rewritten by `ChartInlineSvgDirective.uniquifyIds` (`chart-inline-svg.directive.ts:1663`). Inlined SVG `<style>` is document-global, so two pie charts on one dashboard both define `inetsoft-pie-sweep-0` and the last parsed wins.
- `collectSlicesAndText` lacks the `inetsoft-`-parent guard that `collectTextGroups` has, so a Batik style-wrapper `<g text-rendering="geometricPrecision">` inside an annotation group could be mistaken for a text label group. Not firing for pie today, but the asymmetry is a latent trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)