### PR TITLE
fix(VBM-013): disclose set_date_comparison's forced chart-type override

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -21,6 +21,9 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,6 +116,9 @@ public class DateComparisonService {
     * to change (e.g. a row bound at "month" retargeted to "year" so periods line up), reports
     * the dimension name and the before/after level under {@code retargetedDimension} /
     * {@code retargetedFromLevel} / {@code retargetedToLevel}. Empty when nothing was retargeted.
+    * For a chart, also reports {@code chartTypeOverridden}/{@code chartTypeBefore}/
+    * {@code chartTypeAfter} when applying the comparison forced the chart's runtime style to
+    * change (see {@link #describeChartTypeOverride}).
     */
    public Map<String, Object> set(String sessionToken, Principal user, String assemblyName,
                                   Comparison comparison, String linkUri) throws Exception
@@ -130,11 +136,14 @@ public class DateComparisonService {
                "dimension in its binding.");
          }
 
+         int beforeChartType = chartRTChartType(rvs, assemblyName);
+
          apply(model, comparison);
          comparisonService.setDateComparison(runtimeId, assemblyName,
                                             model.toDateComparisonInfo(), null, linkUri, user,
                                             dispatcher);
          result.putAll(describeRetargetedDimension(rvs, assemblyName));
+         result.putAll(describeChartTypeOverride(rvs, assemblyName, beforeChartType));
       });
 
       return result;
@@ -205,6 +214,75 @@ public class DateComparisonService {
       }
 
       return null;
+   }
+
+   /**
+    * {@code ChartDcProcessor.updateDateComparisonChartType()} unconditionally forces a chart's
+    * primary/value series' runtime style to Bar/Bar-Stack whenever a comparison is applied,
+    * regardless of the chart's original type — e.g. a Line chart with a group-shelf dimension
+    * loses that dimension's only visual-breakdown mechanism (Bar has none) the moment a
+    * comparison is set, with nothing reporting it. {@code get_binding} stays "correct"
+    * throughout, since the binding itself is never touched — only the runtime chart type is.
+    * This compares the runtime chart type read before {@code comparisonService.setDateComparison}
+    * ran against the same read afterward, so the disclosure reflects reality regardless of which
+    * of {@code ChartDcProcessor}'s branches (plain, multi-style, value-plus) actually fired.
+    *
+    * <p>Not a chart, or the type did not change: returns an empty map.
+    */
+   private static Map<String, Object> describeChartTypeOverride(RuntimeViewsheet rvs,
+                                                                 String assemblyName,
+                                                                 int beforeType)
+   {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(beforeType == NOT_A_CHART) {
+         return out;
+      }
+
+      int afterType = chartRTChartType(rvs, assemblyName);
+
+      if(afterType == NOT_A_CHART || afterType == beforeType) {
+         return out;
+      }
+
+      out.put("chartTypeOverridden", true);
+      out.put("chartTypeBefore", GraphTypes.getDisplayName(beforeType));
+      out.put("chartTypeAfter", GraphTypes.getDisplayName(afterType));
+      return out;
+   }
+
+   private static final int NOT_A_CHART = Integer.MIN_VALUE;
+
+   /** The runtime chart type that would be affected by a date-comparison chart-type override. */
+   private static int chartRTChartType(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(!(assembly instanceof ChartVSAssembly)) {
+         return NOT_A_CHART;
+      }
+
+      VSChartInfo cinfo = ((ChartVSAssembly) assembly).getVSChartInfo();
+      return cinfo == null ? NOT_A_CHART : effectiveRTChartType(cinfo);
+   }
+
+   /**
+    * The non-multi-style branch changes {@code VSChartInfo}'s own runtime type; the multi-style
+    * branch changes each aggregate's instead (see {@code ChartDcProcessor
+    * .updateDateComparisonChartType}) — read whichever one the comparison would actually change.
+    */
+   private static int effectiveRTChartType(VSChartInfo cinfo) {
+      if(!cinfo.isMultiStyles()) {
+         return cinfo.getRTChartType();
+      }
+
+      for(ChartAggregateRef agg : cinfo.getAestheticAggregateRefs(true)) {
+         if(agg != null) {
+            return agg.getRTChartType();
+         }
+      }
+
+      return cinfo.getRTChartType();
    }
 
    public void clear(String sessionToken, Principal user, String assemblyName, String linkUri)

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -21,6 +21,9 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.junit.jupiter.api.Tag;
@@ -401,6 +404,72 @@ class DateComparisonServiceTest {
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getVSCrosstabInfo()).thenReturn(crosstabInfo);
       return assembly;
+   }
+
+   // ── reporting a chart-type override ─────────────────────────────────────────
+
+   /**
+    * {@code ChartDcProcessor.updateDateComparisonChartType()} unconditionally forces a chart's
+    * (non-multi-style) runtime type to Bar/Bar-Stack when a comparison is applied, regardless of
+    * the original type — e.g. stripping a Line chart's only group-shelf visual-breakdown
+    * mechanism with nothing reporting it. This must be disclosed.
+    */
+   @Test
+   void reportsAChartTypeOverrideWhenTheRuntimeTypeActuallyChanged() throws Exception {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_LINE, GraphTypes.CHART_BAR);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertEquals(true, result.get("chartTypeOverridden"));
+      assertEquals("Line", result.get("chartTypeBefore"));
+      assertEquals("Bar", result.get("chartTypeAfter"));
+   }
+
+   @Test
+   void returnsAnEmptyMapWhenTheChartTypeDidNotActuallyChange() throws Exception {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertFalse(result.containsKey("chartTypeOverridden"));
+   }
+
+   /**
+    * The multi-style branch of {@code updateDateComparisonChartType} changes each aggregate's
+    * runtime type instead of the info-level one — the disclosure must read from an aggregate in
+    * that case, not the (untouched) info-level type.
+    */
+   @Test
+   void describesAMultiStyleChartTypeOverrideViaItsAggregate() throws Exception {
+      ChartAggregateRef agg = mock(ChartAggregateRef.class);
+      when(agg.getRTChartType()).thenReturn(GraphTypes.CHART_POINT, GraphTypes.CHART_BAR_STACK);
+
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.isMultiStyles()).thenReturn(true);
+      when(cinfo.getAestheticAggregateRefs(true))
+         .thenReturn(java.util.List.of(agg));
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertEquals("Point", result.get("chartTypeBefore"));
+      assertEquals("Stack Bar", result.get("chartTypeAfter"));
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `ChartDcProcessor.updateDateComparisonChartType()` unconditionally forces a chart's primary/value series' runtime type to Bar/Bar-Stack when a date comparison is applied, regardless of the chart's original type — e.g. a Line chart with a `group`-shelf dimension bound loses that dimension's only visual-breakdown mechanism (Bar has none) the instant `set_date_comparison` runs, and `get_binding` still reports the binding as intact since only the runtime chart type changed, not the binding metadata.
- `DateComparisonService.set()` now reports `chartTypeOverridden`/`chartTypeBefore`/`chartTypeAfter` (display names, e.g. "Line"/"Bar") whenever the runtime chart type actually changed, alongside the existing `retargetedDimension` disclosure. Handles both the non-multi-style (info-level `RTChartType`) and multi-style (per-aggregate `RTChartType`) branches of `updateDateComparisonChartType`.
- No change to `ViewsheetAssemblyAgentController.setDateComparison()` — it already relays the service's `Map<String, Object>` verbatim.

Companion plugin PR (stylebi-wiz repo) makes `set_date_comparison`'s disclosure text name the override when this field is present, with a generic fallback so it degrades gracefully if deployed before this PR.

Converged over 3 debug/refute passes — see `docs/teams/2026-09-05-bugs-vbm-vbs-psm/bug-vbm-013/` in stylebi-wiz for the full trail.

## Test plan
- [x] `./mvnw -pl core -o test -Dtest=DateComparisonServiceTest` — 39/39 passed (36 pre-existing + 3 new)
- [x] `./mvnw -pl core -o test-compile` (ran as part of the above test invocation, module compiles clean)