### PR TITLE
Fix false PlanHashMismatchException on paraphrased task (Bug #76472, Presentation area)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
@@ -85,7 +85,7 @@ public class PresentationChangePlanService {
 
       String task = req.getTask().trim();
       List<PlanChange> immutableChanges = Collections.unmodifiableList(changes);
-      return new ResolvedPlan(task, immutableChanges, true, true, hash(task, immutableChanges));
+      return new ResolvedPlan(task, immutableChanges, true, true, hash(immutableChanges));
    }
 
    /**
@@ -360,9 +360,18 @@ public class PresentationChangePlanService {
    /** SHA-256 over the canonical plan, same field-order/control-character-free contract as every
     * other area's own {@code hash} method. Package-visible so {@link PresentationChangesetApplyService}
     * can recompute the identical hash from the same {@link ResolvedChange#planChange()} list
-    * {@link #resolveEntries} already produced, instead of resolving the whole plan a second time. */
-   static String hash(String task, List<PlanChange> changes) {
-      StringBuilder canonical = new StringBuilder(task).append('\n');
+    * {@link #resolveEntries} already produced, instead of resolving the whole plan a second time.
+    *
+    * <p>Deliberately does NOT take {@code task}: the free-text task description is never
+    * canonicalized or otherwise constrained (only checked for non-blank in {@link #resolveEntries}),
+    * so two equally valid paraphrases of the same intent over the identical {@code changes} would
+    * otherwise hash differently and trip a false {@code PlanHashMismatchException} between preview
+    * and apply. {@code task} is write-only downstream -- it flows into
+    * {@link PresentationChangesetApplyService#writeAudit} as
+    * {@code AdminChangeRecord.setTaskDescription}, a plain audit label that is never read back or
+    * compared -- so excluding it from the hash does not weaken the gate against a changed plan. */
+   static String hash(List<PlanChange> changes) {
+      StringBuilder canonical = new StringBuilder();
 
       for(PlanChange change : changes) {
          canonical.append(change.property()).append(SEP)

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
@@ -88,7 +88,7 @@ public class PresentationChangesetApplyService {
          }
 
          String task = req.getTask().trim();
-         String currentHash = PresentationChangePlanService.hash(task, planChanges);
+         String currentHash = PresentationChangePlanService.hash(planChanges);
 
          if(req.getPlanHash() == null || !currentHash.equals(req.getPlanHash())) {
             throw new AdminChangesetApplyService.PlanHashMismatchException(

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
@@ -510,6 +510,19 @@ class PresentationChangePlanServiceTest {
       assertFalse(proposed.emailEnabled());
    }
 
+   // ---------------------------------------------------------------- hash: task is audit-only, not part of the plan identity
+
+   @Test
+   void hashIsUnaffectedByDifferentTaskStrings() throws Exception {
+      stub(PresentationSubModel.FORMATS, currentFor(PresentationSubModel.FORMATS));
+      PresentationChangeRequest raw = change("formats", "organization", specFor(PresentationSubModel.FORMATS));
+
+      var planA = service.resolve(request("Update date format to ISO", raw), PRINCIPAL);
+      var planB = service.resolve(request("Change the date format to ISO 8601", raw), PRINCIPAL);
+
+      assertEquals(planA.planHash(), planB.planHash());
+   }
+
    // ---------------------------------------------------------------- secretFields is per sub-model
 
    @Test

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
@@ -168,6 +168,32 @@ class PresentationChangesetApplyServiceTest {
    }
 
    @Test
+   void applySucceedsWhenTaskIsParaphrasedBetweenPreviewAndApply() throws Exception {
+      // hash() recomputes locally at this call site (PresentationChangesetApplyService.apply), a
+      // second place from PresentationChangePlanService.resolve() where the same "task must not
+      // affect the hash" mistake could be reintroduced independently -- this test guards that
+      // second call site specifically, not just the plan-service-level hash contract.
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationChangeRequest changeReq =
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd"));
+
+      PresentationChangePlanRequest preview = new PresentationChangePlanRequest();
+      preview.setTask("Update date format to ISO");
+      preview.setChanges(List.of(changeReq));
+      var plan = planService.resolve(preview, user);
+
+      PresentationApplyRequest apply = new PresentationApplyRequest();
+      apply.setTask("Change the date format to ISO 8601");
+      apply.setChanges(List.of(changeReq));
+      apply.setPlanHash(plan.planHash());
+      apply.setReviewOutcome("looks good");
+
+      var result = service.apply(apply, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+   }
+
+   @Test
    void applyRefusesAStaleHash() throws Exception {
       seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
       PresentationApplyRequest req = applyRequest("t", "ok", null,


### PR DESCRIPTION
## Summary
- `PresentationChangePlanService.hash()` seeded its canonical string with the free-text `task` description. `task` is validated only for non-blank and is never read back or compared downstream -- it is a write-only audit label (`AdminChangeRecord.setTaskDescription`, `PresentationChangesetApplyService.writeAudit`). Paraphrasing `task` between a `preview` call and the matching `apply` call, with identical `changes`, produced a different `planHash` and a false `PlanHashMismatchException` (HTTP 409) on `apply`.
- Presentation has two call sites that compute the hash: `PresentationChangePlanService.resolve()` and `PresentationChangesetApplyService.apply()` (which recomputes the hash locally from its own re-resolved `changes` + `task`, rather than going through `resolve()`). Both were updated to drop `task` from `hash()`'s signature.
- Added a plan-level regression test (`PresentationChangePlanServiceTest.hashIsUnaffectedByDifferentTaskStrings`: two different `task` strings, identical `changes`, asserts equal `planHash()`).
- Added an apply-level regression test (`PresentationChangesetApplyServiceTest.applySucceedsWhenTaskIsParaphrasedBetweenPreviewAndApply`: `task` paraphrased between preview and apply, identical `changes`, asserts `apply()` succeeds instead of throwing `PlanHashMismatchException`) -- this specifically covers the second call site, since a plan-service-only test would not catch a regression reintroduced there alone.

This is 1 of 5 independent PRs fixing the same defect shape across different admin-chat areas for Bug #76472; this PR is scoped to the Presentation area only (`PresentationChangePlanService`/`PresentationChangesetApplyService`).

## Test plan
- [x] `./mvnw -pl core test -Dtest='PresentationChangePlanServiceTest,PresentationChangesetApplyServiceTest' -o` -- `Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, BUILD SUCCESS` (26 + 8, including both new regression tests)
- [x] Verified red -> green: reverted the two production-file edits only (`git apply -R` on a source-only patch), re-ran the same command -- both new tests failed (`hashIsUnaffectedByDifferentTaskStrings` assertion mismatch, `applySucceedsWhenTaskIsParaphrasedBetweenPreviewAndApply` threw `PlanHashMismatchException`); re-applied the fix and both passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)