### PR TITLE
fix(#76478): resolve/validate input-assembly variable table bindings

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -871,7 +871,9 @@ public class VSInputService {
       textInputAssemblyInfo.setInsetStyle(textInputGeneralPaneModel.isInsetStyle());
       textInputAssemblyInfo.setMultiline(textInputGeneralPaneModel.isMultiLine());
 
-      String table = dataInputPaneModel.getTable();
+      String table = resolveInputTableBinding(viewsheet.getViewsheet().getBaseWorksheet(),
+         viewsheet.getViewsheet(), dataInputPaneModel.getTable(),
+         dataInputPaneModel.getColumnValue());
       textInputAssemblyInfo.setTableName(table == null ? "" : table);
       textInputAssemblyInfo.setColumnValue(dataInputPaneModel.getColumnValue());
       textInputAssemblyInfo.setRowValue(dataInputPaneModel.getRowValue());
@@ -1093,7 +1095,9 @@ public class VSInputService {
       sliderAssemblyInfo.setPrimary(basicGeneralPaneModel.isPrimary());
       sliderAssemblyInfo.setVisibleValue(basicGeneralPaneModel.getVisible());
 
-      String table = dataInputPaneModel.getTable();
+      String table = resolveInputTableBinding(viewsheet.getViewsheet().getBaseWorksheet(),
+         viewsheet.getViewsheet(), dataInputPaneModel.getTable(),
+         dataInputPaneModel.getColumnValue());
       sliderAssemblyInfo.setTableName(table == null ? "" : table);
       sliderAssemblyInfo.setColumnValue(dataInputPaneModel.getColumnValue());
       sliderAssemblyInfo.setRowValue(dataInputPaneModel.getRowValue());
@@ -1996,7 +2000,9 @@ public class VSInputService {
       setListValues(comboBoxAssemblyInfo, value, viewsheet, principal);
 
       // TODO validate column/row variable/expression type
-      String table = dataInputPaneModel.getTable();
+      String table = resolveInputTableBinding(viewsheet.getViewsheet().getBaseWorksheet(),
+         viewsheet.getViewsheet(), dataInputPaneModel.getTable(),
+         dataInputPaneModel.getColumnValue());
       comboBoxAssemblyInfo.setTableName(table == null ? "" : table);
       comboBoxAssemblyInfo.setColumnValue(dataInputPaneModel.getColumnValue());
       comboBoxAssemblyInfo.setRowValue(dataInputPaneModel.getRowValue());
@@ -2287,7 +2293,9 @@ public class VSInputService {
       spinnerAssemblyInfo.setPrimary(basicGeneralPaneModel.isPrimary());
       spinnerAssemblyInfo.setVisibleValue(basicGeneralPaneModel.getVisible());
 
-      String table = dataInputPaneModel.getTable();
+      String table = resolveInputTableBinding(viewsheet.getViewsheet().getBaseWorksheet(),
+         viewsheet.getViewsheet(), dataInputPaneModel.getTable(),
+         dataInputPaneModel.getColumnValue());
       spinnerAssemblyInfo.setTableName(table == null ? "" : table);
       spinnerAssemblyInfo.setColumnValue(dataInputPaneModel.getColumnValue());
       spinnerAssemblyInfo.setRowValue(dataInputPaneModel.getRowValue());
@@ -3773,6 +3781,83 @@ public class VSInputService {
       }
       catch(Exception ex) {
          //ignore the exception
+      }
+
+      return false;
+   }
+
+   /**
+    * Resolves a Data Input pane's {@code table} value against the worksheet before it is
+    * stored, instead of letting an unresolvable value be written silently (bug #76478):
+    * {@code refreshVariable()} keys off this exact string later, at apply time, and no-ops
+    * without any error if it doesn't match a real assembly or variable.
+    *
+    * <p>Accepts the correct {@code "$(varName)"} reference form as-is, provided the variable
+    * actually exists; accepts any real worksheet table/assembly name as-is (a genuine
+    * table+column binding); and normalizes two unambiguous natural mistakes into the
+    * {@code "$(varName)"} form the runtime requires: a bare variable name with no
+    * {@code $(...)} wrapping, and the Composer's own "Variables" tree folder label (not a
+    * selectable leaf -- see {@link #getInputTablesTree}) paired with a {@code columnValue}
+    * that names a real variable. Anything else is rejected loud, by field name, rather than
+    * silently persisted as a broken binding.
+    */
+   private static String resolveInputTableBinding(Worksheet ws, Viewsheet vs, String table,
+                                                   String columnValue)
+   {
+      if(table == null || table.isEmpty() || ws == null) {
+         return table;
+      }
+
+      if(table.startsWith("$(") && table.endsWith(")")) {
+         String vname = table.substring(2, table.length() - 1);
+
+         if(!isKnownVariableName(ws, vs, vname)) {
+            throw new MessageException("Unknown variable '" + vname + "' referenced by " +
+               "table binding '" + table + "'. Use add_variable to create it first.");
+         }
+
+         return table;
+      }
+
+      if(isKnownVariableName(ws, vs, table)) {
+         return "$(" + table + ")";
+      }
+
+      if(ws.getAssembly(table) != null) {
+         return table;
+      }
+
+      if("Variables".equals(table) && columnValue != null && !columnValue.isEmpty() &&
+         isKnownVariableName(ws, vs, columnValue))
+      {
+         return "$(" + columnValue + ")";
+      }
+
+      throw new MessageException("Unknown table binding '" + table + "' for this input. " +
+         "It does not match a worksheet table or a worksheet variable; use " +
+         "\"$(variableName)\" to bind to a variable.");
+   }
+
+   private static boolean isKnownVariableName(Worksheet ws, Viewsheet vs, String name) {
+      if(ws == null || name == null) {
+         return false;
+      }
+
+      if(ws.getAssembly(name) instanceof VariableAssembly) {
+         return true;
+      }
+
+      ArrayList<UserVariable> variableList = new ArrayList<>();
+      Viewsheet.mergeVariables(variableList, ws.getAllVariables());
+
+      if(vs != null) {
+         Viewsheet.mergeVariables(variableList, vs.getAllVariables());
+      }
+
+      for(UserVariable var : variableList) {
+         if(var != null && name.equals(var.getName())) {
+            return true;
+         }
       }
 
       return false;

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -3843,8 +3843,18 @@ public class VSInputService {
          return false;
       }
 
-      if(ws.getAssembly(name) instanceof VariableAssembly) {
+      Assembly assembly = ws.getAssembly(name);
+
+      if(assembly instanceof VariableAssembly) {
          return true;
+      }
+
+      // A concrete worksheet assembly of this name (e.g. a real table) always outranks an
+      // incidental UserVariable of the same name pulled in from some *other* assembly's own
+      // condition/SQL params by Worksheet.getAllVariables() -- that fallback list is not
+      // restricted to VariableAssembly-backed names.
+      if(assembly != null) {
+         return false;
       }
 
       ArrayList<UserVariable> variableList = new ArrayList<>();

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+/*
+ * Regression for Bug #76478: setSliderPropertyDialogModel/setComboboxPropertyDialogModel/
+ * setSpinnerPropertyDialogModel/setTextInputPropertyDialogModel used to copy
+ * dataInputPaneModel.getTable() straight into the assembly's tableName with no check that it
+ * resolved to anything. A caller writing table:"Variables" (the Composer data-input tree's own
+ * non-selectable folder label, not a real leaf value -- see getInputTablesTree) instead of the
+ * required "$(varName)" form was accepted silently: isVariable() came back false, refreshVariable()
+ * later matched nothing, and the value never reached the VariableTable -- while
+ * InputValueService.setValue() still reported {ok:true}.
+ *
+ * resolveInputTableBinding() now runs before the table string is stored: it passes through a
+ * "$(varName)" reference that names a real variable, passes through a real worksheet
+ * table/assembly name unchanged, normalizes two unambiguous natural mistakes (a bare variable
+ * name, and the "Variables" folder label paired with a columnValue naming a real variable) into
+ * the "$(varName)" form the runtime requires, and otherwise throws a MessageException naming the
+ * bad value instead of persisting a binding that can never resolve.
+ */
+
+import inetsoft.uql.asset.DefaultVariableAssembly;
+import inetsoft.uql.asset.EmbeddedTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.util.MessageException;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@WizAgentTestSupport
+class VSInputTableBindingResolutionTest {
+   @Test
+   void passesThroughACorrectlyFormattedVariableReference() throws Exception {
+      Worksheet ws = worksheetWithVariable("discountRate");
+
+      assertEquals("$(discountRate)", resolve(ws, "$(discountRate)", "discountRate"));
+   }
+
+   @Test
+   void rejectsAVariableReferenceToAVariableThatDoesNotExist() {
+      Worksheet ws = new Worksheet();
+
+      MessageException ex = assertThrows(MessageException.class,
+         () -> resolve(ws, "$(discountRate)", "discountRate"));
+      assertTrue(ex.getMessage().contains("discountRate"), ex.getMessage());
+   }
+
+   /** The exact reported shape: the Composer tree's "Variables" folder label, not a leaf value. */
+   @Test
+   void normalizesTheVariablesFolderLabelPairedWithARealVariableColumnValue() throws Exception {
+      Worksheet ws = worksheetWithVariable("discountRate");
+
+      assertEquals("$(discountRate)", resolve(ws, "Variables", "discountRate"));
+   }
+
+   @Test
+   void rejectsTheVariablesFolderLabelWhenTheColumnValueIsNotARealVariable() {
+      Worksheet ws = worksheetWithVariable("discountRate");
+
+      MessageException ex = assertThrows(MessageException.class,
+         () -> resolve(ws, "Variables", "notAVariable"));
+      assertTrue(ex.getMessage().contains("Variables"), ex.getMessage());
+   }
+
+   @Test
+   void normalizesABareVariableNameIntoTheReferenceForm() throws Exception {
+      Worksheet ws = worksheetWithVariable("discountRate");
+
+      assertEquals("$(discountRate)", resolve(ws, "discountRate", null));
+   }
+
+   @Test
+   void passesThroughARealWorksheetTableNameUnchanged() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
+
+      assertEquals("Query1", resolve(ws, "Query1", "DISCOUNT"));
+   }
+
+   @Test
+   void rejectsATableValueThatMatchesNothing() {
+      Worksheet ws = worksheetWithVariable("discountRate");
+
+      MessageException ex = assertThrows(MessageException.class,
+         () -> resolve(ws, "TotallyUnknownTable", "discountRate"));
+      assertTrue(ex.getMessage().contains("TotallyUnknownTable"), ex.getMessage());
+   }
+
+   @Test
+   void leavesAnUnboundInputUntouched() throws Exception {
+      Worksheet ws = new Worksheet();
+
+      assertNull(resolve(ws, null, null));
+      assertEquals("", resolve(ws, "", null));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private static Worksheet worksheetWithVariable(String name) {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, name));
+      return ws;
+   }
+
+   private static String resolve(Worksheet ws, String table, String columnValue)
+      throws Exception
+   {
+      Method method = VSInputService.class.getDeclaredMethod(
+         "resolveInputTableBinding", Worksheet.class,
+         inetsoft.uql.viewsheet.Viewsheet.class, String.class, String.class);
+      method.setAccessible(true);
+
+      try {
+         return (String) method.invoke(null, ws, null, table, columnValue);
+      }
+      catch(InvocationTargetException e) {
+         if(e.getCause() instanceof MessageException messageException) {
+            throw messageException;
+         }
+
+         throw e;
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
@@ -35,9 +35,14 @@ package inetsoft.web.viewsheet.service;
  * bad value instead of persisting a binding that can never resolve.
  */
 
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.DefaultVariableAssembly;
 import inetsoft.uql.asset.EmbeddedTableAssembly;
 import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
 import inetsoft.util.MessageException;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import org.junit.jupiter.api.Test;
@@ -95,6 +100,34 @@ class VSInputTableBindingResolutionTest {
       ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
 
       assertEquals("Query1", resolve(ws, "Query1", "DISCOUNT"));
+   }
+
+   /**
+    * Review round 1 finding: a real table can share its name with a UserVariable that
+    * Worksheet.getAllVariables() pulls in purely because some *other*, unrelated table's own
+    * condition references "$(Query1)" -- no assembly named "Query1" is ever a VariableAssembly.
+    * The real "Query1" table must still win.
+    */
+   @Test
+   void aRealTableOutranksAnUnrelatedConditionVariableOfTheSameName() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
+
+      EmbeddedTableAssembly other = new EmbeddedTableAssembly(ws, "OtherTable");
+      ColumnRef ref = new ColumnRef(new AttributeRef("col1"));
+      Condition cond = new Condition();
+      cond.addValue("$(Query1)");
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(ref, cond, 0));
+      other.setPreConditionList(conditionList);
+      ws.addAssembly(other);
+
+      // sanity check that the collision is actually set up: "Query1" really does show up as
+      // a merged UserVariable name, purely via the unrelated table's condition.
+      assertTrue(java.util.Arrays.stream(ws.getAllVariables())
+                    .anyMatch(v -> "Query1".equals(v.getName())));
+
+      assertEquals("Query1", resolve(ws, "Query1", null));
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `set_input_value` reported `{ok:true}` while silently no-op'ing: Slider/ComboBox/Spinner/TextInput's property-dialog setters copied `dataInputPaneModel.getTable()` into the assembly's `tableName` with no validation, so a caller binding `table:"Variables"` (the Composer data-input tree's own non-selectable folder label, not a real leaf value) instead of the required `"$(varName)"` form produced a binding that read back as configured but never resolved in `refreshVariable()` at apply time.
- Adds `resolveInputTableBinding()`, wired into all four affected setters: passes through a valid `"$(varName)"` reference or a real worksheet table/assembly name unchanged, normalizes two unambiguous natural mistakes (a bare variable name; the `"Variables"` folder label paired with a `columnValue` naming a real variable) into the `"$(varName)"` form the runtime requires, and throws loud (naming the bad value) otherwise — mirroring the existing `set_variable_values`/`editVariable` existence-check precedent (`WorksheetAgentController.java:2308`).
- CheckBox/RadioButton (a related but structurally different gap — they trust a UI-only boolean with no plugin-settable alias) and `InputValueService.setValue()`'s own unconditional `{ok:true}` are deliberately left untouched, out of scope for this fix.

Root-caused via `stylebi-wiz` bug #76478 (Redmine); full diagnosis/refute/fix write-up at `stylebi-wiz` repo `docs/teams/2026-09-05-bugs-76479-76478-76475/bug-76478/`.

## Test plan
- [x] New regression test `VSInputTableBindingResolutionTest` (8 cases: valid `$(var)` pass-through, unknown-variable rejection, the exact reported `"Variables"`+columnValue shape, bad columnValue rejection, bare-name normalization, real-table pass-through, unresolvable-value rejection, null/empty pass-through) — `./mvnw -q -pl core test -Dtest=VSInputTableBindingResolutionTest` — 8/8 pass
- [x] No regression in neighboring suites — `./mvnw -q -pl core test -Dtest="VSComboBoxDateValueTest,CalendarInputServiceTest,AssemblyPropertyServiceTest,WorksheetAgentControllerTest"` — all green (7/7, 29/29, 13/13, 131/131)
- [ ] Live verification via `set_input_value`/`get_viewsheet_image` (not possible this session — no Chrome browser with the Claude extension connected)

No LLM-facing prompt/schema/tool-description text was touched by this PR — Java-side only, no merge hold needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)