### PR TITLE
fix(admin): exclude task narrative from plan hash (Bug #76472, Properties)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -167,16 +167,23 @@ public class AdminChangePlanService {
          .anyMatch(c -> AdminChangeRecord.RISK_HIGH.equals(c.risk()));
 
       return new ResolvedPlan(req.getTask().trim(), Collections.unmodifiableList(changes),
-                              backup, signoff, hash(req.getTask().trim(), changes));
+                              backup, signoff, hash(changes));
    }
 
    /**
     * SHA-256 over the canonical plan. Field order and the record separators are part of the
     * contract: changing them invalidates every outstanding preview, which is safe (an apply is
     * refused with 409) but forces operators to re-review.
+    *
+    * <p>{@code task} is deliberately excluded: it is a free-text narrative that is never compared
+    * or parsed, only carried through to {@code AdminChangesetApplyService}'s {@code writeAudit}
+    * call as {@link AdminChangeRecord#setTaskDescription}, a write-only audit label. Including it
+    * here would let two equivalent narratives describing the identical change list hash
+    * differently, forcing a spurious re-review (a false {@code PlanHashMismatchException}) even
+    * though nothing the gate actually protects has changed.
     */
-   private static String hash(String task, List<PlanChange> changes) {
-      StringBuilder canonical = new StringBuilder(task).append('\n');
+   private static String hash(List<PlanChange> changes) {
+      StringBuilder canonical = new StringBuilder();
 
       for(PlanChange change : changes) {
          canonical.append(change.property()).append(SEP)

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -148,12 +148,19 @@ class AdminChangePlanServiceTest {
    }
 
    @Test
-   void hashChangesWithTheProposedValueAndTheTask() {
+   void hashChangesWithTheProposedValue() {
       sreeEnv.when(() -> SreeEnv.getProperty("query.runtime.maxrow", false, false))
          .thenReturn("100");
       String base = service.resolve(request("t", "max.rows", "500")).planHash();
       assertNotEquals(base, service.resolve(request("t", "max.rows", "600")).planHash());
-      assertNotEquals(base, service.resolve(request("other", "max.rows", "500")).planHash());
+   }
+
+   @Test
+   void hashIsUnaffectedByDifferentTaskStrings() {
+      sreeEnv.when(() -> SreeEnv.getProperty("query.runtime.maxrow", false, false))
+         .thenReturn("100");
+      String base = service.resolve(request("t", "max.rows", "500")).planHash();
+      assertEquals(base, service.resolve(request("other", "max.rows", "500")).planHash());
    }
 
    @Test


### PR DESCRIPTION
## Summary
- Bug #76472, Properties area. `AdminChangePlanService.hash()` seeded its SHA-256 canonical string with the free-text `task` narrative, but `task` is never compared or parsed after `resolve()` returns - it only flows through `AdminChangesetApplyService` into `AdminChangeRecord.setTaskDescription`, a write-only audit label.
- Result: two equally valid narratives describing the identical change list (e.g. "cap query rows at 500" vs "limit max rows to 500") produced different `planHash()` values, so an operator paraphrasing the task between preview and apply got a spurious 409 `PlanHashMismatchException` even though nothing the drift gate actually protects had changed.
- Fix: drop `task` from `hash()`'s signature and canonical-string seed; leave `AdminChangesetApplyService`'s audit-label flow untouched (that's the legitimate use of `task`).

## Test plan
- [x] `AdminChangePlanServiceTest.hashChangesWithTheProposedValueAndTheTask` (which asserted the bug as spec: different `task`, same `changes` -> different hash) replaced with `hashChangesWithTheProposedValue` (keeps the proposed-value-changes-the-hash assertion) and a new `hashIsUnaffectedByDifferentTaskStrings` regression test (different `task`, same `changes` -> equal hash). Verified red on pre-fix code, green after the fix.
- [x] `./mvnw -pl core test -Dtest='AdminChangePlanServiceTest' -o` — Tests run: 29, Failures: 0
- [x] `./mvnw -pl core test -Dtest='AdminChangesetApplyServiceTest' -o` — Tests run: 26, Failures: 0 (no collateral breakage)

This is 1 of 5 independent PRs in the #76472 batch (Properties, Cluster, Licensing, Presentation, Providers) - this PR covers Properties only.