### PR TITLE
fix(wiz): read canonical dependency index in WorksheetAgentController.dependents

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -34,6 +34,7 @@ import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.asset.sync.DependencyTool;
 import inetsoft.uql.asset.sync.DependencyTransformer;
 import inetsoft.uql.asset.sync.RenameDependencyInfo;
 import inetsoft.uql.asset.sync.RenameTransformHandler;
@@ -63,7 +64,6 @@ import inetsoft.uql.util.filereader.TextUtil;
 import inetsoft.util.Catalog;
 import inetsoft.util.CoreTool;
 import inetsoft.util.FileSystemService;
-import inetsoft.util.MissingAssetClassNameException;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.WorksheetControllerService;
 import inetsoft.web.composer.ws.assembly.VariableAssemblyModelInfo;
@@ -89,7 +89,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
-import org.xml.sax.SAXParseException;
 
 import java.awt.*;
 import java.io.*;
@@ -979,12 +978,13 @@ public class WorksheetAgentController {
     * connected worksheet -- i.e. would need attention or would break if it were removed or
     * structurally changed.
     *
-    * <p>Answers "who else uses this worksheet" from the asset repository's own dependency
-    * index rather than from whatever the caller was told: this is the same
-    * {@link AssetRepository#getSheetDependencies} check the Portal's own "remove this
-    * dataset?" dialog runs before a delete ({@code DataSetService.isWorksheetRemoveable}),
-    * not a new dependency-tracking mechanism. It only reports OTHER saved assets that
-    * reference this one -- not the tables/joins/columns inside this worksheet itself.
+    * <p>Answers "who else uses this worksheet" from the canonical reverse-dependency index
+    * ({@link inetsoft.uql.asset.sync.DependencyTool#getDependencies}, the same index-backed
+    * lookup used by {@code RepositoryObjectService.checkAssetEntryDependencies} and
+    * {@code DependencyTransformer}) rather than from whatever the caller was told, and rather
+    * than the legacy per-sheet {@link AssetRepository#getSheetDependencies} scan. It only
+    * reports OTHER saved assets that reference this one -- not the tables/joins/columns inside
+    * this worksheet itself.
     *
     * <p>An unsaved (temporary-scope) worksheet always reports no dependents: nothing can
     * point at an asset that was never saved, so {@code saved} is {@code false} and
@@ -1018,17 +1018,11 @@ public class WorksheetAgentController {
       result.put("saved", true);
       result.put("path", entry.getPath());
 
-      AssetEntry[] deps;
-
-      try {
-         deps = assetRepository.getSheetDependencies(entry, user);
-      }
-      catch(SAXParseException | MissingAssetClassNameException ex) {
-         // same tolerance as AssetRepository#checkSheetRemoveable: if the sheet can't be
-         // read (corrupted asset XML, or a class from a since-uninstalled plugin), treat
-         // it as having no dependents rather than erroring.
-         deps = new AssetEntry[0];
-      }
+      List<AssetObject> rawDeps = DependencyTool.getDependencies(entry.toIdentifier());
+      AssetEntry[] deps = rawDeps.stream()
+         .filter(AssetEntry.class::isInstance)
+         .map(AssetEntry.class::cast)
+         .toArray(AssetEntry[]::new);
 
       List<Map<String, Object>> dependents = new ArrayList<>();
       StringBuilder paths = new StringBuilder();

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -66,7 +66,6 @@ import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
-import inetsoft.util.MissingAssetClassNameException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -80,7 +79,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.server.ResponseStatusException;
-import org.xml.sax.SAXParseException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -528,14 +526,18 @@ class WorksheetAgentControllerTest {
       WorksheetEditService editSvc = mock(WorksheetEditService.class);
       when(editSvc.resolve(eq("TOK-DEP-NONE"), eq(agent))).thenReturn(rws);
 
-      AssetRepository repo = mock(AssetRepository.class);
-      when(repo.getSheetDependencies(eq(entry), eq(agent))).thenReturn(new AssetEntry[0]);
-
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
-         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class), repo);
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
 
-      Map<String, Object> result = ctrl.dependents("TOK-DEP-NONE", agent);
+      Map<String, Object> result;
+
+      try(MockedStatic<DependencyTool> dependencyTool = mockStatic(DependencyTool.class)) {
+         dependencyTool.when(() -> DependencyTool.getDependencies(entry.toIdentifier()))
+            .thenReturn(List.of());
+
+         result = ctrl.dependents("TOK-DEP-NONE", agent);
+      }
 
       assertEquals(Boolean.TRUE, result.get("saved"));
       assertEquals("Orders WS", result.get("path"));
@@ -560,15 +562,18 @@ class WorksheetAgentControllerTest {
       AssetEntry dependentVs = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
          AssetEntry.Type.VIEWSHEET, "Sales Dashboard", null);
 
-      AssetRepository repo = mock(AssetRepository.class);
-      when(repo.getSheetDependencies(eq(entry), eq(agent)))
-         .thenReturn(new AssetEntry[]{ dependentVs });
-
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
-         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class), repo);
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
 
-      Map<String, Object> result = ctrl.dependents("TOK-DEP-SOME", agent);
+      Map<String, Object> result;
+
+      try(MockedStatic<DependencyTool> dependencyTool = mockStatic(DependencyTool.class)) {
+         dependencyTool.when(() -> DependencyTool.getDependencies(entry.toIdentifier()))
+            .thenReturn(List.of(dependentVs));
+
+         result = ctrl.dependents("TOK-DEP-SOME", agent);
+      }
 
       assertEquals(Boolean.TRUE, result.get("saved"));
       @SuppressWarnings("unchecked")
@@ -577,64 +582,6 @@ class WorksheetAgentControllerTest {
       assertEquals("Sales Dashboard", dependents.get(0).get("path"));
       assertEquals("viewsheet", dependents.get(0).get("type"));
       assertTrue(result.get("summary").toString().contains("Sales Dashboard"));
-   }
-
-   /** Mirrors the tolerance {@code AssetRepository#checkSheetRemoveable} applies around this
-    *  same {@code getSheetDependencies} call: if the sheet can't be read back (corrupted asset
-    *  XML, or a class from a since-uninstalled plugin), that's treated as "no dependents"
-    *  rather than propagating and landing on the generic error handler as a 500. */
-   @Test
-   void dependentsToleratesUnreadableSheetXml() throws Exception {
-      Principal agent = TestPrincipals.user("alice", "host-org");
-
-      AssetEntry entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
-         AssetEntry.Type.WORKSHEET, "Orders WS", null);
-      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
-      when(rws.getEntry()).thenReturn(entry);
-
-      WorksheetEditService editSvc = mock(WorksheetEditService.class);
-      when(editSvc.resolve(eq("TOK-DEP-BADXML"), eq(agent))).thenReturn(rws);
-
-      AssetRepository repo = mock(AssetRepository.class);
-      when(repo.getSheetDependencies(eq(entry), eq(agent)))
-         .thenThrow(new SAXParseException("unexpected end of file", null, null, 0, 0));
-
-      WorksheetAgentController ctrl = controller(featureOn(),
-         mock(SheetJoinService.class), mock(SheetSessionService.class),
-         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class), repo);
-
-      Map<String, Object> result = ctrl.dependents("TOK-DEP-BADXML", agent);
-
-      assertEquals(Boolean.TRUE, result.get("saved"));
-      assertEquals(List.of(), result.get("dependents"));
-      assertTrue(result.get("summary").toString().contains("No saved asset"));
-   }
-
-   @Test
-   void dependentsToleratesMissingAssetClass() throws Exception {
-      Principal agent = TestPrincipals.user("alice", "host-org");
-
-      AssetEntry entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
-         AssetEntry.Type.WORKSHEET, "Orders WS", null);
-      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
-      when(rws.getEntry()).thenReturn(entry);
-
-      WorksheetEditService editSvc = mock(WorksheetEditService.class);
-      when(editSvc.resolve(eq("TOK-DEP-BADCLASS"), eq(agent))).thenReturn(rws);
-
-      AssetRepository repo = mock(AssetRepository.class);
-      when(repo.getSheetDependencies(eq(entry), eq(agent)))
-         .thenThrow(new MissingAssetClassNameException("class from an uninstalled plugin"));
-
-      WorksheetAgentController ctrl = controller(featureOn(),
-         mock(SheetJoinService.class), mock(SheetSessionService.class),
-         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class), repo);
-
-      Map<String, Object> result = ctrl.dependents("TOK-DEP-BADCLASS", agent);
-
-      assertEquals(Boolean.TRUE, result.get("saved"));
-      assertEquals(List.of(), result.get("dependents"));
-      assertTrue(result.get("summary").toString().contains("No saved asset"));
    }
 
    // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `WorksheetAgentController.dependents()` read the legacy per-sheet dependency store (`AssetRepository.getSheetDependencies`), which can miss real dependents. Switched it to the canonical reverse-dependency index (`DependencyTool.getDependencies(entry.toIdentifier())`), matching the existing pattern used by `RepositoryObjectService.checkAssetEntryDependencies` and `DependencyTransformer`.
- Removed the now-unreachable `SAXParseException`/`MissingAssetClassNameException` tolerance around the old call: `DependencyTool.getDependencies` swallows internally and only reads already-parsed dependency-storage records (never a sheet's raw XML), so that failure mode can no longer occur via this path.
- No recycle-bin or existence filter added, per the established convention of `DependencyTool.getDependencies`'s other callers.
- Updated `WorksheetAgentControllerTest` to stub `DependencyTool` via `mockStatic` instead of `AssetRepository`, and removed the two tests that covered the now-impossible XML-parse/missing-class failure modes.

This is the **community-side half** of a two-repo fix for Redmine **#76459 Part 2**. The enterprise-side sibling (`ViewsheetChangePlanService.findDependencies`) is already merged/in-review as `stylebi-enterprise` PR #767.

## Test plan
- [x] `./mvnw -pl community/core -am test -Dtest=WorksheetAgentControllerTest -Dsurefire.failIfNoSpecifiedTests=false -o` from the wizard repo root — **130/130 passed, 0 failures, 0 errors, BUILD SUCCESS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)