### PR TITLE
fix(wiz): resolve unapplied-alias columns in remove/rename/set_column_visibility (VBS-009)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -380,7 +380,7 @@ public class WorksheetEditService {
       public void removeColumn(String table, String col) throws PairingException {
          TableAssembly t = requireTable(table);
          ColumnSelection cs = t.getColumnSelection();
-         DataRef toRemove = cs.getAttribute(col);
+         DataRef toRemove = WorksheetMutationSupport.resolveFieldOrNull(t, col, false);
 
          if(toRemove != null) {
             WorksheetMutationSupport.assertSnapshotAllowsColumnRemove(t, table, col, toRemove);
@@ -512,8 +512,7 @@ public class WorksheetEditService {
        */
       public void renameColumn(String table, String col, String newName) throws PairingException {
          TableAssembly t = requireTable(table);
-         ColumnSelection cs = t.getColumnSelection(false);
-         DataRef existing = cs.getAttribute(col);
+         DataRef existing = WorksheetMutationSupport.resolveFieldOrNull(t, col, false);
 
          if(existing instanceof ColumnRef cr) {
             if(!WorksheetControllerService.allowsDeletion(ws, t, cr)) {
@@ -1656,8 +1655,7 @@ public class WorksheetEditService {
          throws PairingException
       {
          TableAssembly t = requireTable(table);
-         ColumnSelection cs = t.getColumnSelection(false);
-         DataRef ref = cs.getAttribute(col);
+         DataRef ref = WorksheetMutationSupport.resolveFieldOrNull(t, col, false);
 
          if(!(ref instanceof ColumnRef cr)) {
             throw new PairingException("Column not found: " + col);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -2329,6 +2329,18 @@ public final class WorksheetMutationSupport {
          }
       }
 
+      DataRef col = resolveFieldOrNull(t, field, post);
+      return col != null ? col : new AttributeRef(null, field);
+   }
+
+   /**
+    * Resolves a field name against the table's column selection only (no AggregateInfo/HAVING
+    * lookup -- callers that need that should go through {@link #resolveField}), returning
+    * {@code null} on a true miss instead of {@link #resolveField}'s {@code AttributeRef}
+    * not-found placeholder. Column mutators (remove/rename/visibility) need a real miss to stay
+    * distinguishable from a match, which the placeholder does not allow.
+    */
+   static DataRef resolveFieldOrNull(TableAssembly t, String field, boolean post) {
       ColumnSelection cs = t.getColumnSelection(post);
 
       if(cs != null && field != null) {
@@ -2351,7 +2363,7 @@ public final class WorksheetMutationSupport {
          }
       }
 
-      return new AttributeRef(null, field);
+      return null;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/composition/execution/JoinDuplicateColumnAliasMechanismTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/JoinDuplicateColumnAliasMechanismTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.IntegrationTestConfiguration;
+import inetsoft.test.SreeHome;
+import inetsoft.test.SwapperTestConfiguration;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.util.XEmbeddedTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * VBS-009: settles, against a real join-execution pipeline (not a hand-set {@code ColumnRef}
+ * flag), whether a duplicate non-key column surviving a join actually ends up with
+ * {@code aalias == false} -- the mechanism the original diagnosis proposed and the refuter found
+ * no supporting code path for. This mirrors production exactly: {@code RelationalJoinTableAssembly}
+ * built the same way {@link inetsoft.web.wiz.worksheet.WorksheetEditService.Editor#addJoin} builds
+ * it, then {@link AssetQuerySandbox#refreshColumnSelection} run the same way
+ * {@code WorksheetEventUtil.refreshColumnSelection} runs it from
+ * {@code WorksheetEditService#refreshAssemblies} after every agent write (with the sandbox set
+ * active, matching {@code RuntimeWorksheet}'s own {@code box.setActive(true)}, so this exercises
+ * the real query-execution branch of {@code refreshColumnSelection}, not its inactive/metadata
+ * shortcut).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, IntegrationTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class JoinDuplicateColumnAliasMechanismTest {
+
+   @Test
+   void innerJoinOfTwoTablesSharingANonKeyColumnProducesAnAliasWithApplyingAliasTrue() throws Exception {
+      Worksheet ws = new Worksheet();
+
+      EmbeddedTableAssembly left = new EmbeddedTableAssembly(ws, "REGIONS_LEFT");
+      ColumnSelection leftCs = new ColumnSelection();
+      leftCs.addAttribute(new ColumnRef(new AttributeRef("ID")));
+      leftCs.addAttribute(new ColumnRef(new AttributeRef("REGION")));
+      left.setColumnSelection(leftCs, false);
+      left.setEmbeddedData(new XEmbeddedTable(new String[]{ "string", "string" },
+         new Object[][]{
+            { "ID", "REGION" },
+            { "1", "West" },
+            { "2", "East" },
+         }));
+      ws.addAssembly(left);
+
+      EmbeddedTableAssembly right = new EmbeddedTableAssembly(ws, "REGIONS_RIGHT");
+      ColumnSelection rightCs = new ColumnSelection();
+      rightCs.addAttribute(new ColumnRef(new AttributeRef("ID")));
+      rightCs.addAttribute(new ColumnRef(new AttributeRef("REGION")));
+      right.setColumnSelection(rightCs, false);
+      right.setEmbeddedData(new XEmbeddedTable(new String[]{ "string", "string" },
+         new Object[][]{
+            { "ID", "REGION" },
+            { "1", "Western" },
+            { "2", "Eastern" },
+         }));
+      ws.addAssembly(right);
+
+      // Mirrors WorksheetEditService.Editor#addJoin's own construction of the operator/assembly,
+      // including using a FULL join (the original bug report's own join type).
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable("REGIONS_LEFT");
+      op.setRightTable("REGIONS_RIGHT");
+      op.setLeftAttribute(new AttributeRef(null, "ID"));
+      op.setRightAttribute(new AttributeRef(null, "ID"));
+      op.setOperation(TableAssemblyOperator.FULL_JOIN);
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      top.addOperator(op);
+
+      RelationalJoinTableAssembly joined = new RelationalJoinTableAssembly(
+         ws, "JOINED", new TableAssembly[]{ left, right }, new TableAssemblyOperator[]{ top });
+      ws.addAssembly(joined);
+
+      // Mirrors RuntimeWorksheet's own AssetQuerySandbox construction (active=true), and
+      // WorksheetEventUtil.refreshColumnSelection -> AssetQuerySandbox#refreshColumnSelection,
+      // which is what WorksheetEditService#refreshAssemblies runs after every agent write op.
+      AssetQuerySandbox box = new AssetQuerySandbox(ws, null, new VariableTable());
+      box.setActive(true);
+      box.refreshColumnSelection("JOINED", false);
+
+      ColumnSelection result = joined.getColumnSelection(true);
+      ColumnRef duplicate = null;
+
+      for(int i = 0; i < result.getAttributeCount(); i++) {
+         DataRef ref = result.getAttribute(i);
+
+         if(ref instanceof ColumnRef cr && cr.getAlias() != null && cr.getAlias().startsWith("REGION_")) {
+            duplicate = cr;
+         }
+      }
+
+      assertNotNull(duplicate,
+         "the real join-execution pipeline must alias one side's duplicate REGION column, " +
+         "matching the bug report's observed \"REGION_1\"-style name");
+      assertTrue(duplicate.isApplyingAlias(),
+         "AssetUtil.fixAlias (the code path that actually produces this alias) never touches " +
+         "the aalias flag, so it must still be true here -- this disproves the original " +
+         "diagnosis's specific \"FULL join duplicate columns end up with aalias == false\" claim");
+      assertNotNull(result.getAttribute(duplicate.getAlias()),
+         "since aalias is true, ColumnRef.getName() returns the alias, so a bare " +
+         "ColumnSelection.getAttribute(alias) call -- the exact lookup removeColumn/renameColumn/" +
+         "setColumnVisibility perform -- must already resolve this column. remove_column's real " +
+         "server-side failure on VBS-009's actual repro is therefore NOT explained by the " +
+         "aalias mechanism; it must come from something else (e.g. the caller/model posting a " +
+         "different or stale identifier than what fixAlias actually assigned, or a bug elsewhere " +
+         "in this pipeline this test does not cover).");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -207,6 +207,63 @@ class WorksheetEditServiceMutatorsTest {
       assertFalse(t.getPreConditionList().isEmpty());
    }
 
+   // VBS-009: removeColumn/renameColumn/setColumnVisibility had the identical bare
+   // ColumnSelection.getAttribute(col) resolution weakness as add_filter's pre-fix
+   // requireColumn -- these three mirror addFilterAcceptsAColumnMatchedOnlyByItsUnappliedAlias
+   // above, pinning the defect class (a column reachable only via an unapplied alias) for each
+   // mutator now routed through WorksheetMutationSupport.resolveFieldOrNull.
+
+   @Test
+   void removeColumnAcceptsAColumnMatchedOnlyByItsUnappliedAlias() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a", "b");
+      ColumnRef aliased = (ColumnRef) t.getColumnSelection(false).getAttribute("a");
+      aliased.setAlias("aliasA");
+      aliased.setApplyingAlias(false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.removeColumn("T", "aliasA"));
+
+      assertNull(t.getColumnSelection(false).getAttribute("a"),
+         "the column must actually be removed when addressed by its unapplied alias");
+   }
+
+   @Test
+   void renameColumnAcceptsAColumnMatchedOnlyByItsUnappliedAlias() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a", "b");
+      ColumnRef aliased = (ColumnRef) t.getColumnSelection(false).getAttribute("a");
+      aliased.setAlias("aliasA");
+      aliased.setApplyingAlias(false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.renameColumn("T", "aliasA", "renamed"));
+
+      assertEquals("renamed", aliased.getAlias(),
+         "the column must actually be renamed when addressed by its unapplied alias");
+   }
+
+   @Test
+   void setColumnVisibilityAcceptsAColumnMatchedOnlyByItsUnappliedAlias() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a", "b");
+      ColumnRef aliased = (ColumnRef) t.getColumnSelection(false).getAttribute("a");
+      aliased.setAlias("aliasA");
+      aliased.setApplyingAlias(false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setColumnVisibility("T", "aliasA", false));
+
+      assertFalse(aliased.isVisible(),
+         "the column's visibility must actually change when addressed by its unapplied alias");
+   }
+
    @Test
    void addFilterRejectsEmbeddedTable() throws Exception {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
## Summary

`WorksheetEditService.Editor.removeColumn`/`renameColumn`/`setColumnVisibility` all resolved
their `column` argument via a bare `ColumnSelection.getAttribute(col)`, which only matches when
`ColumnRef.getName()` returns the alias (requires `aalias == true`). This is the identical defect
class already hit and fixed once for `add_filter` (see
`WorksheetEditServiceMutatorsTest#addFilterAcceptsAColumnMatchedOnlyByItsUnappliedAlias`), which
was routed through `WorksheetMutationSupport.resolveField`'s alias-scan fallback. These three
mutators never received that fix.

**Fix:** extracted `resolveField`'s two lookup steps (`cs.getAttribute(field)` then the
alias-scan loop) into a shared `WorksheetMutationSupport.resolveFieldOrNull(t, field, post)`,
returning `null` on a true miss (rather than `resolveField`'s `AttributeRef` not-found
placeholder, since these mutators need to tell a real miss apart from a match). Routed
`removeColumn`, `renameColumn`, and `setColumnVisibility` through it.

## On the reported repro's actual mechanism -- read before assuming this fully explains VBS-009

Two earlier review passes (diagnosis + refute, linked in the internal bug tracker) disagreed on
*why* this triggers. The diagnosis proposed "a FULL join's duplicate columns end up with
`ColumnRef.aalias == false`"; the refuter found active counter-evidence against it (neither
known alias-producing path, `AssetUtil.fixAlias` nor `WsServiceHelper.initCompositeColumnSelection`,
ever touches `aalias`).

I built a real join-execution regression test
(`JoinDuplicateColumnAliasMechanismTest`) to settle this directly: two embedded tables sharing a
non-key column name, joined via the same `RelationalJoinTableAssembly` construction
`Editor#addJoin` uses, then run through `AssetQuerySandbox#refreshColumnSelection` with the
sandbox `active` (matching `RuntimeWorksheet`'s own `setActive(true)`, and matching what
`WorksheetEditService#refreshAssemblies` triggers after every agent write via
`WorksheetEventUtil.refreshColumnSelection`).

**Result: the refuter was right.** `AssetUtil.fixAlias` produces the "REGION_1"-style alias, but
leaves `aalias == true`, and a bare `ColumnSelection.getAttribute("REGION_1")` **already
resolves it** in this real pipeline. This means the diagnosis's specific causal story does not
hold, and **VBS-009's original report's true server-side trigger is still unidentified** by this
PR. What this PR closes is a real, demonstrated defect class (confirmed via a hand-set
`aalias == false` unit test per mutator, mirroring `add_filter`'s existing regression test) that
is safe and worth fixing regardless -- but if the original repro recurs after this deploys, the
actual cause lies elsewhere in the pipeline (e.g. the caller/model posting a different or stale
identifier than what `fixAlias` actually assigned).

## Tests

- `JoinDuplicateColumnAliasMechanismTest` (new) -- real join + `AssetQuerySandbox` mechanism
  check described above.
- `WorksheetEditServiceMutatorsTest`: added
  `removeColumnAcceptsAColumnMatchedOnlyByItsUnappliedAlias`,
  `renameColumnAcceptsAColumnMatchedOnlyByItsUnappliedAlias`,
  `setColumnVisibilityAcceptsAColumnMatchedOnlyByItsUnappliedAlias`, mirroring the existing
  `add_filter` test.

```
./mvnw -pl core -o test -Dtest="inetsoft.web.wiz.worksheet.**"
Tests run: 481, Failures: 0, Errors: 0, Skipped: 0 -- BUILD SUCCESS

./mvnw -pl core -o test -Dtest=WorksheetEditServiceMutatorsTest,JoinDuplicateColumnAliasMechanismTest
Tests run: 236, Failures: 0, Errors: 0, Skipped: 0 -- BUILD SUCCESS
```

## Out of scope, left alone

- `changeColumnType` (`WorksheetEditService.java:1706-1712`) has the same weakness but already
  retries against the other column selection; not touched.
- `setColumnDescription` (`WorksheetEditService.java:2637`) has the identical bare
  `getAttribute` weakness and was not in this task's scope (only remove/rename/visibility) --
  flagging here for a follow-up.