### PR TITLE
Bug VBM-006: fix Gauge rangeValues dropped color band

### DIFF
--- a/core/src/main/java/inetsoft/report/gui/viewsheet/gauge/DefaultVSGauge.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/gauge/DefaultVSGauge.java
@@ -206,6 +206,19 @@ public class DefaultVSGauge extends VSGauge {
          double rangeBegin = info.getMin();
          double rangeEnd = 0.0;
 
+         // index of the last non-NaN boundary; any NaN entry beyond it is a trailing,
+         // unset boundary (e.g. rangeValues=[60,90,"",""]) that should extend to the
+         // gauge's own max rather than collapse to a zero-width band. A NaN entry at or
+         // before this index is an interior gap (a genuinely malformed config) and keeps
+         // the prior, pre-existing behavior of collapsing to a zero-width band.
+         int lastBoundaryIndex = -1;
+
+         for(int i = 0; i < ranges.length; i++) {
+            if(!Double.isNaN(ranges[i])) {
+               lastBoundaryIndex = i;
+            }
+         }
+
          Loop:
          for(int i = 0; i < ranges.length; i++) {
             for(int k = i - 1; i != 0 && k >= 0; k--) {
@@ -225,8 +238,11 @@ public class DefaultVSGauge extends VSGauge {
             {
                rangeEnd = info.getMax();
             }
+            else if(Double.isNaN(ranges[i])) {
+               rangeEnd = i > lastBoundaryIndex ? info.getMax() : rangeEnd;
+            }
             else {
-               rangeEnd = !Double.isNaN(ranges[i]) ? ranges[i] : rangeEnd;
+               rangeEnd = ranges[i];
             }
 
             double rangeDelta = rangeEnd - rangeBegin;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.model.vs.RangePaneModel;
 import inetsoft.web.composer.vs.dialog.*;
 import inetsoft.web.viewsheet.service.VSInputService;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
@@ -245,8 +246,47 @@ public class AssemblyPropertyService {
             model = PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
          }
 
+         if(type.equals("gauge")) {
+            requireNoInteriorGapInGaugeRangeValues(model);
+         }
+
          writeModel(runtimeId, type, assemblyName, model, linkUri, user, dispatcher);
       });
+   }
+
+   /**
+    * A trailing blank {@code rangeValues} entry (e.g. {@code ["60","90","",""]}) is an
+    * unambiguous "extend the last band to the gauge's own max" request -- the renderer
+    * (fillRanges0) now handles that correctly on its own, so it is left to pass through
+    * silently. A <em>blank followed by a populated entry</em> (e.g. {@code ["60","","150"]})
+    * is genuinely ambiguous -- the renderer has no principled way to resolve it and would
+    * silently collapse that band to nothing -- so that shape is refused here instead of
+    * being allowed to reach a plausible-but-wrong render.
+    */
+   private void requireNoInteriorGapInGaugeRangeValues(Object model) {
+      Object rangePane = PropertyPath.get(model, "gaugeAdvancedPaneModel.rangePaneModel");
+
+      if(!(rangePane instanceof RangePaneModel range)) {
+         return;
+      }
+
+      String[] rangeValues = range.getRangeValues();
+      int lastPopulated = -1;
+
+      for(int i = 0; i < rangeValues.length; i++) {
+         if(rangeValues[i] != null && !rangeValues[i].isEmpty()) {
+            lastPopulated = i;
+         }
+      }
+
+      for(int i = 0; i < lastPopulated; i++) {
+         if(rangeValues[i] == null || rangeValues[i].isEmpty()) {
+            throw new IllegalArgumentException(
+               "rangeValues[" + i + "] is blank but a later entry is set -- rangeValues may " +
+               "only have a blank trailing entry (meaning \"extend to the gauge's own max\"), " +
+               "not a gap in the middle.");
+         }
+      }
    }
 
    // ── convention dispatch ───────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -246,7 +246,9 @@ public class AssemblyPropertyService {
             model = PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
          }
 
-         if(type.equals("gauge")) {
+         if(type.equals("gauge") && resolved.values().stream()
+            .anyMatch(path -> path.startsWith("gaugeAdvancedPaneModel.rangePaneModel")))
+         {
             requireNoInteriorGapInGaugeRangeValues(model);
          }
 
@@ -262,6 +264,12 @@ public class AssemblyPropertyService {
     * is genuinely ambiguous -- the renderer has no principled way to resolve it and would
     * silently collapse that band to nothing -- so that shape is refused here instead of
     * being allowed to reach a plausible-but-wrong render.
+    *
+    * <p>Only invoked by the caller when this call's own patch touches
+    * {@code gaugeAdvancedPaneModel.rangePaneModel}. The human Composer GUI has no equivalent
+    * validation, so a gauge can already have an interior gap saved from that path (or from a
+    * call before this guard existed); an unrelated later patch (e.g. {@code max}) must not be
+    * blocked by state it never touched.
     */
    private void requireNoInteriorGapInGaugeRangeValues(Object model) {
       Object rangePane = PropertyPath.get(model, "gaugeAdvancedPaneModel.rangePaneModel");

--- a/core/src/test/java/inetsoft/report/gui/viewsheet/gauge/DefaultVSGaugeTest.java
+++ b/core/src/test/java/inetsoft/report/gui/viewsheet/gauge/DefaultVSGaugeTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.gui.viewsheet.gauge;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.internal.GaugeVSAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * VBM-006: a trailing blank/NaN {@code rangeValues} boundary (e.g.
+ * {@code rangeValues=[60,90,"",""]}) used to collapse the last color band to a zero-width arc
+ * that painted nothing, because {@code fillRanges0} treated any NaN boundary as "repeat the
+ * previous boundary" with no distinction from a genuine interior gap.
+ *
+ * <p>Constructing a real {@code GaugeVSAssemblyInfo} runs {@code VSAssemblyInfo}'s constructor,
+ * which reads {@code SreeEnv} and therefore needs a Spring context -- hence the harness
+ * annotations, which mirror {@code ViewsheetReadServiceTest}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class DefaultVSGaugeTest {
+   @Test
+   void trailingNaNBoundaryExtendsTheLastColorBandToMax() {
+      RecordingGauge gauge = gaugeWithMinMax(0, 200);
+
+      gauge.fillRanges0(null,
+                        new double[]{ 60, 90, Double.NaN, Double.NaN },
+                        new Color[]{ Color.RED, Color.YELLOW, Color.GREEN, null },
+                        false);
+
+      assertEquals(4, gauge.calls.size());
+      // band index 2 (green) must now stretch from the previous boundary (90) to max (200),
+      // not collapse to a zero-width arc the way it did before this fix.
+      assertNotEquals(0d, gauge.calls.get(2).delta(), 1e-9,
+                       "the last populated color band must extend to the gauge's own max");
+      // the extra padding band (index 3, no real color pair) still contributes nothing visible.
+      assertEquals(0d, gauge.calls.get(3).delta(), 1e-9);
+   }
+
+   @Test
+   void interiorNaNBoundaryStillCollapsesToZero() {
+      RecordingGauge gauge = gaugeWithMinMax(0, 200);
+
+      gauge.fillRanges0(null,
+                        new double[]{ 60, Double.NaN, 150 },
+                        new Color[]{ Color.RED, Color.YELLOW, Color.GREEN, null },
+                        false);
+
+      assertEquals(3, gauge.calls.size());
+      // a blank boundary followed by a later, real boundary is a malformed config, not an
+      // "extend to max" request -- it must keep collapsing to zero, not be silently resolved.
+      assertEquals(0d, gauge.calls.get(1).delta(), 1e-9,
+                   "an interior gap must not be silently resolved to a nonzero band");
+   }
+
+   @Test
+   void allBlankRangeValuesExtendsTheSingleBandToMax() {
+      RecordingGauge gauge = gaugeWithMinMax(0, 200);
+
+      gauge.fillRanges0(null,
+                        new double[]{ Double.NaN },
+                        new Color[]{ Color.RED, null },
+                        false);
+
+      assertEquals(1, gauge.calls.size());
+      assertNotEquals(0d, gauge.calls.get(0).delta(), 1e-9,
+                       "a single all-blank boundary must cover the whole min..max span");
+   }
+
+   private static RecordingGauge gaugeWithMinMax(double min, double max) {
+      GaugeVSAssemblyInfo info = new GaugeVSAssemblyInfo();
+      info.setMin(String.valueOf(min));
+      info.setMax(String.valueOf(max));
+
+      RecordingGauge gauge = new RecordingGauge();
+      gauge.setAssemblyInfo(info);
+      // a real gauge face parses this out of gauge.xml; a nonzero sweep angle is needed so the
+      // arithmetic under test (rangeDelta -> nonzero vs. zero angular delta) is observable.
+      gauge.angle = Math.toRadians(270);
+
+      return gauge;
+   }
+
+   /** Records each band's begin/end radian instead of actually painting, so the resolved
+    *  {@code rangeEnd}/{@code rangeDelta} arithmetic can be asserted on directly. */
+   private static class RecordingGauge extends DefaultVSGauge {
+      final List<Call> calls = new ArrayList<>();
+
+      @Override
+      protected void fillRange(Graphics2D g, Point2D center, double beginRadian,
+                               double endRadian, Color color1, Color color2, double radius,
+                               double rangeWidth, boolean leftRound, boolean rightRound,
+                               boolean gradient)
+      {
+         calls.add(new Call(beginRadian, endRadian));
+      }
+   }
+
+   private record Call(double beginRadian, double endRadian) {
+      double delta() {
+         return beginRadian - endRadian;
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -271,6 +271,27 @@ class AssemblyPropertyServiceTest {
                  "must name the blank index: " + thrown.getMessage());
    }
 
+   /**
+    * VBM-006 review round 1: the interior-gap guard must only fire for a patch that actually
+    * touches {@code gaugeAdvancedPaneModel.rangePaneModel}. A gauge can already have an interior
+    * {@code rangeValues} gap saved from a source the guard does not cover (the human Composer
+    * GUI, or a call made before this guard existed); an unrelated later patch (here, {@code max})
+    * must still succeed instead of being blocked by state it never touched.
+    */
+   @Test
+   void ignoresAPreExistingInteriorGapWhenThePatchDoesNotTouchRanges() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      model.getGaugeAdvancedPaneModel().getRangePaneModel()
+         .setRangeValues(new String[]{ "60", "", "150" });
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      assertDoesNotThrow(() -> service.set("tok", principal(), "Gauge1",
+         Map.of("max", "999"), ""));
+
+      assertEquals("999", model.getGaugeGeneralPaneModel().getNumberRangePaneModel().getMax(),
+                   "the unrelated property must still have been written");
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -234,6 +234,43 @@ class AssemblyPropertyServiceTest {
          model.getGaugeAdvancedPaneModel().getRangePaneModel().getRangeValues());
    }
 
+   /**
+    * VBM-006: a trailing blank {@code rangeValues} entry (e.g. {@code ["60","90","",""]}) is an
+    * unambiguous "extend the last color band to the gauge's own max" request that the renderer
+    * ({@code DefaultVSGauge.fillRanges0}) now resolves correctly on its own, so it must be
+    * allowed to pass through silently -- no normalization needed here, and no error either.
+    */
+   @Test
+   void allowsATrailingBlankGaugeRangeValue() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      assertDoesNotThrow(() -> service.set("tok", principal(), "Gauge1",
+         Map.of("gaugeAdvancedPaneModel.rangePaneModel.rangeValues",
+                java.util.List.of("60", "90", "", "")),
+         ""));
+   }
+
+   /**
+    * VBM-006: unlike a trailing blank, a blank entry followed by a later populated entry is
+    * genuinely ambiguous -- the renderer has no principled way to resolve it and would silently
+    * collapse that band to nothing. This must be refused loudly instead, naming the field.
+    */
+   @Test
+   void refusesAnInteriorGapInGaugeRangeValues() {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "Gauge1",
+            Map.of("gaugeAdvancedPaneModel.rangePaneModel.rangeValues",
+                   java.util.List.of("60", "", "150")),
+            ""));
+
+      assertTrue(thrown.getMessage().contains("rangeValues[1]"),
+                 "must name the blank index: " + thrown.getMessage());
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {


### PR DESCRIPTION
## Summary
- A trailing blank/NaN `rangeValues` boundary (e.g. `["60","90","",""]`, meant as "N-1 breakpoints define N bands, last band goes to max") was silently rendering as a dropped color band: `DefaultVSGauge.fillRanges0()` treated a NaN boundary as "repeat the previous boundary" instead of "extend to the gauge's own max", producing a zero-width arc that painted nothing.
- Fixed at the render layer (`fillRanges0`), not just the wiz-agent tool layer, so the fix also covers the ordinary Composer GUI, which reaches the identical renderer through `GaugePropertyDialogService` and has no validation preventing a human from creating the same blank-boundary state.
- An **interior** blank (a gap followed by a later populated boundary, e.g. `["60","","150"]`) is deliberately left alone at the render layer — it's still a genuinely ambiguous config, not resolved to anything.
- `AssemblyPropertyService.set()` (the wiz agent's `set_assembly_properties` path) now refuses that interior-gap shape with a field-named `IllegalArgumentException`, per this repo's "tool-misuse is a plugin gap" principle — a trailing blank is unambiguous and renders correctly now, so it passes through silently; an interior gap has no principled resolution and would otherwise silently render wrong.

## Root cause
`RangeOutputVSAssemblyInfo.getRanges()` converts a blank `rangeValues` string to `NaN`. `DefaultVSGauge.fillRanges0()` had no NaN guard: every comparison branch short-circuits false for NaN (IEEE 754), falling through to a branch that keeps the previous `rangeEnd`, making that band's angular delta zero — a zero-delta arc paints nothing.

## Fix
`fillRanges0()` now precomputes the index of the last non-NaN boundary. A NaN entry *after* that index (a trailing run) resolves to the gauge's own `max`. A NaN entry *at or before* that index (an interior gap) keeps the pre-existing, unchanged behavior (zero-delta / dropped band) — treated as a config error, not silently resolved.

## Test plan
- [x] `DefaultVSGaugeTest` (new): trailing NaN resolves to max; interior NaN still collapses to zero; an all-blank `rangeValues` extends the single band to max. `./mvnw -pl core -o test -Dtest=DefaultVSGaugeTest`
- [x] `AssemblyPropertyServiceTest` (extended): a trailing blank gauge rangeValues patch is allowed through unchanged; an interior gap is refused with a message naming `rangeValues[1]`. `./mvnw -pl core -o test -Dtest=AssemblyPropertyServiceTest`
- [x] Full `inetsoft.web.wiz.viewsheet` package (672 tests) and `inetsoft.report.gui.viewsheet` package (11 tests) re-run clean, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)