### PR TITLE
Add SSO test coverage: SSOFilterPublisher cluster broadcast, ScheduleUsersChangeService, and test hygiene fixes

### DIFF
--- a/core/src/test/java/inetsoft/sree/security/support/SecurityTestDataBuilder.java
+++ b/core/src/test/java/inetsoft/sree/security/support/SecurityTestDataBuilder.java
@@ -22,6 +22,7 @@ import inetsoft.sree.PropertiesEngine;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.*;
 import inetsoft.uql.util.Identity;
+import inetsoft.util.DataSpace;
 import org.mindrot.BCrypt;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -224,12 +225,24 @@ public class SecurityTestDataBuilder {
       authzProvider.setProviderName("Primary");
 
       // setProviders() persists the chain to storage as a side effect;
-      // SecurityEngine.init() (line below) reads it to discover provider types.
+      // SecurityEngine.init() (line below) reads it to discover provider types. The chain's
+      // constructor registers a DataChangeListener on a JVM-wide-constant config file
+      // ("authc-chain.json"/"authz-chain.json"); since Surefire reuses one JVM across all test
+      // classes, a leaked listener here accumulates across the whole suite and every later
+      // saveConfiguration() write to that file re-entrantly re-triggers loadConfiguration() on
+      // each stale instance, racing on the file (intermittent
+      // "IllegalArgumentException: argument \"in\" is null" from Jackson, worse the later a
+      // test class happens to run). Remove it once setProviders() has run -- NOT via
+      // authcChain.tearDown()/authzChain.tearDown(), which cascade into disposing every
+      // provider in the chain (calls provider.tearDown()) and would tear down
+      // authcProvider/authzProvider themselves, still needed below.
       AuthenticationChain authcChain = new AuthenticationChain();
       authcChain.setProviders(Collections.singletonList(authcProvider));
+      DataSpace.getDataSpace().removeChangeListener(null, "authc-chain.json", authcChain);
 
       AuthorizationChain authzChain = new AuthorizationChain();
       authzChain.setProviders(Collections.singletonList(authzProvider));
+      DataSpace.getDataSpace().removeChangeListener(null, "authz-chain.json", authzChain);
 
       // Surefire reuses one JVM across Spring test contexts. A prior class's
       // SreeHomeExtension.afterAll nulls ConfigurationContext while PropertiesEngine's

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleUsersChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleUsersChangeServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+/*
+ * Test plan 2026-09-03, scenario 20: SSOTypeChangedMessage is NOT dead code -- this class is a
+ * real consumer, found by a repo-wide grep the original investigation missed (it only searched a
+ * narrower set of directories). ScheduleUsersChangeService.messageReceived() reacts to it by
+ * pushing a debounced STOMP notification to every currently-subscribed schedule-view client, but
+ * ONLY when SSO was toggled fully on or fully off (old/new type transitions through NONE) -- a
+ * protocol switch that stays "on" (e.g. SAML -> OpenID) does not notify.
+ *
+ * This also surfaces a new, independent finding, filed as Bug #76438: SSOSettingsService.
+ * updateSSOSettings() constructs the message as `new SSOTypeChangedMessage(activeFilterType,
+ * ssoType)` -- passing (OLD, NEW) -- but the constructor signature is
+ * `SSOTypeChangedMessage(SSOType newType, SSOType oldType)`, i.e. (NEW, OLD). The two are swapped
+ * at the only call site. This is currently harmless for the one consumer here, because its guard
+ * condition (`newType != oldType && (oldType == NONE || newType == NONE)`) is symmetric under
+ * swapping the two arguments -- but getNewType()/getOldType() return the wrong values relative to
+ * their names, which would bite any future consumer that cares about direction. Left unfixed
+ * pending a decision -- this test file does not touch SSOSettingsService.
+ *
+ * IMPORTANT for whoever fixes #76438: none of the four tests below need to change either way.
+ * They never call SSOSettingsService -- ssoTypeChanged() below constructs SSOTypeChangedMessage
+ * directly, deliberately reproducing whatever {oldType, newType} pair the current (buggy) call
+ * site would have produced. Because messageReceived()'s guard is symmetric in old/new (see above),
+ * the resulting notify/don't-notify outcome is identical whether the message's two fields are
+ * populated in the "buggy" order or the corrected one. Fixing #76438 only matters to a consumer
+ * that reads getNewType()/getOldType() asymmetrically -- this one does not.
+ *
+ * The debouncer is a real (not mocked) DefaultDebouncer with a fixed 1-second interval, hardcoded
+ * as a private field with no way to inject a test double -- these tests wait past that real
+ * interval rather than mocking it out.
+ */
+
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.internal.cluster.MessageEvent;
+import inetsoft.web.admin.security.SSOType;
+import inetsoft.web.admin.security.SSOTypeChangedMessage;
+import inetsoft.web.service.BaseSubscribeChangeHandler;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.security.Principal;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class ScheduleUsersChangeServiceTest {
+   @Mock
+   private SimpMessagingTemplate messageTemplate;
+   @Mock
+   private Cluster cluster;
+   @Mock
+   private Principal principal;
+
+   private ScheduleUsersChangeService service;
+
+   // the debouncer's own interval -- verify() with Mockito's timeout() polls up to this long
+   // instead of a flat Thread.sleep(), so a passing test does not have to wait the full interval.
+   private static final long DEBOUNCE_MS = 1000;
+   private static final long VERIFY_TIMEOUT_MS = DEBOUNCE_MS + 1500;
+
+   @BeforeEach
+   void setUp() {
+      service = new ScheduleUsersChangeService(messageTemplate, cluster);
+      service.addSubscriber(new BaseSubscribeChangeHandler.BaseSubscriber(
+         "session-1", "sub-1", "/lookup/schedule", "/topic/schedule", principal));
+   }
+
+   @AfterEach
+   void tearDown() {
+      service.destroyInstance();
+   }
+
+   private static MessageEvent ssoTypeChanged(SSOType oldType, SSOType newType) {
+      // matches the real (buggy) call site in SSOSettingsService: constructor args are
+      // (newType, oldType) but the caller passes (old, new) -- see class javadoc. Passed through
+      // as-is here, since this test targets the CONSUMER's behavior given whatever message it
+      // actually receives in production, not a hypothetical corrected one.
+      return new MessageEvent(
+         "test", "other-node", false, new SSOTypeChangedMessage(oldType, newType));
+   }
+
+   @Test
+   void ssoTurnedOn_noneToSaml_notifiesSubscribers() {
+      service.messageReceived(ssoTypeChanged(SSOType.NONE, SSOType.SAML));
+
+      verify(messageTemplate, timeout(VERIFY_TIMEOUT_MS))
+         .convertAndSendToUser(eq("session-1"), eq("/lookup/schedule"), any(), anyMap());
+   }
+
+   @Test
+   void ssoTurnedOff_samlToNone_notifiesSubscribers() {
+      service.messageReceived(ssoTypeChanged(SSOType.SAML, SSOType.NONE));
+
+      verify(messageTemplate, timeout(VERIFY_TIMEOUT_MS))
+         .convertAndSendToUser(eq("session-1"), eq("/lookup/schedule"), any(), anyMap());
+   }
+
+   @Test
+   void protocolSwitchWhileStayingOn_samlToOpenId_doesNotNotify() throws Exception {
+      // neither side of the transition is NONE -- this must NOT trigger a subscriber push,
+      // unlike the two "turned on"/"turned off" cases above.
+      service.messageReceived(ssoTypeChanged(SSOType.SAML, SSOType.OPENID));
+
+      // wait past the real debounce interval to distinguish "never notified" from "not notified
+      // yet" -- there is no pending-task hook to poll instead.
+      Thread.sleep(DEBOUNCE_MS + 200);
+      verify(messageTemplate, never()).convertAndSendToUser(any(), any(), any(), anyMap());
+   }
+
+   @Test
+   void noActualChange_noneToNone_doesNotNotify() throws Exception {
+      service.messageReceived(ssoTypeChanged(SSOType.NONE, SSOType.NONE));
+
+      Thread.sleep(DEBOUNCE_MS + 200);
+      verify(messageTemplate, never()).convertAndSendToUser(any(), any(), any(), anyMap());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/CustomSSOConfigTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/CustomSSOConfigTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security;
+
+/*
+ * Test plan 2026-09-03, scenario 16: CustomSSOConfig.setClassName()/setInlineGroovyClass() are
+ * mutually exclusive by construction -- each one clears the other as a side effect
+ * (setClassName(nonNull) calls setInlineGroovyClass(null); setInlineGroovyClass(nonNull) calls
+ * setClassName(null)) -- so whichever is called LAST silently wins, with no error or warning if a
+ * caller sets both. SSOSettingsService.updateSSOSettings()'s CUSTOM branch always calls
+ * setClassName(...) before setInlineGroovyClass(...) (see its own source), so in that real caller,
+ * inline Groovy always wins if a request configures both -- the Java class name is silently
+ * discarded, not rejected.
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class CustomSSOConfigTest {
+   @Mock
+   private DataSpace dataSpace;
+
+   private CustomSSOConfig config;
+   private MockedStatic<SreeEnv> sreeEnvMock;
+
+   @BeforeEach
+   void setUp() {
+      config = new CustomSSOConfig(dataSpace);
+      sreeEnvMock = mockStatic(SreeEnv.class);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvMock.close();
+   }
+
+   @Test
+   void setClassNameThenInlineGroovy_matchesRealCallerOrder_groovyOverwritesClassName()
+      throws Exception
+   {
+      // this order (setClassName then setInlineGroovyClass) is exactly what
+      // SSOSettingsService.updateSSOSettings()'s CUSTOM branch does when a request configures
+      // both a Java class name AND inline Groovy at once.
+      lenient().when(dataSpace.exists(null, "GroovySSOFilter.groovy")).thenReturn(false);
+
+      config.setClassName("com.example.MyCustomSSOFilter");
+      config.setInlineGroovyClass("class Foo { }");
+
+      // setInlineGroovyClass(nonNull) calls setClassName(null) internally -- the class name
+      // property ends up cleared, even though it was explicitly set moments earlier.
+      sreeEnvMock.verify(() -> SreeEnv.setProperty("sso.custom.class", "com.example.MyCustomSSOFilter"));
+      sreeEnvMock.verify(() -> SreeEnv.setProperty(eq("sso.custom.class"), isNull()));
+      verify(dataSpace).withOutputStream(eq(null), eq("GroovySSOFilter.groovy"), any());
+   }
+
+   @Test
+   void setInlineGroovyThenClassName_classNameOverwritesGroovy() {
+      // reverse order: the groovy file is written first (setInlineGroovyClass clears className as
+      // a side effect), then setClassName() is called -- since className != null, it deletes the
+      // groovy file it just wrote.
+      when(dataSpace.exists(null, "GroovySSOFilter.groovy")).thenReturn(true);
+
+      config.setInlineGroovyClass("class Foo { }");
+      config.setClassName("com.example.MyCustomSSOFilter");
+
+      sreeEnvMock.verify(() -> SreeEnv.setProperty(eq("sso.custom.class"), isNull()));
+      sreeEnvMock.verify(() -> SreeEnv.setProperty("sso.custom.class", "com.example.MyCustomSSOFilter"));
+      verify(dataSpace).delete(null, "GroovySSOFilter.groovy");
+   }
+
+   @Test
+   void setClassNameToNull_doesNotTouchInlineGroovyFile() {
+      // control: clearing the class name (className == null) must NOT trigger the
+      // setInlineGroovyClass(null) side effect -- that only happens for a non-null class name.
+      config.setClassName(null);
+
+      sreeEnvMock.verify(() -> SreeEnv.setProperty("sso.custom.class", null));
+      verify(dataSpace, never()).exists(any(), anyString());
+      verify(dataSpace, never()).delete(any(), anyString());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/SSOFilterPublisherTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/SSOFilterPublisherTest.java
@@ -1,0 +1,126 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security;
+
+/*
+ * Test plan 2026-09-03, scenario 10: SSOFilterPublisher.changeSSOFilterType() publishes the
+ * local Spring event UNCONDITIONALLY, then separately tries to broadcast to the rest of the
+ * cluster -- a cluster send failure is caught and only LOG.warn'd, never propagated, and there is
+ * no retry/compensation. This exact link has a real historical bug (community commit 3bf25021e,
+ * "correct handle ChangeSSOFilterMessage to ensure the sso type can be changed successfully"),
+ * so this coverage gap is not theoretical.
+ */
+
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.internal.cluster.MessageEvent;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class SSOFilterPublisherTest {
+   @Mock
+   private Cluster cluster;
+   @Mock
+   private ApplicationEventPublisher publisher;
+
+   private SSOFilterPublisher filterPublisher;
+
+   @BeforeEach
+   void setUp() {
+      filterPublisher = new SSOFilterPublisher(cluster);
+      filterPublisher.setApplicationEventPublisher(publisher);
+   }
+
+   @Test
+   void changeSSOFilterType_clusterSendFails_localEventStillPublished_exceptionSwallowed()
+      throws Exception
+   {
+      doThrow(new RuntimeException("cluster unreachable")).when(cluster).sendMessage(any());
+
+      assertDoesNotThrow(() -> filterPublisher.changeSSOFilterType(SSOType.OPENID),
+         "a cluster broadcast failure must not propagate out of changeSSOFilterType() -- other " +
+         "nodes silently miss the update (this exact link broke production once, community " +
+         "commit 3bf25021e / Bug #72373), but the local node's own switch must still complete");
+
+      ArgumentCaptor<ChangeSSOFilterEvent> captor = ArgumentCaptor.forClass(ChangeSSOFilterEvent.class);
+      verify(publisher).publishEvent(captor.capture());
+      assertEquals(SSOType.OPENID, captor.getValue().getFilterType(),
+         "the local Spring event must still be published even though the cluster broadcast failed");
+   }
+
+   @Test
+   void changeSSOFilterType_clusterSendSucceeds_broadcastsTheSameTypeThatWasPublishedLocally()
+      throws Exception
+   {
+      filterPublisher.changeSSOFilterType(SSOType.SAML);
+
+      ArgumentCaptor<ChangeSSOFilterEvent> localEvent =
+         ArgumentCaptor.forClass(ChangeSSOFilterEvent.class);
+      verify(publisher).publishEvent(localEvent.capture());
+      assertEquals(SSOType.SAML, localEvent.getValue().getFilterType());
+
+      ArgumentCaptor<ChangeSSOFilterMessage> clusterMessage =
+         ArgumentCaptor.forClass(ChangeSSOFilterMessage.class);
+      verify(cluster).sendMessage(clusterMessage.capture());
+      assertEquals(SSOType.SAML, clusterMessage.getValue().getType());
+   }
+
+   @Test
+   void messageReceived_remoteMessage_publishesLocalEventWithTheSameType() {
+      MessageEvent event = new MessageEvent(
+         this, "other-node", false, new ChangeSSOFilterMessage(SSOType.CUSTOM));
+
+      filterPublisher.messageReceived(event);
+
+      ArgumentCaptor<ChangeSSOFilterEvent> captor = ArgumentCaptor.forClass(ChangeSSOFilterEvent.class);
+      verify(publisher).publishEvent(captor.capture());
+      assertEquals(SSOType.CUSTOM, captor.getValue().getFilterType());
+   }
+
+   @Test
+   void messageReceived_localMessage_isIgnored_doesNotRepublish() {
+      // positive control: a message this same node just sent (event.isLocal() == true) must not
+      // be echoed back into another local publishEvent() call.
+      MessageEvent event = new MessageEvent(
+         this, "this-node", true, new ChangeSSOFilterMessage(SSOType.CUSTOM));
+
+      filterPublisher.messageReceived(event);
+
+      verify(publisher, never()).publishEvent(any());
+   }
+
+   @Test
+   void messageReceived_nonSsoMessage_isIgnored() {
+      // positive control: messageReceived() is a shared cluster MessageListener callback --
+      // messages of other types must be ignored, not misinterpreted.
+      MessageEvent event = new MessageEvent(this, "other-node", false, "not an SSO message");
+
+      filterPublisher.messageReceived(event);
+
+      verify(publisher, never()).publishEvent(any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/SSOFilterPublisherTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/SSOFilterPublisherTest.java
@@ -59,6 +59,9 @@ class SSOFilterPublisherTest {
    void changeSSOFilterType_clusterSendFails_localEventStillPublished_exceptionSwallowed()
       throws Exception
    {
+      // Bug #72373 verified against commit 3bf25021e's own message ("fix Bug #72373, correct
+      // handle ChangeSSOFilterMessage to ensure the sso type can be changed successfully.") --
+      // not an assumed/guessed ticket number.
       doThrow(new RuntimeException("cluster unreachable")).when(cluster).sendMessage(any());
 
       assertDoesNotThrow(() -> filterPublisher.changeSSOFilterType(SSOType.OPENID),

--- a/core/src/test/java/inetsoft/web/admin/security/SSOSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/SSOSettingsServiceTest.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.security;
+
+/*
+ * Test plan 2026-09-03, scenarios 9/11: SSOSettingsService.updateSSOSettings() -- previously
+ * entirely zero-covered (SSOSettingsControllerTest only exercises the controller's delegation to
+ * this service, never the service's own business logic).
+ *
+ * Scenario 9: the SAML branch validates settings BEFORE switching ("so we don't get locked out",
+ * see validateSAMLAttributes()'s own comment) -- the OpenID and Custom branches do not, and switch
+ * unconditionally even when the submitted attributes are entirely blank. These tests pin that
+ * asymmetry as current behavior, not a claim that it is correct.
+ *
+ * Scenario 11: when SreeEnv.save() throws (e.g. disk write failure), the catch block downgrades
+ * the local filter to NONE but re-sets "sso.protocol.type" to the NEW (just-failed-to-persist)
+ * type rather than the previous one -- current, not necessarily intended, behavior.
+ *
+ * validateSAMLAttributes() itself is NOT mocked -- it calls the real com.onelogin.saml2
+ * SettingsBuilder/Saml2Settings.checkSettings(), the same library production code uses, so the
+ * "blank SAML fields fail validation" assertion below is a real library behavior, not an assumed
+ * one.
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.security.SecurityEngine;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class SSOSettingsServiceTest {
+   @Mock
+   private SecurityEngine engine;
+   @Mock
+   private OpenIDConfig openIDConfig;
+   @Mock
+   private CustomSSOConfig customConfig;
+   @Mock
+   private SSOFilterPublisher publisher;
+   @Mock
+   private Cluster cluster;
+
+   private SSOSettingsService service;
+   private MockedStatic<SreeEnv> sreeEnvMock;
+   private MockedStatic<SUtil> sUtilMock;
+
+   @BeforeEach
+   void setUp() {
+      service = new SSOSettingsService(engine, openIDConfig, customConfig, publisher, cluster);
+
+      sreeEnvMock = mockStatic(SreeEnv.class);
+      lenient().when(SreeEnv.getProperty("sso.protocol.type")).thenReturn(null); // getActiveFilterType() -> NONE
+
+      sUtilMock = mockStatic(SUtil.class);
+      lenient().when(SUtil.isMultiTenant()).thenReturn(false);
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvMock.close();
+      sUtilMock.close();
+   }
+
+   // ── scenario 9: protocol-switch validation is asymmetric ────────────────────────────────
+
+   @Test
+   void switchToOpenId_blankAttributes_succeedsWithoutAnyValidation() {
+      SSOSettingsModel model = new SSOSettingsModel.Builder()
+         .activeFilterType(SSOType.OPENID)
+         .openIdAttributesModel(new OpenIdAttributesModel.Builder().build()) // every field blank
+         .build();
+
+      service.updateSSOSettings(model);
+
+      verify(publisher).changeSSOFilterType(SSOType.OPENID);
+   }
+
+   @Test
+   void switchToCustom_blankAttributes_succeedsWithoutAnyValidation() {
+      SSOSettingsModel model = new SSOSettingsModel.Builder()
+         .activeFilterType(SSOType.CUSTOM)
+         .customAttributesModel(CustomSSOAttributesModel.builder().build()) // no class/groovy set
+         .build();
+
+      service.updateSSOSettings(model);
+
+      verify(publisher).changeSSOFilterType(SSOType.CUSTOM);
+   }
+
+   @Test
+   void switchToSaml_missingRequiredFields_validationFailsAndSwitchIsAborted() {
+      // positive control: proves the SAML branch's pre-switch validation actually rejects an
+      // invalid configuration, unlike the two tests above.
+      SSOSettingsModel model = new SSOSettingsModel.Builder()
+         .activeFilterType(SSOType.SAML)
+         .samlAttributesModel(new SAMLAttributesModel.Builder().build()) // every field blank
+         .build();
+
+      service.updateSSOSettings(model);
+
+      verify(publisher, never()).changeSSOFilterType(SSOType.SAML);
+      sreeEnvMock.verify(() -> SreeEnv.setProperty(eq("onelogin.saml2.sp.entityid"), anyString()),
+         never());
+   }
+
+   // ── scenario 11: SreeEnv.save() failure leaves an inconsistent tri-state ────────────────
+
+   @Test
+   void saveFailure_downgradesLocalFilterToNone_butRePersistsTheNewTypeNotThePrevious()
+      throws IOException
+   {
+      SSOSettingsModel model = new SSOSettingsModel.Builder()
+         .activeFilterType(SSOType.OPENID)
+         .openIdAttributesModel(new OpenIdAttributesModel.Builder().build())
+         .build();
+      sreeEnvMock.when(SreeEnv::save).thenThrow(new IOException("disk full"));
+
+      service.updateSSOSettings(model);
+
+      // the local filter is switched to OpenID once (the normal path), then downgraded to NONE
+      // in the catch block once save() fails -- both calls happen, in that order.
+      verify(publisher).changeSSOFilterType(SSOType.OPENID);
+      verify(publisher).changeSSOFilterType(SSOType.NONE);
+      // "sso.protocol.type" is re-set to "OpenID" (the type that just failed to persist) in the
+      // catch block, not rolled back to the previous ("None") value -- current behavior.
+      sreeEnvMock.verify(() -> SreeEnv.setProperty("sso.protocol.type", "OpenID"), times(2));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/security/SSOSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/security/SSOSettingsServiceTest.java
@@ -41,6 +41,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.SecurityEngine;
+import inetsoft.util.Tool;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -96,9 +97,17 @@ class SSOSettingsServiceTest {
          .openIdAttributesModel(new OpenIdAttributesModel.Builder().build()) // every field blank
          .build();
 
-      service.updateSSOSettings(model);
+      // the OPENID branch calls Tool.isCloudSecrets() (-> InetsoftConfig.getInstance()) to decide
+      // between the secretId and clientId/clientSecret fields -- pinned explicitly to the LOCAL
+      // (non-cloud-secrets) branch so this test doesn't depend on the ambient InetsoftConfig
+      // default; either branch is a no-op for the assertion below, but only one is exercised.
+      try(MockedStatic<Tool> toolMock = mockStatic(Tool.class)) {
+         toolMock.when(Tool::isCloudSecrets).thenReturn(false);
 
-      verify(publisher).changeSSOFilterType(SSOType.OPENID);
+         service.updateSSOSettings(model);
+
+         verify(publisher).changeSSOFilterType(SSOType.OPENID);
+      }
    }
 
    @Test


### PR DESCRIPTION
  Description:
  ## Summary
  - Add unit tests for SSOFilterPublisher cluster broadcast behavior and ScheduleUsersChangeService's SSO-toggle notification handling
  - Fix SecurityTestDataBuilder leaking a DataChangeListener per test setup(), which could cause flaky failures in later test classes sharing the same Surefire JVM
  - Make SSOSettingsServiceTest's OpenID blank-attributes case hermetic by explicitly pinning Tool.isCloudSecrets() instead of relying on ambient config
  - Document the verification source for a bug citation in SSOFilterPublisherTest