### PR TITLE
fix(#76472-licensing): drop task from LicenseChangePlanService.hash() seed

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanService.java
@@ -132,7 +132,7 @@ public class LicenseChangePlanService {
 
       String task = req.getTask().trim();
       return new ResolvedPlan(task, Collections.unmodifiableList(changes), true, true,
-                              hash(task, changes, installed.size()));
+                              hash(changes, installed.size()));
    }
 
    // ---------------------------------------------------------------- add
@@ -252,10 +252,18 @@ public class LicenseChangePlanService {
     * section 5) -- the de-licensing warning depends on the WHOLE deployment's installed count, not
     * only the keys this plan touches, so a concurrent add/remove of a key this plan never mentions
     * must still perturb the hash.
+    *
+    * <p>Deliberately does NOT fold {@code task} into the canonical string: {@code task} is
+    * caller-supplied free-text narrative, not an opaque token the caller is required to echo
+    * verbatim between {@code preview} and {@code apply}. Its only downstream use after {@code
+    * resolve()} returns is {@code LicenseChangesetApplyService.writeAudit}'s
+    * {@code record.setTaskDescription(task)} -- an audit label, never compared, parsed, or used to
+    * gate a mutation -- so a caller paraphrasing {@code task} between {@code preview} and {@code
+    * apply} must not change the hash and trip a false-positive {@code PlanHashMismatchException}.
     */
-   private static String hash(String task, List<PlanChange> changes, int installedCount) {
-      StringBuilder canonical = new StringBuilder(task).append('\n')
-         .append("installedCount:").append(installedCount).append(SEP);
+   private static String hash(List<PlanChange> changes, int installedCount) {
+      StringBuilder canonical = new StringBuilder("installedCount:")
+         .append(installedCount).append(SEP);
 
       for(PlanChange change : changes) {
          canonical.append(change.property()).append(SEP)

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanServiceTest.java
@@ -274,4 +274,18 @@ class LicenseChangePlanServiceTest {
 
       assertNotEquals(before.planHash(), after.planHash());
    }
+
+   /** stylebi#76472 -- {@code task} is caller-supplied free-text narrative that an LLM caller may
+    * paraphrase between {@code preview} and {@code apply}; it must not perturb the hash, or a
+    * paraphrase alone would trip a false-positive {@code PlanHashMismatchException} at apply time
+    * even though {@code changes}/{@code installedCount} (the actual plan) are unchanged. */
+   @Test void hashIsUnaffectedByDifferentTaskStrings() {
+      License installed = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(installed);
+
+      ResolvedPlan preview = service.resolve(request("remove the old K1 key", List.of(remove("K1"))));
+      ResolvedPlan apply = service.resolve(request("please remove license K1", List.of(remove("K1"))));
+
+      assertEquals(preview.planHash(), apply.planHash());
+   }
 }


### PR DESCRIPTION
## Summary

- `LicenseChangePlanService.hash()` folded the caller-supplied `task` narrative into the SHA-256 canonical string used for `ResolvedPlan.planHash()`. Since `task` is free-text (never an opaque token the caller is required to echo verbatim), an LLM agent naturally paraphrasing `task` between `preview` and `apply` produces a different hash even though the actual plan (`changes` + live `installedCount`) is identical, causing `LicenseChangesetApplyService.apply()`'s hash-comparison gate to throw a false-positive `PlanHashMismatchException` (HTTP 409).
- `task`'s only downstream use after `resolve()` returns is an audit label (`writeAudit`'s `record.setTaskDescription(task)`) -- never compared, parsed, or used to gate a mutation -- so removing it from the hash seed is safe.
- `installedCount` is left untouched: it is a live read of `licenseManager.getInstalledLicenses()` and legitimately should keep perturbing the hash (a concurrent add/remove of a key the plan never mentions must still be caught).

This is 1 of 5 independent fixes for Bug #76472 (each sibling area -- Properties, Cluster, Licensing, Presentation, Providers -- gets its own PR).

## Test plan

- [x] Added `LicenseChangePlanServiceTest.hashIsUnaffectedByDifferentTaskStrings` -- confirmed it fails on pre-fix code (two different SHA-256 digests for two `task` phrasings over identical `changes`/`installedCount`) and passes after the fix.
- [x] `./mvnw -pl core test -Dtest='LicenseChangePlanServiceTest,LicenseChangesetApplyServiceTest' -o` -- `Tests run: 32, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)