### PR TITLE
Fix #76316 (UD-003): chat-generated crosstabs default Shrink to Fit off

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -4915,6 +4915,10 @@ public class WizVsService {
                                                      VisualizationConfig config)
    {
       CrosstabVSAssembly crosstab = new CrosstabVSAssembly(vs, name);
+      // Chat-generated crosstabs default to Shrink to Fit = true (bug #76316, UD-003); the
+      // server default (TableDataVSAssemblyInfo) is false, which looks cramped/misaligned
+      // for AI-authored crosstabs shown in the chat panel.
+      crosstab.getCrosstabInfo().setShrinkValue(true);
 
       if(config != null && config.getBindingInfo() instanceof CrosstabBinding binding) {
          VSCrosstabInfo cinfo = crosstab.getVSCrosstabInfo();

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateCrosstabAssemblyShrinkTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCreateCrosstabAssemblyShrinkTest.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.CrosstabVSAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug #76316 (symptom UD-003): a chat-generated crosstab rendered with StyleBI's "Shrink to Fit"
+ * property off, because createCrosstabAssembly never set it and the server default
+ * (TableDataVSAssemblyInfo) is false. Pins the fix: a freshly created crosstab must default to
+ * Shrink to Fit = true.
+ *
+ * <p>Deliberately does not cover the sync path ({@code SyncCrosstabHandler.syncProperties}), which
+ * copies {@code isShrink()} from a pre-existing source assembly on later chat-driven modification
+ * turns — an existing crosstab created before this fix (shrink=false) keeps that value through
+ * sync. That is an accepted, disclosed limitation, not a defect this fix addresses.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceCreateCrosstabAssemblyShrinkTest {
+   private static WizVsService newService() throws Exception {
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return new WizVsService(vsService, engine, sec, null, null, null);
+   }
+
+   @Test
+   void newlyCreatedCrosstabDefaultsToShrinkToFit() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      WizVsService service = newService();
+
+      Method createCrosstabAssembly = WizVsService.class.getDeclaredMethod(
+         "createCrosstabAssembly", Viewsheet.class, String.class,
+         inetsoft.web.wiz.model.VisualizationConfig.class);
+      createCrosstabAssembly.setAccessible(true);
+
+      CrosstabVSAssembly crosstab =
+         (CrosstabVSAssembly) createCrosstabAssembly.invoke(service, vs, "Crosstab1", null);
+
+      assertTrue(((CrosstabVSAssemblyInfo) crosstab.getVSAssemblyInfo()).isShrink(),
+                 "chat-generated crosstabs must default to Shrink to Fit = true");
+   }
+}


### PR DESCRIPTION
## Summary
- `WizVsService.createCrosstabAssembly()` never set the crosstab's `shrink` property, so chat-generated crosstabs inherited the server's unconditional default (`false`, from `TableDataVSAssemblyInfo`'s constructor), rendering cramped/misaligned in the chat panel.
- Fix: set `crosstab.getCrosstabInfo().setShrinkValue(true)` right after the assembly is constructed, so freshly-created chat crosstabs default to Shrink to Fit = true.

## Scope / disclosed limitation
This fix only changes the moment a crosstab is first created. It does **not** touch `SyncCrosstabHandler.syncProperties()` (the other call site that sets shrink, via `targetInfo.setShrinkValue(sourceInfo.isShrink())` during later chat-driven modification turns). That means:
- A crosstab created **before** this fix (shrink=false) keeps shrink=false through subsequent chat-driven refinement, because sync intentionally preserves whatever the existing source assembly already has (it must not fight a user who deliberately turned Shrink to Fit back off).
- Only newly-created crosstabs (from the moment this fix ships) get the better default.

This is deliberate, not an oversight: `SyncCrosstabHandler` is shared infrastructure also used by the manual Composer sync feature, and touching it risks broader regressions for what is a P2 chat-only cosmetic default.

`WizVsService.createTableAssembly()` has the identical gap for plain (non-crosstab) tables. Out of scope here — UD-003 is crosstab-specific per the reporter — left as a candidate for a separate ticket.

## Test plan
- Added `WizVsServiceCreateCrosstabAssemblyShrinkTest` (`core/src/test/java/inetsoft/web/wiz/service/`), following the existing `WizVsServiceDuplicateAssemblyTest`/`WizAutoBindingServiceCrosstabPinsTest` convention (Spring test context, mocked collaborators, reflection to invoke the private `createCrosstabAssembly`). Asserts `((CrosstabVSAssemblyInfo) crosstab.getVSAssemblyInfo()).isShrink() == true`.
- Verified red -> green: test fails against the pre-fix code (`expected: <true> but was: <false>`), passes with the fix.
- `./mvnw -pl core test -Dtest=WizVsServiceCreateCrosstabAssemblyShrinkTest,WizAutoBindingServiceCrosstabPinsTest` — both pass (1/1 and 5/5), no regressions in the sibling crosstab-pins suite.

Redmine bug #76316, symptom UD-003.