### PR TITLE
fix(VBS-005): route set_format target:text through the chart's aesthetic-bound field

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
@@ -1628,6 +1628,22 @@ public class FormatPainterService {
             ref = (ChartRef) info.getDCBIndingRef(columnName);
          }
 
+         // getDCBIndingRef() only searches getRuntimeDateComparisonRefs() (date-comparison-
+         // specific), not the full runtime-field lookup getChartBindable() itself falls back to
+         // below — replicate that fallback here too, or a legitimately-bound runtime-only field
+         // on a date-comparison chart would incorrectly fail the unresolved-field check just below.
+         if(ref == null && chartInfo.isAppliedDateComparison()) {
+            ref = chartInfo.getFieldByName(columnName, true);
+         }
+
+         if(ref == null && (region.equals(ChartFormatConstants.TEXT) ||
+            region.equals(ChartFormatConstants.TEXT_FIELD)))
+         {
+            throw new IllegalArgumentException(
+               "set_format: '" + columnName + "' is not bound to chart '" + name + "'s " + region +
+               " aesthetic (or any other field on this chart) — nothing to format.");
+         }
+
          if(!(GraphTypes.isRadarN(chartInfo) && GraphUtil.isMeasure(ref) ||
             GraphTypes.isRadarOne(chartInfo)) ||
             region.equals(ChartFormatConstants.TEXT) ||

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.report.StyleConstants;
 import inetsoft.report.TableDataPath;
 import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
+import inetsoft.web.adhoc.model.chart.ChartFormatConstants;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -57,16 +58,27 @@ public class ViewsheetFormatService {
     * @param reset      clear formatting back to the default rather than applying {@code format}
     * @param target     {@code "object"} (default, when null/blank) formats the whole assembly;
     *                   {@code "title"} formats only that assembly's own title-bar text, distinct
-    *                   from a chart's axis titles or any other sub-region
+    *                   from a chart's axis titles or any other sub-region; {@code "text"} formats
+    *                   a single chart's {@code text}-aesthetic-bound field (its data labels)
+    * @param field      required when {@code target} is {@code "text"} — the column currently
+    *                   bound to the chart's text aesthetic channel
     */
    public record FormatRequest(List<String> assemblies,
                                VSObjectFormatInfoModel format,
                                boolean reset,
-                               String target)
+                               String target,
+                               String field)
    {
-      /** Kept for existing callers that predate {@code target} — defaults it to whole-object. */
+      /** Kept for existing callers that predate {@code target}/{@code field} — defaults both. */
       public FormatRequest(List<String> assemblies, VSObjectFormatInfoModel format, boolean reset) {
-         this(assemblies, format, reset, null);
+         this(assemblies, format, reset, null, null);
+      }
+
+      /** Kept for existing callers that predate {@code field} — defaults it to null. */
+      public FormatRequest(List<String> assemblies, VSObjectFormatInfoModel format, boolean reset,
+                           String target)
+      {
+         this(assemblies, format, reset, target, null);
       }
 
       /**
@@ -88,9 +100,10 @@ public class ViewsheetFormatService {
       public static FormatRequest fromJson(@JsonProperty("assemblies") List<String> assemblies,
                                            @JsonProperty("format") JsonNode format,
                                            @JsonProperty("reset") boolean reset,
-                                           @JsonProperty("target") String target)
+                                           @JsonProperty("target") String target,
+                                           @JsonProperty("field") String field)
       {
-         return new FormatRequest(assemblies, toModel(format), reset, target);
+         return new FormatRequest(assemblies, toModel(format), reset, target, field);
       }
 
       private static VSObjectFormatInfoModel toModel(JsonNode format) {
@@ -314,32 +327,58 @@ public class ViewsheetFormatService {
 
       String target = requireTarget(request.target());
 
+      if("text".equals(target)) {
+         if(request.assemblies().size() != 1) {
+            throw new IllegalArgumentException(
+               "set_format: target 'text' formats a single chart's aesthetic-bound field at a " +
+               "time; got " + request.assemblies().size() + " assemblies.");
+         }
+
+         if(request.field() == null || request.field().isBlank()) {
+            throw new IllegalArgumentException(
+               "set_format: target 'text' requires 'field' — the column bound to the chart's " +
+               "text aesthetic channel.");
+         }
+      }
+
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          FormatVSObjectEvent event = new FormatVSObjectEvent();
-         event.setObjects(request.assemblies().toArray(new String[0]));
          event.setFormat(request.format());
          event.setReset(request.reset());
-         // FormatPainterService iterates `event.getCharts().length` unguarded, so a null here is an
-         // immediate NPE — every set_format call, format or reset alike, failed with a 500. An
-         // empty array is the correct value for assembly-level formatting: the chart-region
-         // branches that read getColumnNames()/getIndexes()/getRegions() all live inside that
-         // loop, so they never execute for these requests.
-         event.setCharts(new String[0]);
 
-         // TITLEPATH is FormatPainterService's own per-assembly TableDataPath[] mechanism
-         // (event.getData(), indexed 1:1 with event.getObjects()) — the same generic slot every
-         // titled assembly (table, gauge, crosstab, chart, ...) already stores its own title-bar
-         // format in, entirely separate from a chart's axis/legend descriptors. Leaving data null
-         // (the default) falls through to a whole-OBJECT write, same as before this parameter
-         // existed.
-         if("title".equals(target)) {
-            ArrayList<TableDataPath[]> data = new ArrayList<>();
+         if("text".equals(target)) {
+            // Routes through FormatPainterService's per-chart loop instead of the whole-object
+            // path: a single named field on the chart's text aesthetic, all points (-1).
+            event.setObjects(new String[0]);
+            event.setCharts(request.assemblies().toArray(new String[0]));
+            event.setRegions(new String[]{ ChartFormatConstants.TEXT });
+            event.setColumnNames(new String[][]{ { request.field() } });
+            event.setIndexes(new int[][]{ { -1 } });
+         }
+         else {
+            event.setObjects(request.assemblies().toArray(new String[0]));
+            // FormatPainterService iterates `event.getCharts().length` unguarded, so a null here
+            // is an immediate NPE — every set_format call, format or reset alike, failed with a
+            // 500. An empty array is the correct value for assembly-level formatting: the
+            // chart-region branches that read getColumnNames()/getIndexes()/getRegions() all live
+            // inside that loop, so they never execute for these requests.
+            event.setCharts(new String[0]);
 
-            for(int i = 0; i < request.assemblies().size(); i++) {
-               data.add(new TableDataPath[]{ VSAssemblyInfo.TITLEPATH });
+            // TITLEPATH is FormatPainterService's own per-assembly TableDataPath[] mechanism
+            // (event.getData(), indexed 1:1 with event.getObjects()) — the same generic slot
+            // every titled assembly (table, gauge, crosstab, chart, ...) already stores its own
+            // title-bar format in, entirely separate from a chart's axis/legend descriptors.
+            // Leaving data null (the default) falls through to a whole-OBJECT write, same as
+            // before this parameter existed.
+            if("title".equals(target)) {
+               ArrayList<TableDataPath[]> data = new ArrayList<>();
+
+               for(int i = 0; i < request.assemblies().size(); i++) {
+                  data.add(new TableDataPath[]{ VSAssemblyInfo.TITLEPATH });
+               }
+
+               event.setData(data);
             }
-
-            event.setData(data);
          }
 
          painter.setFormat(runtimeId, event, user, dispatcher, linkUri);
@@ -350,13 +389,14 @@ public class ViewsheetFormatService {
    private static String requireTarget(String target) {
       String name = target == null || target.isBlank() ? "object" : target.trim().toLowerCase();
 
-      if(!"object".equals(name) && !"title".equals(name)) {
+      if(!"object".equals(name) && !"title".equals(name) && !"text".equals(name)) {
          throw new IllegalArgumentException(
-            "set_format 'target' must be 'object' or 'title', got '" + target + "'. 'object' " +
-            "(the default) formats the whole assembly, including — for a chart — the default " +
-            "text style that unstyled axis titles and tick labels fall back to. 'title' formats " +
-            "only that assembly's own title-bar text; for a chart's x/y axis titles, use " +
-            "set_chart_region_properties with region 'title' instead.");
+            "set_format 'target' must be 'object', 'title' or 'text', got '" + target + "'. " +
+            "'object' (the default) formats the whole assembly, including — for a chart — the " +
+            "default text style that unstyled axis titles and tick labels fall back to. 'title' " +
+            "formats only that assembly's own title-bar text; for a chart's x/y axis titles, use " +
+            "set_chart_region_properties with region 'title' instead. 'text' formats a single " +
+            "chart's text-aesthetic-bound field (its data labels) — requires 'field'.");
       }
 
       return name;

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/FormatPainterServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/FormatPainterServiceTest.java
@@ -168,6 +168,12 @@ class FormatPainterServiceTest {
    void refusesATextFieldThatDoesNotResolveToAnyBoundField() {
       when(viewsheet.getLayoutInfo()).thenReturn(new LayoutInfo());
 
+      // PlotDescriptor always starts with its own fresh default CompositeTextFormat (never
+      // null) — the prior bug replaced this exact instance via plot.setTextFormat(fmt), so the
+      // regression check is identity, not nullity.
+      CompositeTextFormat originalPlotFormat =
+         chart.getChartDescriptor().getPlotDescriptor().getTextFormat();
+
       VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
       format.setFormat("currency");
       format.setFormatSpec("$#,##0");
@@ -184,8 +190,9 @@ class FormatPainterServiceTest {
          () -> service.setFormat("Viewsheet1", event, null, dispatcher, ""));
       assertTrue(thrown.getMessage().contains("NOT_A_REAL_FIELD"), thrown.getMessage());
       assertTrue(thrown.getMessage().contains("Chart1"), thrown.getMessage());
-      assertNull(chart.getChartDescriptor().getPlotDescriptor().getTextFormat(),
-                "the plot's shared default text format must not be mutated by a bogus field");
+      assertSame(originalPlotFormat,
+                chart.getChartDescriptor().getPlotDescriptor().getTextFormat(),
+                "the plot's shared default text format must not be replaced by a bogus field");
    }
 
    /**
@@ -199,6 +206,9 @@ class FormatPainterServiceTest {
    @Test
    void resolvesATextFieldThroughTheDateComparisonRuntimeFallback() throws Exception {
       when(viewsheet.getLayoutInfo()).thenReturn(new LayoutInfo());
+
+      CompositeTextFormat originalPlotFormat =
+         chart.getChartDescriptor().getPlotDescriptor().getTextFormat();
 
       ChartRef dcOnlyField = mock(ChartRef.class);
       when(dcOnlyField.getFullName()).thenReturn("DC_ONLY_FIELD");
@@ -221,7 +231,8 @@ class FormatPainterServiceTest {
 
       assertDoesNotThrow(() -> service.setFormat("Viewsheet1", event, null, dispatcher, ""));
       verify(dcOnlyField).setTextFormat(any());
-      assertNull(chart.getChartDescriptor().getPlotDescriptor().getTextFormat(),
+      assertSame(originalPlotFormat,
+                chart.getChartDescriptor().getPlotDescriptor().getTextFormat(),
                 "a resolved field must write its own text format, not the plot's shared default");
    }
 

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/FormatPainterServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/FormatPainterServiceTest.java
@@ -25,8 +25,11 @@ import inetsoft.report.composition.region.ChartArea;
 import inetsoft.test.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
+import inetsoft.uql.viewsheet.vslayout.LayoutInfo;
 import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.objects.command.SetCurrentFormatCommand;
+import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.GetVSObjectFormatEvent;
 import inetsoft.web.graph.handler.ChartRegionHandler;
 import inetsoft.web.viewsheet.command.ViewsheetCommand;
@@ -151,6 +154,75 @@ class FormatPainterServiceTest {
       assertFalse(commands.get(0).getModel().isVAlignmentEnabled());
       assertFalse(commands.get(1).getModel().isHAlignmentEnabled());
       assertFalse(commands.get(1).getModel().isVAlignmentEnabled());
+   }
+
+   /**
+    * VBS-005: before this guard, a `field` that resolved to nothing on the chart did not error —
+    * it fell all the way through {@code GraphFormatUtil.setBindingTextFormat} to
+    * {@code plot.setTextFormat(fmt)}, silently overwriting the chart's whole shared
+    * {@code PlotDescriptor} default text format with a format meant for one field. This asserts
+    * both that the call now refuses instead, and that the plot's default text format is left
+    * untouched (the real prior bug, not merely "a disconnected format got created").
+    */
+   @Test
+   void refusesATextFieldThatDoesNotResolveToAnyBoundField() {
+      when(viewsheet.getLayoutInfo()).thenReturn(new LayoutInfo());
+
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+      format.setFormat("currency");
+      format.setFormatSpec("$#,##0");
+
+      FormatVSObjectEvent event = new FormatVSObjectEvent();
+      event.setObjects(new String[0]);
+      event.setCharts(new String[]{ "Chart1" });
+      event.setRegions(new String[]{ "text" });
+      event.setColumnNames(new String[][]{ { "NOT_A_REAL_FIELD" } });
+      event.setIndexes(new int[][]{ { -1 } });
+      event.setFormat(format);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.setFormat("Viewsheet1", event, null, dispatcher, ""));
+      assertTrue(thrown.getMessage().contains("NOT_A_REAL_FIELD"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("Chart1"), thrown.getMessage());
+      assertNull(chart.getChartDescriptor().getPlotDescriptor().getTextFormat(),
+                "the plot's shared default text format must not be mutated by a bogus field");
+   }
+
+   /**
+    * VBS-005 correction #1: {@code info.getDCBIndingRef()} only searches
+    * {@code getRuntimeDateComparisonRefs()}, not the full runtime-field lookup
+    * {@code getChartBindable()} itself falls back to
+    * ({@code getFieldByName(columnName, true)} gated on {@code isAppliedDateComparison()}). The
+    * new guard must replicate that fallback, or a legitimately-bound runtime-only field on a
+    * date-comparison chart would incorrectly fail the unresolved-field check.
+    */
+   @Test
+   void resolvesATextFieldThroughTheDateComparisonRuntimeFallback() throws Exception {
+      when(viewsheet.getLayoutInfo()).thenReturn(new LayoutInfo());
+
+      ChartRef dcOnlyField = mock(ChartRef.class);
+      when(dcOnlyField.getFullName()).thenReturn("DC_ONLY_FIELD");
+
+      VSChartInfo chartInfo = chart.getVSChartInfo();
+      chartInfo.setRTXFields(new ChartRef[]{ dcOnlyField });
+      chartInfo.setRuntimeDateComparisonRefs(new ChartRef[]{ dcOnlyField });
+
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+      format.setFormat("currency");
+      format.setFormatSpec("$#,##0");
+
+      FormatVSObjectEvent event = new FormatVSObjectEvent();
+      event.setObjects(new String[0]);
+      event.setCharts(new String[]{ "Chart1" });
+      event.setRegions(new String[]{ "text" });
+      event.setColumnNames(new String[][]{ { "DC_ONLY_FIELD" } });
+      event.setIndexes(new int[][]{ { -1 } });
+      event.setFormat(format);
+
+      assertDoesNotThrow(() -> service.setFormat("Viewsheet1", event, null, dispatcher, ""));
+      verify(dcOnlyField).setTextFormat(any());
+      assertNull(chart.getChartDescriptor().getPlotDescriptor().getTextFormat(),
+                "a resolved field must write its own text format, not the plot's shared default");
    }
 
    @Captor ArgumentCaptor<SetCurrentFormatCommand> argCaptor;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -419,7 +419,7 @@ class ViewsheetFormatServiceTest {
    }
 
    @Test
-   void refusesATargetThatIsNeitherObjectNorTitle() {
+   void refusesATargetThatIsNeitherObjectNorTitleNorText() {
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
          () -> serviceWith(mock(FormatPainterService.class)).setFormat(
@@ -428,6 +428,61 @@ class ViewsheetFormatServiceTest {
                List.of("Chart1"), new VSObjectFormatInfoModel(), false, "axis"), ""));
       assertTrue(thrown.getMessage().contains("target"), thrown.getMessage());
       assertTrue(thrown.getMessage().contains("axis"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("text"), thrown.getMessage());
+   }
+
+   /**
+    * `target: "text"` routes a chart's aesthetic-bound field format through the same
+    * `event.getCharts()`/`getRegions()`/`getColumnNames()`/`getIndexes()` mechanism the
+    * interactive Composer's own "aggregate text format" editor already drives
+    * ({@code vs-binding-pane.component.ts}'s {@code createUpdateFormatEvent()}) — previously
+    * dead for the wiz-agent path because {@code event.setCharts(new String[0])} was hardcoded.
+    */
+   @Test
+   void targetTextRoutesThroughTheChartsArrayWithTheNamedField() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+      format.setFormat("currency");
+      format.setFormatSpec("$#,##0");
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(
+            List.of("Chart1"), format, false, "text", "NET_REVENUE_SUM"), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      FormatVSObjectEvent event = captor.getValue();
+      assertArrayEquals(new String[0], event.getObjects());
+      assertArrayEquals(new String[]{ "Chart1" }, event.getCharts());
+      assertArrayEquals(new String[]{ "text" }, event.getRegions());
+      assertArrayEquals(new String[][]{ { "NET_REVENUE_SUM" } }, event.getColumnNames());
+      assertArrayEquals(new int[][]{ { -1 } }, event.getIndexes());
+   }
+
+   @Test
+   void targetTextRequiresExactlyOneAssembly() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> serviceWith(mock(FormatPainterService.class)).setFormat(
+            "tok", principal(),
+            new ViewsheetFormatService.FormatRequest(
+               List.of("Chart1", "Chart2"), new VSObjectFormatInfoModel(), false, "text",
+               "NET_REVENUE_SUM"), ""));
+      assertTrue(thrown.getMessage().contains("2"), thrown.getMessage());
+   }
+
+   @Test
+   void targetTextRequiresField() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> serviceWith(mock(FormatPainterService.class)).setFormat(
+            "tok", principal(),
+            new ViewsheetFormatService.FormatRequest(
+               List.of("Chart1"), new VSObjectFormatInfoModel(), false, "text", null), ""));
+      assertTrue(thrown.getMessage().contains("field"), thrown.getMessage());
    }
 
    private static ViewsheetFormatService serviceWith(FormatPainterService painter) {


### PR DESCRIPTION
## Summary
- `ViewsheetFormatService.setFormat()` hardcoded `event.setCharts(new String[0])`, so a chart's text-aesthetic (data label) number format was unreachable from the wiz-agent's `set_format` tool, even though the interactive Composer's own binding-pane "aggregate text format" editor drives the exact same `FormatPainterService` code path. `FormatRequest` gains a `field` component; `target:"text"` populates `charts`/`regions`/`columnNames`/`indexes` instead of the whole-object path. `requireTarget()` now accepts `object`/`title`/`text`.
- Closes a real validation gap in `FormatPainterService.getChartRegionFormat()`: a `field` that didn't resolve to anything on the chart previously fell all the way through `GraphFormatUtil.setBindingTextFormat` to `plot.setTextFormat(fmt)` — silently overwriting the chart's whole shared `PlotDescriptor` default text format with a format meant for one field. Now throws instead, naming the field and assembly.
- The new guard replicates `ChartRegionHandler.getChartBindable()`'s runtime-field fallback (`getFieldByName(columnName, true)` gated on `isAppliedDateComparison()`) so a legitimately-bound runtime-only field name on a date-comparison chart doesn't false-positive against the new throw.

Design/refutation: `docs/teams/2026-09-05-bugs-vbm-vbs-psm/bug-vbs-005/01-diagnosis.md` and `02-refute.md` in the `stylebi-wiz` repo. Companion plugin-side PR: stylebi-wiz#2233.

## Test plan
- [x] `ViewsheetFormatServiceTest`: target:"text" routes charts/regions/columnNames/indexes correctly; requires exactly one assembly; requires field; `requireTarget` message now lists all three targets — 26 tests, 0 failures
- [x] `FormatPainterServiceTest`: bogus field now throws (naming field + assembly) instead of replacing the plot's shared default text format (asserted via identity, since `PlotDescriptor` always starts with a non-null default format); a field resolvable only via the date-comparison runtime fallback does not throw and writes to the field's own format, not the plot's — 5 tests, 0 failures
- [x] Broader regression sweep: `inetsoft.web.wiz.**` + `inetsoft.web.composer.vs.controller.*` — 3171 tests, 0 failures/errors
- [ ] Live composer-chat verification — not attempted; no `mcp__...viz-chat__*` tools available in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)