### PR TITLE
fix(uql): resolve table-qualified column refs before the fuzzy fallback (bug #76449 WBS-004)

### DIFF
--- a/core/src/main/java/inetsoft/uql/ColumnSelection.java
+++ b/core/src/main/java/inetsoft/uql/ColumnSelection.java
@@ -365,6 +365,18 @@ public class ColumnSelection implements XMLSerializable, Cloneable, Serializable
             String attr = dr.getAttribute();
             String oname = entity == null || entity.length() == 0 ? attr : entity + "." + attr;
 
+            // fix Bug #76449: match a genuinely table-qualified reference (e.g.
+            // "RETURNS.ORDER_ID") against its entity-qualified form directly, before the
+            // fuzzy fallback below gets a chance to strip the qualifier and match the first
+            // same-named column from ANY table. Without this, a qualified reference to a
+            // column that also carries a display alias (getName() prefers the alias over the
+            // qualified form, so the exact-match loop above can never see it) always fell
+            // through to the fuzzy fallback and could silently resolve to the wrong table's
+            // column when two joined tables share a bare attribute name.
+            if(oname.equals(name)) {
+               return dr;
+            }
+
             if(oname.equals(dr.getName()) && dr.getAttribute().equals(name)) {
                return dr;
             }

--- a/core/src/test/java/inetsoft/uql/ColumnSelectionTest.java
+++ b/core/src/test/java/inetsoft/uql/ColumnSelectionTest.java
@@ -18,6 +18,7 @@
 package inetsoft.uql;
 
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import org.junit.jupiter.api.BeforeEach;
@@ -201,6 +202,80 @@ class ColumnSelectionTest {
          // entity itself contains a dot: full "entity.attribute" name is looked up
          Arguments.of(new AttributeRef("a.b", "c"), "a.b.c")
       );
+   }
+
+   // ---- join-collision alias resolution (bug 76449 WBS-004 settling test) ----
+
+   /*
+    * Reproduces JoinQuery.getDefaultColumnSelection0()'s exact per-table merge sequence
+    * (AssetUtil.getOuterAttribute wraps each side's column with the join member's table
+    * name as entity, then AssetUtil.fixAlias runs after each table is merged in) so this
+    * exercises the real production code path that builds a join's persisted column
+    * selection, not a hand-rolled substitute.
+    */
+   @Nested
+   class JoinCollisionAliasResolutionTests {
+      @Test
+      void fixAliasSuffixesTheSecondTablesCollidingColumn() {
+         ColumnSelection joined = new ColumnSelection();
+         ColumnRef ordersOrderId = new ColumnRef(
+            AssetUtil.getOuterAttribute("ORDERS", new ColumnRef(new AttributeRef(null, "ORDER_ID"))));
+         joined.addAttribute(ordersOrderId);
+         AssetUtil.fixAlias(joined);
+
+         ColumnRef returnsOrderId = new ColumnRef(
+            AssetUtil.getOuterAttribute("RETURNS", new ColumnRef(new AttributeRef(null, "ORDER_ID"))));
+         joined.addAttribute(returnsOrderId);
+         AssetUtil.fixAlias(joined);
+
+         assertNull(ordersOrderId.getAlias());
+         assertEquals("ORDER_ID_1", returnsOrderId.getAlias());
+      }
+
+      @Test
+      void getAttributeByDisambiguatingAliasResolvesToCorrectSide() {
+         ColumnSelection joined = new ColumnSelection();
+         ColumnRef ordersOrderId = new ColumnRef(
+            AssetUtil.getOuterAttribute("ORDERS", new ColumnRef(new AttributeRef(null, "ORDER_ID"))));
+         joined.addAttribute(ordersOrderId);
+         AssetUtil.fixAlias(joined);
+
+         ColumnRef returnsOrderId = new ColumnRef(
+            AssetUtil.getOuterAttribute("RETURNS", new ColumnRef(new AttributeRef(null, "ORDER_ID"))));
+         joined.addAttribute(returnsOrderId);
+         AssetUtil.fixAlias(joined);
+
+         // This is the exact lookup WorksheetMutationSupport.resolveField()/fieldExists()
+         // perform for set_conditions: ColumnSelection.getAttribute(field), i.e. the one-arg
+         // overload, which delegates to getAttribute(field, true).
+         DataRef resolved = joined.getAttribute("ORDER_ID_1");
+         assertSame(returnsOrderId, resolved);
+      }
+
+      @Test
+      void getAttributeByQualifiedNameResolvesToCorrectSide() {
+         // Regression test for the CONFIRMED half of bug 76449 WBS-004: a table-qualified
+         // reference ("RETURNS.ORDER_ID") used to miss both exact-match loops (ColumnRef
+         // .getName() returns the alias, never the entity-qualified form, once an alias is
+         // set) and fall into the fuzzy fallback, which strips the "RETURNS." prefix and
+         // returns the FIRST bare-attribute match in the whole selection -- the ORDERS-side
+         // column, not the RETURNS-side one it actually named. Fixed by matching the
+         // qualified form directly before the fuzzy fallback runs.
+         ColumnSelection joined = new ColumnSelection();
+         ColumnRef ordersOrderId = new ColumnRef(
+            AssetUtil.getOuterAttribute("ORDERS", new ColumnRef(new AttributeRef(null, "ORDER_ID"))));
+         joined.addAttribute(ordersOrderId);
+         AssetUtil.fixAlias(joined);
+
+         ColumnRef returnsOrderId = new ColumnRef(
+            AssetUtil.getOuterAttribute("RETURNS", new ColumnRef(new AttributeRef(null, "ORDER_ID"))));
+         joined.addAttribute(returnsOrderId);
+         AssetUtil.fixAlias(joined);
+
+         DataRef resolved = joined.getAttribute("RETURNS.ORDER_ID");
+         assertSame(returnsOrderId, resolved);
+         assertNotSame(ordersOrderId, resolved);
+      }
    }
 
    // ---- findAttribute ----


### PR DESCRIPTION
## Summary

Fixes the confirmed half of Redmine #76449 WBS-004: `set_conditions` (StyleBI Composer-agent
`/edit` endpoint) silently rebinding a table-qualified condition field (e.g. `"RETURNS.ORDER_ID"`)
to the wrong column when two joined tables share a bare attribute name.

Root cause: `ColumnSelection.getAttribute(name, entity, fuzz)`'s fuzzy fallback
(`ColumnSelection.java:391-399`) strips a qualified reference's entity prefix and re-searches by
the bare attribute name **across every column in the selection**, returning the first match --
regardless of which table it actually came from. The two preceding exact-match loops never catch
a qualified reference first because `ColumnRef.getName()` (`ColumnRef.java:271-273`) returns the
column's display **alias** when one is set, never its entity-qualified form -- so once a column
carries a disambiguating alias (exactly the situation table-qualification exists to resolve), a
qualified lookup always falls through to the collision-prone fallback.

Fix: match the entity-qualified form (`entity + "." + attribute`) directly against the input
before the fuzzy fallback runs, so a genuinely qualified reference resolves to its named column
instead of an arbitrary same-named one.

## Also settled: the sibling alias-form question

The open half of WBS-004 asked whether the plain alias form (`field: "ORDER_ID_1"`, the exact
alias StyleBI itself reports via `read_worksheet_model`) resolves correctly. A settling JUnit test
that reproduces `JoinQuery.getDefaultColumnSelection0()`'s real column-merge sequence
(`AssetUtil.getOuterAttribute` + `AssetUtil.fixAlias`, the same production methods used when a
join's column selection is built/refreshed) confirms this form **already resolves correctly today**
via the first exact-match loop -- no separate defect there. Left unchanged.

## Test plan

- [x] New `ColumnSelectionTest$JoinCollisionAliasResolutionTests` (3 cases): confirms
      `AssetUtil.fixAlias` suffixes the second table's colliding column, confirms the alias form
      resolves to the correct side, and is a regression test for the qualified-name fix (fails
      pre-fix with `expected ORDER_ID_1 but was ORDERS.ORDER_ID`, passes post-fix).
- [x] `./mvnw test -pl community/core -Dtest=ColumnSelectionTest` -- 57/57 pass.
- [x] Collateral-regression sweep across every test class touching `ColumnSelection.getAttribute`
      (`CrosstabSortByValueAliasedAggregateNameTest`, `AssemblyConditionDialogServiceTest`,
      `RenameColumnControllerTest`, `WizAgentTestSupportTest`, `GenerateWsServiceAggregateTypeTest`,
      `GenerateWsServiceFieldTest`, `WizVsServiceAddFiltersTest`,
      `WizVsServiceCorrectsWrongGeoMapTypeTest`, `WizVsServiceHighlightRebindTest`,
      `WorksheetTableServiceAggregateDescriptionTest`, `WorksheetTableServiceConditionTest`,
      `WorksheetTableServiceGroupAliasTest`, `WorksheetTableServiceWindowColumnsTest`,
      `WsMergeServiceTest`, `WsServiceHelperCompositeDescriptionTest`,
      `WorksheetAgentControllerTest`, `WorksheetEditServiceMutatorsTest`,
      `WorksheetEditServiceTest`, `WorksheetReadServiceTest`, `WorksheetScriptControllerTest`)
      -- 599/599 pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)