### PR TITLE
fix(wiz): L8 parity fixes -- conditions, highlights, date comparison

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -711,7 +711,7 @@ public class CalcTableService {
          clauses.add(new ConditionVocabulary.Clause(
             column, String.valueOf(clause.get("operator")), values,
             junction == null ? null : String.valueOf(junction),
-            Boolean.TRUE.equals(clause.get("negated"))));
+            Boolean.TRUE.equals(clause.get("negated")), false, 0));
       }
 
       return clauses;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -284,12 +284,33 @@ public class AssemblyHighlightService {
 
       Map<String, Object> out = new LinkedHashMap<>();
       out.put("fontFamily", font.getFontFamily());
-      out.put("fontSize", font.getFontSize() == null ? null : Integer.valueOf(font.getFontSize()));
+      out.put("fontSize", describeFontSize(font.getFontSize()));
       out.put("bold", "bold".equals(font.getFontWeight()));
       out.put("italic", "italic".equals(font.getFontStyle()));
       out.put("underline", "underline".equals(font.getFontUnderline()));
       out.put("strikethrough", "strikethrough".equals(font.getFontStrikethrough()));
       return out;
+   }
+
+   /**
+    * {@code FontInfo.toFont()} parses the same stored string with an unguarded
+    * {@code Integer.parseInt}, so a malformed size is a pre-existing risk — but that path only
+    * runs once a highlight is applied, while this one is now reachable straight from
+    * {@code list_highlights}'s read. Reporting the raw stored value on a parse failure keeps the
+    * read itself from throwing, while still surfacing that something is off (a caller expecting
+    * an int wouldn't get a string here otherwise).
+    */
+   private static Object describeFontSize(String fontSize) {
+      if(fontSize == null) {
+         return null;
+      }
+
+      try {
+         return Integer.valueOf(fontSize);
+      }
+      catch(NumberFormatException e) {
+         return fontSize;
+      }
    }
 
    private HighlightDialogModel read(String runtimeId, String assemblyName, Region region,

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.web.adhoc.model.FontInfo;
 import inetsoft.web.wiz.binding.VisualFrameAliases;
 import inetsoft.web.composer.model.vs.HighlightDialogModel;
 import inetsoft.web.composer.model.vs.HighlightModel;
@@ -80,7 +81,7 @@ public class AssemblyHighlightService {
    }
 
    /** One highlight in the agent vocabulary. Colours are {@code #RRGGBB}. */
-   public record Highlight(String name, String foreground, String background,
+   public record Highlight(String name, String foreground, String background, FontInfo font,
                            List<ConditionVocabulary.Clause> conditions, boolean applyRow) {}
 
    public Map<String, Object> list(String sessionToken, Principal user, String assemblyName,
@@ -239,6 +240,10 @@ public class AssemblyHighlightService {
          out.setBackground(VisualFrameAliases.normalizeColor(highlight.background()));
       }
 
+      if(highlight.font() != null) {
+         out.setFontInfo(highlight.font());
+      }
+
       out.setApplyRow(highlight.applyRow());
 
       // The embedded condition model reuses spec #4's vocabulary rather than a parallel one,
@@ -262,11 +267,28 @@ public class AssemblyHighlightService {
       out.put("name", highlight.getName());
       out.put("foreground", highlight.getForeground());
       out.put("background", highlight.getBackground());
+      out.put("font", describeFont(highlight.getFontInfo()));
       out.put("applyRow", highlight.isApplyRow());
       out.put("conditions", highlight.getVsConditionDialogModel() == null
          ? List.of()
          : ConditionVocabulary.describe(
             highlight.getVsConditionDialogModel().getConditionList()));
+      return out;
+   }
+
+   /** {@code null} when no font override is stored, mirroring {@code foreground}/{@code background}. */
+   private static Map<String, Object> describeFont(FontInfo font) {
+      if(font == null || font.getFontFamily() == null) {
+         return null;
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("fontFamily", font.getFontFamily());
+      out.put("fontSize", font.getFontSize() == null ? null : Integer.valueOf(font.getFontSize()));
+      out.put("bold", "bold".equals(font.getFontWeight()));
+      out.put("italic", "italic".equals(font.getFontStyle()));
+      out.put("underline", "underline".equals(font.getFontUnderline()));
+      out.put("strikethrough", "strikethrough".equals(font.getFontStrikethrough()));
       return out;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
@@ -63,7 +63,7 @@ public final class ConditionVocabulary {
 
    /** One condition in the flat vocabulary. {@code junction} points at the *next* condition. */
    public record Clause(String field, String operator, List<Object> values, String junction,
-                        boolean negated) {}
+                        boolean negated, boolean equal, int level) {}
 
    /**
     * Builds the alternating array.
@@ -115,6 +115,8 @@ public final class ConditionVocabulary {
             clause.put("operator", operatorToken(condition.getOperation()));
             clause.put("values", values(condition.getValues()));
             clause.put("negated", condition.isNegated());
+            clause.put("equal", condition.isEqual());
+            clause.put("level", condition.getLevel());
             clause.put("junction", junctionAfter(conditionList, i));
             out.add(clause);
          }
@@ -184,19 +186,168 @@ public final class ConditionVocabulary {
 
       ConditionModel condition = new ConditionModel();
       condition.setField(field);
-      condition.setOperation(OPERATORS.get(operator));
+      int operation = OPERATORS.get(operator);
+      condition.setOperation(operation);
       condition.setNegated(clause.negated());
-      condition.setLevel(0);
-      condition.setValues(values.stream().map(ConditionVocabulary::value)
-                             .toArray(ConditionValueModel[]::new));
+      condition.setEqual(clause.equal());
+      condition.setLevel(clause.level());
+
+      if(operation == XCondition.TOP_N || operation == XCondition.BOTTOM_N) {
+         requireExactlyOneValue(values, index);
+         condition.setValues(new ConditionValueModel[] { rankingValue(values.get(0), index, fields) });
+      }
+      else {
+         condition.setValues(values.stream().map(raw -> value(raw, index, fields))
+                                .toArray(ConditionValueModel[]::new));
+      }
+
       return condition;
    }
 
-   private static ConditionValueModel value(Object raw) {
+   /**
+    * A plain scalar (string/number/boolean/null) means {@code VALUE}, exactly as before. An
+    * object carrying a recognized {@code type} discriminator selects one of the four non-VALUE
+    * shapes ConditionUtil actually knows how to read: comparing a column to another column
+    * ({@code field}), to a prompted variable ({@code variable}), to a built-in session value
+    * ({@code session_data}), or to a computed expression ({@code expression}). SUBQUERY is
+    * deliberately not supported here -- its payload is a full sub-query definition with no
+    * tractable minimal-field summary.
+    */
+   private static ConditionValueModel value(Object raw, int index, Map<String, DataRefModel> fields) {
+      if(raw instanceof Map<?, ?> map && map.get("type") instanceof String typeToken) {
+         return typedValue(typeToken, map, index, fields);
+      }
+
       ConditionValueModel value = new ConditionValueModel();
       value.setValue(raw);
       value.setType(ConditionValueModel.VALUE);
       return value;
+   }
+
+   private static ConditionValueModel typedValue(String typeToken, Map<?, ?> map, int index,
+                                                  Map<String, DataRefModel> fields)
+   {
+      String type = typeToken.trim().toLowerCase();
+      ConditionValueModel value = new ConditionValueModel();
+
+      switch(type) {
+         case "field" -> {
+            String name = requireString(map.get("field"), index, "field");
+            DataRefModel resolved = fields.get(name.toLowerCase());
+
+            if(resolved == null) {
+               throw new IllegalArgumentException(
+                  "Condition " + index + "'s field-typed value names '" + name + "', which this " +
+                  "assembly cannot filter on. Available fields: " + fieldList(fields) + ".");
+            }
+
+            value.setValue(resolved);
+            value.setType(ConditionValueModel.FIELD);
+         }
+         case "variable" -> {
+            String name = requireString(map.get("name"), index, "name");
+            value.setValue("$(" + name + ")");
+            value.setType(ConditionValueModel.VARIABLE);
+            Object choiceQuery = map.get("choiceQuery");
+
+            if(choiceQuery instanceof String query && !query.isBlank()) {
+               value.setChoiceQuery(query);
+            }
+         }
+         case "session_data" -> {
+            String name = requireString(map.get("name"), index, "name").trim().toUpperCase();
+
+            if(!SESSION_DATA_NAMES.contains(name)) {
+               throw new IllegalArgumentException(
+                  "Condition " + index + "'s session_data value must be one of " +
+                  SESSION_DATA_NAMES + ", got '" + map.get("name") + "'.");
+            }
+
+            value.setValue("$(" + name + ")");
+            value.setType(ConditionValueModel.SESSION_DATA);
+         }
+         case "expression" -> {
+            String expression = requireString(map.get("expression"), index, "expression");
+            Object languageRaw = map.get("language");
+            String language = languageRaw == null ? "js" :
+               String.valueOf(languageRaw).trim().toLowerCase();
+            ExpressionValueModel exprModel = new ExpressionValueModel();
+            exprModel.setExpression(expression);
+            exprModel.setType("sql".equals(language) ?
+               ExpressionValueModel.SQL : ExpressionValueModel.JS);
+            value.setValue(exprModel);
+            value.setType(ConditionValueModel.EXPRESSION);
+         }
+         default -> throw new IllegalArgumentException(
+            "Condition " + index + " has a value of unknown type '" + typeToken + "'. Supported " +
+            "typed values: field, variable, session_data, expression.");
+      }
+
+      return value;
+   }
+
+   private static String requireString(Object raw, int index, String fieldName) {
+      if(!(raw instanceof String str) || str.isBlank()) {
+         throw new IllegalArgumentException(
+            "Condition " + index + "'s value needs a non-empty '" + fieldName + "'.");
+      }
+
+      return str.trim();
+   }
+
+   /**
+    * {@code TOP_N}/{@code BOTTOM_N} carry a ranking value -- {@code n} and the group-by field --
+    * rather than a plain scalar. ConditionUtil unconditionally casts {@code getValue()} to
+    * {@code RankingValueModel} for these two operations, so this is the one branch that MUST
+    * produce that shape.
+    */
+   private static ConditionValueModel rankingValue(Object raw, int index,
+                                                    Map<String, DataRefModel> fields)
+   {
+      if(!(raw instanceof Map<?, ?> map)) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " uses a ranking operator (top_n/bottom_n) and needs a value " +
+            "shaped {n, groupField}, not a plain value.");
+      }
+
+      Object nRaw = map.get("n");
+
+      if(!(nRaw instanceof Number number) || number.intValue() <= 0 ||
+         number.doubleValue() != number.intValue())
+      {
+         throw new IllegalArgumentException(
+            "Condition " + index + "'s ranking value needs a positive integer 'n', got " + nRaw + ".");
+      }
+
+      String groupFieldName = requireString(map.get("groupField"), index, "groupField");
+      DataRefModel groupField = fields.get(groupFieldName.toLowerCase());
+
+      if(groupField == null) {
+         throw new IllegalArgumentException(
+            "Condition " + index + "'s ranking groupField '" + groupFieldName + "' is not a " +
+            "field this assembly can filter on. Available fields: " + fieldList(fields) + ".");
+      }
+
+      RankingValueModel ranking = new RankingValueModel();
+      ranking.setN(number.intValue());
+      ranking.setDataRef(groupField);
+
+      ConditionValueModel value = new ConditionValueModel();
+      value.setValue(ranking);
+      value.setType(ConditionValueModel.VALUE);
+      return value;
+   }
+
+   private static void requireExactlyOneValue(List<Object> values, int index) {
+      if(values.size() != 1) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " uses a ranking operator (top_n/bottom_n), which needs " +
+            "exactly one value shaped {n, groupField}, got " + values.size() + ".");
+      }
+   }
+
+   private static String fieldList(Map<String, DataRefModel> fields) {
+      return fields.isEmpty() ? "(none)" : String.join(", ", new TreeSet<>(names(fields)));
    }
 
    private static JunctionOperatorModel junction(String token, int index) {
@@ -270,11 +421,79 @@ public final class ConditionVocabulary {
 
       if(values != null) {
          for(ConditionValueModel value : values) {
-            out.add(value == null ? null : value.getValue());
+            out.add(describeValue(value));
          }
       }
 
       return out;
+   }
+
+   /**
+    * The reverse of {@link #typedValue} / {@link #rankingValue}: a non-VALUE value reads back as
+    * the same typed-object shape it would be written as, rather than leaking the raw Java model
+    * (a {@code DataRefModel}, {@code ExpressionValueModel}, ...) into the agent-facing JSON.
+    */
+   private static Object describeValue(ConditionValueModel value) {
+      if(value == null) {
+         return null;
+      }
+
+      String type = value.getType();
+
+      if(ConditionValueModel.FIELD.equals(type) && value.getValue() instanceof DataRefModel field) {
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("type", "field");
+         out.put("field", field.getName());
+         return out;
+      }
+
+      if(ConditionValueModel.VARIABLE.equals(type)) {
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("type", "variable");
+         out.put("name", variableName(value.getValue()));
+
+         if(value.getChoiceQuery() != null) {
+            out.put("choiceQuery", value.getChoiceQuery());
+         }
+
+         return out;
+      }
+
+      if(ConditionValueModel.SESSION_DATA.equals(type)) {
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("type", "session_data");
+         out.put("name", variableName(value.getValue()));
+         return out;
+      }
+
+      if(ConditionValueModel.EXPRESSION.equals(type) &&
+         value.getValue() instanceof ExpressionValueModel expr)
+      {
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("type", "expression");
+         out.put("expression", expr.getExpression());
+         out.put("language", expr.getType() == ExpressionValueModel.SQL ? "sql" : "js");
+         return out;
+      }
+
+      if(value.getValue() instanceof RankingValueModel ranking) {
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("n", ranking.getN());
+         out.put("groupField", ranking.getDataRef() == null ? null : ranking.getDataRef().getName());
+         return out;
+      }
+
+      // SUBQUERY and anything else read back as the raw value, unchanged from before -- SUBQUERY's
+      // payload has no tractable minimal-field summary (see the write-side note on typedValue).
+      return value.getValue();
+   }
+
+   private static String variableName(Object value) {
+      if(value instanceof String str && str.startsWith("$(") && str.endsWith(")")) {
+         return str.substring(2, str.length() - 1);
+      }
+
+      return String.valueOf(value);
    }
 
    /** An unmapped operation reads back as itself rather than as a guessed token. */
@@ -297,7 +516,10 @@ public final class ConditionVocabulary {
    /** The canonical spelling per operation, used when reading back. */
    private static final Set<String> CANONICAL = Set.of(
       "equals", "one_of", "less_than", "greater_than", "between", "starts_with", "contains",
-      "null", "top_n", "date_in", "like");
+      "null", "top_n", "bottom_n", "date_in", "like");
+
+   /** The only names StyleBI recognizes as built-in session values (see Condition.isSessionVariable). */
+   private static final Set<String> SESSION_DATA_NAMES = Set.of("_USER_", "_ROLES_", "_GROUPS_");
 
    private static Map<String, Integer> operators() {
       Map<String, Integer> map = new LinkedHashMap<>();
@@ -318,6 +540,7 @@ public final class ConditionVocabulary {
       map.put("null", XCondition.NULL);
       map.put("is_null", XCondition.NULL);
       map.put("top_n", XCondition.TOP_N);
+      map.put("bottom_n", XCondition.BOTTOM_N);
       map.put("date_in", XCondition.DATE_IN);
       map.put("like", XCondition.LIKE);
       return Collections.unmodifiableMap(map);

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
@@ -174,8 +174,7 @@ public final class ConditionVocabulary {
       if(field == null) {
          throw new IllegalArgumentException(
             "Condition " + index + " names '" + clause.field() + "', which this assembly " +
-            "cannot filter on. Available fields: " +
-            (fields.isEmpty() ? "(none)" : String.join(", ", new TreeSet<>(names(fields)))) +
+            "cannot filter on. Available fields: " + fieldList(fields) +
             ". A condition on an unknown column is the recorded cause of a downstream cast " +
             "failure, so it is refused here.");
       }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -78,10 +78,17 @@ public class DateComparisonService {
     * @param endToday         anchor the range on today instead of an explicit end
     * @param comparisonOption what the numbers mean — value, change, percentChange,
     *                        changeAndValue, or percentChangeAndValue
+    * @param shareAssembly   another DateCompareAble assembly to share this assembly's
+    *                        date-comparison config from, instead of setting its own
+    * @param toDate    whether the period's range runs only up to the same point-in-time as
+    *                  today, within its level (e.g. Jan 1 - Mar 15 for a quarter, not the whole
+    *                  quarter) — the standard period pane's own "to date" checkbox
+    * @param inclusive whether the period's end date is included in its range
     */
    public record Comparison(Integer periods, String level, String endDate, boolean endToday,
                             String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
-                            String comparisonOption) {}
+                            String comparisonOption, String shareAssembly, Boolean toDate,
+                            Boolean inclusive) {}
 
    /** The current settings, normalized. Never echoes the raw cell format. */
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
@@ -100,8 +107,20 @@ public class DateComparisonService {
       boolean enabled = model != null &&
          comparisonService.isDateComparisonEnabled(runtimeId, assemblyName, user);
 
+      // The share-from assembly is worth reporting even when this assembly's own comparison
+      // reads as disabled — sharing is exactly the case where this assembly has no comparison
+      // of its own and relies entirely on another assembly's.
+      String shareFrom = model == null ? null :
+         comparisonService.getShare(runtimeId, assemblyName, user).getShareFromAssembly();
+      boolean hasShareFrom = shareFrom != null && !shareFrom.isBlank();
+
       if(!enabled) {
          out.put("enabled", false);
+
+         if(hasShareFrom) {
+            out.put("shareFrom", shareFrom);
+         }
+
          return out;
       }
 
@@ -111,6 +130,11 @@ public class DateComparisonService {
       out.put("onlyShowMostRecentDate", model.isOnlyShowMostRecentDate());
       out.put("period", describePeriod(model.getPeriodPaneModel()));
       out.put("interval", describeInterval(model.getIntervalPaneModel()));
+
+      if(hasShareFrom) {
+         out.put("shareFrom", shareFrom);
+      }
+
       return out;
    }
 
@@ -145,7 +169,8 @@ public class DateComparisonService {
 
          apply(model, comparison);
          comparisonService.setDateComparison(runtimeId, assemblyName,
-                                            model.toDateComparisonInfo(), null, linkUri, user,
+                                            model.toDateComparisonInfo(),
+                                            comparison.shareAssembly(), linkUri, user,
                                             dispatcher);
          result.putAll(describeRetargetedDimension(rvs, assemblyName));
          result.putAll(describeChartTypeOverride(rvs, assemblyName, beforeChartType));
@@ -353,7 +378,9 @@ public class DateComparisonService {
          || comparison.level() != null
          || (comparison.endDate() != null && !comparison.endDate().isBlank())
          || comparison.endToday()
-         || comparison.interval() != null;
+         || comparison.interval() != null
+         || comparison.toDate() != null
+         || comparison.inclusive() != null;
    }
 
    private static void apply(DateComparisonPaneModel model, Comparison comparison) {
@@ -406,6 +433,14 @@ public class DateComparisonService {
          setDynamic(standard.getDateLevel(), normalizeLevel(comparison.level()));
       }
 
+      if(comparison.toDate() != null) {
+         standard.setToDate(comparison.toDate());
+      }
+
+      if(comparison.inclusive() != null) {
+         standard.setInclusive(comparison.inclusive());
+      }
+
       // Setting the end date clears the today anchor, because leaving it set is what discarded
       // the date.
       if(comparison.endToday()) {
@@ -419,7 +454,7 @@ public class DateComparisonService {
       IntervalPaneModel interval = model.getIntervalPaneModel();
 
       if(comparison.interval() != null && interval != null) {
-         setDynamic(interval.getLevel(), comparison.interval());
+         setDynamic(interval.getLevel(), normalizeInterval(comparison.interval()));
       }
    }
 
@@ -511,6 +546,36 @@ public class DateComparisonService {
       return COMPARISON_OPTION_NAMES.get(comparisonOption);
    }
 
+   private static final Map<String, Integer> INTERVAL_WORDS = Map.of(
+      "all", DateComparisonInfo.ALL,
+      "yeartodate", DateComparisonInfo.YEAR_TO_DATE,
+      "quartertodate", DateComparisonInfo.QUARTER_TO_DATE,
+      "monthtodate", DateComparisonInfo.MONTH_TO_DATE,
+      "weektodate", DateComparisonInfo.WEEK_TO_DATE,
+      "samequarter", DateComparisonInfo.SAME_QUARTER,
+      "samemonth", DateComparisonInfo.SAME_MONTH,
+      "sameweek", DateComparisonInfo.SAME_WEEK,
+      "sameday", DateComparisonInfo.SAME_DAY
+   );
+
+   /**
+    * Translates the agent vocabulary's interval-level word to the {@code DateComparisonInfo}
+    * bitmask {@code date-comparison-interval-pane.component.ts}'s {@code intervalLevels} dropdown
+    * sends. Mirrors {@link #normalizeLevel(String)} — writing the raw word through untranslated
+    * is the same class of defect that method exists to prevent.
+    */
+   private static String normalizeInterval(String interval) {
+      Integer code = INTERVAL_WORDS.get(interval.trim().toLowerCase().replace(" ", ""));
+
+      if(code == null) {
+         throw new IllegalArgumentException(
+            "'interval' must be one of: all, yearToDate, quarterToDate, monthToDate, " +
+            "weekToDate, sameQuarter, sameMonth, sameWeek, sameDay. Got '" + interval + "'.");
+      }
+
+      return code.toString();
+   }
+
    private static void setDynamic(DynamicValueModel target, String value) {
       if(target == null) {
          throw new IllegalArgumentException(
@@ -538,6 +603,7 @@ public class DateComparisonService {
          out.put("endToday", standard.isToDayAsEndDay());
          out.put("endDate", standard.isToDayAsEndDay() ? null : value(standard.getEndDay()));
          out.put("inclusive", standard.isInclusive());
+         out.put("toDate", standard.isToDate());
       }
 
       return out;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -76,64 +76,12 @@ public class DateComparisonService {
     * @param level            the period level — the date level token, e.g. year, quarter, month
     * @param endDate          the range end. Required unless {@code endToday} is set.
     * @param endToday         anchor the range on today instead of an explicit end
-    * @param comparisonOption what the numbers mean — one of: value, change, percentChange
+    * @param comparisonOption what the numbers mean — value, change, percentChange,
+    *                        changeAndValue, or percentChangeAndValue
     */
    public record Comparison(Integer periods, String level, String endDate, boolean endToday,
                             String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
                             String comparisonOption) {}
-
-   /**
-    * The agent vocabulary's comparisonOption tokens, mapped to {@link Calculator}'s constants.
-    * Deliberately only the three the plugin's own schema documents and can send — see
-    * {@code dateComparisonTools.ts}'s {@code normalizeComparisonOption}. {@link
-    * DateComparisonInfo#CHANGE_VALUE}/{@link DateComparisonInfo#PERCENT_VALUE} ("Change and
-    * Value" / "Percent Change and Value" in the interactive Composer's own dialog) are real,
-    * reachable settings, but extending the write side to accept them would be inert without a
-    * matching plugin-schema change to let an agent actually send those tokens — tracked as a
-    * follow-on, not folded into this fix.
-    */
-   private static final Map<String, Integer> COMPARISON_OPTION_WORDS = Map.of(
-      "value", Calculator.VALUE,
-      "change", Calculator.CHANGE,
-      "percentchange", Calculator.PERCENT
-   );
-
-   /**
-    * The inverse of {@link #COMPARISON_OPTION_WORDS}, plus the two composite options the write
-    * side does not (yet) accept but the read side can still name accurately: {@link
-    * DateComparisonInfo#CHANGE_VALUE}/{@link DateComparisonInfo#PERCENT_VALUE}. A value outside
-    * even this wider set (e.g. a {@link Calculator} type this dialog should never produce) is
-    * reported as {@code null} rather than a bare int — this service does not echo raw magic
-    * numbers to the caller.
-    */
-   private static final Map<Integer, String> COMPARISON_OPTION_NAMES = Map.of(
-      Calculator.VALUE, "value",
-      Calculator.CHANGE, "change",
-      Calculator.PERCENT, "percentChange",
-      DateComparisonInfo.CHANGE_VALUE, "changeAndValue",
-      DateComparisonInfo.PERCENT_VALUE, "percentChangeAndValue"
-   );
-
-   /**
-    * Translates the agent vocabulary's comparisonOption word to {@link Calculator}'s numeric
-    * constant, mirroring {@link #normalizeLevel(String)}'s case-insensitive, fail-loud pattern.
-    */
-   private static int normalizeComparisonOption(String option) {
-      Integer code = COMPARISON_OPTION_WORDS.get(option.trim().toLowerCase());
-
-      if(code == null) {
-         throw new IllegalArgumentException(
-            "'comparisonOption' must be one of: value, change, percentChange. Got '" + option +
-            "'.");
-      }
-
-      return code;
-   }
-
-   /** The inverse of {@link #normalizeComparisonOption(String)}, for reporting it back. */
-   private static String comparisonOptionWord(int option) {
-      return COMPARISON_OPTION_NAMES.get(option);
-   }
 
    /** The current settings, normalized. Never echoes the raw cell format. */
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
@@ -158,7 +106,7 @@ public class DateComparisonService {
       }
 
       out.put("enabled", true);
-      out.put("comparisonOption", comparisonOptionWord(model.getComparisonOption()));
+      out.put("comparisonOption", describeComparisonOption(model.getComparisonOption()));
       out.put("useFacet", model.isUseFacet());
       out.put("onlyShowMostRecentDate", model.isOnlyShowMostRecentDate());
       out.put("period", describePeriod(model.getPeriodPaneModel()));
@@ -512,6 +460,55 @@ public class DateComparisonService {
    /** The inverse of {@link #normalizeLevel(String)}, for reporting a level back to the caller. */
    private static String levelWord(int level) {
       return LEVEL_NAMES.getOrDefault(level, String.valueOf(level));
+   }
+
+   private static final Map<String, Integer> COMPARISON_OPTION_WORDS = Map.of(
+      "value", Calculator.VALUE,
+      "change", Calculator.CHANGE,
+      "percentchange", Calculator.PERCENT,
+      "changeandvalue", DateComparisonInfo.CHANGE_VALUE,
+      "percentchangeandvalue", DateComparisonInfo.PERCENT_VALUE
+   );
+
+   /**
+    * Translates the agent vocabulary's comparison-option word to
+    * {@code DateComparisonPaneModel#setComparisonOption(int)}'s expected int. The Angular dialog
+    * shows 5 options (Value Only / Change / Change and Value / Percent Change / Percent Change
+    * and Value), one flat int each — {@link Calculator}'s VALUE/CHANGE/PERCENT constants for the
+    * first three, and {@link DateComparisonInfo}'s CHANGE_VALUE/PERCENT_VALUE constants (101/102)
+    * for the combined two. There is no separate "also show value" flag to set alongside a
+    * 3-value enum; the combined options are their own int.
+    */
+   private static int normalizeComparisonOption(String comparisonOption) {
+      Integer code = COMPARISON_OPTION_WORDS.get(comparisonOption.trim().toLowerCase());
+
+      if(code == null) {
+         throw new IllegalArgumentException(
+            "'comparisonOption' must be one of: value, change, percentChange, changeAndValue, " +
+            "percentChangeAndValue. Got '" + comparisonOption + "'.");
+      }
+
+      return code;
+   }
+
+   /**
+    * The inverse of {@link #COMPARISON_OPTION_WORDS}. Not reachable through this dialog in
+    * practice ({@link Calculator}'s other constants — RUNNINGTOTAL/MOVING/CUSTOM/COMPOUNDGROWTH —
+    * never end up on a date-comparison model), but a comparisonOption outside even this wider
+    * read-side vocabulary is reported as {@code null} rather than a bare int — this service does
+    * not echo raw magic numbers to the caller.
+    */
+   private static final Map<Integer, String> COMPARISON_OPTION_NAMES = Map.of(
+      Calculator.VALUE, "value",
+      Calculator.CHANGE, "change",
+      Calculator.PERCENT, "percentChange",
+      DateComparisonInfo.CHANGE_VALUE, "changeAndValue",
+      DateComparisonInfo.PERCENT_VALUE, "percentChangeAndValue"
+   );
+
+   /** The inverse of {@link #normalizeComparisonOption(String)}, for reporting it back. */
+   private static String describeComparisonOption(int comparisonOption) {
+      return COMPARISON_OPTION_NAMES.get(comparisonOption);
    }
 
    private static void setDynamic(DynamicValueModel target, String value) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -585,6 +585,23 @@ public class DateComparisonService {
       target.setValue(value);
    }
 
+   private static final Map<Integer, String> INTERVAL_NAMES = Map.of(
+      DateComparisonInfo.ALL, "all",
+      DateComparisonInfo.YEAR_TO_DATE, "yearToDate",
+      DateComparisonInfo.QUARTER_TO_DATE, "quarterToDate",
+      DateComparisonInfo.MONTH_TO_DATE, "monthToDate",
+      DateComparisonInfo.WEEK_TO_DATE, "weekToDate",
+      DateComparisonInfo.SAME_QUARTER, "sameQuarter",
+      DateComparisonInfo.SAME_MONTH, "sameMonth",
+      DateComparisonInfo.SAME_WEEK, "sameWeek",
+      DateComparisonInfo.SAME_DAY, "sameDay"
+   );
+
+   /** The inverse of {@link #normalizeInterval(String)}, for reporting it back. */
+   private static String intervalWord(int interval) {
+      return INTERVAL_NAMES.getOrDefault(interval, String.valueOf(interval));
+   }
+
    // ── read normalization ────────────────────────────────────────────────────
 
    private static Map<String, Object> describePeriod(PeriodPaneModel periods) {
@@ -599,7 +616,7 @@ public class DateComparisonService {
 
       if(standard != null) {
          out.put("periods", value(standard.getPreCount()));
-         out.put("level", value(standard.getDateLevel()));
+         out.put("level", describeCode(standard.getDateLevel(), DateComparisonService::levelWord));
          out.put("endToday", standard.isToDayAsEndDay());
          out.put("endDate", standard.isToDayAsEndDay() ? null : value(standard.getEndDay()));
          out.put("inclusive", standard.isInclusive());
@@ -616,7 +633,7 @@ public class DateComparisonService {
          return out;
       }
 
-      out.put("level", value(interval.getLevel()));
+      out.put("level", describeCode(interval.getLevel(), DateComparisonService::intervalWord));
       out.put("granularity", value(interval.getGranularity()));
       out.put("endDayAsToDate", interval.isEndDayAsToDate());
       out.put("inclusive", interval.isInclusive());
@@ -625,6 +642,37 @@ public class DateComparisonService {
 
    private static Object value(DynamicValueModel model) {
       return model == null ? null : model.getValue();
+   }
+
+   /**
+    * Reads a dynamic value written by {@link #normalizeLevel(String)}/{@link
+    * #normalizeInterval(String)} back as the word an agent caller understands, mirroring {@link
+    * #describeComparisonOption(int)}. Written but never wired up when {@code level}/{@code
+    * interval}'s write-side word-to-code normalization first landed -- {@code get_date_comparison}
+    * kept reporting the raw StyleBI numeric/bitmask code, asymmetric with comparisonOption's own
+    * two-way translation. Falls back to the raw stored string for a non-numeric dynamic value
+    * (a formula/expression) or a code the map does not recognize, rather than throwing --  a
+    * DynamicValueModel is not guaranteed to hold a plain int literal.
+    */
+   private static Object describeCode(DynamicValueModel model, java.util.function.IntFunction<String> word) {
+      if(model == null) {
+         return null;
+      }
+
+      Object rawValue = model.getValue();
+
+      if(rawValue == null) {
+         return null;
+      }
+
+      String raw = rawValue.toString();
+
+      try {
+         return word.apply(Integer.parseInt(raw.trim()));
+      }
+      catch(NumberFormatException e) {
+         return raw;
+      }
    }
 
    private final ViewsheetSessionService sessions;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -787,11 +787,12 @@ public class ViewsheetAssemblyAgentController {
    }
 
    public record HighlightRequest(String assembly, Integer row, Integer col, String colName,
+                                  Boolean axis, Boolean text,
                                   String name, String foreground, String background,
                                   List<ConditionClause> conditions, Boolean applyRow,
                                   Boolean replace) {
       AssemblyHighlightService.Region region() {
-         return highlightRegion(row, col, colName);
+         return highlightRegion(row, col, colName, axis, text);
       }
 
       AssemblyHighlightService.Highlight highlight() {
@@ -814,12 +815,14 @@ public class ViewsheetAssemblyAgentController {
                                              @RequestParam(required = false) Integer row,
                                              @RequestParam(required = false) Integer col,
                                              @RequestParam(required = false) String colName,
+                                             @RequestParam(required = false) Boolean axis,
+                                             @RequestParam(required = false) Boolean text,
                                              Principal user)
       throws Exception
    {
       requireEnabled();
       return highlightService.list(sessionToken, user, assembly,
-                                   highlightRegion(row, col, colName));
+                                   highlightRegion(row, col, colName, axis, text));
    }
 
    /**
@@ -843,10 +846,13 @@ public class ViewsheetAssemblyAgentController {
     * even while normalizing {@code row}/{@code col} to 0.
     */
    private static AssemblyHighlightService.Region highlightRegion(Integer row, Integer col,
-                                                                   String colName)
+                                                                   String colName, Boolean axis,
+                                                                   Boolean text)
    {
-      return row == null && col == null && colName == null ? null
-         : new AssemblyHighlightService.Region(row, col, colName, false, false);
+      return row == null && col == null && colName == null &&
+         axis == null && text == null ? null
+         : new AssemblyHighlightService.Region(row, col, colName, Boolean.TRUE.equals(axis),
+                                               Boolean.TRUE.equals(text));
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/highlights")

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -696,12 +696,18 @@ public class ViewsheetAssemblyAgentController {
    /**
     * One clause in the flat condition vocabulary. {@code junction} joins it to the NEXT clause,
     * so the last clause must not carry one — {@link ConditionVocabulary} enforces that.
+    *
+    * <p>{@code equal} turns {@code less_than}/{@code greater_than} into their "or equal to" form.
+    * {@code level} is the clause's nesting depth for parenthesization — omitted or {@code null}
+    * means flat (level 0), matching the historical behavior.
     */
    public record ConditionClause(String field, String operator, List<Object> values,
-                                 String junction, Boolean negated) {
+                                 String junction, Boolean negated, Boolean equal, Integer level) {
       ConditionVocabulary.Clause toClause() {
          return new ConditionVocabulary.Clause(field, operator, values, junction,
-                                               Boolean.TRUE.equals(negated));
+                                               Boolean.TRUE.equals(negated),
+                                               Boolean.TRUE.equals(equal),
+                                               level == null ? 0 : level);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -40,6 +40,7 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.MessageException;
 import inetsoft.web.composer.ws.dialog.WorksheetPropertyDialogService;
+import inetsoft.web.adhoc.model.FontInfo;
 import inetsoft.web.wiz.script.ScriptImageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -786,9 +787,30 @@ public class ViewsheetAssemblyAgentController {
       conditionService.clear(sessionToken, user, request.assembly(), linkUri);
    }
 
+   /**
+    * A minimal, LLM-facing font override for a highlight. Booleans rather than
+    * {@link FontInfo}'s CSS-style-string fields (e.g. {@code fontStyle: "italic"}), matching the
+    * boolean {@code bold}/{@code italic} shape {@code ApplyHighlightModel.FontInfo} already uses
+    * elsewhere in this package for the same concept.
+    */
+   public record FontRequest(String fontFamily, Integer fontSize, Boolean bold, Boolean italic,
+                             Boolean underline, Boolean strikethrough) {
+      FontInfo toFontInfo() {
+         FontInfo info = new FontInfo();
+         info.setFontFamily(fontFamily);
+         info.setFontSize(fontSize == null ? null : String.valueOf(fontSize));
+         info.setFontWeight(Boolean.TRUE.equals(bold) ? "bold" : "normal");
+         info.setFontStyle(Boolean.TRUE.equals(italic) ? "italic" : "normal");
+         info.setFontUnderline(Boolean.TRUE.equals(underline) ? "underline" : "normal");
+         info.setFontStrikethrough(Boolean.TRUE.equals(strikethrough) ? "strikethrough" : "normal");
+         return info;
+      }
+   }
+
    public record HighlightRequest(String assembly, Integer row, Integer col, String colName,
                                   Boolean axis, Boolean text,
                                   String name, String foreground, String background,
+                                  FontRequest fontInfo,
                                   List<ConditionClause> conditions, Boolean applyRow,
                                   Boolean replace) {
       AssemblyHighlightService.Region region() {
@@ -804,8 +826,9 @@ public class ViewsheetAssemblyAgentController {
             }
          }
 
-         return new AssemblyHighlightService.Highlight(name, foreground, background, clauses,
-                                                       Boolean.TRUE.equals(applyRow));
+         return new AssemblyHighlightService.Highlight(
+            name, foreground, background, fontInfo == null ? null : fontInfo.toFontInfo(),
+            clauses, Boolean.TRUE.equals(applyRow));
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -876,11 +876,12 @@ public class ViewsheetAssemblyAgentController {
    public record DateComparisonRequest(String assembly, Integer periods, String level,
                                        String endDate, Boolean endToday, String interval,
                                        Boolean useFacet, Boolean onlyShowMostRecentDate,
-                                       String comparisonOption) {
+                                       String comparisonOption, String shareAssembly,
+                                       Boolean toDate, Boolean inclusive) {
       DateComparisonService.Comparison comparison() {
          return new DateComparisonService.Comparison(
             periods, level, endDate, Boolean.TRUE.equals(endToday), interval, useFacet,
-            onlyShowMostRecentDate, comparisonOption);
+            onlyShowMostRecentDate, comparisonOption, shareAssembly, toDate, inclusive);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
+++ b/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
@@ -60,7 +60,7 @@ class ConditionUtilTest {
 
       Object[] model = ConditionVocabulary.toConditionList(
          List.of(new ConditionVocabulary.Clause(
-            "OrderDate", "date_in", List.of(builtinName), null, false)),
+            "OrderDate", "date_in", List.of(builtinName), null, false, false, 0)),
          new DataRefModel[]{ field });
 
       Principal principal = () -> "admin";
@@ -88,11 +88,11 @@ class ConditionUtilTest {
 
       Object[] correctModel = ConditionVocabulary.toConditionList(
          List.of(new ConditionVocabulary.Clause(
-            "OrderDate", "date_in", List.of(correctlyCasedName), null, false)),
+            "OrderDate", "date_in", List.of(correctlyCasedName), null, false, false, 0)),
          new DataRefModel[]{ field });
       Object[] wrongCaseModel = ConditionVocabulary.toConditionList(
          List.of(new ConditionVocabulary.Clause(
-            "OrderDate", "date_in", List.of(wrongCasedName), null, false)),
+            "OrderDate", "date_in", List.of(wrongCasedName), null, false, false, 0)),
          new DataRefModel[]{ field });
 
       Principal principal = () -> "admin";
@@ -118,7 +118,7 @@ class ConditionUtilTest {
 
       Object[] model = ConditionVocabulary.toConditionList(
          List.of(new ConditionVocabulary.Clause(
-            "OrderDate", "date_in", List.of("Last Decade"), null, false)),
+            "OrderDate", "date_in", List.of("Last Decade"), null, false, false, 0)),
          new DataRefModel[]{ field });
 
       Principal principal = () -> "admin";
@@ -151,7 +151,7 @@ class ConditionUtilTest {
 
       Object[] model = ConditionVocabulary.toConditionList(
          List.of(new ConditionVocabulary.Clause(
-            "OrderDate", "date_in", List.of("myrange"), null, false)),
+            "OrderDate", "date_in", List.of("myrange"), null, false, false, 0)),
          new DataRefModel[]{ field });
 
       Principal principal = () -> "admin";
@@ -193,7 +193,7 @@ class ConditionUtilTest {
 
       Object[] model = ConditionVocabulary.toConditionList(
          List.of(new ConditionVocabulary.Clause(
-            "OrderDate", "date_in", List.of("MyRange"), null, false)),
+            "OrderDate", "date_in", List.of("MyRange"), null, false, false, 0)),
          new DataRefModel[]{ field });
 
       Principal principal = () -> "admin";

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyConditionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyConditionServiceTest.java
@@ -54,7 +54,7 @@ class AssemblyConditionServiceTest {
    private static ConditionVocabulary.Clause clause(String f, String op, List<Object> v,
                                                     String junction)
    {
-      return new ConditionVocabulary.Clause(f, op, v, junction, false);
+      return new ConditionVocabulary.Clause(f, op, v, junction, false, false, 0);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -61,14 +61,14 @@ class AssemblyHighlightServiceTest {
    private static AssemblyHighlightService.Highlight highlight(String name) {
       return new AssemblyHighlightService.Highlight(
          name, null, "#ff0000",
-         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
+         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false, false, 0)),
          false);
    }
 
    private static AssemblyHighlightService.Highlight highlightApplyRow(String name) {
       return new AssemblyHighlightService.Highlight(
          name, null, "#ff0000",
-         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
+         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false, false, 0)),
          true);
    }
 
@@ -182,7 +182,8 @@ class AssemblyHighlightServiceTest {
                              new AssemblyHighlightService.Highlight(
                                 "Bad", null, "#fff",
                                 List.of(new ConditionVocabulary.Clause("Profit", ">",
-                                                                       List.of(1), null, false)),
+                                                                       List.of(1), null, false,
+                                                                       false, 0)),
                                 false),
                              false, ""));
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -605,6 +605,27 @@ class AssemblyHighlightServiceTest {
       assertNull(highlights.get(0).get("font"));
    }
 
+   // FontInfo.toFont() parses the same stored string with an unguarded Integer.parseInt(), so a
+   // malformed size is a pre-existing risk elsewhere -- but list_highlights' read path must not
+   // throw on it, since it is now reachable straight from an agent's read-only call.
+   @Test
+   void reportsTheRawFontSizeWhenItIsNotANumber() throws Exception {
+      HighlightModel stored = existing("Styled");
+      inetsoft.web.adhoc.model.FontInfo font = new inetsoft.web.adhoc.model.FontInfo();
+      font.setFontFamily("Arial");
+      font.setFontSize("not-a-number");
+      stored.setFontInfo(font);
+      Harness h = harness(model(stored));
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Table1", null);
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> highlights = (List<Map<String, Object>>) listed.get("highlights");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> reportedFont = (Map<String, Object>) highlights.get(0).get("font");
+      assertEquals("not-a-number", reportedFont.get("fontSize"));
+   }
+
    @Test
    void eachWriteIsOneCheckpoint() throws Exception {
       Harness h = harness(model());

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -60,14 +60,14 @@ class AssemblyHighlightServiceTest {
 
    private static AssemblyHighlightService.Highlight highlight(String name) {
       return new AssemblyHighlightService.Highlight(
-         name, null, "#ff0000",
+         name, null, "#ff0000", null,
          List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
          false);
    }
 
    private static AssemblyHighlightService.Highlight highlightApplyRow(String name) {
       return new AssemblyHighlightService.Highlight(
-         name, null, "#ff0000",
+         name, null, "#ff0000", null,
          List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
          true);
    }
@@ -165,7 +165,7 @@ class AssemblyHighlightServiceTest {
       Exception thrown = assertThrows(
          Exception.class,
          () -> h.service.set("tok", principal(), "Table1", null,
-                             new AssemblyHighlightService.Highlight("Nothing", null, null,
+                             new AssemblyHighlightService.Highlight("Nothing", null, null, null,
                                                                     List.of(), false),
                              false, ""));
 
@@ -180,7 +180,7 @@ class AssemblyHighlightServiceTest {
          Exception.class,
          () -> h.service.set("tok", principal(), "Table1", null,
                              new AssemblyHighlightService.Highlight(
-                                "Bad", null, "#fff",
+                                "Bad", null, "#fff", null,
                                 List.of(new ConditionVocabulary.Clause("Profit", ">",
                                                                        List.of(1), null, false)),
                                 false),
@@ -542,6 +542,66 @@ class AssemblyHighlightServiceTest {
       verify(h.highlights).getHighlightDialogModel(eq("rt1"), eq("Table1"), eq(2), eq(1),
                                                    eq("Sales"), eq(false), eq(false),
                                                    any(Principal.class));
+   }
+
+   // ── font (L8 parity finding 1) ───────────────────────────────────────────
+
+   @Test
+   void setsTheFontInfoOnTheStoredHighlight() throws Exception {
+      Harness h = harness(model());
+      inetsoft.web.adhoc.model.FontInfo font = new inetsoft.web.adhoc.model.FontInfo();
+      font.setFontFamily("Arial");
+      font.setFontSize("12");
+      font.setFontWeight("bold");
+      font.setFontStyle("italic");
+      AssemblyHighlightService.Highlight highlight = new AssemblyHighlightService.Highlight(
+         "Styled", null, "#ff0000", font,
+         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
+         false);
+
+      h.service.set("tok", principal(), "Table1", null, highlight, false, "");
+
+      HighlightModel added = capture(h.highlights).getHighlights()[0];
+      assertNotNull(added.getFontInfo());
+      assertEquals("Arial", added.getFontInfo().getFontFamily());
+      assertEquals("bold", added.getFontInfo().getFontWeight());
+      assertEquals("italic", added.getFontInfo().getFontStyle());
+   }
+
+   @Test
+   void reportsTheFontBackOnListWhenSet() throws Exception {
+      HighlightModel stored = existing("Styled");
+      inetsoft.web.adhoc.model.FontInfo font = new inetsoft.web.adhoc.model.FontInfo();
+      font.setFontFamily("Arial");
+      font.setFontSize("14");
+      font.setFontWeight("bold");
+      font.setFontUnderline("underline");
+      stored.setFontInfo(font);
+      Harness h = harness(model(stored));
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Table1", null);
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> highlights = (List<Map<String, Object>>) listed.get("highlights");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> reportedFont = (Map<String, Object>) highlights.get(0).get("font");
+      assertNotNull(reportedFont);
+      assertEquals("Arial", reportedFont.get("fontFamily"));
+      assertEquals(14, reportedFont.get("fontSize"));
+      assertEquals(true, reportedFont.get("bold"));
+      assertEquals(true, reportedFont.get("underline"));
+      assertEquals(false, reportedFont.get("italic"));
+   }
+
+   @Test
+   void reportsNullFontWhenNoOverrideIsStored() throws Exception {
+      Harness h = harness(model(existing("Plain")));
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Table1", null);
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> highlights = (List<Map<String, Object>>) listed.get("highlights");
+      assertNull(highlights.get(0).get("font"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
@@ -22,7 +22,9 @@ import inetsoft.uql.XCondition;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.condition.ConditionModel;
 import inetsoft.web.composer.model.condition.ConditionValueModel;
+import inetsoft.web.composer.model.condition.ExpressionValueModel;
 import inetsoft.web.composer.model.condition.JunctionOperatorModel;
+import inetsoft.web.composer.model.condition.RankingValueModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +47,14 @@ class ConditionVocabularyTest {
    private static ConditionVocabulary.Clause clause(String field, String operator,
                                                     List<Object> values, String junction)
    {
-      return new ConditionVocabulary.Clause(field, operator, values, junction, false);
+      return new ConditionVocabulary.Clause(field, operator, values, junction, false, false, 0);
+   }
+
+   private static ConditionVocabulary.Clause clause(String field, String operator,
+                                                    List<Object> values, String junction,
+                                                    boolean equal, int level)
+   {
+      return new ConditionVocabulary.Clause(field, operator, values, junction, false, equal, level);
    }
 
    // ── the alternating array ─────────────────────────────────────────────────
@@ -325,6 +334,242 @@ class ConditionVocabularyTest {
       assertEquals("or", described.get(0).get("junction"));
       assertEquals("and", described.get(1).get("junction"));
       assertNull(described.get(2).get("junction"));
+   }
+
+   // ── L8 parity finding 1: TOP_N/BOTTOM_N ranking values ─────────────────────
+
+   @Test
+   void bottomNIsARecognizedOperator() {
+      assertEquals(XCondition.BOTTOM_N, operationOfRanking("bottom_n"));
+   }
+
+   @Test
+   void topNBuildsARankingValueModelFromNAndGroupField() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "top_n",
+                        List.of(Map.of("n", 5, "groupField", "Region")), null)),
+         FIELDS);
+
+      ConditionModel condition = (ConditionModel) list[0];
+      assertEquals(XCondition.TOP_N, condition.getOperation());
+      RankingValueModel ranking = assertInstanceOf(
+         RankingValueModel.class, condition.getValues()[0].getValue());
+      assertEquals(5, ranking.getN());
+      assertEquals("Region", ranking.getDataRef().getName());
+   }
+
+   @Test
+   void topNRefusesANonObjectValue() {
+      assertThrows(IllegalArgumentException.class, () -> ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "top_n", List.of(5), null)), FIELDS));
+   }
+
+   @Test
+   void topNRefusesANonPositiveN() {
+      assertThrows(IllegalArgumentException.class, () -> ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "top_n",
+                        List.of(Map.of("n", 0, "groupField", "Region")), null)),
+         FIELDS));
+   }
+
+   @Test
+   void topNRefusesAnUnknownGroupFieldListingWhatItCan() {
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Revenue", "top_n",
+                           List.of(Map.of("n", 5, "groupField", "Nope")), null)),
+            FIELDS));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void topNRefusesMoreThanOneValue() {
+      assertThrows(IllegalArgumentException.class, () -> ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "top_n",
+                        List.of(Map.of("n", 5, "groupField", "Region"),
+                                Map.of("n", 1, "groupField", "Region")),
+                        null)),
+         FIELDS));
+   }
+
+   @Test
+   void topNReadsBackNAndGroupField() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "top_n",
+                        List.of(Map.of("n", 5, "groupField", "Region")), null)),
+         FIELDS);
+
+      @SuppressWarnings("unchecked")
+      List<Object> values = (List<Object>) ConditionVocabulary.describe(list).get(0).get("values");
+      Map<?, ?> ranking = (Map<?, ?>) values.get(0);
+
+      assertEquals(5, ranking.get("n"));
+      assertEquals("Region", ranking.get("groupField"));
+   }
+
+   private static int operationOfRanking(String operator) {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", operator,
+                        List.of(Map.of("n", 5, "groupField", "Region")), null)),
+         FIELDS);
+      return ((ConditionModel) list[0]).getOperation();
+   }
+
+   // ── L8 parity finding 3: "or equal to" ──────────────────────────────────────
+
+   @Test
+   void equalDefaultsToFalse() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "less_than", List.of(10), null)), FIELDS);
+
+      assertFalse(((ConditionModel) list[0]).isEqual());
+   }
+
+   @Test
+   void equalCanBeSetTrueAndReadBack() {
+      ConditionVocabulary.Clause c = new ConditionVocabulary.Clause(
+         "Revenue", "less_than", List.of(10), null, false, true, 0);
+
+      Object[] list = ConditionVocabulary.toConditionList(List.of(c), FIELDS);
+
+      assertTrue(((ConditionModel) list[0]).isEqual());
+      assertEquals(true, ConditionVocabulary.describe(list).get(0).get("equal"));
+   }
+
+   // ── L8 parity finding 4: nesting level ──────────────────────────────────────
+
+   @Test
+   void levelDefaultsToZero() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("East"), null)), FIELDS);
+
+      assertEquals(0, ((ConditionModel) list[0]).getLevel());
+   }
+
+   @Test
+   void levelCanBeSetAndReadBack() {
+      ConditionVocabulary.Clause c = new ConditionVocabulary.Clause(
+         "Region", "equals", List.of("East"), null, false, false, 2);
+
+      Object[] list = ConditionVocabulary.toConditionList(List.of(c), FIELDS);
+
+      assertEquals(2, ((ConditionModel) list[0]).getLevel());
+      assertEquals(2, ConditionVocabulary.describe(list).get(0).get("level"));
+   }
+
+   /**
+    * The destructive round trip this finding fixes: get_condition's own output, fed straight
+    * back into set_condition as an apparently unchanged edit, used to silently flatten a nested
+    * condition's level to 0.
+    */
+   @Test
+   void aNonZeroLevelSurvivesAGetConditionThenSetConditionRoundTrip() {
+      ConditionVocabulary.Clause authored = new ConditionVocabulary.Clause(
+         "Region", "equals", List.of("East"), null, false, false, 1);
+      Object[] originalList = ConditionVocabulary.toConditionList(List.of(authored), FIELDS);
+
+      Map<String, Object> described = ConditionVocabulary.describe(originalList).get(0);
+      assertEquals(1, described.get("level"));
+
+      @SuppressWarnings("unchecked")
+      ConditionVocabulary.Clause replayed = new ConditionVocabulary.Clause(
+         (String) described.get("field"), (String) described.get("operator"),
+         (List<Object>) described.get("values"), null, false, false,
+         (int) described.get("level"));
+      Object[] replayedList = ConditionVocabulary.toConditionList(List.of(replayed), FIELDS);
+
+      assertEquals(1, ((ConditionModel) replayedList[0]).getLevel(),
+                   "replaying get_condition's own output must not flatten the nesting level");
+   }
+
+   // ── L8 parity finding 5: typed condition values ─────────────────────────────
+
+   @Test
+   void aPlainScalarValueStillMeansValueType() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("East"), null)), FIELDS);
+
+      ConditionValueModel value = ((ConditionModel) list[0]).getValues()[0];
+      assertEquals(ConditionValueModel.VALUE, value.getType());
+      assertEquals("East", value.getValue());
+   }
+
+   @Test
+   void fieldTypedValueComparesToAnotherColumn() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "greater_than",
+                        List.of(Map.of("type", "field", "field", "Region")), null)),
+         FIELDS);
+
+      ConditionValueModel value = ((ConditionModel) list[0]).getValues()[0];
+      assertEquals(ConditionValueModel.FIELD, value.getType());
+      assertEquals("Region", ((DataRefModel) value.getValue()).getName());
+   }
+
+   @Test
+   void fieldTypedValueRefusesAnUnknownColumn() {
+      assertThrows(IllegalArgumentException.class, () -> ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "greater_than",
+                        List.of(Map.of("type", "field", "field", "Nope")), null)),
+         FIELDS));
+   }
+
+   @Test
+   void variableTypedValueBuildsTheDollarParenForm() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals",
+                        List.of(Map.of("type", "variable", "name", "region")), null)),
+         FIELDS);
+
+      ConditionValueModel value = ((ConditionModel) list[0]).getValues()[0];
+      assertEquals(ConditionValueModel.VARIABLE, value.getType());
+      assertEquals("$(region)", value.getValue());
+   }
+
+   @Test
+   void sessionDataTypedValueAcceptsOnlyTheKnownNames() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals",
+                        List.of(Map.of("type", "session_data", "name", "_USER_")), null)),
+         FIELDS);
+
+      ConditionValueModel value = ((ConditionModel) list[0]).getValues()[0];
+      assertEquals(ConditionValueModel.SESSION_DATA, value.getType());
+      assertEquals("$(_USER_)", value.getValue());
+
+      assertThrows(IllegalArgumentException.class, () -> ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals",
+                        List.of(Map.of("type", "session_data", "name", "_BOGUS_")), null)),
+         FIELDS));
+   }
+
+   @Test
+   void expressionTypedValueBuildsAnExpressionValueModel() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "greater_than",
+                        List.of(Map.of("type", "expression", "expression", "field['Cost'] * 2",
+                                       "language", "js")),
+                        null)),
+         FIELDS);
+
+      ConditionValueModel value = ((ConditionModel) list[0]).getValues()[0];
+      assertEquals(ConditionValueModel.EXPRESSION, value.getType());
+      ExpressionValueModel expr = assertInstanceOf(
+         ExpressionValueModel.class, value.getValue());
+      assertEquals("field['Cost'] * 2", expr.getExpression());
+      assertEquals(ExpressionValueModel.JS, expr.getType());
+   }
+
+   @Test
+   void anUnknownTypedValueDiscriminatorFailsLoudRatherThanFallingBackToValue() {
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Region", "equals", List.of(Map.of("type", "bogus", "x", "y")), null)),
+            FIELDS));
+
+      assertTrue(thrown.getMessage().contains("bogus"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -25,6 +25,7 @@ import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.junit.jupiter.api.Tag;
@@ -251,6 +252,45 @@ class DateComparisonServiceTest {
          () -> harness(model).service.set("tok", principal(), "Chart1", comparison, ""));
 
       assertTrue(thrown.getMessage().contains("level"), thrown.getMessage());
+   }
+
+   // ── comparisonOption ─────────────────────────────────────────────────────
+
+   /**
+    * The Angular dialog shows 5 options — Value Only / Change / Change and Value / Percent
+    * Change / Percent Change and Value — as one flat int each: {@link Calculator}'s
+    * VALUE/CHANGE/PERCENT for the first three, {@link DateComparisonInfo}'s
+    * CHANGE_VALUE/PERCENT_VALUE (101/102) for the combined two. Confirms all 5 actually reach
+    * {@code model.setComparisonOption}, not just the 3 {@code Calculator} defines.
+    */
+   @ParameterizedTest
+   @CsvSource({
+      "value, 6",
+      "change, 2",
+      "percentChange, 1",
+      "changeAndValue, 101",
+      "percentChangeAndValue, 102",
+      "VALUE, 6",
+      "PercentChange, 1"
+   })
+   void setsTheComparisonOptionForAllFiveUiValues(String word, int code) throws Exception {
+      DateComparisonPaneModel model = model();
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         null, null, null, false, null, null, null, word);
+
+      harness(model).service.set("tok", principal(), "Chart1", comparison, "");
+
+      assertEquals(code, model.getComparisonOption());
+   }
+
+   @Test
+   void readsTheComparisonOptionAsAName() throws Exception {
+      DateComparisonPaneModel model = model();
+      when(model.getComparisonOption()).thenReturn(DateComparisonInfo.CHANGE_VALUE);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      assertEquals("changeAndValue", read.get("comparisonOption"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -808,6 +808,56 @@ class DateComparisonServiceTest {
       assertEquals(false, read.get("enabled"));
    }
 
+   /**
+    * {@code levelWord()} existed since the level/interval write-side word-to-code normalization
+    * first landed, but was never wired into {@code describePeriod()} -- the read side kept
+    * reporting the raw {@code XConstants} group code, asymmetric with comparisonOption's own
+    * two-way translation. Caught live, testing this fix's own build, before it shipped further.
+    */
+   @Test
+   void describesTheStandardPeriodLevelAsAWordNotARawCode() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.getPeriodPaneModel().getStandardPeriodPaneModel().getDateLevel()
+         .setValue(String.valueOf(XConstants.YEAR_DATE_GROUP));
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> period = (Map<String, Object>) read.get("period");
+      assertEquals("year", period.get("level"));
+   }
+
+   @Test
+   void describesTheIntervalLevelAsAWordNotARawCode() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.getIntervalPaneModel().getLevel()
+         .setValue(String.valueOf(DateComparisonInfo.YEAR_TO_DATE));
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> interval = (Map<String, Object>) read.get("interval");
+      assertEquals("yearToDate", interval.get("level"));
+   }
+
+   /**
+    * A level/interval dynamic value is not guaranteed to hold a plain int literal -- falling back
+    * to the raw string rather than throwing keeps a formula/unrecognized code readable instead of
+    * breaking the whole read.
+    */
+   @Test
+   void fallsBackToTheRawStringForAnUnrecognizedLevelCode() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.getPeriodPaneModel().getStandardPeriodPaneModel().getDateLevel()
+         .setValue("not-a-number");
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> period = (Map<String, Object>) read.get("period");
+      assertEquals("not-a-number", period.get("level"));
+   }
+
    @Test
    void hidesTheEndDateWhenTheRangeAnchorsOnToday() throws Exception {
       Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -68,7 +68,7 @@ class DateComparisonServiceTest {
 
    private static DateComparisonService.Comparison comparison(String endDate, boolean endToday) {
       return new DateComparisonService.Comparison(4, "year", endDate, endToday, null, null, null,
-                                                  null);
+                                                  null, null, null, null);
    }
 
    /**
@@ -106,12 +106,13 @@ class DateComparisonServiceTest {
    }
 
    private static DateComparisonService.Comparison facetOnly() {
-      return new DateComparisonService.Comparison(null, null, null, false, null, true, null, null);
+      return new DateComparisonService.Comparison(null, null, null, false, null, true, null, null,
+                                                   null, null, null);
    }
 
    private static DateComparisonService.Comparison comparisonOptionOnly(String comparisonOption) {
       return new DateComparisonService.Comparison(null, null, null, false, null, null, null,
-                                                  comparisonOption);
+                                                  comparisonOption, null, null, null);
    }
 
    // ── the recorded defect ───────────────────────────────────────────────────
@@ -179,7 +180,7 @@ class DateComparisonServiceTest {
       assertThrows(IllegalArgumentException.class,
                    () -> DateComparisonService.requireEndAnchor(
                       new DateComparisonService.Comparison(0, "year", null, true, null, null,
-                                                           null, null)));
+                                                           null, null, null, null, null)));
    }
 
    @Test
@@ -230,7 +231,7 @@ class DateComparisonServiceTest {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison =
          new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
-                                              null);
+                                              null, null, null, null);
 
       harness(model).service.set("tok", principal(), "Chart1", comparison, "");
 
@@ -245,7 +246,7 @@ class DateComparisonServiceTest {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison =
          new DateComparisonService.Comparison(4, word, "2026-03-31", false, null, null, null,
-                                              null);
+                                              null, null, null, null);
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
@@ -276,7 +277,7 @@ class DateComparisonServiceTest {
    void setsTheComparisonOptionForAllFiveUiValues(String word, int code) throws Exception {
       DateComparisonPaneModel model = model();
       DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
-         null, null, null, false, null, null, null, word);
+         null, null, null, false, null, null, null, word, null, null, null);
 
       harness(model).service.set("tok", principal(), "Chart1", comparison, "");
 
@@ -291,6 +292,128 @@ class DateComparisonServiceTest {
       Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
 
       assertEquals("changeAndValue", read.get("comparisonOption"));
+   }
+
+   // ── shareAssembly ─────────────────────────────────────────────────────────
+
+   @Test
+   void threadsTheShareAssemblyThroughToSetDateComparison() throws Exception {
+      Harness h = harness(model());
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         4, "year", "2026-03-31", false, null, null, null, null, "Chart2", null, null);
+
+      h.service.set("tok", principal(), "Chart1", comparison, "");
+
+      verify(h.comparisons).setDateComparison(eq("rt1"), eq("Chart1"), any(), eq("Chart2"),
+                                              anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void reportsTheShareFromAssemblyOnRead() throws Exception {
+      Harness h = harness(model());
+      DateComparisonDialogModel shareModel = new DateComparisonDialogModel();
+      shareModel.setShareFromAssembly("Chart2");
+      when(h.comparisons().getShare(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(shareModel);
+
+      Map<String, Object> read = h.service.read("tok", principal(), "Chart1");
+
+      assertEquals("Chart2", read.get("shareFrom"));
+   }
+
+   @Test
+   void omitsShareFromWhenThereIsNone() throws Exception {
+      Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
+
+      assertFalse(read.containsKey("shareFrom"));
+   }
+
+   // ── toDate / inclusive (period level) ────────────────────────────────────
+
+   @Test
+   void setsToDateAndInclusiveOnTheStandardPeriod() throws Exception {
+      DateComparisonPaneModel model = model();
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         4, "year", "2026-03-31", false, null, null, null, null, null, true, false);
+
+      harness(model).service.set("tok", principal(), "Chart1", comparison, "");
+
+      StandardPeriodPaneModel standard =
+         model.getPeriodPaneModel().getStandardPeriodPaneModel();
+      assertTrue(standard.isToDate());
+      assertFalse(standard.isInclusive());
+   }
+
+   /**
+    * toDate/inclusive live on the same standard-period pane as preCount/dateLevel, whose write
+    * path unconditionally re-sets (or blanks) the end day once it runs — so touching them alone
+    * needs the same end-anchor guard as touching periods/level does.
+    */
+   @Test
+   void settingOnlyToDateStillNeedsAnEndAnchor() {
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         null, null, null, false, null, null, null, null, null, true, null);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> DateComparisonService.requireEndAnchor(comparison));
+   }
+
+   @Test
+   void readsToDateAlongsidePeriod() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.getPeriodPaneModel().getStandardPeriodPaneModel().setToDate(true);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> period = (Map<String, Object>) read.get("period");
+      assertEquals(true, period.get("toDate"));
+   }
+
+   // ── interval-level normalization ─────────────────────────────────────────
+
+   /**
+    * {@code interval.getLevel()} is read as a {@code DateComparisonInfo} bitmask, the same way
+    * {@code standard.getDateLevel()} is read as an {@code XConstants} group code — writing the
+    * raw agent-vocabulary word through untranslated is the same class of defect
+    * {@link #translatesThePeriodLevelWordToTheNumericGroupCode} guards for the period level.
+    */
+   @ParameterizedTest
+   @CsvSource({
+      "all, 0",
+      "yearToDate, 48",
+      "quarterToDate, 40",
+      "monthToDate, 36",
+      "weekToDate, 34",
+      "sameQuarter, 72",
+      "sameMonth, 68",
+      "sameWeek, 66",
+      "sameDay, 65",
+      "YearToDate, 48",
+      "SAMEDAY, 65",
+      "Same Day, 65"
+   })
+   void translatesTheIntervalWordToTheBitmaskCode(String word, String code) throws Exception {
+      DateComparisonPaneModel model = model();
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         null, null, null, true, word, null, null, null, null, null, null);
+
+      harness(model).service.set("tok", principal(), "Chart1", comparison, "");
+
+      assertEquals(code, model.getIntervalPaneModel().getLevel().getValue());
+   }
+
+   @Test
+   void refusesAnUnrecognizedInterval() {
+      DateComparisonPaneModel model = model();
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         null, null, null, true, "bogus", null, null, null, null, null, null);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(model).service.set("tok", principal(), "Chart1", comparison, ""));
+
+      assertTrue(thrown.getMessage().contains("interval"), thrown.getMessage());
    }
 
    @Test
@@ -728,6 +851,8 @@ class DateComparisonServiceTest {
             .thenReturn(model);
          when(comparisons.isDateComparisonEnabled(anyString(), anyString(), any(Principal.class)))
             .thenReturn(model != null);
+         when(comparisons.getShare(anyString(), anyString(), any(Principal.class)))
+            .thenReturn(new DateComparisonDialogModel());
       }
       catch(Exception e) {
          throw new IllegalStateException(e);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -786,8 +786,8 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
       var request = new ViewsheetAssemblyAgentController.HighlightRequest(
-         "Table1", null, null, null, null, null, "HighRevenue", null, "#FFDDDD", List.of(), false,
-         false);
+         "Table1", null, null, null, null, null, "HighRevenue", null, "#FFDDDD", null, List.of(),
+         false, false);
 
       controller.setHighlight("tok", request, "", principal());
 
@@ -800,7 +800,7 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
       var request = new ViewsheetAssemblyAgentController.HighlightRequest(
-         "Table1", 0, 0, null, null, null, "HighRevenue", null, "#FFDDDD", List.of(), false,
+         "Table1", 0, 0, null, null, null, "HighRevenue", null, "#FFDDDD", null, List.of(), false,
          false);
 
       controller.setHighlight("tok", request, "", principal());
@@ -817,7 +817,7 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
       var request = new ViewsheetAssemblyAgentController.HighlightRequest(
-         "Chart1", null, null, "Sum(Sales)", false, true, "HighRevenue", null, "#FFDDDD",
+         "Chart1", null, null, "Sum(Sales)", false, true, "HighRevenue", null, "#FFDDDD", null,
          List.of(), false, false);
 
       controller.setHighlight("tok", request, "", principal());
@@ -826,6 +826,33 @@ class ViewsheetAssemblyAgentControllerTest {
                                    eq(new AssemblyHighlightService.Region(null, null, "Sum(Sales)",
                                                                           false, true)),
                                    any(), eq(false), eq(""));
+   }
+
+   /** L8 parity finding 1: a {@code fontInfo} on the request reaches the built {@code Highlight}. */
+   @Test
+   void setHighlightBuildsTheHighlightsFontFromTheRequest() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+      var font = new ViewsheetAssemblyAgentController.FontRequest(
+         "Arial", 12, true, false, true, false);
+      var request = new ViewsheetAssemblyAgentController.HighlightRequest(
+         "Table1", null, null, null, null, null, "HighRevenue", null, "#FFDDDD", font, List.of(),
+         false, false);
+
+      controller.setHighlight("tok", request, "", principal());
+
+      ArgumentCaptor<AssemblyHighlightService.Highlight> captor =
+         ArgumentCaptor.forClass(AssemblyHighlightService.Highlight.class);
+      verify(highlightService).set(eq("tok"), any(Principal.class), eq("Table1"), isNull(),
+                                   captor.capture(), eq(false), eq(""));
+      inetsoft.web.adhoc.model.FontInfo built = captor.getValue().font();
+      assertNotNull(built);
+      assertEquals("Arial", built.getFontFamily());
+      assertEquals("12", built.getFontSize());
+      assertEquals("bold", built.getFontWeight());
+      assertEquals("normal", built.getFontStyle());
+      assertEquals("underline", built.getFontUnderline());
+      assertEquals("normal", built.getFontStrikethrough());
    }
 
    /** Feature enabled, only {@code highlightService} wired -- for the highlight-region tests. */

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -722,7 +722,7 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
 
-      controller.listHighlights("tok", "Table1", null, null, null, principal());
+      controller.listHighlights("tok", "Table1", null, null, null, null, null, principal());
 
       verify(highlightService).list(eq("tok"), any(Principal.class), eq("Table1"),
                                     isNull());
@@ -733,10 +733,29 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
 
-      controller.listHighlights("tok", "Table1", 1, 1, null, principal());
+      controller.listHighlights("tok", "Table1", 1, 1, null, null, null, principal());
 
       verify(highlightService).list(eq("tok"), any(Principal.class), eq("Table1"),
                                     eq(new AssemblyHighlightService.Region(1, 1, null, false,
+                                                                          false)));
+   }
+
+   /**
+    * {@code axis}/{@code text} were hardcoded {@code false} regardless of the caller's request —
+    * the Region/service layer already supported them, but the wiz REST wire layer never forwarded
+    * them (L8 parity finding 2).
+    */
+   @Test
+   void listHighlightsPassesAxisAndTextRegionFlagsThrough() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+
+      controller.listHighlights("tok", "Chart1", null, null, "Sum(Sales)", true, false,
+                                principal());
+
+      verify(highlightService).list(eq("tok"), any(Principal.class), eq("Chart1"),
+                                    eq(new AssemblyHighlightService.Region(null, null,
+                                                                          "Sum(Sales)", true,
                                                                           false)));
    }
 
@@ -752,7 +771,8 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
 
-      controller.listHighlights("tok", "Chart1", null, null, "Sum(Sales)", principal());
+      controller.listHighlights("tok", "Chart1", null, null, "Sum(Sales)", null, null,
+                                principal());
 
       verify(highlightService).list(eq("tok"), any(Principal.class), eq("Chart1"),
                                     eq(new AssemblyHighlightService.Region(null, null,
@@ -766,7 +786,8 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
       var request = new ViewsheetAssemblyAgentController.HighlightRequest(
-         "Table1", null, null, null, "HighRevenue", null, "#FFDDDD", List.of(), false, false);
+         "Table1", null, null, null, null, null, "HighRevenue", null, "#FFDDDD", List.of(), false,
+         false);
 
       controller.setHighlight("tok", request, "", principal());
 
@@ -779,13 +800,31 @@ class ViewsheetAssemblyAgentControllerTest {
       AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
       ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
       var request = new ViewsheetAssemblyAgentController.HighlightRequest(
-         "Table1", 0, 0, null, "HighRevenue", null, "#FFDDDD", List.of(), false, false);
+         "Table1", 0, 0, null, null, null, "HighRevenue", null, "#FFDDDD", List.of(), false,
+         false);
 
       controller.setHighlight("tok", request, "", principal());
 
       verify(highlightService).set(eq("tok"), any(Principal.class), eq("Table1"),
                                    eq(new AssemblyHighlightService.Region(0, 0, null, false,
                                                                           false)),
+                                   any(), eq(false), eq(""));
+   }
+
+   /** Same wiring for {@code set}, reached through {@code HighlightRequest.region()}. */
+   @Test
+   void setHighlightPassesAxisAndTextRegionFlagsThrough() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+      var request = new ViewsheetAssemblyAgentController.HighlightRequest(
+         "Chart1", null, null, "Sum(Sales)", false, true, "HighRevenue", null, "#FFDDDD",
+         List.of(), false, false);
+
+      controller.setHighlight("tok", request, "", principal());
+
+      verify(highlightService).set(eq("tok"), any(Principal.class), eq("Chart1"),
+                                   eq(new AssemblyHighlightService.Region(null, null, "Sum(Sales)",
+                                                                          false, true)),
                                    any(), eq(false), eq(""));
    }
 


### PR DESCRIPTION
## Summary
- Backend implementation for lane L8's parity-audit fixes to the wiz agent's condition/highlight/date-comparison endpoints (`inetsoft.web.wiz.viewsheet`). Companion PR on the plugin side: stylebi-wiz#2249.
- **Reconciles with an independently-landed upstream fix for the same gap**: commit 92730d759 ("add comparisonOption to the date-comparison wire schema", VBM-012) fixed the same `comparisonOption` schema mismatch for 3 of 5 UI values and explicitly flagged extending to the other 2 as a follow-on. This PR is that follow-on -- it keeps 92730d759's naming and its documented `null`-for-out-of-vocabulary design (confirmed by that commit's own regression test), and extends `COMPARISON_OPTION_WORDS`/`COMPARISON_OPTION_NAMES` to the 2 composite values (`changeAndValue`/`percentChangeAndValue`).
- Full audit trail -- per-finding evidence, owner routing, live-testing arms and results -- is in the companion plugin PR's `docs/parity/L8-conditions-highlights-date-comparison/L8-parity-report.md` (+ `.zh-CN.md`).

## What changed
- `ConditionVocabulary.java`: Top N/Bottom N ranking now builds a real `RankingValueModel` from `{n, groupField}` instead of crashing; added `equal` (or-equal-to) and `level` (nesting, item-level) to the read/write conversion; added typed condition values for `FIELD`/`VARIABLE`/`SESSION_DATA`/`EXPRESSION` (`SUBQUERY` intentionally deferred).
- `AssemblyHighlightService.java` / `ViewsheetAssemblyAgentController.java`: threaded a `fontInfo` parameter through to `HighlightModel`; threaded `axis`/`text` region flags through to `Region` (the backend model already supported both end-to-end -- this closed a wire-layer gap only).
- `DateComparisonService.java`: `comparisonOption` now covers all 5 real values on both read and write; added `shareAssembly`/`shareFrom` threading through the existing `getShare()`/`setDateComparison(shareAssembly,...)` calls; added the `toDate`/`inclusive` period-level pair; added interval-word write-side normalization (`INTERVAL_WORDS`/`normalizeInterval()`, mirroring the existing `normalizeLevel()`); wired the already-present `levelWord()` (and new `intervalWord()`) into the read path so `level`/`interval` report as words (`"year"`, `"yearToDate"`), not raw StyleBI codes -- a gap only found live-testing this same batch of fixes surfaced.

## Test plan
- [x] `mvn test` -- 237/237 passing for every touched class (`ConditionVocabularyTest`, `AssemblyHighlightServiceTest`, `DateComparisonServiceTest`, `ViewsheetAssemblyAgentControllerTest`, `AssemblyConditionServiceTest`, `ConditionUtilTest`) after a clean rebuild
- [x] Clean full `core` compile
- [x] Live-verified against a running instance rebuilt from this branch, through the plugin's own MCP tools on a scratch viewsheet -- see the companion PR's parity report for the specific arms and results (9 of these findings confirmed this way, including a visual render check for the font/axis-highlight changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)