### PR TITLE
Fix #76483 WBS-017: read_worksheet_model reports DATE_IN/ranking conditions as raw ordinals

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -647,6 +647,9 @@ public class WorksheetReadService {
          case XCondition.CONTAINS      -> "CONTAINS";
          case XCondition.LIKE          -> "LIKE";
          case XCondition.NULL          -> negated ? "NOT_NULL" : "NULL";
+         case XCondition.DATE_IN       -> "DATE_IN";
+         case XCondition.TOP_N         -> "TOP_N";
+         case XCondition.BOTTOM_N      -> "BOTTOM_N";
          default                       -> String.valueOf(xc.getOperation());
       };
    }
@@ -668,6 +671,17 @@ public class WorksheetReadService {
 
          return Collections.singletonList(
             n instanceof UserVariable uvar ? "$(" + uvar.getName() + ")" : n.toString());
+      }
+
+      if(xc instanceof DateCondition dc) {
+         // DATE_IN's value is a named range (e.g. "Last quarter"), not a literal in
+         // getValue()/getValueCount() -- DateCondition is a sibling of Condition, not a
+         // subtype (both extend AbstractCondition directly), so it never reaches the
+         // instanceof Condition branch below and always fell through to []. getName() is
+         // exactly the range name addFilter/resolveDateInCondition resolved this condition
+         // from, so surfacing it here is what makes the read round-trippable.
+         String name = dc.getName();
+         return name != null ? Collections.singletonList(name) : Collections.emptyList();
       }
 
       if(!(xc instanceof Condition c)) {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -256,6 +256,46 @@ class WorksheetReadServiceTest {
       assertEquals(List.of("5"), ranking.values());
    }
 
+   // Bug #76483 WBS-017: operationName() had no case for DATE_IN (ordinal 11), so a date_in
+   // pre-condition reported operation:"11" instead of "DATE_IN", and extractValues()'s
+   // "instanceof Condition" check excludes DateCondition (a sibling of Condition, not a
+   // subtype), so the range name was silently dropped to []. Round-trips through the actual
+   // production mutator (WorksheetMutationSupport.addFilter), matching this file's own
+   // convention of exercising the real mutation path rather than hand-building the condition.
+   @Test
+   void dateInPreConditionReportsAReadableOperationAndTheRangeName() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate");
+      ((ColumnRef) t.getColumnSelection(false).getAttribute("orderDate")).setDataType(XSchema.DATE);
+      ws.addAssembly(t);
+
+      WorksheetMutationSupport.addFilter(t, "orderDate", "DATE_IN", "Last quarter");
+
+      WorksheetModel.FilterModel condition =
+         tableNamed(read(ws), "T").preConditions().get(0);
+
+      assertEquals("DATE_IN", condition.operation());
+      assertEquals(List.of("Last quarter"), condition.values());
+   }
+
+   // Same operationName() gap, systemic across any XCondition subtype that isn't a plain
+   // Condition: RankingCondition's own operation (TOP_N/BOTTOM_N) fell to the same
+   // String.valueOf(ordinal) default as DATE_IN did. extractValues() already handles
+   // RankingCondition correctly (Bug #75950) -- only the operation name was still raw.
+   @Test
+   void bottomNRankingConditionReportsAReadableOperationName() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total");
+      ws.addAssembly(t);
+      WorksheetMutationSupport.setRanking(t,
+         new WorksheetMutationSupport.RankingSpec("total", 10, "BOTTOM_N", false));
+
+      WorksheetModel.FilterModel ranking = tableNamed(read(ws), "T").rankingConditions().get(0);
+
+      assertEquals("BOTTOM_N", ranking.operation());
+      assertEquals(List.of("10"), ranking.values());
+   }
+
    private static WorksheetModel.TableModel tableNamed(WorksheetModel m, String name) {
       return m.tables().stream().filter(t -> name.equals(t.name())).findFirst().orElseThrow();
    }


### PR DESCRIPTION
## Summary

Wiz-side ticket: Redmine #76483, WBS-017 (`stylebi-wiz` repo). `read_worksheet_model`'s `preConditions`/`rankingConditions` entries reported a `date_in` condition as `{"operation": "11", "values": []}` instead of a readable operator name plus the date-range value.

Root cause, both in `WorksheetReadService.java`:

- `operationName()` is a `switch` over `xc.getOperation()` with no case for `XCondition.DATE_IN` (11) — the `default` branch returns the raw ordinal as a string.
- `extractValues()` does `if(!(xc instanceof Condition c)) return Collections.emptyList();`. `DateCondition` is a **sibling** of `Condition` (both `extend AbstractCondition` directly, not a subclass relationship), so a `date_in` condition's range name was always dropped to `[]`.

The same `operationName()`/`extractValues()` pair also serves `rankingConditions`. `RankingCondition` is likewise a sibling of `Condition`, not a subtype, and its own operation (`TOP_N`/`BOTTOM_N`, ordinals 9/10) fell to the same raw-ordinal default. Its *value* (`getN()`) was already recovered correctly (fixed for Bug #75950) — only the operation name needed the same fix as `DATE_IN`.

## Changes

- `operationName()`: added `DATE_IN -> "DATE_IN"`, `TOP_N -> "TOP_N"`, `BOTTOM_N -> "BOTTOM_N"` — matching the exact strings `WorksheetMutationSupport.parseOperation()`/`parseRankingOperation()` already accept, so the read stays round-trippable.
- `extractValues()`: added a `DateCondition` branch (checked before the `instanceof Condition` fallback) that returns `dc.getName()` — the built-in range name (e.g. `"Last quarter"`) set via `DateCondition.getBuiltinDateConditions()`/`resolveDateInCondition()`, the same name `addFilter()` resolved the condition from.

## Test plan

- [x] Added `dateInPreConditionReportsAReadableOperationAndTheRangeName` and `bottomNRankingConditionReportsAReadableOperationName` to `WorksheetReadServiceTest.java`, both round-tripping through the real `WorksheetMutationSupport.addFilter`/`setRanking` production mutators.
- [x] Confirmed red-to-green: stashed only the source fix, reran — both new tests failed with `expected: <DATE_IN> but was: <11>` / `expected: <BOTTOM_N> but was: <10>`; restored the fix and reran — `Tests run: 36, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`.
- [x] Ran via `./mvnw.cmd -pl core test -Dtest=WorksheetReadServiceTest` (no full-module build needed — both touched methods are `private` with no callers outside this file).

Not merging this myself — cross-repo backend change, needs a human sign-off.