### PR TITLE
fix(VBS-007): refuse a dimension on a map chart's x/y shelf

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -88,6 +88,12 @@ public class BindingReadService {
          shelves.put("y", refs(chart.getYFields(), perField));
          shelves.put("group", refs(chart.getGroupFields()));
 
+         // A map's geo dimension lives on its own list, separate from x/y/group — surface it
+         // so a caller doesn't mistake x/y (lat/lon measures on a map) for "nothing is bound".
+         if(GraphTypes.isGeo(chart.getChartType()) || !chart.getGeoFields().isEmpty()) {
+            shelves.put("geo", refs(chart.getGeoFields()));
+         }
+
          for(String shelf : ChartBindingMutator.SHELVES) {
             sorts.putAll(ChartBindingMutator.describeSorts(chart, shelf));
          }

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -106,6 +106,7 @@ public final class ChartBindingMutator {
       }
 
       requireColumnLimit(chartInfo, readShelf(model, name).size(), fields == null ? 0 : fields.size());
+      requireNoMapDimensionOnXY(chartInfo, name, fields);
 
       List<ChartRefModel> refs = new ArrayList<>();
 
@@ -220,6 +221,33 @@ public final class ChartBindingMutator {
 
       if(total > Util.getOrganizationMaxColumn()) {
          throw new IllegalArgumentException(Util.getColumnLimitMessage());
+      }
+   }
+
+   /**
+    * On a map, {@code x}/{@code y} hold lat/lon measures ({@code MapInfo.isLat}/{@code isLon}),
+    * not a dimension shelf — a map's geo dimension lives on {@code geoFields}, a 4th list this
+    * class does not write, and {@code set_chart_type(type: "map")} already populates it
+    * automatically on retype. A dimension bound here has no valid interpretation: it silently
+    * flips {@code VSMapInfo.isFacet()} via {@code MapInfo.hasXYDimension()}, splitting the map
+    * into one tiny facet panel per value instead of rendering it as a single map.
+    */
+   private static void requireNoMapDimensionOnXY(VSChartInfo chartInfo, String shelf,
+                                                  List<FieldRef> fields)
+   {
+      if(!(chartInfo instanceof VSMapInfo) || fields == null ||
+         !("x".equals(shelf) || "y".equals(shelf)))
+      {
+         return;
+      }
+
+      for(FieldRef field : fields) {
+         if("dimension".equalsIgnoreCase(field.type())) {
+            throw new IllegalArgumentException(
+               "'" + shelf + "' holds lat/lon measures on a map, not dimensions. The geo " +
+               "dimension is set automatically by set_chart_type and reads back on the 'geo' " +
+               "shelf; bind any other dimension to 'group' instead.");
+         }
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
@@ -258,6 +258,32 @@ class BindingReadServiceTest {
                  "a single-field shelf carries no chart type");
    }
 
+   /**
+    * A map's geo dimension lives on {@code geoFields}, a 4th list fully separate from
+    * x/y/group — surfacing it here is the read-side half of VBS-007, closing the
+    * discoverability gap that led a caller to rebind the dimension onto x (see
+    * {@link ChartBindingMutator} for the write-side refusal).
+    */
+   @Test
+   void surfacesAMapsGeoFieldsAsTheGeoShelf() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setChartType(GraphTypes.CHART_MAP);
+      model.setGeoFields(List.of(new ChartDimensionRefModel() {{
+         setColumnValue("STATE");
+      }}));
+
+      AssemblyBinding result = read(model);
+
+      assertTrue(result.shelves().containsKey("geo"), "a map must expose a geo shelf");
+      assertEquals("STATE", result.shelves().get("geo").get(0).column());
+   }
+
+   /** Only a map exposes the geo shelf — every other chart type keeps reporting x/y/group only. */
+   @Test
+   void doesNotAdvertiseAGeoShelfForANonMapChart() {
+      assertFalse(read(new ChartBindingModel()).shelves().containsKey("geo"));
+   }
+
    private AssemblyBinding read(ChartBindingModel model) {
       VSBindingService binding = mock(VSBindingService.class);
       when(binding.createModel(any())).thenReturn(model);

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -541,8 +541,11 @@ class ChartBindingMutatorTest {
          chartInfo.addGeoField(new VSChartGeoRef());
          ChartBindingModel model = new ChartBindingModel();
 
+         // A measure here, not a dimension -- x/y hold lat/lon measures on a map, so this
+         // exercises the column-limit logic (1 y + 1 geo + 1 new x = 3, within the limit of 3)
+         // without tripping the dimension-on-x/y guard below.
          ChartBindingMutator.setShelf(
-            model, "x", List.of(new FieldRef("Region", "dimension", null, null, null)),
+            model, "x", List.of(new FieldRef("Longitude", "measure", "Sum", null, null)),
             null, null, null, chartInfo);
 
          assertEquals(1, model.getXFields().size());
@@ -550,5 +553,50 @@ class ChartBindingMutatorTest {
       finally {
          SreeEnv.setProperty("max.col.count", original);
       }
+   }
+
+   // ── dimension-on-x/y refused for a map (VBS-007) ──────────────────────────
+
+   @Test
+   void refusesADimensionOnXForAMapChart() {
+      VSMapInfo chartInfo = new VSMapInfo();
+      ChartBindingModel model = new ChartBindingModel();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setShelf(
+            model, "x", List.of(new FieldRef("State", "dimension", null, null, null)),
+            null, null, null, chartInfo));
+
+      assertTrue(thrown.getMessage().contains("x"), thrown.getMessage());
+      assertTrue(thrown.getMessage().toLowerCase().contains("map"), thrown.getMessage());
+   }
+
+   @Test
+   void refusesADimensionOnYForAMapChart() {
+      VSMapInfo chartInfo = new VSMapInfo();
+      ChartBindingModel model = new ChartBindingModel();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setShelf(
+            model, "y", List.of(new FieldRef("State", "dimension", null, null, null)),
+            null, null, null, chartInfo));
+
+      assertTrue(thrown.getMessage().contains("y"), thrown.getMessage());
+      assertTrue(thrown.getMessage().toLowerCase().contains("map"), thrown.getMessage());
+   }
+
+   @Test
+   void allowsADimensionOnGroupForAMapChart() throws Exception {
+      VSMapInfo chartInfo = new VSMapInfo();
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartBindingMutator.setShelf(
+         model, "group", List.of(new FieldRef("Category", "dimension", null, null, null)),
+         null, null, null, chartInfo);
+
+      assertEquals(1, model.getGroupFields().size());
+      assertInstanceOf(ChartDimensionRefModel.class, model.getGroupFields().get(0));
    }
 }


### PR DESCRIPTION
## Root cause

A map's geo dimension lives on `MapInfo.geoFields`, a 4th binding list fully separate from `x`/`y`/`group`. `ChartBindingMutator.SHELVES` and `BindingReadService.read` never surfaced it, even though `ChartBindingModel.getGeoFields()` already existed. `set_chart_type(type:"map")` already auto-populates `geoFields` correctly on retype (traced end-to-end: `ChartBindingService.setChartType` → `ChangeChartTypeService.changeChartType` → `ChangeChartTypeProcessor.process()` → `fixChartInfo()` → `copyFields()`) — but since nothing showed this, a caller who saw `x`/`y` empty assumed nothing was bound and rebound the dimension onto `x` or `y`.

On a map, `x`/`y` hold lat/lon **measures** (`MapInfo.isLat`/`isLon`), not a dimension shelf. `VSMapInfo.isFacet()` → `MapInfo.hasXYDimension()` unconditionally forces facet mode when any non-measure ref is on `x`/`y` — splitting the map into one facet panel per value instead of rendering as a single map. `group` isn't checked by this method at all, which is why the existing workaround (binding the dimension to `group` too) happened to work.

## Fix

1. `ChartBindingMutator.setShelf` now refuses a dimension bound to `x`/`y` on a `VSMapInfo`, throwing an `IllegalArgumentException` naming the shelf and explaining that x/y hold lat/lon measures on a map, dimensions belong on `group`, and the geo dimension is set automatically by `set_chart_type`. This check runs **after** the existing `requireColumnLimit` call, so the existing `countsGeoFieldsTowardTheLimitOnAMapChart` test still throws from the column-limit check specifically, not this new one.
2. `BindingReadService.read` now surfaces `geoFields` as `shelves["geo"]` for a map chart — closing the read-side discoverability gap that caused the misuse in the first place.

## Tests

- Repointed `allowsAMapChartWriteWhenGeoAndFieldsTogetherStayWithinTheLimit` to bind a measure instead of a dimension, preserving its original column-limit-testing intent (a dimension there is now correctly refused by the new check).
- Added `refusesADimensionOnXForAMapChart`, `refusesADimensionOnYForAMapChart`, `allowsADimensionOnGroupForAMapChart` in `ChartBindingMutatorTest`.
- Added `surfacesAMapsGeoFieldsAsTheGeoShelf`, `doesNotAdvertiseAGeoShelfForANonMapChart` in `BindingReadServiceTest`.
- Confirmed `countsGeoFieldsTowardTheLimitOnAMapChart` still passes unmodified (throws from the column-limit check).
- Full `inetsoft.web.wiz.binding` package: 586/586 passing, including `ChartAestheticMutatorTest` and `ChartBindingServiceTest` (the only other test callers binding dimensions to x/y, confirmed unaffected — they use mocked `VSChartInfo`/`ChartVSAssembly`, not a real `VSMapInfo`).

Part of the VBM/VBS/PSM batch (VBS-007). Not consolidated with the sibling VBS-008 fix (different chart family, different mechanism, agreed independently by both bugs' refuters).

## Test plan

- [x] `mvn -pl core -am -Dtest=ChartBindingMutatorTest,BindingReadServiceTest test` — 44/44 passing
- [x] `mvn -pl core -am -Dtest='inetsoft.web.wiz.binding.**' test` — 586/586 passing
- [ ] Live end-to-end verification against a running StyleBI instance (not attempted — no composer-chat MCP tool access in this session)