### PR TITLE
fix(wiz): contain post-write refresh failures in modifyCalculateField (VBS-003)

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/controller/ModifyCalculateFieldService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ModifyCalculateFieldService.java
@@ -55,6 +55,8 @@ import inetsoft.web.vswizard.command.*;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardEditModes;
 import inetsoft.web.vswizard.recommender.WizardRecommenderUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -247,9 +249,14 @@ public class ModifyCalculateFieldService {
             calc.setVSAssemblyInfo(calcInfo);
          }
 
-         AggregateInfo ainfo = createAggregateInfo(engine.getAssetRepository(), vs,
-                                                   calc.getAbsoluteName(), calc.getSourceInfo(), principal);
-         calcInfo.setAggregateInfo(ainfo);
+         try {
+            AggregateInfo ainfo = createAggregateInfo(engine.getAssetRepository(), vs,
+                                                      calc.getAbsoluteName(), calc.getSourceInfo(), principal);
+            calcInfo.setAggregateInfo(ainfo);
+         }
+         catch(Exception e) {
+            warnRefreshFailure(dispatcher, "refresh calc table aggregate info", tname, refname, e);
+         }
       }
 
       // remodified other chart/crosstab aggregate info
@@ -310,29 +317,40 @@ public class ModifyCalculateFieldService {
       if(ass instanceof ChartVSAssembly) {
          ChartVSAssembly chart = (ChartVSAssembly) ass;
 
-         if(changeCalcType) {
-            chart.changeBindingCalcType(refname, chart.getVSChartInfo(), cref, event.wizard());
-            chart.getVSChartInfo().setAggregateInfo(new AggregateInfo());
-            chartHandler.fixAggregateInfo(chart.getChartInfo(), vs, null);
+         try {
+            if(changeCalcType) {
+               chart.changeBindingCalcType(refname, chart.getVSChartInfo(), cref, event.wizard());
+               chart.getVSChartInfo().setAggregateInfo(new AggregateInfo());
+               chartHandler.fixAggregateInfo(chart.getChartInfo(), vs, null);
+            }
+            else {
+               chartHandler.fixAggregateInfo(chart.getChartInfo(), vs, chart.getAggregateInfo());
+            }
          }
-         else {
-            chartHandler.fixAggregateInfo(chart.getChartInfo(), vs, chart.getAggregateInfo());
+         catch(Exception e) {
+            warnRefreshFailure(dispatcher, "refresh chart aggregate info", tname, refname, e);
          }
       }
       else if(ass instanceof CrosstabVSAssembly) {
          CrosstabVSAssembly cross = (CrosstabVSAssembly) ass;
-         TableAssembly tbl = VSEventUtil.getTableAssembly(vs, cross.getSourceInfo(),
-                                                          engine.getAssetRepository(), principal);
-         AggregateInfo nainfo = new AggregateInfo();
 
-         if(changeCalcType) {
-            VSEventUtil.createAggregateInfo(tbl, nainfo, null, vs, true);
-         }
-         else {
-            VSEventUtil.createAggregateInfo(tbl, nainfo, cross.getAggregateInfo(), vs, true);
-         }
+         try {
+            TableAssembly tbl = VSEventUtil.getTableAssembly(vs, cross.getSourceInfo(),
+                                                             engine.getAssetRepository(), principal);
+            AggregateInfo nainfo = new AggregateInfo();
 
-         cross.getVSCrosstabInfo().setAggregateInfo(nainfo);
+            if(changeCalcType) {
+               VSEventUtil.createAggregateInfo(tbl, nainfo, null, vs, true);
+            }
+            else {
+               VSEventUtil.createAggregateInfo(tbl, nainfo, cross.getAggregateInfo(), vs, true);
+            }
+
+            cross.getVSCrosstabInfo().setAggregateInfo(nainfo);
+         }
+         catch(Exception e) {
+            warnRefreshFailure(dispatcher, "refresh crosstab aggregate info", tname, refname, e);
+         }
       }
 
       if(event.wizard()) {
@@ -374,10 +392,22 @@ public class ModifyCalculateFieldService {
          VSWizardEditModes.WIZARD_DASHBOARD.equalsIgnoreCase(event.wizardOriginalMode());
 
       if((!event.wizard() || event.remove() && wizardNewVs) && (infoChanged || !create)) {
-         WizardRecommenderUtil.setIgnoreRefreshTempAssembly(event.wizard());
-         VSRefreshEvent refresh = VSRefreshEvent.builder().confirmed(false).build();
-         refreshController.refreshViewsheet(refresh, principal, dispatcher, linkUri);
-         WizardRecommenderUtil.setIgnoreRefreshTempAssembly(null);
+         try {
+            WizardRecommenderUtil.setIgnoreRefreshTempAssembly(event.wizard());
+            VSRefreshEvent refresh = VSRefreshEvent.builder().confirmed(false).build();
+            refreshController.refreshViewsheet(refresh, principal, dispatcher, linkUri);
+         }
+         catch(Exception e) {
+            // A session-less caller (e.g. the wiz agent) has no WebSocket-session-scoped
+            // runtime id for VSRefreshController's own cluster-affinity routing to key on,
+            // so this best-effort post-write refresh can NPE (RuntimeSheetCache.getAffinityKey)
+            // even though the calc field mutation above already committed -- see PCB-006
+            // 04-reverify-after-redeploy.md.
+            warnRefreshFailure(dispatcher, "refresh the viewsheet", tname, refname, e);
+         }
+         finally {
+            WizardRecommenderUtil.setIgnoreRefreshTempAssembly(null);
+         }
       }
 
       if(ass != null) {
@@ -400,6 +430,23 @@ public class ModifyCalculateFieldService {
 
       engine.flushRuntimeSheet(id);
       return null;
+   }
+
+   // The calc field mutation has already committed by the time any of these post-write refresh
+   // steps run (see the try/catch around vs.addCalcField/removeCalcField above) -- a failure here
+   // is a stale-shelf-metadata degradation, not a failed write, so the caller gets a warning
+   // instead of either a false hard error or silent, unreported staleness.
+   private void warnRefreshFailure(CommandDispatcher dispatcher, String step, String tname,
+                                   String refname, Exception e)
+   {
+      LOG.warn("Failed to {} after calc field \"{}\" change on \"{}\" -- the calc field write " +
+               "itself already committed", step, refname, tname, e);
+      MessageCommand command = new MessageCommand();
+      command.setType(MessageCommand.Type.WARNING);
+      command.setMessage("The \"" + refname + "\" calc field change on \"" + tname +
+         "\" was saved, but a secondary step (" + step + ") failed -- some assemblies bound " +
+         "to this table may not reflect the change until the sheet is reopened.");
+      dispatcher.sendCommand(command);
    }
 
    private AggregateInfo createAggregateInfo(AssetRepository engine, Viewsheet vs,
@@ -732,4 +779,6 @@ public class ModifyCalculateFieldService {
    private final VSWizardBindingHandler wizardBindingHandler;
    private final VSAssemblyInfoHandler assemblyInfoHandler;
    private final DataSourceRegistry dataSourceRegistry;
+
+   private static final Logger LOG = LoggerFactory.getLogger(ModifyCalculateFieldService.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -440,15 +440,26 @@ public class BindingAgentController {
                                         linkUri);
    }
 
+   /**
+    * @param warnings messages from any post-write shelf-metadata refresh steps that were caught
+    *                 rather than propagated -- the calc field write itself already committed
+    *                 either way (see {@code ViewsheetSessionService.mutate}/
+    *                 {@code CalcFieldAgentService.modify}); empty when nothing warned. Distinct
+    *                 from {@code handleCommandError}'s 409 body, which is for a write that did
+    *                 NOT commit.
+    */
+   public record CalcFieldResponse(List<String> warnings) {}
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc-field")
-   public void modifyCalcField(@PathVariable String sessionToken,
+   public CalcFieldResponse modifyCalcField(@PathVariable String sessionToken,
                                @RequestBody CalcFieldAgentService.CalcFieldRequest request,
                                @RequestParam(required = false, defaultValue = "") String linkUri,
                                Principal user)
       throws Exception
    {
       requireEnabled();
-      calcFieldService.modify(sessionToken, user, request, linkUri);
+      List<String> warnings = calcFieldService.modify(sessionToken, user, request, linkUri);
+      return new CalcFieldResponse(warnings);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/source")

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcFieldAgentService.java
@@ -92,7 +92,14 @@ public class CalcFieldAgentService {
                                   String expression, String dataType, Boolean sql,
                                   Boolean baseOnDetail, boolean remove, boolean create) {}
 
-   public void modify(String sessionToken, Principal agent, CalcFieldRequest req, String linkUri)
+   /**
+    * @return the messages of any warnings the write's post-write shelf-metadata refresh steps
+    *         caught rather than propagated (see {@code ModifyCalculateFieldService}'s guarded
+    *         refresh steps) -- empty when nothing warned. The write itself has already committed
+    *         either way; these are advisory, not an error.
+    */
+   public List<String> modify(String sessionToken, Principal agent, CalcFieldRequest req,
+                              String linkUri)
       throws Exception
    {
       // ModifyCalculateFieldService.modifyCalculateField itself performs no permission check --
@@ -125,7 +132,7 @@ public class CalcFieldAgentService {
       String newName = req.newName() != null && !req.newName().isBlank()
          ? req.newName() : req.name();
 
-      sessions.mutate(sessionToken, agent, (rvs, runtimeId, dispatcher) -> {
+      return sessions.mutate(sessionToken, agent, (rvs, runtimeId, dispatcher) -> {
          String tableName = requireBindableTable(runtimeId, req.table(), agent);
 
          CalculateRefModel model = null;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.util.List;
 
 /**
  * Resolves a pairing session to a live viewsheet runtime and runs mutations against it.
@@ -139,12 +140,23 @@ public class ViewsheetSessionService {
     *
     * <p>One checkpoint per call, matching what a single Composer dialog OK does, so the
     * human's Ctrl+Z steps back through agent edits one at a time.
+    *
+    * @return the messages of any {@code MessageCommand}s of {@code Type.WARNING} the mutation
+    *         dispatched -- e.g. a best-effort post-write refresh step that was contained rather
+    *         than allowed to fail the whole call. Empty when nothing warned. Unlike an ERROR
+    *         (which fails the call via {@link CommandErrorException}), a WARNING does not stop
+    *         the write from being reported as a success; the caller decides whether/how to
+    *         surface these to the agent.
     */
-   public void mutate(String sessionToken, Principal agent, Mutation mutation) throws Exception {
+   public List<String> mutate(String sessionToken, Principal agent, Mutation mutation)
+      throws Exception
+   {
       JoinSession session = requireSession(sessionToken, agent);
       RuntimeViewsheet rvs = (RuntimeViewsheet) runtimeAccess.getSheetForPairing(
          SheetType.VIEWSHEET, session.runtimeId(), agent);
       applySocketSession(rvs, session);
+
+      List<String> warnings = List.of();
 
       // The checkpoint and the broadcast happen even when the mutation fails. A composer service
       // partially applies before it ERRORs -- that is precisely why it ERRORs rather than throwing
@@ -154,9 +166,9 @@ public class ViewsheetSessionService {
       // no step for the partial change. The partial edit is real, so it gets an undo step and the
       // browser is told about it.
       try {
-         CapturingCommandDispatcher.withCapturingDispatcher(agent, dispatcher -> {
+         warnings = CapturingCommandDispatcher.withCapturingDispatcher(agent, dispatcher -> {
             mutation.run(rvs, session.runtimeId(), dispatcher);
-            return null;
+            return dispatcher.getWarnings();
          });
       }
       catch(CommandErrorException e) {
@@ -187,6 +199,8 @@ public class ViewsheetSessionService {
 
          broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
       }
+
+      return warnings;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/binding/controller/ModifyCalculateFieldServiceTest.java
+++ b/core/src/test/java/inetsoft/web/binding/controller/ModifyCalculateFieldServiceTest.java
@@ -24,8 +24,11 @@ import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.viewsheet.CalculateRef;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
+import inetsoft.uql.viewsheet.VSCrosstabInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.drm.CalculateRefModel;
 import inetsoft.web.binding.event.ModifyCalculateFieldEvent;
@@ -35,12 +38,14 @@ import inetsoft.web.binding.handler.VSChartHandler;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.XRepository;
+import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.viewsheet.controller.VSRefreshController;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -127,5 +132,157 @@ class ModifyCalculateFieldServiceTest {
       verify(vsBindingTreeService).getBinding(
          eq(id), any(RefreshBindingTreeEvent.class), eq(principal), eq(dispatcher));
       verify(vs).addCalcField(eq("Orders"), eq(cref));
+   }
+
+   /**
+    * VBS-003: a calc field add against a crosstab whose base table shape (e.g. a multi-way join
+    * with duplicate/aliased columns) makes the post-write crosstab AggregateInfo rebuild throw
+    * used to let that exception escape modifyCalculateField uncaught, which
+    * WizControllerErrorHandler.handleUnexpected then turned into a generic "unexpected server
+    * error" -- even though vs.addCalcField(...) had already committed a few lines earlier. The fix
+    * wraps that rebuild in its own try/catch so the write's own success is what reaches the
+    * caller; this test proves the exception no longer propagates and the caller gets a warning
+    * MessageCommand instead of silence or a false failure.
+    */
+   @Test
+   void containsCrosstabAggregateInfoRefreshFailureInsteadOfPropagatingIt() throws Exception {
+      String id = "rt-calcfield-2";
+      Principal principal = mock(Principal.class);
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+
+      ExpressionRef exprRef = new ExpressionRef();
+      exprRef.setName("DoubleQty");
+      exprRef.setExpression("field['QUANTITY'] * 2");
+      CalculateRef cref = new CalculateRef(true);
+      cref.setDataRef(exprRef);
+      cref.setSQL(false);
+
+      CalculateRefModel calcModel = mock(CalculateRefModel.class);
+      when(calcModel.createDataRef()).thenReturn(cref);
+
+      ModifyCalculateFieldEvent event = mock(ModifyCalculateFieldEvent.class);
+      when(event.calculateRef()).thenReturn(calcModel);
+      when(event.tableName()).thenReturn("OrdersJoined");
+      when(event.refName()).thenReturn("DoubleQty");
+      when(event.create()).thenReturn(true);
+      when(event.remove()).thenReturn(false);
+      when(event.name()).thenReturn("Crosstab1");
+      when(event.wizard()).thenReturn(false);
+      when(event.wizardOriginalMode()).thenReturn(null);
+
+      CrosstabVSAssembly cross = mock(CrosstabVSAssembly.class);
+      when(cross.getVSCrosstabInfo()).thenReturn(mock(VSCrosstabInfo.class));
+      // 1st call (initial-setup check) succeeds; the 2nd call, in the post-write refresh block
+      // this fix guards, is where the join/duplicate-column-shaped table throws.
+      when(cross.getSourceInfo())
+         .thenReturn(mock(SourceInfo.class))
+         .thenThrow(new NullPointerException("simulated join-table aggregate-info refresh NPE"));
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssemblies()).thenReturn(new Assembly[0]);
+      when(vs.getAssembly(eq("Crosstab1"))).thenReturn(cross);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(mock(ViewsheetSandbox.class)));
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      when(viewsheetService.getViewsheet(eq(id), eq(principal))).thenReturn(rvs);
+
+      ModifyCalculateFieldService service = new ModifyCalculateFieldService(
+         mock(VSBindingService.class), mock(VSBindingTreeControllerServiceProxy.class),
+         mock(VSChartHandler.class), mock(XRepository.class), mock(VSWizardBindingHandler.class),
+         mock(VSRefreshController.class), viewsheetService, mock(VSAssemblyInfoHandler.class),
+         mock(DataSourceRegistry.class));
+
+      assertDoesNotThrow(
+         () -> service.modifyCalculateField(id, event, principal, dispatcher, ""));
+
+      verify(vs).addCalcField(eq("OrdersJoined"), eq(cref));
+
+      ArgumentCaptor<MessageCommand> captor = ArgumentCaptor.forClass(MessageCommand.class);
+      verify(dispatcher, atLeastOnce()).sendCommand(captor.capture());
+      boolean sawCrosstabWarning = captor.getAllValues().stream().anyMatch(
+         c -> c.getType() == MessageCommand.Type.WARNING &&
+            c.getMessage() != null && c.getMessage().contains("crosstab"));
+      assertTrue(sawCrosstabWarning,
+         "expected a WARNING MessageCommand about the crosstab refresh failure");
+   }
+
+   /**
+    * VBS-003 / PCB-006 04-reverify-after-redeploy: even after PR #4971 fixed the non-wizard
+    * binding-tree-refresh branch, edit_calc_field/remove_calc_field still hit an unguarded
+    * NullPointerException from RuntimeSheetCache.getAffinityKey via
+    * refreshController.refreshViewsheet(...), because a session-less caller (the wiz agent) has
+    * no WebSocket-session-scoped runtime id for that call's cluster-affinity routing to key on.
+    * This fires whenever infoChanged || !create -- i.e. on essentially every edit/remove. This
+    * test simulates that exact call throwing and proves the calc field edit still completes (the
+    * write already committed) with a warning instead of the generic 500.
+    */
+   @Test
+   void containsRefreshViewsheetFailureOnEditInsteadOfPropagatingIt() throws Exception {
+      String id = "rt-calcfield-3";
+      Principal principal = mock(Principal.class);
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+
+      ExpressionRef exprRef = new ExpressionRef();
+      exprRef.setName("DoubleQty");
+      exprRef.setExpression("field['QUANTITY'] * 3");
+      CalculateRef cref = new CalculateRef(true);
+      cref.setDataRef(exprRef);
+      cref.setSQL(false);
+
+      CalculateRef oldCalcRef = (CalculateRef) cref.clone();
+
+      CalculateRefModel calcModel = mock(CalculateRefModel.class);
+      when(calcModel.createDataRef()).thenReturn(cref);
+
+      ModifyCalculateFieldEvent event = mock(ModifyCalculateFieldEvent.class);
+      when(event.calculateRef()).thenReturn(calcModel);
+      when(event.tableName()).thenReturn("OrderDetails");
+      when(event.refName()).thenReturn("DoubleQty");
+      when(event.create()).thenReturn(false);
+      when(event.remove()).thenReturn(false);
+      when(event.name()).thenReturn(null);
+      when(event.wizard()).thenReturn(false);
+      when(event.wizardOriginalMode()).thenReturn(null);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssemblies()).thenReturn(new Assembly[0]);
+      // 1st call resolves the pre-edit ref; the 2nd ("any real change?") call must come back
+      // null so the pre-existing "no-op edit" short-circuit doesn't return before this fix's
+      // guarded refreshViewsheet call is ever reached.
+      when(vs.getCalcField(eq("OrderDetails"), eq("DoubleQty")))
+         .thenReturn(oldCalcRef, (CalculateRef) null);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(mock(ViewsheetSandbox.class)));
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      when(viewsheetService.getViewsheet(eq(id), eq(principal))).thenReturn(rvs);
+
+      VSRefreshController refreshController = mock(VSRefreshController.class);
+      doThrow(new NullPointerException("Ouch! Argument cannot be null: key"))
+         .when(refreshController).refreshViewsheet(any(), eq(principal), eq(dispatcher), anyString());
+
+      ModifyCalculateFieldService service = new ModifyCalculateFieldService(
+         mock(VSBindingService.class), mock(VSBindingTreeControllerServiceProxy.class),
+         mock(VSChartHandler.class), mock(XRepository.class), mock(VSWizardBindingHandler.class),
+         refreshController, viewsheetService, mock(VSAssemblyInfoHandler.class),
+         mock(DataSourceRegistry.class));
+
+      assertDoesNotThrow(
+         () -> service.modifyCalculateField(id, event, principal, dispatcher, ""));
+
+      verify(vs).addCalcField(eq("OrderDetails"), eq(cref));
+
+      ArgumentCaptor<MessageCommand> captor = ArgumentCaptor.forClass(MessageCommand.class);
+      verify(dispatcher, atLeastOnce()).sendCommand(captor.capture());
+      boolean sawRefreshWarning = captor.getAllValues().stream().anyMatch(
+         c -> c.getType() == MessageCommand.Type.WARNING &&
+            c.getMessage() != null && c.getMessage().contains("viewsheet"));
+      assertTrue(sawRefreshWarning,
+         "expected a WARNING MessageCommand about the refreshViewsheet failure");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -510,6 +510,70 @@ class BindingAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // VBS-003 review round 1 (important, confidence 85): a warning captured during a calc-field
+   // write must reach the wiz-agent-facing response body, not just get built and discarded
+   // internally. This is the "tool-facing response" layer of that chain -- CalcFieldAgentService
+   // is mocked here precisely so this test proves THIS controller method's own wiring, not the
+   // service's (see CalcFieldAgentServiceTest/ViewsheetSessionServiceTest for those layers).
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void modifyCalcFieldReturnsTheWarningsTheServiceReported() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      CalcFieldAgentService calcFieldService = mock(CalcFieldAgentService.class);
+      List<String> expectedWarnings = List.of(
+         "Crosstab1: could not refresh the crosstab's aggregate info after the write; the " +
+         "calc field was saved");
+      when(calcFieldService.modify(eq("tok"), any(Principal.class), any(), eq("")))
+         .thenReturn(expectedWarnings);
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions,
+         mock(BindableFieldsService.class), mock(BindingReadService.class),
+         mock(ChartBindingService.class), mock(ChartAestheticAgentService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(SelectionBindingService.class), calcFieldService, mock(SheetAgentBroadcastService.class));
+
+      CalcFieldAgentService.CalcFieldRequest request = new CalcFieldAgentService.CalcFieldRequest(
+         "ORDERS", "Crosstab1", "NetTotal", null, "field['Total']", "double", false, true, false,
+         true);
+
+      BindingAgentController.CalcFieldResponse response =
+         controller.modifyCalcField("tok", request, "", principal());
+
+      assertEquals(expectedWarnings, response.warnings());
+   }
+
+   /** A clean write (no guarded refresh failure) must report an empty warnings list, not null. */
+   @Test
+   void modifyCalcFieldReturnsAnEmptyWarningsListWhenNothingWarned() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      CalcFieldAgentService calcFieldService = mock(CalcFieldAgentService.class);
+      when(calcFieldService.modify(eq("tok"), any(Principal.class), any(), eq("")))
+         .thenReturn(List.of());
+
+      BindingAgentController controller = new BindingAgentController(
+         feature, mock(SheetJoinService.class), mock(SheetSessionService.class), sessions,
+         mock(BindableFieldsService.class), mock(BindingReadService.class),
+         mock(ChartBindingService.class), mock(ChartAestheticAgentService.class),
+         mock(TableBindingService.class), mock(CalcTableService.class),
+         mock(SelectionBindingService.class), calcFieldService, mock(SheetAgentBroadcastService.class));
+
+      CalcFieldAgentService.CalcFieldRequest request = new CalcFieldAgentService.CalcFieldRequest(
+         "ORDERS", "Crosstab1", "NetTotal", null, "field['Total']", "double", false, true, false,
+         true);
+
+      BindingAgentController.CalcFieldResponse response =
+         controller.modifyCalcField("tok", request, "", principal());
+
+      assertTrue(response.warnings().isEmpty());
+   }
+
+   // ---------------------------------------------------------------------------
    // detach -- C2(a): must notify the tab bar the agent is no longer attached
    // ---------------------------------------------------------------------------
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcFieldAgentServiceTest.java
@@ -383,6 +383,44 @@ class CalcFieldAgentServiceTest {
       assertEquals("double", calc.getDataType(), "dataType must be preserved when omitted");
    }
 
+   /**
+    * VBS-003 review round 1 (important, confidence 85): {@code sessions.mutate} now returns any
+    * warnings its dispatcher captured (a caught post-write refresh failure inside
+    * {@code ModifyCalculateFieldService}), but nothing forwarded them out of {@code modify} --
+    * so the wiz agent got a clean, indistinguishable-from-success return for a call that
+    * actually degraded. This asserts {@code modify} returns exactly what {@code mutate} reports,
+    * not that {@code mutate} was merely called.
+    */
+   @Test
+   void modifyReturnsTheWarningsMutateCaptured() throws Exception {
+      ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      List<String> expectedWarnings = List.of(
+         "Crosstab1: could not refresh the crosstab's aggregate info after the write; the " +
+         "calc field was saved");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.mutate(anyString(), any(Principal.class), any())).thenAnswer(invocation -> {
+         ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+         mutation.run(rvs, "rt1", null);
+         return expectedWarnings;
+      });
+
+      CalcFieldAgentService service = new CalcFieldAgentService(
+         sessions, fieldsServiceWithOrdersTable(), proxy, allowingSecurityEngine());
+
+      CalcFieldRequest req = new CalcFieldRequest(
+         "ORDERS", "Crosstab1", "NetTotal", null, "field['Total']", "double", false, true, false,
+         true);
+
+      List<String> warnings = service.modify("tok", principal(), req, "");
+
+      assertEquals(expectedWarnings, warnings);
+   }
+
    @Test
    void baseOnDetailFalseIsPreserved() throws Exception {
       ModifyCalculateFieldServiceProxy proxy = mock(ModifyCalculateFieldServiceProxy.class);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceTest.java
@@ -19,10 +19,12 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.wiz.pairing.*;
 import org.junit.jupiter.api.Test;
 
 import java.security.Principal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -94,6 +96,71 @@ class ViewsheetSessionServiceTest {
       }));
 
       verify(rvs).bumpWriteRevision();
+   }
+
+   /**
+    * VBS-003 review round 1 (important, confidence 85): a caught post-write refresh failure
+    * dispatches a {@code MessageCommand} of {@code Type.WARNING}, but {@code mutate} discarded
+    * whatever the dispatcher captured -- so a wiz-agent call that hit one of those guarded
+    * failures returned a clean success indistinguishable from one where nothing degraded.
+    * Drives the REAL {@link inetsoft.web.wiz.dispatch.CapturingCommandDispatcher} {@code mutate}
+    * constructs internally (not a mock), so this proves the wiring, not just that some method
+    * was called.
+    */
+   @Test
+   void mutateReturnsTheDispatchersCapturedWarnings() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Viewsheet/foo-7", "alice~;~host-org",
+                                      SheetType.VIEWSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq("Viewsheet/foo-7"), eq(agent)))
+         .thenReturn(rvs);
+
+      ViewsheetSessionService svc = new ViewsheetSessionService(sessions, runtimeAccess, broadcast);
+
+      List<String> warnings = svc.mutate("TOK", agent, (r, runtimeId, dispatcher) -> {
+         MessageCommand warning = new MessageCommand();
+         warning.setType(MessageCommand.Type.WARNING);
+         warning.setMessage("Crosstab1: could not refresh the crosstab's aggregate info after " +
+                            "the write; the calc field was saved");
+         dispatcher.sendCommand(warning);
+      });
+
+      assertEquals(List.of("Crosstab1: could not refresh the crosstab's aggregate info after " +
+                            "the write; the calc field was saved"), warnings);
+   }
+
+   /** A mutation that dispatches nothing must not report a phantom warning. */
+   @Test
+   void mutateReturnsAnEmptyListWhenNothingWarned() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Viewsheet/foo-7", "alice~;~host-org",
+                                      SheetType.VIEWSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq("Viewsheet/foo-7"), eq(agent)))
+         .thenReturn(rvs);
+
+      ViewsheetSessionService svc = new ViewsheetSessionService(sessions, runtimeAccess, broadcast);
+
+      List<String> warnings = svc.mutate("TOK", agent, (r, runtimeId, dispatcher) -> {});
+
+      assertTrue(warnings.isEmpty());
    }
 
    /**


### PR DESCRIPTION
## Summary

`add_calc_field`/`edit_calc_field`/`remove_calc_field` against a viewsheet whose base table shape (e.g. a multi-way join with duplicate/aliased columns) made the post-write crosstab/chart/calc-table `AggregateInfo` rebuild throw -- or, for edit/remove, whose downstream `refreshController.refreshViewsheet(...)` call threw -- would let that exception escape `ModifyCalculateFieldService.modifyCalculateField` uncaught, even though `vs.addCalcField`/`removeCalcField` had already committed a few lines earlier. `WizControllerErrorHandler`'s catch-all then reported a generic "unexpected server error" for what was actually a successful write -- a false negative (VBS-003 / PCB-006).

This landed after PR #4971 (merged 2026-09-03), which fixed a *different*, previously-unguarded call site in this same method (the non-wizard binding-tree-refresh branch, `vsBindingTreeService.getBinding`). A live re-verify after that fix (`docs/teams/2026-09-02-bugs-p0-p2-composer/bug-PCB-006/04-reverify-after-redeploy.md` in the `stylebi-wiz` repo) confirmed `add_calc_field` now succeeds but `edit_calc_field` still hit the identical generic 500 -- from `refreshController.refreshViewsheet(...)` NPEing in `RuntimeSheetCache.getAffinityKey` for a session-less (wiz-agent) caller, gated by `infoChanged || !create` (fires on essentially every edit/remove).

## Changes

In `ModifyCalculateFieldService.modifyCalculateField`, wrap four previously-unguarded post-write steps in their own try/catch, sending a warning `MessageCommand` (matching this method's existing `MessageCommand` pattern) instead of letting the exception propagate or silently swallowing it:

1. `CalcTableVSAssembly` initial `AggregateInfo` rebuild
2. `ChartVSAssembly` aggregate-info refresh (`chartHandler.fixAggregateInfo`)
3. `CrosstabVSAssembly` aggregate-info refresh (`VSEventUtil.createAggregateInfo`)
4. `refreshController.refreshViewsheet(...)` -- the confirmed-live NPE site for edit/remove

Each of these runs *after* the actual calc-field mutation (`vs.addCalcField`/`removeCalcField`) has already committed, so containing a failure here is safe -- the write itself is not at risk, only best-effort shelf-metadata refresh.

## Test plan

- Added two regression tests to `ModifyCalculateFieldServiceTest`:
  - `containsCrosstabAggregateInfoRefreshFailureInsteadOfPropagatingIt` -- simulates the crosstab aggregate-info refresh throwing on a join-shaped table; asserts the calc field write still commits and the caller gets a warning `MessageCommand` instead of a propagated exception.
  - `containsRefreshViewsheetFailureOnEditInsteadOfPropagatingIt` -- simulates the exact `RuntimeSheetCache.getAffinityKey` NPE PCB-006's live re-verify found on `edit_calc_field`; asserts the same containment.
- `mvn -pl core -am test -Dtest=ModifyCalculateFieldServiceTest`: 3/3 pass (1 pre-existing + 2 new).
- `mvn -pl core -am test -Dtest=CalcFieldAgentServiceTest`: 13/13 pass, no regressions in the wiz-agent-facing caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)