### PR TITLE
Add regression test for bug #74951 (Ignite shutdown race, already fixed)

### DIFF
--- a/core/src/test/java/inetsoft/sree/internal/cluster/ignite/IgniteClusterShutdownRaceTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/cluster/ignite/IgniteClusterShutdownRaceTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.internal.cluster.ignite;
+
+import inetsoft.sree.internal.cluster.*;
+import inetsoft.test.*;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Regression test for bug #74951: removing a replicated map listener after the
+ * cluster has already been closed (e.g. shutdownInetsoft()/ClusterJobStore
+ * closing the Ignite-backed cluster before a bean like Plugins/BlobStorage
+ * unregisters its listener during its own shutdown) must not throw
+ * IgniteIllegalStateException. Fixed as a side effect of commit 1b6ae84fbc.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class IgniteClusterShutdownRaceTest {
+   @TempDir
+   static Path clusterDir;
+
+   @Test
+   void removeReplicatedMapListenerAfterCloseDoesNotThrow() {
+      TcpDiscoveryIpFinder ipFinder = new TcpDiscoveryVmIpFinder(true);
+      IgniteCluster cluster = IgniteClusterTestUtils.getIgniteCluster("bug74951", ipFinder, clusterDir);
+
+      MapChangeListener<String, String> listener = new MapChangeListener<String, String>() {
+         @Override
+         public void entryAdded(EntryEvent<String, String> event) {
+         }
+
+         @Override
+         public void entryUpdated(EntryEvent<String, String> event) {
+         }
+
+         @Override
+         public void entryRemoved(EntryEvent<String, String> event) {
+         }
+      };
+
+      cluster.addReplicatedMapListener("bug74951-map", listener);
+      cluster.close();
+
+      assertDoesNotThrow(() -> cluster.removeReplicatedMapListener("bug74951-map", listener));
+   }
+}


### PR DESCRIPTION
## Summary

This PR touches **only test code, no production source**.

Bug #74951 reported an `IgniteIllegalStateException` thrown from
`IgniteCluster.removeCacheEventListener()` (via `LocalKeyValueStorage.close()`
-> `BlobStorage.close()` -> `Plugins.close()`) when Ignite's kernal gateway was
already `STOPPED` during Spring bean shutdown.

Investigation (diagnosis + independent adversarial refute, both archived
internally) found this bug was already fixed — as an unintentional side effect
— by commit `1b6ae84fbc` ("Epic 70095 Distributed Sessions", 2026-05-26, ~12
days after this bug was filed), which added:
- `mapListeners.clear()` in `IgniteCluster.close()`
- an `if(!closed)` guard (redundant with the existing `mapListeners.get(name)
  != null` check) in `IgniteCluster.removeCacheEventListener()`

No production code change is proposed here. This PR adds a permanent,
non-`@Disabled` JUnit regression test so a future refactor of `IgniteCluster`
can't silently reintroduce the race.

## Test plan

- [x] New test `IgniteClusterShutdownRaceTest` (embedded single-node Ignite,
      no Spring context beyond the config scaffolding shared with sibling
      tests in this package) registers a replicated map listener, calls
      `cluster.close()` (simulating shutdown having already run), then calls
      `removeReplicatedMapListener()` for the same name and asserts it does
      not throw.
- [x] Confirmed the test **passes** against current `HEAD`.
- [x] Adversarially reverted the two guard lines above (temporarily, not
      committed) and confirmed the test **fails** with the exact reported
      exception: `IgniteIllegalStateException: ... state=STOPPED`. Restored
      the guards and reconfirmed `git status --porcelain` clean aside from
      the new test file.
- [x] Ran the full `core` module test suite (`./mvnw -o -pl core -am test`):
      `Tests run: 8758, Failures: 0, Errors: 0, Skipped: 69` (the 69 skips are
      pre-existing `@Disabled` classes, unrelated to this change).

Note: the existing `IgniteClusterTest`/`IgniteDistributedMapTest` etc. in this
package are entirely `@Disabled` at the class level (confirmed via git blame
this predates and is unrelated to `1b6ae84fbc`), so this regression test was
added as a new, separate, non-`@Disabled` test class rather than a method on
one of those classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)