### PR TITLE
fix(#76472-cluster): exclude task from ClusterChangePlanService plan hash

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java
@@ -119,7 +119,7 @@ public class ClusterChangePlanService {
 
       String task = req.getTask().trim();
       return new ResolvedPlan(task, Collections.unmodifiableList(changes), false, true,
-                              hash(task, changes));
+                              hash(changes));
    }
 
    private PlanChange resolveOne(String server, String verb) {
@@ -222,17 +222,22 @@ public class ClusterChangePlanService {
    // ---------------------------------------------------------------- hash
 
    /**
-    * SHA-256 over the canonical plan: task text, plus per-entry (server, currentValue, proposedValue,
-    * risk, snapshotScope) -- same field set and control-character canonicalization convention every
+    * SHA-256 over the canonical plan: per-entry (server, currentValue, proposedValue, risk,
+    * snapshotScope) -- same field set and control-character canonicalization convention every
     * prior area's own {@code hash} method uses (03-reconcile.md's precision line; no whole-chain
     * projection input, unlike providers -- cluster has no "chain" concept). Because
     * {@code currentValue} is captured live at preview time, a node that changes status between
     * preview and apply (crashes, or another admin/EM session pauses or resumes it) produces a
     * different hash on apply's fresh re-resolve, refused via the existing
     * {@code AdminChangesetApplyService.PlanHashMismatchException}/HTTP 409 path.
+    * <p>{@code task} is deliberately excluded from this canonical string: it is a free-text,
+    * audit-only label that flows only to {@code AdminChangeRecord.setTaskDescription} via
+    * {@code ClusterChangesetApplyService.writeAudit()}, never compared, parsed, or used to gate a
+    * mutation, so paraphrasing it between {@code preview} and {@code apply} must not change the
+    * plan's identity or trigger a false plan-drift refusal.
     */
-   private static String hash(String task, List<PlanChange> changes) {
-      StringBuilder canonical = new StringBuilder(task).append('\n');
+   private static String hash(List<PlanChange> changes) {
+      StringBuilder canonical = new StringBuilder();
 
       for(PlanChange change : changes) {
          canonical.append(change.property()).append(SEP)

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java
@@ -242,6 +242,19 @@ class ClusterChangePlanServiceTest {
       assertEquals(hash1, hash2);
    }
 
+   // stylebi#76472: task is a free-text, audit-only label -- paraphrasing it between preview and
+   // apply must not change the plan's identity hash, or apply falsely refuses with a plan-drift 409
+   // even though nothing about the actual plan changed.
+   @Test void hashIsUnaffectedByDifferentTaskStrings() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash1 = service.resolve(request("pause server s1 for maintenance",
+                                              List.of(pause("s1")))).planHash();
+      String hash2 = service.resolve(request("pausing s1 to do maintenance work",
+                                              List.of(pause("s1")))).planHash();
+      assertEquals(hash1, hash2);
+   }
+
    // -------------------------------------------------------------------------
    // helpers
    // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bug #76472 (Cluster area, 1 of 5 independent sibling PRs for this batch — the other four areas, Properties/Licensing/Presentation/Providers, each get their own PR).
- `ClusterChangePlanService.hash(String task, List<PlanChange> changes)` folded the free-text, audit-only `task` narrative into the SHA-256 canonical string used for `planHash()`. Paraphrasing `task` between `preview` and `apply` — with `changes` byte-identical — produced a different hash, causing `ClusterChangesetApplyService.apply()`'s plan-hash equality gate to falsely refuse with `PlanHashMismatchException` (HTTP 409), even though nothing about the actual plan changed.
- Traced every downstream use of `task`: it only ever reaches `AdminChangeRecord.setTaskDescription()` via `writeAudit()` — never compared, parsed, tokenized, or used to gate a mutation — so it is safe to drop from the plan-identity hash.

## Changes
- `core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java`: dropped `task` from `hash()`'s signature and canonical-string seed; updated the `resolve()` call site to match; added a Javadoc paragraph explaining why `task` is excluded (audit-only, per `ClusterChangesetApplyService.writeAudit()`).
- `core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java`: added `hashIsUnaffectedByDifferentTaskStrings` — two `resolve()` calls with different `task` text and identical `changes`, asserting equal `planHash()`. Verified red (fails with a hash mismatch) on pre-fix code and green after the fix, via a scoped `git apply -R`/`git apply` round trip on just the service file.
- `ClusterChangesetApplyService.java` is untouched — it has no direct `hash()` call; it re-resolves the whole plan via `resolve()`, so it picks up the new hash signature automatically. Verified via `grep` — no other production call site for `hash()` exists.

## Test plan
- [x] `./mvnw -pl core test -Dtest='ClusterChangePlanServiceTest' -o` — `Tests run: 20, Failures: 0, Errors: 0` (was `Tests run: 20, Failures: 1` on pre-fix code, confirming red→green).
- [x] `./mvnw -pl core test -Dtest='ClusterChangesetApplyServiceTest' -o` — `Tests run: 10, Failures: 0, Errors: 0` (no collateral breakage).