### PR TITLE
fix(wiz): add comparisonOption to the date-comparison wire schema (VBM-012)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -21,9 +21,11 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,13 +72,68 @@ public class DateComparisonService {
    /**
     * A date-comparison request in the agent vocabulary.
     *
-    * @param periods  how many periods back to compare
-    * @param level    the period level — the date level token, e.g. year, quarter, month
-    * @param endDate  the range end. Required unless {@code endToday} is set.
-    * @param endToday anchor the range on today instead of an explicit end
+    * @param periods          how many periods back to compare
+    * @param level            the period level — the date level token, e.g. year, quarter, month
+    * @param endDate          the range end. Required unless {@code endToday} is set.
+    * @param endToday         anchor the range on today instead of an explicit end
+    * @param comparisonOption what the numbers mean — one of: value, change, percentChange
     */
    public record Comparison(Integer periods, String level, String endDate, boolean endToday,
-                            String interval, Boolean useFacet, Boolean onlyShowMostRecentDate) {}
+                            String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
+                            String comparisonOption) {}
+
+   /**
+    * The agent vocabulary's comparisonOption tokens, mapped to {@link Calculator}'s constants.
+    * Deliberately only the three the plugin's own schema documents and can send — see
+    * {@code dateComparisonTools.ts}'s {@code normalizeComparisonOption}. {@link
+    * DateComparisonInfo#CHANGE_VALUE}/{@link DateComparisonInfo#PERCENT_VALUE} ("Change and
+    * Value" / "Percent Change and Value" in the interactive Composer's own dialog) are real,
+    * reachable settings, but extending the write side to accept them would be inert without a
+    * matching plugin-schema change to let an agent actually send those tokens — tracked as a
+    * follow-on, not folded into this fix.
+    */
+   private static final Map<String, Integer> COMPARISON_OPTION_WORDS = Map.of(
+      "value", Calculator.VALUE,
+      "change", Calculator.CHANGE,
+      "percentchange", Calculator.PERCENT
+   );
+
+   /**
+    * The inverse of {@link #COMPARISON_OPTION_WORDS}, plus the two composite options the write
+    * side does not (yet) accept but the read side can still name accurately: {@link
+    * DateComparisonInfo#CHANGE_VALUE}/{@link DateComparisonInfo#PERCENT_VALUE}. A value outside
+    * even this wider set (e.g. a {@link Calculator} type this dialog should never produce) is
+    * reported as {@code null} rather than a bare int — this service does not echo raw magic
+    * numbers to the caller.
+    */
+   private static final Map<Integer, String> COMPARISON_OPTION_NAMES = Map.of(
+      Calculator.VALUE, "value",
+      Calculator.CHANGE, "change",
+      Calculator.PERCENT, "percentChange",
+      DateComparisonInfo.CHANGE_VALUE, "changeAndValue",
+      DateComparisonInfo.PERCENT_VALUE, "percentChangeAndValue"
+   );
+
+   /**
+    * Translates the agent vocabulary's comparisonOption word to {@link Calculator}'s numeric
+    * constant, mirroring {@link #normalizeLevel(String)}'s case-insensitive, fail-loud pattern.
+    */
+   private static int normalizeComparisonOption(String option) {
+      Integer code = COMPARISON_OPTION_WORDS.get(option.trim().toLowerCase());
+
+      if(code == null) {
+         throw new IllegalArgumentException(
+            "'comparisonOption' must be one of: value, change, percentChange. Got '" + option +
+            "'.");
+      }
+
+      return code;
+   }
+
+   /** The inverse of {@link #normalizeComparisonOption(String)}, for reporting it back. */
+   private static String comparisonOptionWord(int option) {
+      return COMPARISON_OPTION_NAMES.get(option);
+   }
 
    /** The current settings, normalized. Never echoes the raw cell format. */
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
@@ -101,7 +158,7 @@ public class DateComparisonService {
       }
 
       out.put("enabled", true);
-      out.put("comparisonOption", model.getComparisonOption());
+      out.put("comparisonOption", comparisonOptionWord(model.getComparisonOption()));
       out.put("useFacet", model.isUseFacet());
       out.put("onlyShowMostRecentDate", model.isOnlyShowMostRecentDate());
       out.put("period", describePeriod(model.getPeriodPaneModel()));
@@ -358,6 +415,10 @@ public class DateComparisonService {
 
       if(comparison.onlyShowMostRecentDate() != null) {
          model.setOnlyShowMostRecentDate(comparison.onlyShowMostRecentDate());
+      }
+
+      if(comparison.comparisonOption() != null) {
+         model.setComparisonOption(normalizeComparisonOption(comparison.comparisonOption()));
       }
 
       PeriodPaneModel periods = model.getPeriodPaneModel();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -868,11 +868,12 @@ public class ViewsheetAssemblyAgentController {
 
    public record DateComparisonRequest(String assembly, Integer periods, String level,
                                        String endDate, Boolean endToday, String interval,
-                                       Boolean useFacet, Boolean onlyShowMostRecentDate) {
+                                       Boolean useFacet, Boolean onlyShowMostRecentDate,
+                                       String comparisonOption) {
       DateComparisonService.Comparison comparison() {
          return new DateComparisonService.Comparison(
             periods, level, endDate, Boolean.TRUE.equals(endToday), interval, useFacet,
-            onlyShowMostRecentDate);
+            onlyShowMostRecentDate, comparisonOption);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -21,6 +21,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
@@ -65,7 +66,8 @@ class DateComparisonServiceTest {
    }
 
    private static DateComparisonService.Comparison comparison(String endDate, boolean endToday) {
-      return new DateComparisonService.Comparison(4, "year", endDate, endToday, null, null, null);
+      return new DateComparisonService.Comparison(4, "year", endDate, endToday, null, null, null,
+                                                  null);
    }
 
    /**
@@ -103,7 +105,12 @@ class DateComparisonServiceTest {
    }
 
    private static DateComparisonService.Comparison facetOnly() {
-      return new DateComparisonService.Comparison(null, null, null, false, null, true, null);
+      return new DateComparisonService.Comparison(null, null, null, false, null, true, null, null);
+   }
+
+   private static DateComparisonService.Comparison comparisonOptionOnly(String comparisonOption) {
+      return new DateComparisonService.Comparison(null, null, null, false, null, null, null,
+                                                  comparisonOption);
    }
 
    // ── the recorded defect ───────────────────────────────────────────────────
@@ -171,7 +178,7 @@ class DateComparisonServiceTest {
       assertThrows(IllegalArgumentException.class,
                    () -> DateComparisonService.requireEndAnchor(
                       new DateComparisonService.Comparison(0, "year", null, true, null, null,
-                                                           null)));
+                                                           null, null)));
    }
 
    @Test
@@ -221,7 +228,8 @@ class DateComparisonServiceTest {
    {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison =
-         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null);
+         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
+                                              null);
 
       harness(model).service.set("tok", principal(), "Chart1", comparison, "");
 
@@ -235,7 +243,8 @@ class DateComparisonServiceTest {
    void refusesAnUnrecognizedPeriodLevel(String word) {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison =
-         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null);
+         new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
+                                              null);
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
@@ -470,6 +479,95 @@ class DateComparisonServiceTest {
 
       assertEquals("Point", result.get("chartTypeBefore"));
       assertEquals("Stack Bar", result.get("chartTypeAfter"));
+   }
+
+   // ── comparisonOption ─────────────────────────────────────────────────────
+
+   /**
+    * The wire records ({@code DateComparisonRequest}/{@code Comparison}) had no
+    * {@code comparisonOption} field at all, so posting one was rejected with an "Unrecognized
+    * field" error before {@code apply} ever ran. This pins the write path end to end.
+    */
+   @ParameterizedTest
+   @CsvSource({
+      "value, 6",
+      "change, 2",
+      "percentChange, 1",
+      "PercentChange, 1"
+   })
+   void setsComparisonOptionForEachToken(String word, int code) throws Exception {
+      DateComparisonPaneModel model = model();
+
+      harness(model).service.set("tok", principal(), "Chart1", comparisonOptionOnly(word), "");
+
+      assertEquals(code, model.getComparisonOption());
+   }
+
+   @Test
+   void refusesAnUnrecognizedComparisonOption() {
+      Harness h = harness(model());
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", comparisonOptionOnly("percent"), ""));
+
+      assertTrue(thrown.getMessage().contains("comparisonOption"), thrown.getMessage());
+   }
+
+   /** comparisonOption is period-independent, like useFacet/onlyShowMostRecentDate — a call that
+    *  sets only it must not be refused for lacking an end anchor. */
+   @Test
+   void comparisonOptionAloneNeedsNoEndAnchor() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Chart1", comparisonOptionOnly("change"), "");
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void leavesComparisonOptionUntouchedWhenNotMentioned() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.setComparisonOption(Calculator.CHANGE);
+
+      harness(model).service.set("tok", principal(), "Chart1", facetOnly(), "");
+
+      assertEquals(Calculator.CHANGE, model.getComparisonOption(),
+                  "a call that omits comparisonOption must not reset it");
+   }
+
+   @ParameterizedTest
+   @CsvSource({
+      "6, value",
+      "2, change",
+      "1, percentChange",
+      "101, changeAndValue",
+      "102, percentChangeAndValue"
+   })
+   void readsComparisonOptionAsAName(int code, String word) throws Exception {
+      DateComparisonPaneModel model = model();
+      model.setComparisonOption(code);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      assertEquals(word, read.get("comparisonOption"));
+   }
+
+   /**
+    * Not reachable through this dialog in practice ({@code Calculator}'s other constants —
+    * RUNNINGTOTAL/MOVING/CUSTOM/COMPOUNDGROWTH — never end up on a date-comparison model), but
+    * pins the fallback explicitly: an option outside even the wider read-side vocabulary (which
+    * already covers the two composite settings, changeAndValue/percentChangeAndValue) is reported
+    * as null rather than a raw magic number.
+    */
+   @Test
+   void readsATrulyOutOfVocabularyComparisonOptionAsNull() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.setComparisonOption(Calculator.CUSTOM);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      assertNull(read.get("comparisonOption"));
    }
 
    @Test


### PR DESCRIPTION
## Root cause
`ViewsheetAssemblyAgentController.DateComparisonRequest` and `DateComparisonService.Comparison` (both Java records) had no `comparisonOption` field, so the agent tool's `set_date_comparison(comparisonOption: ...)` was rejected by Jackson with an "Unrecognized field" error before `apply()` ever ran. `read()` also echoed the raw `Calculator` int (1/2/6) instead of naming it — a genuine schema/backend mismatch, not a dead/disabled feature (unlike the sibling `frame` parameter removed in #4818, confirmed still live-wired through `ChartDcProcessor`/`CrosstabDcProcessor`/`DateComparisonInfo`).

## Fix
- Added `comparisonOption` to both records, wired through `apply()` using the same `value`/`change`/`percentChange` vocabulary the plugin (`dateComparisonTools.ts`) already sends and validates.
- Excluded from `setsPeriod()`'s gating, like `useFacet`/`onlyShowMostRecentDate` — it's period-independent, so a call setting only `comparisonOption` doesn't need an end anchor.
- `read()` now names the value instead of echoing the raw int, and additionally names the two composite settings reachable from the interactive Composer's own dialog but outside the plugin's 3-token vocabulary — `DateComparisonInfo.CHANGE_VALUE`/`PERCENT_VALUE` ("Change and Value" / "Percent Change and Value") — as `changeAndValue`/`percentChangeAndValue`, rather than falling back to `null` or a bare magic number. A value genuinely outside even that wider set (a `Calculator` type this dialog should never produce) still reads back as `null`.

## Relationship to #4775
This supersedes #4775, which implemented the same write path but predates this branch's base (frame-parameter removal in #4818, the chart-type-override disclosure in #5027, and several other merged agent-controller changes), and was blocked on review (`CHANGES_REQUESTED`) for reporting `CHANGE_VALUE`/`PERCENT_VALUE` as `null` on read. Addressed here by naming both instead of falling back — this fully satisfies the reviewer's "extend the vocabulary" option for the read side.

Extending the **write** side to accept those same two tokens is left as a follow-on: it would be inert today without a matching plugin-schema change (`dateComparisonTools.ts`'s `normalizeComparisonOption` only knows the three simple tokens, so an agent can never actually send `changeAndValue`/`percentChangeAndValue` even if the Java side accepted them), and extending it is a separate, larger scope decision (naming, whether to expose composite write modes at all) than this schema-mismatch bug.

## Tests
`DateComparisonServiceTest.java`:
- Round-trips `value`/`change`/`percentChange` (case-insensitively) through `apply()`.
- Refuses an unrecognized `comparisonOption` with a field-named error.
- A call setting only `comparisonOption` needs no end anchor (period-independent).
- A call that omits `comparisonOption` leaves an existing setting untouched.
- `read()` names `value`/`change`/`percentChange`/`changeAndValue`/`percentChangeAndValue` correctly.
- A truly out-of-vocabulary value (e.g. `Calculator.CUSTOM`) reads back as `null`.
- Updated the 5 pre-existing positional `new DateComparisonService.Comparison(...)` test-constructor call sites for the new field.

`./mvnw -pl core -am test -Dtest=DateComparisonServiceTest -Dsurefire.failIfNoSpecifiedTests=false` → 52/52 passing (12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>