### PR TITLE
Fix VBM-008: add group_as_selection_container edit op

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -17,7 +17,12 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.analytic.composition.event.VSEventUtil;
+import inetsoft.uql.asset.AbstractSheet;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.AbstractSelectionVSAssembly;
+import inetsoft.uql.viewsheet.CurrentSelectionVSAssembly;
+import inetsoft.uql.viewsheet.GroupContainerVSAssembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
 import inetsoft.uql.viewsheet.TabVSAssembly;
 import inetsoft.uql.viewsheet.TitledVSAssembly;
@@ -35,6 +40,7 @@ import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.web.viewsheet.controller.VSRefreshService;
 import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
+import inetsoft.web.viewsheet.service.CoreLifecycleService;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.RenderWaitSupport;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
@@ -42,6 +48,8 @@ import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.awt.Dimension;
+import java.awt.Point;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -66,7 +74,8 @@ public class ViewsheetEditService {
                                ViewsheetReadService reader,
                                ComposerGroupService groups,
                                GroupingService grouping,
-                               VSRefreshService refreshService)
+                               VSRefreshService refreshService,
+                               CoreLifecycleService coreLifecycleService)
    {
       this.sessions = sessions;
       this.objects = objects;
@@ -76,13 +85,15 @@ public class ViewsheetEditService {
       this.groups = groups;
       this.grouping = grouping;
       this.refreshService = refreshService;
+      this.coreLifecycleService = coreLifecycleService;
    }
 
    /** Ops this service understands, named in the error when an unknown one arrives. */
    static final List<String> OPS = List.of(
       "move", "resize", "resize_title", "add", "remove", "rename", "copy", "cut", "paste",
-      "set_z_index", "set_lock", "set_title", "group", "group_as_tab", "ungroup",
-      "move_from_container", "align", "distribute", "refresh", "refresh_viewsheet");
+      "set_z_index", "set_lock", "set_title", "group", "group_as_tab",
+      "group_as_selection_container", "ungroup", "move_from_container", "align", "distribute",
+      "refresh", "refresh_viewsheet");
 
    public void apply(String sessionToken, Principal user, EditRequest request, String linkUri)
       throws Exception
@@ -103,6 +114,8 @@ public class ViewsheetEditService {
       case "set_title" -> setTitle(sessionToken, user, request);
       case "group" -> group(sessionToken, user, request, linkUri);
       case "group_as_tab" -> groupAsTab(sessionToken, user, request, linkUri);
+      case "group_as_selection_container" ->
+         groupAsSelectionContainer(sessionToken, user, request, linkUri);
       case "ungroup" -> ungroup(sessionToken, user, request, linkUri);
       case "move_from_container" -> moveFromContainer(sessionToken, user, request, linkUri);
       case "align", "distribute" -> arrange(sessionToken, user, request, linkUri, op);
@@ -477,6 +490,59 @@ public class ViewsheetEditService {
       });
    }
 
+   /**
+    * Creates a Selection Container ({@code CurrentSelectionVSAssembly}) combining the given
+    * selection filters -- the container the native Composer's "combine filters into one
+    * compacted panel" gesture produces. Unlike {@link #groupAsTab}, {@code GroupingService}'s
+    * {@code selection=true} mode has no lazy-create fallback (it asserts the container already
+    * exists), so the container is built here first via the same factory {@code add} already
+    * uses, then each named filter is folded in with the same call
+    * {@code VSBindingService.addAssembly} uses for "drag a new filter onto an existing Selection
+    * Container".
+    */
+   private void groupAsSelectionContainer(String sessionToken, Principal user,
+                                          EditRequest request, String linkUri) throws Exception
+   {
+      List<String> names = request.assemblies();
+
+      if(names == null || names.size() < 2) {
+         throw new IllegalArgumentException(
+            "Edit op 'group_as_selection_container' requires 'assemblies' with at least two " +
+            "assembly names.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         Viewsheet vs = rvs.getViewsheet();
+         List<VSAssembly> members = new ArrayList<>();
+
+         for(String name : names) {
+            VSAssembly assembly = requireVSAssembly(rvs, vs, name);
+
+            if(!(assembly instanceof AbstractSelectionVSAssembly)) {
+               throw new IllegalArgumentException(
+                  "'" + name + "' is a " + assembly.getClass().getSimpleName() + ", not a " +
+                  "selection filter -- edit(op:'group_as_selection_container') only combines " +
+                  "Selection List, Selection Tree, Time Slider or Calendar assemblies.");
+            }
+
+            members.add(assembly);
+         }
+
+         CurrentSelectionVSAssembly container = (CurrentSelectionVSAssembly) VSEventUtil
+            .createVSAssembly(rvs, AbstractSheet.CURRENTSELECTION_ASSET);
+         Point[] locs = GroupContainerVSAssembly.getUpperLeftAndBottomRight(
+            vs, names.toArray(new String[0]));
+         container.setPixelOffset(locs[0]);
+         container.setPixelSize(new Dimension(locs[1].x - locs[0].x, locs[1].y - locs[0].y));
+
+         coreLifecycleService.addDeleteVSObject(rvs, container, dispatcher);
+
+         for(VSAssembly member : members) {
+            grouping.groupComponents(rvs, container, member, true, linkUri, dispatcher);
+         }
+      });
+   }
+
    private VSAssembly requireVSAssembly(RuntimeViewsheet rvs, Viewsheet vs, String name) {
       requireExisting(rvs, name);
       VSAssembly assembly = vs == null ? null : (VSAssembly) vs.getAssembly(name);
@@ -509,6 +575,18 @@ public class ViewsheetEditService {
                "by group_as_tab. To take an assembly out of the tab, use " +
                "edit(op:'move_from_container') on it instead -- the tab is removed " +
                "automatically once only one assembly remains in it.");
+         }
+
+         // Same failure class as the Tab guard above: group_as_selection_container produces a
+         // CurrentSelectionVSAssembly, which ComposerGroupService.ungroup also does not unwrap.
+         if(assembly instanceof CurrentSelectionVSAssembly) {
+            throw new IllegalArgumentException(
+               "'" + request.assembly() + "' is a Selection Container, not a Group -- " +
+               "edit(op:'ungroup') only reverses the GroupContainer that group creates; it does " +
+               "not undo a Selection Container created by group_as_selection_container. To take " +
+               "an assembly out of it, use edit(op:'move_from_container') on it instead -- " +
+               "unlike a Tab or Group, the container is NOT removed automatically when it is " +
+               "down to one member; remove it explicitly with edit(op:'remove') once empty.");
          }
 
          groups.ungroup(runtimeId, request.assembly(), linkUri, user, dispatcher);
@@ -830,4 +908,5 @@ public class ViewsheetEditService {
    private final ComposerGroupService groups;
    private final GroupingService grouping;
    private final VSRefreshService refreshService;
+   private final CoreLifecycleService coreLifecycleService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.analytic.composition.event.VSEventUtil;
+import inetsoft.uql.asset.AbstractSheet;
 import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
 import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
@@ -33,11 +35,14 @@ import inetsoft.web.viewsheet.controller.VSRefreshService;
 import inetsoft.web.viewsheet.event.RefreshVSAssemblyEvent;
 import inetsoft.web.viewsheet.event.VSRefreshEvent;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.CurrentSelectionVSAssembly;
+import inetsoft.uql.viewsheet.SelectionListVSAssembly;
 import inetsoft.uql.viewsheet.TableDataVSAssembly;
 import inetsoft.uql.viewsheet.TabVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.viewsheet.service.CoreLifecycleService;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
@@ -50,7 +55,10 @@ import inetsoft.web.composer.vs.objects.event.ResizeVSObjectTitleEvent;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
+import java.awt.Dimension;
+import java.awt.Point;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -624,6 +632,28 @@ class ViewsheetEditServiceTest {
       assertTrue(thrown.getMessage().contains("Tab"));
    }
 
+   /**
+    * Same failure class as PVA-013, for the Selection Container this bug's fix introduces:
+    * {@code ComposerGroupService.ungroup} only unwraps a GroupContainerVSAssembly, so without
+    * this guard "ungroup" on a Selection Container would report success while leaving it intact.
+    */
+   @Test
+   void ungroupOnASelectionContainerFailsLoudInsteadOfSilentlyDoingNothing() {
+      ComposerGroupService groups = mock(ComposerGroupService.class);
+      RuntimeViewsheet rvs = runtimeWith("Selection1", mock(CurrentSelectionVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(new AssemblyNode(
+         "Selection1", "CurrentSelection", 0, 0, 200, 200, 0, null, true)),
+         mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request("ungroup", "Selection1"), ""));
+
+      assertTrue(thrown.getMessage().contains("Selection1"));
+      assertTrue(thrown.getMessage().contains("Selection Container"));
+      verifyNoInteractions(groups);
+   }
+
    @Test
    void groupAsTabRejectsFewerThanTwoAssemblies() {
       ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
@@ -665,6 +695,88 @@ class ViewsheetEditServiceTest {
 
       verify(grouping).groupComponents(eq(rvs), eq(a), eq(b), eq(false), anyString(), any());
       verify(grouping).groupComponents(eq(rvs), eq(a), eq(c), eq(false), anyString(), any());
+      verifyNoMoreInteractions(grouping);
+   }
+
+   @Test
+   void groupAsSelectionContainerRejectsFewerThanTwoAssemblies() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(),
+            arrange("group_as_selection_container", List.of("A"), null), ""));
+      assertTrue(thrown.getMessage().contains("two"));
+   }
+
+   /**
+    * VBM-008: only Selection List/Tree/Time Slider/Calendar (AbstractSelectionVSAssembly) can
+    * join a Selection Container -- a Chart, say, cannot. The error must name the offending
+    * assembly and its actual type, not just fail generically.
+    */
+   @Test
+   void groupAsSelectionContainerRejectsANonSelectionAssemblyNamingTheOffender() {
+      VSAssembly a = mock(SelectionListVSAssembly.class);
+      VSAssembly bad = mock(ChartVSAssembly.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("Chart1")).thenReturn(bad);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "SelectionList", 0, 0, 100, 100, 0, null, true),
+         new AssemblyNode("Chart1", "Chart", 100, 0, 100, 100, 0, null, true));
+      ViewsheetEditService service = serviceWithRuntime(rvs, reader,
+         mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(),
+            arrange("group_as_selection_container", List.of("A", "Chart1"), null), ""));
+
+      assertTrue(thrown.getMessage().contains("Chart1"));
+   }
+
+   /**
+    * Unlike group_as_tab, GroupingService's selection=true mode has no lazy-create fallback, so
+    * the container must be built once up front (via VSEventUtil.createVSAssembly, notified to the
+    * client via coreLifecycleService.addDeleteVSObject) and then each member folded in with its
+    * own groupComponents call -- once per member, not pairwise.
+    */
+   @Test
+   void groupAsSelectionContainerCreatesContainerOnceAndCallsGroupComponentsOncePerMember()
+      throws Exception
+   {
+      GroupingService grouping = mock(GroupingService.class);
+      CoreLifecycleService coreLifecycleService = mock(CoreLifecycleService.class);
+      VSAssembly a = mock(SelectionListVSAssembly.class);
+      VSAssembly b = mock(SelectionListVSAssembly.class);
+      CurrentSelectionVSAssembly container = mock(CurrentSelectionVSAssembly.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("A")).thenReturn(a);
+      when(vs.getAssembly("B")).thenReturn(b);
+      when(vs.getPixelPositionInViewsheet(any())).thenAnswer(inv -> new Point(0, 0));
+      when(vs.getPixelSize(any())).thenAnswer(inv -> new Dimension(100, 100));
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "SelectionList", 0, 0, 100, 100, 0, null, true),
+         new AssemblyNode("B", "SelectionList", 100, 0, 100, 100, 0, null, true));
+      ViewsheetEditService service = serviceWithRuntimeAndGrouping(rvs, reader, grouping,
+         coreLifecycleService);
+
+      try(MockedStatic<VSEventUtil> vsEventUtil = mockStatic(VSEventUtil.class)) {
+         vsEventUtil.when(() ->
+            VSEventUtil.createVSAssembly(rvs, AbstractSheet.CURRENTSELECTION_ASSET))
+            .thenReturn(container);
+
+         service.apply("tok", principal(),
+                       arrange("group_as_selection_container", List.of("A", "B"), null), "");
+      }
+
+      verify(coreLifecycleService).addDeleteVSObject(eq(rvs), eq(container), any());
+      verify(grouping).groupComponents(eq(rvs), eq(container), eq(a), eq(true), anyString(), any());
+      verify(grouping).groupComponents(eq(rvs), eq(container), eq(b), eq(true), anyString(), any());
       verifyNoMoreInteractions(grouping);
    }
 
@@ -977,7 +1089,8 @@ class ViewsheetEditServiceTest {
                                       mock(ClipboardControllerService.class),
                                       mock(VSObjectPropertyService.class), reader,
                                       mock(ComposerGroupService.class),
-                                      mock(GroupingService.class), refreshService);
+                                      mock(GroupingService.class), refreshService,
+                                      mock(CoreLifecycleService.class));
    }
 
    /** Runs the mutation against a supplied runtime, for the guards that inspect the assembly. */
@@ -1016,7 +1129,8 @@ class ViewsheetEditServiceTest {
                                       propertyService, reader,
                                       mock(ComposerGroupService.class),
                                       mock(GroupingService.class),
-                                      mock(VSRefreshService.class));
+                                      mock(VSRefreshService.class),
+                                      mock(CoreLifecycleService.class));
    }
 
    private static ViewsheetEditService serviceWith(ComposerObjectService objects,
@@ -1031,6 +1145,18 @@ class ViewsheetEditServiceTest {
    private static ViewsheetEditService serviceWithRuntimeAndGrouping(RuntimeViewsheet rvs,
                                                                      ViewsheetReadService reader,
                                                                      GroupingService grouping)
+   {
+      return serviceWithRuntimeAndGrouping(rvs, reader, grouping,
+                                           mock(CoreLifecycleService.class));
+   }
+
+   /**
+    * Exposes {@code coreLifecycleService} too -- for group_as_selection_container's
+    * addDeleteVSObject call.
+    */
+   private static ViewsheetEditService serviceWithRuntimeAndGrouping(
+      RuntimeViewsheet rvs, ViewsheetReadService reader, GroupingService grouping,
+      CoreLifecycleService coreLifecycleService)
    {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
 
@@ -1049,7 +1175,7 @@ class ViewsheetEditServiceTest {
                                       mock(ClipboardControllerService.class),
                                       mock(VSObjectPropertyService.class), reader,
                                       mock(ComposerGroupService.class), grouping,
-                                      mock(VSRefreshService.class));
+                                      mock(VSRefreshService.class), coreLifecycleService);
    }
 
    private static ViewsheetEditService serviceWith(ComposerObjectService objects,
@@ -1073,6 +1199,7 @@ class ViewsheetEditServiceTest {
 
       return new ViewsheetEditService(sessions, objects, clipboard,
                                      mock(VSObjectPropertyService.class), reader, groups,
-                                     grouping, mock(VSRefreshService.class));
+                                     grouping, mock(VSRefreshService.class),
+                                     mock(CoreLifecycleService.class));
    }
 }


### PR DESCRIPTION
## Summary
- Adds `group_as_selection_container` to `ViewsheetEditService`: builds a `CurrentSelectionVSAssembly` from two or more existing selection filters (SelectionList/SelectionTree/TimeSlider/Calendar), mirroring `group_as_tab`'s shape but constructing the container up front via `VSEventUtil.createVSAssembly` (unlike Tab's lazy-create fallback, `GroupingService`'s `selection=true` mode asserts the container already exists), positioning it via `GroupContainerVSAssembly.getUpperLeftAndBottomRight`, notifying the client via a newly-injected `CoreLifecycleService.addDeleteVSObject`, then folding in each member with `GroupingService.groupComponents(..., selection=true, ...)` — the same call `VSBindingService.addAssembly` uses for "drop a filter onto an existing Selection Container".
- Extends the existing `ungroup` op's Tab fail-loud guard (PVA-013) to also reject a `CurrentSelectionVSAssembly` name, since `ComposerGroupService.ungroup` only unwraps `GroupContainerVSAssembly` and would otherwise silently no-op on a Selection Container — folded into this PR per the design's refuter-recommended scope.
- Design: `docs/teams/2026-09-05-bugs-vbm-vbs-psm/bug-vbm-008/01-diagnosis.md` + `02-refute.md` in the `stylebi-wiz` repo.

## Test plan
- [x] `./mvnw -pl core -o test -Dtest=ViewsheetEditServiceTest` — 54/54 passed (new tests: `groupAsSelectionContainerRejectsFewerThanTwoAssemblies`, `groupAsSelectionContainerRejectsANonSelectionAssemblyNamingTheOffender`, `groupAsSelectionContainerCreatesContainerOnceAndCallsGroupComponentsOncePerMember`, `ungroupOnASelectionContainerFailsLoudInsteadOfSilentlyDoingNothing`)
- [x] `./mvnw -pl core -o test -Dtest="inetsoft.web.wiz.viewsheet.**"` — all 27 test classes green (1580+ tests)
- [ ] Live Composer verification (no MCP composer-chat access in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)