### PR TITLE
Bug #76473: fix classic-script embed parse error (elements/viewer-element)

### DIFF
--- a/web/gulp/elements.js
+++ b/web/gulp/elements.js
@@ -21,16 +21,27 @@ const sass = require("gulp-dart-sass");
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
 const cssnano = require("cssnano");
+const glob = require("glob");
+const path = require("path");
 const requireNonEmptyStream = require("./require-non-empty-stream");
+const { verifyClassicScriptBundle } = require("./verify-classic-script");
+const { rebundleMainForClassicScript } = require("./esbuild-classic-script-rebundle");
 
 // The esbuild @angular/build:application builder (in use for this project since the
 // Angular 17->18/esbuild migration) hashes output filenames as "<name>-<HASH>.js" and does
 // not emit a separate runtime chunk -- unlike the older Webpack builder's "<name>.<hash>.js"
 // convention these patterns used to target.
+const ngOutputDir = "target/generated-resources/ng/inetsoft/web/resources/elements";
+const rebundleDir = "target/generated-resources/gulp/tmp/elements";
+const appDir = "target/generated-resources/gulp/inetsoft/web/resources/app";
+
 const scriptFiles = [
-   "target/generated-resources/ng/inetsoft/web/resources/elements/polyfills-*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/elements/scripts-*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/elements/main-*.js"
+   path.join(ngOutputDir, "polyfills-*.js"),
+   path.join(ngOutputDir, "scripts-*.js"),
+   // Bug #76473: this is the esbuild-rebundled (format=iife, import.meta.url captured via
+   // ESM_SCRIPT_URL_BANNER) copy of Angular's main-*.js, not the raw ng build output -- see
+   // esbuild-classic-script-rebundle.js and docs/teams/2026-09-04-bug-76473/02b-fix-approach-decision.md.
+   path.join(rebundleDir, "main-*.js")
 ];
 
 const cssFiles = [
@@ -38,12 +49,61 @@ const cssFiles = [
    "target/generated-resources/ng/inetsoft/web/resources/elements/styles-*.css"
 ];
 
-gulp.task("elements:scripts", function () {
+// Bug #76473, piece 1+2: Angular's built main-*.js contains a literal import.meta.url
+// reference (HeartbeatWorkerService's Worker construction, reached via StompClientService),
+// which is a parse-time SyntaxError once concatenated into a classic (non-module) <script>.
+// Re-bundling it with esbuild --format=iife removes the literal import.meta, but only the
+// banner/define pair below makes the substitution a real, working script URL instead of
+// esbuild's silent empty-object stub (which would make the Worker construction throw a
+// caught TypeError and permanently, invisibly degrade to the setInterval fallback -- see
+// docs/teams/2026-09-04-bug-76473/01-hypothesis-esbuild-rebundle.md and 02b-fix-approach-decision.md).
+gulp.task("elements:scripts:bundle-main", function (callback) {
+   rebundleMainForClassicScript(ngOutputDir, rebundleDir);
+   callback();
+});
+
+// Bug #76473, piece 3: worker-*.js (Angular's own build output) must be a sibling of the
+// concatenated elements.js at serve time, since the rebundled main-*.js resolves the
+// Worker's URL relative to elements.js's own script URL (document.currentScript.src,
+// captured by ESM_SCRIPT_URL_BANNER). It is not a sibling today -- it lands under
+// .../resources/elements/ (a separate, unmapped Maven <resource> root from
+// .../resources/app/, per web/pom.xml, and for this project specifically that root is also
+// excluded entirely from the packaged jar by the maven-jar-plugin config in the same pom.xml).
+gulp.task("elements:scripts:copy-worker", function () {
+   const workerFiles = glob.sync(path.join(ngOutputDir, "worker-*.js"));
+
+   if(workerFiles.length === 0) {
+      return Promise.reject(new Error(
+         `elements:scripts:copy-worker found no worker-*.js in ${ngOutputDir} -- ` +
+         "expected Angular's production build to emit HeartbeatWorkerService's worker chunk."));
+   }
+
+   return gulp.src(workerFiles)
+      .pipe(gulp.dest(appDir));
+});
+
+gulp.task("elements:scripts:concat", function () {
    return gulp.src(scriptFiles)
       .pipe(requireNonEmptyStream("elements:scripts"))
       .pipe(concat("elements.js"))
-      .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/app/"));
+      .pipe(gulp.dest(appDir));
 });
+
+// Bug #76473: fail the build loudly if the concatenated bundle regresses back to being
+// unparseable as a classic script, or silently degrades via esbuild's import.meta stub --
+// same discipline as requireNonEmptyStream() above (added for Bug #76468), for a different
+// check.
+gulp.task("elements:scripts:verify", function (callback) {
+   verifyClassicScriptBundle(path.join(appDir, "elements.js"));
+   callback();
+});
+
+gulp.task("elements:scripts", gulp.series([
+   "elements:scripts:bundle-main",
+   "elements:scripts:copy-worker",
+   "elements:scripts:concat",
+   "elements:scripts:verify"
+]));
 
 gulp.task("elements:concat-css", function () {
    return gulp.src(cssFiles)

--- a/web/gulp/elements.js
+++ b/web/gulp/elements.js
@@ -21,12 +21,16 @@ const sass = require("gulp-dart-sass");
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
 const cssnano = require("cssnano");
+const requireNonEmptyStream = require("./require-non-empty-stream");
 
+// The esbuild @angular/build:application builder (in use for this project since the
+// Angular 17->18/esbuild migration) hashes output filenames as "<name>-<HASH>.js" and does
+// not emit a separate runtime chunk -- unlike the older Webpack builder's "<name>.<hash>.js"
+// convention these patterns used to target.
 const scriptFiles = [
-   "target/generated-resources/ng/inetsoft/web/resources/elements/runtime.*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/elements/polyfills.*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/elements/scripts.*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/elements/main.*.js"
+   "target/generated-resources/ng/inetsoft/web/resources/elements/polyfills-*.js",
+   "target/generated-resources/ng/inetsoft/web/resources/elements/scripts-*.js",
+   "target/generated-resources/ng/inetsoft/web/resources/elements/main-*.js"
 ];
 
 const cssFiles = [
@@ -36,6 +40,7 @@ const cssFiles = [
 
 gulp.task("elements:scripts", function () {
    return gulp.src(scriptFiles)
+      .pipe(requireNonEmptyStream("elements:scripts"))
       .pipe(concat("elements.js"))
       .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/app/"));
 });

--- a/web/gulp/elements.js
+++ b/web/gulp/elements.js
@@ -35,7 +35,7 @@ const scriptFiles = [
 
 const cssFiles = [
    "target/generated-resources/gulp/inetsoft/web/resources/app/global.css",
-   "target/generated-resources/ng/inetsoft/web/resources/elements/styles.*.css"
+   "target/generated-resources/ng/inetsoft/web/resources/elements/styles-*.css"
 ];
 
 gulp.task("elements:scripts", function () {

--- a/web/gulp/esbuild-classic-script-rebundle.js
+++ b/web/gulp/esbuild-classic-script-rebundle.js
@@ -59,6 +59,14 @@ function rebundleMainForClassicScript(ngOutputDir, rebundleDir) {
 
    const mainFile = matches[0];
    const outFile = path.join(rebundleDir, path.basename(mainFile));
+
+   // Angular's output filename is content-hashed, so on a workspace that isn't freshly cleaned
+   // between builds a code change produces a new hash and this would otherwise leave the
+   // previous run's main-<oldHash>.js sitting alongside it -- elements.js/viewer-element.js's
+   // scriptFiles glob (main-*.js against this same directory) would then match both, and
+   // gulp-concat would silently concatenate both into the final bundle (duplicate
+   // customElements.define(...) calls at runtime). Clear any stale content first.
+   fs.rmSync(rebundleDir, { recursive: true, force: true });
    fs.mkdirSync(rebundleDir, { recursive: true });
 
    esbuild.buildSync({

--- a/web/gulp/esbuild-classic-script-rebundle.js
+++ b/web/gulp/esbuild-classic-script-rebundle.js
@@ -1,0 +1,80 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+const fs = require("fs");
+const path = require("path");
+const glob = require("glob");
+const esbuild = require("esbuild");
+
+// Bug #76473: Angular's production build of the elements/viewer-element projects emits a
+// main-*.js that contains a literal import.meta.url reference (HeartbeatWorkerService's
+// `new Worker(new URL("worker-<HASH>.js", import.meta.url))`, reached via StompClientService --
+// see docs/teams/2026-09-04-bug-76473/00-map.md and 02-root-cause.md). That is correct code for
+// an ES module, but a parse-time SyntaxError once gulp-concat'd into the classic (non-module)
+// <script src="..."> these two projects' bundles are meant to be loaded as.
+//
+// A plain `esbuild --bundle --format=iife` pass over main-*.js does make the SyntaxError go
+// away, but silently: esbuild substitutes an empty-object stub for import.meta
+// ("var import_meta = {}", every import.meta.url read site rewritten to import_meta.url), which
+// makes the Worker construction throw a caught TypeError and permanently, invisibly degrade to
+// the setInterval heartbeat fallback -- no build or parse error to notice it by. This banner
+// captures the classic script's own URL synchronously (the one moment document.currentScript is
+// guaranteed non-null, per MDN) into a plain variable, and --define substitutes every
+// import.meta.url reference with that variable instead of esbuild's stub, so the Worker
+// construction resolves to a real, correct URL at runtime. Demonstrated working end-to-end
+// (both the naive stub trap and this fix) in
+// docs/teams/2026-09-04-bug-76473/01-hypothesis-esbuild-rebundle.md -- this is that exact
+// invocation, wired into a real gulp task instead of an ad hoc CLI command.
+const ESM_SCRIPT_URL_BANNER =
+   "var __esm_script_url = (typeof document!==\"undefined\" && document.currentScript) " +
+   "? document.currentScript.src : undefined;";
+
+// Resolves the real, hashed main-*.js in ngOutputDir (Angular's production build output for
+// the elements/viewer-element project) and re-bundles it in place into rebundleDir, under the
+// same filename, so callers concatenating scripts can glob for "main-*.js" in rebundleDir
+// exactly as they previously did against ngOutputDir directly.
+function rebundleMainForClassicScript(ngOutputDir, rebundleDir) {
+   const matches = glob.sync(path.join(ngOutputDir, "main-*.js"));
+
+   if(matches.length !== 1) {
+      throw new Error(
+         `Expected exactly one main-*.js in ${ngOutputDir}, found ${matches.length} ` +
+         `(${matches.join(", ")}) -- check the Angular production build actually ran and its ` +
+         "output filename convention hasn't changed.");
+   }
+
+   const mainFile = matches[0];
+   const outFile = path.join(rebundleDir, path.basename(mainFile));
+   fs.mkdirSync(rebundleDir, { recursive: true });
+
+   esbuild.buildSync({
+      entryPoints: [mainFile],
+      bundle: true,
+      format: "iife",
+      outfile: outFile,
+      allowOverwrite: true,
+      banner: { js: ESM_SCRIPT_URL_BANNER },
+      define: { "import.meta.url": "__esm_script_url" }
+   });
+
+   return outFile;
+}
+
+module.exports = {
+   ESM_SCRIPT_URL_BANNER,
+   rebundleMainForClassicScript
+};

--- a/web/gulp/require-non-empty-stream.js
+++ b/web/gulp/require-non-empty-stream.js
@@ -1,0 +1,46 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+const through = require("through2");
+
+// Bug #76468: a gulp.src() glob that matches zero files feeds gulp-concat an empty stream,
+// which silently writes nothing while the task still reports "Finished" -- exactly what
+// happened here for ~4 months after an Angular builder migration changed the hashed output
+// filename convention and these tasks' glob patterns went stale. Insert this immediately
+// after gulp.src() to fail the task loudly instead, so a future naming-convention change is
+// caught at build time rather than producing a silently-missing bundle.
+module.exports = function requireNonEmptyStream(taskName) {
+   let matchedCount = 0;
+
+   return through.obj(
+      function(file, encoding, callback) {
+         matchedCount++;
+         callback(null, file);
+      },
+      function(callback) {
+         if(matchedCount === 0) {
+            callback(new Error(
+               `Task '${taskName}' matched zero input files -- its glob patterns likely no ` +
+               "longer match the real build output filenames (e.g. after an Angular builder " +
+               "change). Check the patterns against the actual output directory."));
+         }
+         else {
+            callback();
+         }
+      }
+   );
+};

--- a/web/gulp/verify-classic-script.js
+++ b/web/gulp/verify-classic-script.js
@@ -1,0 +1,118 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+const fs = require("fs");
+
+// Bug #76473: elements.js/viewer-element.js are gulp-concatenated (plain text
+// concatenation, no bundler pass) from Angular's production build output, and are meant to be
+// loaded as a classic (non-module) <script src="..."> tag by third-party embed pages. Any
+// ESM-only construct that survives into the concatenated output (e.g. import.meta, used by
+// HeartbeatWorkerService's Worker construction) is a parse-time SyntaxError in that context,
+// regardless of whether the code path that uses it is ever reached at runtime.
+//
+// Deliberately does NOT use `node --check`: community/web/package.json has "type": "module",
+// so Node resolves these *.js files as ES modules by default, and import.meta is legal in a
+// module -- `node --check` gives a false pass on exactly the bug this function exists to
+// catch. new Function(source) forces true classic-script (non-module) parse semantics, which
+// is the only reliable local check found so far (see docs/teams/2026-09-04-bug-76473/00-map.md).
+function assertClassicScriptParses(filePath) {
+   const source = fs.readFileSync(filePath, "utf8");
+
+   try {
+      new Function(source);
+   }
+   catch(e) {
+      throw new Error(
+         `${filePath} does not parse as a classic (non-module) script: ${e.name}: ${e.message}\n` +
+         "This file is loaded via <script src=\"...\"> (not type=\"module\"), so any ESM-only " +
+         "construct (import.meta, a top-level import/export statement) is a parse-time failure " +
+         "here even if the code path that uses it is never reached.");
+   }
+
+   return source;
+}
+
+// Bug #76473 fix-approach trap (see docs/teams/2026-09-04-bug-76473/02b-fix-approach-decision.md
+// and 01-hypothesis-esbuild-rebundle.md): a naive `esbuild --bundle --format=iife` re-bundle
+// pass makes assertClassicScriptParses() above pass -- the parse-time SyntaxError is gone --
+// but only because esbuild silently substitutes an empty-object stub for the now-unsupported
+// import.meta ("var import_meta = {};", with every import.meta.url read site rewritten to
+// import_meta.url instead). That stub makes HeartbeatWorkerService's
+// `new Worker(new URL(..., import.meta.url))` throw a TypeError at runtime, caught by the same
+// try/catch that already guards "Worker unavailable", so the Worker silently and permanently
+// degrades to the setInterval heartbeat fallback -- no build error, no parse error, nothing to
+// notice it by.
+//
+// This check is NOT redundant with assertClassicScriptParses(): that check only asks "does this
+// parse," which a naive/incomplete fix satisfies while still being wrong. This check asks a
+// different question -- "did esbuild quietly paper over an import.meta it couldn't actually
+// support" -- by looking for the specific fingerprint esbuild leaves behind when it does. A
+// correct fix (banner/define capturing the script's own URL synchronously, per
+// 01-hypothesis-esbuild-rebundle.md) does not leave this fingerprint, because import.meta.url is
+// substituted with a real expression instead of an empty stub.
+function assertNoEsbuildImportMetaStub(filePath, source) {
+   source = source === undefined ? fs.readFileSync(filePath, "utf8") : source;
+
+   // esbuild's stub var is named "import_meta", suffixed ("import_meta2", ...) only if the
+   // bundle already has a colliding identifier -- \d* covers that without being tied to a
+   // specific suffix.
+   const stubDeclaration = /\bimport_meta\d*\s*=\s*\{\}/;
+   const stubUsage = /\bimport_meta\d*\.url\b/;
+
+   if(stubDeclaration.test(source) && stubUsage.test(source)) {
+      throw new Error(
+         `${filePath} contains esbuild's silent import.meta stub substitution ` +
+         "(an \"import_meta = {}\" declaration together with an \"import_meta.url\" read site). " +
+         "The file parses as a classic script, but any code that read import.meta.url now reads " +
+         "undefined instead -- e.g. HeartbeatWorkerService's " +
+         "`new Worker(new URL(..., import.meta.url))` will throw a TypeError that silently " +
+         "degrades to a fallback, with no build or parse error to notice it by. See " +
+         "docs/teams/2026-09-04-bug-76473/02b-fix-approach-decision.md.");
+   }
+}
+
+// Runs both checks. Throws on the first failure with a message identifying which check failed
+// and why. Intended to be callable from a gulp task (let the throw/rejection fail the task) or
+// from the CLI entry point below (e.g. from a CI step).
+function verifyClassicScriptBundle(filePath) {
+   const source = assertClassicScriptParses(filePath);
+   assertNoEsbuildImportMetaStub(filePath, source);
+}
+
+module.exports = {
+   assertClassicScriptParses,
+   assertNoEsbuildImportMetaStub,
+   verifyClassicScriptBundle
+};
+
+if(require.main === module) {
+   const target = process.argv[2];
+
+   if(!target) {
+      console.error("Usage: node verify-classic-script.js <path-to-built-bundle.js>");
+      process.exit(2);
+   }
+
+   try {
+      verifyClassicScriptBundle(target);
+      console.log(`OK: ${target} parses as a classic script and contains no import.meta stub.`);
+   }
+   catch(e) {
+      console.error(`FAIL: ${e.message}`);
+      process.exit(1);
+   }
+}

--- a/web/gulp/viewer-element.js
+++ b/web/gulp/viewer-element.js
@@ -22,12 +22,16 @@ const sass = require("gulp-dart-sass");
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
 const cssnano = require("cssnano");
+const requireNonEmptyStream = require("./require-non-empty-stream");
 
+// The esbuild @angular/build:application builder (in use for this project since the
+// Angular 17->18/esbuild migration) hashes output filenames as "<name>-<HASH>.js" and does
+// not emit a separate runtime chunk -- unlike the older Webpack builder's "<name>.<hash>.js"
+// convention these patterns used to target.
 const scriptFiles = [
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/runtime.*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/polyfills.*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/scripts.*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/main.*.js"
+   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/polyfills-*.js",
+   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/scripts-*.js",
+   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/main-*.js"
 ];
 
 const cssFiles = [
@@ -37,6 +41,7 @@ const cssFiles = [
 
 gulp.task("viewer-element:scripts", function () {
    return gulp.src(scriptFiles)
+      .pipe(requireNonEmptyStream("viewer-element:scripts"))
       .pipe(concat("viewer-element.js"))
       .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/app/"));
 });

--- a/web/gulp/viewer-element.js
+++ b/web/gulp/viewer-element.js
@@ -22,16 +22,27 @@ const sass = require("gulp-dart-sass");
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
 const cssnano = require("cssnano");
+const glob = require("glob");
+const path = require("path");
 const requireNonEmptyStream = require("./require-non-empty-stream");
+const { verifyClassicScriptBundle } = require("./verify-classic-script");
+const { rebundleMainForClassicScript } = require("./esbuild-classic-script-rebundle");
 
 // The esbuild @angular/build:application builder (in use for this project since the
 // Angular 17->18/esbuild migration) hashes output filenames as "<name>-<HASH>.js" and does
 // not emit a separate runtime chunk -- unlike the older Webpack builder's "<name>.<hash>.js"
 // convention these patterns used to target.
+const ngOutputDir = "target/generated-resources/ng/inetsoft/web/resources/viewer-element";
+const rebundleDir = "target/generated-resources/gulp/tmp/viewer-element";
+const appDir = "target/generated-resources/gulp/inetsoft/web/resources/app";
+
 const scriptFiles = [
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/polyfills-*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/scripts-*.js",
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/main-*.js"
+   path.join(ngOutputDir, "polyfills-*.js"),
+   path.join(ngOutputDir, "scripts-*.js"),
+   // Bug #76473: this is the esbuild-rebundled (format=iife, import.meta.url captured via
+   // ESM_SCRIPT_URL_BANNER) copy of Angular's main-*.js, not the raw ng build output -- see
+   // esbuild-classic-script-rebundle.js and docs/teams/2026-09-04-bug-76473/02b-fix-approach-decision.md.
+   path.join(rebundleDir, "main-*.js")
 ];
 
 const cssFiles = [
@@ -39,12 +50,48 @@ const cssFiles = [
    "target/generated-resources/ng/inetsoft/web/resources/viewer-element/styles-*.css"
 ];
 
-gulp.task("viewer-element:scripts", function () {
+// Bug #76473, piece 1+2 -- see elements.js's identical task for the full explanation.
+gulp.task("viewer-element:scripts:bundle-main", function (callback) {
+   rebundleMainForClassicScript(ngOutputDir, rebundleDir);
+   callback();
+});
+
+// Bug #76473, piece 3 -- see elements.js's identical task for the full explanation.
+gulp.task("viewer-element:scripts:copy-worker", function () {
+   const workerFiles = glob.sync(path.join(ngOutputDir, "worker-*.js"));
+
+   if(workerFiles.length === 0) {
+      return Promise.reject(new Error(
+         `viewer-element:scripts:copy-worker found no worker-*.js in ${ngOutputDir} -- ` +
+         "expected Angular's production build to emit HeartbeatWorkerService's worker chunk."));
+   }
+
+   return gulp.src(workerFiles)
+      .pipe(gulp.dest(appDir));
+});
+
+gulp.task("viewer-element:scripts:concat", function () {
    return gulp.src(scriptFiles)
       .pipe(requireNonEmptyStream("viewer-element:scripts"))
       .pipe(concat("viewer-element.js"))
-      .pipe(gulp.dest("target/generated-resources/gulp/inetsoft/web/resources/app/"));
+      .pipe(gulp.dest(appDir));
 });
+
+// Bug #76473: fail the build loudly if the concatenated bundle regresses back to being
+// unparseable as a classic script, or silently degrades via esbuild's import.meta stub --
+// same discipline as requireNonEmptyStream() above (added for Bug #76468), for a different
+// check.
+gulp.task("viewer-element:scripts:verify", function (callback) {
+   verifyClassicScriptBundle(path.join(appDir, "viewer-element.js"));
+   callback();
+});
+
+gulp.task("viewer-element:scripts", gulp.series([
+   "viewer-element:scripts:bundle-main",
+   "viewer-element:scripts:copy-worker",
+   "viewer-element:scripts:concat",
+   "viewer-element:scripts:verify"
+]));
 
 gulp.task("viewer-element:concat-css", function () {
    return gulp.src(cssFiles)

--- a/web/gulp/viewer-element.js
+++ b/web/gulp/viewer-element.js
@@ -36,7 +36,7 @@ const scriptFiles = [
 
 const cssFiles = [
    "target/generated-resources/gulp/inetsoft/web/resources/app/global.css",
-   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/styles.*.css"
+   "target/generated-resources/ng/inetsoft/web/resources/viewer-element/styles-*.css"
 ];
 
 gulp.task("viewer-element:scripts", function () {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -84,6 +84,7 @@
         "concurrently": "^8.2.2",
         "cssnano": "^4.1.10",
         "del": "^5.1.0",
+        "esbuild": "0.27.3",
         "eslint": "^10.6.0",
         "form-data": "^4.0.5",
         "gulp": "^4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -97,6 +97,7 @@
     "concurrently": "^8.2.2",
     "cssnano": "^4.1.10",
     "del": "^5.1.0",
+    "esbuild": "0.27.3",
     "eslint": "^10.6.0",
     "form-data": "^4.0.5",
     "gulp": "^4.0.2",

--- a/web/projects/portal/src/app/embed/chart/embed-chart-url-matcher.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart-url-matcher.ts
@@ -1,0 +1,97 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { UrlMatchResult, UrlSegment } from "@angular/router";
+
+// Split out of embed-chart.routes.ts so embed-chart.component.ts (which needs the matcher) and
+// embed-chart.routes.ts (which needs EmbedChartComponent, for the "elements" web-component
+// bundle's eager route -- see embedChartRoutesEager below) don't import each other.
+export function EMBED_CHART_URL_MATCHER(url: UrlSegment[]): UrlMatchResult {
+   let result: UrlMatchResult = null;
+
+   if(url && url.length > 0) {
+      const params: { [name: string]: UrlSegment } = {};
+      result = {
+         consumed: url,
+         posParams: params
+      };
+
+      if(url.length > 0) {
+         let assetScope: UrlSegment = null;
+         let assetOwner: UrlSegment = null;
+         let assetPath: string = null;
+         let assetId: string = null;
+
+         if(url[0].path === "global") {
+            assetScope = url[0];
+
+            if(url.length > 1) {
+               assetPath = url.slice(1, url.length - 1).map((s) => s.path).join("/");
+               assetId = `1^128^__NULL__^${assetPath}`;
+            }
+         }
+         else if(url[0].path === "user") {
+            assetScope = url[0];
+
+            if(url.length > 1) {
+               assetOwner = url[1];
+
+               if(url.length > 2) {
+                  assetPath = url.slice(2, url.length - 1).map((s) => s.path).join("/");
+                  assetId = `4^128^${assetOwner.path}^${assetPath}`;
+               }
+            }
+         }
+         else {
+            assetId = url.slice(0, url.length - 1).map((s) => s.path).join("/");
+            const match = /^([14])+\^128\^([^^]+)\^(.+)$/.exec(assetId);
+
+            if(match) {
+               if(match[1] == "1") {
+                  assetScope = new UrlSegment("global", {});
+               }
+               else {
+                  assetScope = new UrlSegment("user", {});
+                  assetOwner = new UrlSegment(match[2], {});
+               }
+
+               assetPath = match[3];
+            }
+         }
+
+         if(assetScope) {
+            params.assetScope = assetScope;
+         }
+
+         if(assetOwner) {
+            params.assetOwner = assetOwner;
+         }
+
+         if(assetPath) {
+            params.assetPath = new UrlSegment(assetPath, {});
+         }
+
+         if(assetId) {
+            params.assetId = new UrlSegment(assetId, {});
+         }
+
+         params.assemblyName = new UrlSegment(url[url.length - 1].path, {});
+      }
+   }
+
+   return result;
+}

--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
@@ -60,7 +60,7 @@ import {
    ActionsContextmenuComponent
 } from "../../widget/fixed-dropdown/actions-contextmenu.component";
 import { FixedDropdownService } from "../../widget/fixed-dropdown/fixed-dropdown.service";
-import { EMBED_CHART_URL_MATCHER } from "./embed-chart.routes";
+import { EMBED_CHART_URL_MATCHER } from "./embed-chart-url-matcher";
 import { DownloadService } from "../../../../../shared/download/download.service";
 import { TooltipService } from "../../widget/tooltip/tooltip.service";
 import { ShadowDomService } from "../shadow-dom.service";

--- a/web/projects/portal/src/app/embed/chart/embed-chart.route-providers.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.route-providers.ts
@@ -1,0 +1,89 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Injector, Optional } from "@angular/core";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { DndService } from "../../common/dnd/dnd.service";
+import { VSDndService } from "../../common/dnd/vs-dnd.service";
+import { FullScreenService } from "../../common/services/full-screen.service";
+import { UIContextService } from "../../common/services/ui-context.service";
+import { ViewsheetClientService } from "../../common/viewsheet-client";
+import { ChartService } from "../../graph/services/chart.service";
+import {
+   ComposerToken,
+   ContextProvider,
+   EmbedAssemblyContextProviderFactory
+} from "../../vsobjects/context-provider.service";
+import { RichTextService } from "../../vsobjects/dialog/rich-text-dialog/rich-text.service";
+import { VSChartService } from "../../vsobjects/objects/chart/services/vs-chart.service";
+import { DataTipService } from "../../vsobjects/objects/data-tip/data-tip.service";
+import { PopComponentService } from "../../vsobjects/objects/data-tip/pop-component.service";
+import { MiniToolbarService } from "../../vsobjects/objects/mini-toolbar/mini-toolbar.service";
+import { ShowHyperlinkService } from "../../vsobjects/show-hyperlink.service";
+import { CheckFormDataService } from "../../vsobjects/util/check-form-data.service";
+import { VSTabService } from "../../vsobjects/util/vs-tab.service";
+import { ModelService } from "../../widget/services/model.service";
+import { ScaleService } from "../../widget/services/scale/scale-service";
+import { VSScaleService } from "../../widget/services/scale/vs-scale.service";
+import {
+   DialogService,
+   ViewerDialogServiceFactory
+} from "../../widget/slide-out/dialog-service.service";
+import { SlideOutService } from "../../widget/slide-out/slide-out.service";
+import { AdhocFilterService } from "../../vsobjects/objects/data-tip/adhoc-filter.service";
+
+// Split out of embed-chart.routes.ts so the "elements" web-component bundle's eager route file
+// (embed-chart.routes-eager.ts) can share this provider set without importing anything that
+// contains a dynamic import() -- see embed-chart.routes-eager.ts for why that matters.
+export const EMBED_CHART_ROUTE_PROVIDERS = [
+   DataTipService,
+   PopComponentService,
+   MiniToolbarService,
+   VSChartService,
+   SlideOutService,
+   UIContextService,
+   CheckFormDataService,
+   ShowHyperlinkService,
+   VSTabService,
+   RichTextService,
+   FullScreenService,
+   AdhocFilterService,
+   {
+      provide: DialogService,
+      useFactory: ViewerDialogServiceFactory,
+      deps: [NgbModal, SlideOutService, Injector, UIContextService]
+   },
+   {
+      provide: DndService,
+      useClass: VSDndService,
+      deps: [ModelService, NgbModal, ViewsheetClientService]
+   },
+   {
+      provide: ScaleService,
+      useClass: VSScaleService
+   },
+   {
+      provide: ContextProvider,
+      useFactory: EmbedAssemblyContextProviderFactory,
+      deps: [[new Optional(), ComposerToken]]
+   },
+   {
+      provide: ChartService,
+      useExisting: VSChartService
+   },
+   NgbModal
+];

--- a/web/projects/portal/src/app/embed/chart/embed-chart.routes-eager.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.routes-eager.ts
@@ -1,0 +1,47 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Route, Routes } from "@angular/router";
+import { canDeactivateGuard } from "../../common/services/can-deactivate-guard.service";
+import { EMBED_CHART_URL_MATCHER } from "./embed-chart-url-matcher";
+import { EMBED_CHART_ROUTE_PROVIDERS } from "./embed-chart.route-providers";
+import { EmbedChartComponent } from "./embed-chart.component";
+
+// Bug #76468: the "elements" web-component bundle (main-elements.ts) already imports
+// EmbedChartComponent statically and uses it immediately (createCustomElement) -- it is never
+// actually deferred there. But embed-chart.routes.ts's embedChartRoutes (used by the full portal
+// app, where the component genuinely is lazy) defines its route via
+// `loadComponent: () => import("./embed-chart.component")...`, and esbuild's application builder
+// treats that dynamic import() as a hard chunk-split point for *any* build that pulls in the
+// module containing it -- even if the specific export using it (embedChartRoutes) is otherwise
+// unused and would tree-shake away. main-elements.ts must therefore avoid importing
+// embed-chart.routes.ts (or anything that imports it) entirely; this file exists purely so it can
+// get an equivalent route with zero `import()` syntax anywhere in its own module graph, so
+// EmbedChartComponent's ~1.9MB of code bundles directly into main-elements.ts's main.js instead
+// of being split into a separate chunk that the gulp-concatenated elements.js never references or
+// copies (which produced a broken, non-functional bundle -- see PR #5007 review).
+//
+// Keep this file's providers in sync with embed-chart.routes.ts's embedChartRoutes by sharing
+// EMBED_CHART_ROUTE_PROVIDERS from embed-chart.route-providers.ts rather than duplicating it.
+export const embedChartRoutesEager: Routes = [
+   {
+      component: EmbedChartComponent,
+      canDeactivate: [canDeactivateGuard],
+      matcher: EMBED_CHART_URL_MATCHER,
+      providers: EMBED_CHART_ROUTE_PROVIDERS
+   } as Route
+];

--- a/web/projects/portal/src/app/embed/chart/embed-chart.routes.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.routes.ts
@@ -15,157 +15,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Injector, Optional } from "@angular/core";
-import { Routes, UrlMatchResult, UrlSegment } from "@angular/router";
-import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
-import { DndService } from "../../common/dnd/dnd.service";
-import { VSDndService } from "../../common/dnd/vs-dnd.service";
-import { FullScreenService } from "../../common/services/full-screen.service";
-import { UIContextService } from "../../common/services/ui-context.service";
-import { ViewsheetClientService } from "../../common/viewsheet-client";
-import { ChartService } from "../../graph/services/chart.service";
-import {
-   ComposerToken,
-   ContextProvider,
-   EmbedAssemblyContextProviderFactory
-} from "../../vsobjects/context-provider.service";
-import { RichTextService } from "../../vsobjects/dialog/rich-text-dialog/rich-text.service";
-import { VSChartService } from "../../vsobjects/objects/chart/services/vs-chart.service";
-import { DataTipService } from "../../vsobjects/objects/data-tip/data-tip.service";
-import { PopComponentService } from "../../vsobjects/objects/data-tip/pop-component.service";
-import { MiniToolbarService } from "../../vsobjects/objects/mini-toolbar/mini-toolbar.service";
-import { ShowHyperlinkService } from "../../vsobjects/show-hyperlink.service";
-import { CheckFormDataService } from "../../vsobjects/util/check-form-data.service";
-import { VSTabService } from "../../vsobjects/util/vs-tab.service";
-import { ModelService } from "../../widget/services/model.service";
-import { ScaleService } from "../../widget/services/scale/scale-service";
-import { VSScaleService } from "../../widget/services/scale/vs-scale.service";
-import {
-   DialogService,
-   ViewerDialogServiceFactory
-} from "../../widget/slide-out/dialog-service.service";
-import { SlideOutService } from "../../widget/slide-out/slide-out.service";
-import { AdhocFilterService } from "../../vsobjects/objects/data-tip/adhoc-filter.service";
+import { Routes } from "@angular/router";
 import { canDeactivateGuard } from "../../common/services/can-deactivate-guard.service";
+import { EMBED_CHART_URL_MATCHER } from "./embed-chart-url-matcher";
+import { EMBED_CHART_ROUTE_PROVIDERS } from "./embed-chart.route-providers";
 
-export function EMBED_CHART_URL_MATCHER(url: UrlSegment[]): UrlMatchResult {
-   let result: UrlMatchResult = null;
-
-   if(url && url.length > 0) {
-      const params: { [name: string]: UrlSegment } = {};
-      result = {
-         consumed: url,
-         posParams: params
-      };
-
-      if(url.length > 0) {
-         let assetScope: UrlSegment = null;
-         let assetOwner: UrlSegment = null;
-         let assetPath: string = null;
-         let assetId: string = null;
-
-         if(url[0].path === "global") {
-            assetScope = url[0];
-
-            if(url.length > 1) {
-               assetPath = url.slice(1, url.length - 1).map((s) => s.path).join("/");
-               assetId = `1^128^__NULL__^${assetPath}`;
-            }
-         }
-         else if(url[0].path === "user") {
-            assetScope = url[0];
-
-            if(url.length > 1) {
-               assetOwner = url[1];
-
-               if(url.length > 2) {
-                  assetPath = url.slice(2, url.length - 1).map((s) => s.path).join("/");
-                  assetId = `4^128^${assetOwner.path}^${assetPath}`;
-               }
-            }
-         }
-         else {
-            assetId = url.slice(0, url.length - 1).map((s) => s.path).join("/");
-            const match = /^([14])+\^128\^([^^]+)\^(.+)$/.exec(assetId);
-
-            if(match) {
-               if(match[1] == "1") {
-                  assetScope = new UrlSegment("global", {});
-               }
-               else {
-                  assetScope = new UrlSegment("user", {});
-                  assetOwner = new UrlSegment(match[2], {});
-               }
-
-               assetPath = match[3];
-            }
-         }
-
-         if(assetScope) {
-            params.assetScope = assetScope;
-         }
-
-         if(assetOwner) {
-            params.assetOwner = assetOwner;
-         }
-
-         if(assetPath) {
-            params.assetPath = new UrlSegment(assetPath, {});
-         }
-
-         if(assetId) {
-            params.assetId = new UrlSegment(assetId, {});
-         }
-
-         params.assemblyName = new UrlSegment(url[url.length - 1].path, {});
-      }
-   }
-
-   return result;
-}
-
+// Lazily loaded route used by the full portal app (app.routes.ts's `loadChildren` on this whole
+// module). NOTE: nothing in the "elements" web-component bundle (main-elements.ts) may import
+// this file -- see embed-chart.routes-eager.ts for the equivalent eager route that bundle uses
+// instead, and why (Bug #76468: this file's `import()` below is a hard chunk-split point for
+// esbuild in *any* build that pulls this module in, whether or not embedChartRoutes itself ends
+// up used by that build).
 export const embedChartRoutes: Routes = [
    {
       loadComponent: () => import("./embed-chart.component").then(m => m.EmbedChartComponent),
       canDeactivate: [canDeactivateGuard],
       matcher: EMBED_CHART_URL_MATCHER,
-      providers: [
-         DataTipService,
-         PopComponentService,
-         MiniToolbarService,
-         VSChartService,
-         SlideOutService,
-         UIContextService,
-         CheckFormDataService,
-         ShowHyperlinkService,
-         VSTabService,
-         RichTextService,
-         FullScreenService,
-         AdhocFilterService,
-         {
-            provide: DialogService,
-            useFactory: ViewerDialogServiceFactory,
-            deps: [NgbModal, SlideOutService, Injector, UIContextService]
-         },
-         {
-            provide: DndService,
-            useClass: VSDndService,
-            deps: [ModelService, NgbModal, ViewsheetClientService]
-         },
-         {
-            provide: ScaleService,
-            useClass: VSScaleService
-         },
-         {
-            provide: ContextProvider,
-            useFactory: EmbedAssemblyContextProviderFactory,
-            deps: [[new Optional(), ComposerToken]]
-         },
-         {
-            provide: ChartService,
-            useExisting: VSChartService
-         },
-         NgbModal
-      ]
+      providers: EMBED_CHART_ROUTE_PROVIDERS
    }
 ];

--- a/web/projects/portal/src/main-elements.ts
+++ b/web/projects/portal/src/main-elements.ts
@@ -20,13 +20,17 @@ import { createCustomElement } from "@angular/elements";
 import { provideRouter } from "@angular/router";
 import { EmbedChartComponent } from "./app/embed/chart/embed-chart.component";
 import { embedElementConfig } from "./app/embed/embed-element.config";
-import { embedChartRoutes } from "./app/embed/chart/embed-chart.routes";
+import { embedChartRoutesEager } from "./app/embed/chart/embed-chart.routes-eager";
 import "./main-base-element";
 
 createApplication({
    providers: [
       ...embedElementConfig.providers,
-      provideRouter(embedChartRoutes)
+      // Use the eager route variant here (not embedChartRoutes) -- see the comment on
+      // embedChartRoutesEager for why: EmbedChartComponent is always needed immediately in this
+      // bundle (it's created below regardless), so the lazy loadComponent() portal routing uses
+      // only costs this single-component bundle a broken build (Bug #76468).
+      provideRouter(embedChartRoutesEager)
    ]
 }).then(app => {
    const embedChart = createCustomElement(EmbedChartComponent, {injector: app.injector});


### PR DESCRIPTION
## Summary

`elements.js`/`viewer-element.js` (the gulp-concatenated Web Component embed bundles, loaded via `<script src="...">` as classic, non-module scripts) contain a literal `import.meta.url` reference, which is a parse-time `SyntaxError` outside of ES module context.

**Root cause**: `HeartbeatWorkerService.getWorker()` (`web/projects/portal/src/app/common/services/heartbeat-worker.service.ts`) constructs its Web Worker via `new Worker(new URL("../workers/heartbeat.worker", import.meta.url))` — correct, standard code for an ES module, but reached by every viewsheet-communicating component (via `StompClientService`), including the embed bundles, as a side effect of Bug #75401/PR #3992 (Worker-based STOMP heartbeat), not anything touching embed-bundle code directly.

**Why a naive fix is dangerous**: a plain `esbuild --bundle --format=iife` rebundle pass over Angular's built `main-*.js` does make the `SyntaxError` disappear — but only because esbuild silently substitutes an empty-object stub for `import.meta` (`var import_meta = {}`), which makes the Worker construction throw a caught `TypeError` and permanently, invisibly degrade to the `setInterval` heartbeat fallback. No build error, no parse error, nothing to notice it by — it looks completely correct while silently never using a real Worker.

## The three-piece fix (both `elements.js` and `viewer-element.js`)

1. **esbuild rebundle** — a new `<project>:scripts:bundle-main` gulp task re-bundles Angular's real, hashed `main-*.js` with `esbuild.buildSync({ bundle: true, format: "iife" })` (programmatic `esbuild` package, already present in `node_modules`, no subprocess).
2. **Banner/define URL correction** — `--banner:js` captures the script's own URL synchronously (`document.currentScript.src`, the one moment it's guaranteed non-null) into `__esm_script_url`, and `--define:import.meta.url=__esm_script_url` substitutes every `import.meta.url` read site with that real variable instead of esbuild's stub, so the Worker's URL resolves correctly at runtime.
3. **Worker file colocation** — a new `<project>:scripts:copy-worker` task copies the real `worker-*.js` (filename preserved) into the same `.../resources/app/` directory the concatenated bundle lands in. Previously the two lived in separate, unmapped Maven `<resource>` roots (`generated-resources/gulp` vs `generated-resources/ng`) — and for the `elements` project specifically, the raw `ng` output root is excluded from the packaged jar entirely by the existing `maven-jar-plugin` config in `web/pom.xml`, so without this the worker file wouldn't ship at all.

Both `*:scripts` public tasks (unchanged names, still what `package.json`'s `build:prod` invokes) are now a `gulp.series` of `:bundle-main` → `:copy-worker` → `:concat` → `:verify`, the last of which calls a new `verify-classic-script.js` guard (parses the final output as a classic script, and checks for esbuild's stub-substitution fingerprint) so a future regression fails the build loudly — same discipline as Bug #76468's `requireNonEmptyStream()` guard already in these tasks.

## Test plan

- [x] Real production builds: `ng build elements --configuration production` and `ng build viewer-element --configuration production`, both succeed (only pre-existing, unrelated warnings).
- [x] Real `gulp elements:scripts` / `gulp viewer-element:scripts` runs, full new pipeline, both green.
- [x] `node gulp/verify-classic-script.js <output>` passes (exit 0) for both projects.
- [x] Independently re-confirmed beyond the tool: zero real `import.meta` occurrences in either final bundle (the only substring hits are inside Acorn parser's own error-message strings, already identified as false positives in this bug's investigation), zero esbuild stub pattern occurrences.
- [x] Worker file colocation confirmed: `target/.../resources/app/` contains both the concatenated bundle and the real `worker-*.js`, filename matching the bundle's own `new URL("worker-<HASH>.js", __esm_script_url)` call site exactly.
- [x] No regression of Bug #76468's chunk-exclusion problem: both final bundles are multi-MB (not collapsed to a stub); the real `getWorker()` method body is present verbatim in both.
- [x] `elements:css`/`viewer-element:css` and the full `gulp --tasks-simple` task set run/list without error.
- [x] Closer-to-runtime check (no live server, per this bug's own established scope): loaded the copied `worker-*.js` directly via `node:worker_threads`, confirming it's genuine, complete, executable Worker source (reaches the `'online'` event; the only error is `addEventListener is not defined`, expected since that's a browser Worker-global API Node's `worker_threads` doesn't provide — not a parse or truncation failure).
- [ ] Not verified: actual browser `new Worker(...)` construction against a live-served deployment (out of scope per this bug's own charter, which established no live stack/browser is needed for this fix).

Fixes Redmine #76473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)