### PR TITLE
fix(#76472-providers): exclude task from ProviderChangePlanService plan hash

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
@@ -123,7 +123,7 @@ public class ProviderChangePlanService {
 
       String task = req.getTask().trim();
       return new ResolvedPlan(task, Collections.unmodifiableList(changes), true, true,
-                              hash(task, changes, chainProjections));
+                              hash(changes, chainProjections));
    }
 
    // ---------------------------------------------------------------- create
@@ -502,11 +502,16 @@ public class ProviderChangePlanService {
     * reorder on a touched chain changes that chain's projection, so {@code apply}'s fresh re-resolve
     * produces a different hash and is refused via the existing 409 path -- no new conflict-handling
     * code needed.
+    * <p>
+    * {@code task} is deliberately excluded from this hash: it is a free-text audit narrative, never
+    * compared, parsed, or gated on -- it flows only into {@code ProviderChangesetApplyService
+    * .writeAudit}'s {@code record.setTaskDescription(task)}. Including it here would fail the
+    * apply-time plan-hash check whenever a caller paraphrases the task description between preview
+    * and apply while the actual {@code changes}/chain state stay identical.
     */
-   private static String hash(String task, List<PlanChange> changes,
-                              Map<ProviderChain, String> chainProjections)
+   private static String hash(List<PlanChange> changes, Map<ProviderChain, String> chainProjections)
    {
-      StringBuilder canonical = new StringBuilder(task).append('\n');
+      StringBuilder canonical = new StringBuilder();
 
       for(ProviderChain chain : ProviderChain.values()) {
          String projection = chainProjections.get(chain);

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
@@ -400,6 +400,16 @@ class ProviderChangePlanServiceTest {
       assertEquals(first.planHash(), second.planHash());
    }
 
+   @Test void hashIsUnaffectedByDifferentTaskStrings() throws Exception {
+      stubHealthyAuthenticationChainOf("p1", "p2");
+      when(authenticationProviderService.getAuthenticationProvider("p2")).thenReturn(fileModel("p2"));
+
+      ResolvedPlan first = service.resolve(request("delete p2", List.of(deleteAuth("p2"))), user);
+      ResolvedPlan second = service.resolve(
+         request("please remove provider p2", List.of(deleteAuth("p2"))), user);
+      assertEquals(first.planHash(), second.planHash());
+   }
+
    @Test void hashChangesWhenProviderOrderChangesButMembershipDoesNot() throws Exception {
       // A create -- no preflight involved -- isolates the whole-chain projection's own order
       // sensitivity (section 5) from the delete preflight's own membership requirements.


### PR DESCRIPTION
## Summary
- Bug #76472 (Providers area, one of 5 independent sibling areas in this batch — this PR covers Providers only).
- `ProviderChangePlanService.hash()` seeded its SHA-256 canonical string with the free-text `task` narrative. `task` is verified audit-label-only downstream (`ProviderChangesetApplyService.writeAudit`'s `record.setTaskDescription(task)`) — never compared, parsed, or gated on anywhere in the apply/rollback flow.
- Consequence: if a caller (e.g. an LLM agent) paraphrases `task` between `preview` and `apply` while `changes` and live provider-chain state stay identical, `resolve()` at apply time recomputes a different `planHash`, and `apply()`'s equality gate throws `PlanHashMismatchException` (HTTP 409) even though nothing about the actual plan changed.
- Fix: drop `task` from `hash()`'s parameter list and canonical-string seed; update the sole call site in `resolve()` to `hash(changes, chainProjections)`. `chainProjections` (a live concurrent-modification detector for touched provider chains, independent of `task`) and the `changes` loop are left byte-for-byte untouched, per the same "drop only the first parameter" pattern already applied to the DataSource/Viewsheet siblings in #76454.

## Test plan
- [x] Added `hashIsUnaffectedByDifferentTaskStrings` to `ProviderChangePlanServiceTest.java`: two `resolve()` calls with different `task` strings but identical `changes`/chain state assert equal `planHash()`.
- [x] Confirmed red before the fix (reverted just the source file via `git apply -R`, re-ran the suite): `Tests run: 30, Failures: 1` — the new test failed with the exact hash-divergence mechanism.
- [x] Confirmed green after re-applying the fix: `Tests run: 30, Failures: 0` (`ProviderChangePlanServiceTest`) and `Tests run: 13, Failures: 0` (`ProviderChangesetApplyServiceTest`, confirming no collateral breakage on the apply-side gate).
- Command: `cd E:/wt/76472-providers && ./mvnw -pl core test -Dtest='ProviderChangePlanServiceTest,ProviderChangesetApplyServiceTest' -o`

🤖 Generated with [Claude Code](https://claude.com/claude-code)