### PR TITLE
feat(elastic): add Elasticsearch as tabular catalog connector; make dataset ids opaque

### DIFF
--- a/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticCatalog.java
+++ b/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticCatalog.java
@@ -25,6 +25,7 @@ import inetsoft.uql.tabular.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -203,6 +204,8 @@ final class ElasticCatalog {
          throw new Exception("Elasticsearch was asked to describe a blank dataset id.");
       }
 
+      validateIndexName(datasetId);
+
       Map<?, ?> byIndex = asMap(parse(ElasticRestRuntime.getMetadata(
          ds, "/" + datasetId + "/_mapping")));
 
@@ -263,6 +266,58 @@ final class ElasticCatalog {
       return new TabularDatasetSchema(datasetId, columns, List.of(), params, false,
          datasetDescription(ds, datasetId, mappings, columns, unaddressable, arrays,
                             unrecognizedTypes));
+   }
+
+   /**
+    * Rejects a {@code datasetId} that could not possibly be a real Elasticsearch index name,
+    * before it ever reaches {@link ElasticRestRuntime#getMetadata} or {@link #searchSuffix} and is
+    * embedded into a live URL.
+    *
+    * <p>{@code describeDataset} does not, and cannot, confirm {@code datasetId} came from this
+    * data source's own {@link #listDatasets} — {@code TabularCatalogService.describeTable} passes
+    * the caller-supplied target straight through, and {@code validateDatasetIdEchoed} only checks
+    * self-consistency AFTER the connector already ran. That gap is not this connector's to close:
+    * it is the same one {@code SharepointOnlineCatalog}'s own class javadoc argues at length is
+    * deliberately accepted SPI-wide, since anyone who can author a query can already point
+    * {@code runQuery} at any string through the connector's own unvalidated {@code setSuffix}. What
+    * IS this connector's to fix is narrower: a name reaching {@link ElasticRestRuntime#getMetadata}
+    * with a character its javadoc claims can't occur, embedded verbatim into a request URL.
+    *
+    * <p>The rejected characters and shapes below were checked against a live Elasticsearch 7.9.2,
+    * not assumed: {@code PUT /<name>} for each one, reading back the server's own
+    * {@code invalid_index_name_exception} message. A name containing a legal, non-leading
+    * {@code .} — {@code logs-2026.09.04}, this round's own G1 fixture — is deliberately NOT
+    * rejected here; only the exact strings {@code .}/{@code ..} and a leading {@code +} are.
+    *
+    * @throws Exception naming the offending id and which rule it broke.
+    */
+   private static void validateIndexName(String datasetId) throws Exception {
+      String reason = null;
+
+      if(datasetId.getBytes(StandardCharsets.UTF_8).length > 255) {
+         reason = "longer than 255 bytes";
+      }
+      else if(".".equals(datasetId) || "..".equals(datasetId)) {
+         reason = "must not be '.' or '..'";
+      }
+      else if(datasetId.startsWith("+")) {
+         reason = "must not start with '+'";
+      }
+      else {
+         for(int i = 0; i < datasetId.length(); i++) {
+            char c = datasetId.charAt(i);
+
+            if(FORBIDDEN_NAME_CHARS.indexOf(c) >= 0) {
+               reason = "must not contain '" + c + "'";
+               break;
+            }
+         }
+      }
+
+      if(reason != null) {
+         throw new Exception("Elasticsearch was asked to describe dataset id '" + datasetId +
+            "', which is not a legal Elasticsearch index name: " + reason + ".");
+      }
    }
 
    /**
@@ -577,6 +632,14 @@ final class ElasticCatalog {
 
    private static final String ALIAS = "alias";
    private static final String NESTED = "nested";
+
+   /**
+    * Every character Elasticsearch 7.9.2 refuses in an index name, measured with
+    * {@code PUT /<name>} against a live container: {@code \ / * ? " < > | , #} and a space. Used
+    * by {@link #validateIndexName} — kept as one literal string rather than a
+    * {@code Set<Character>} since every use is a single {@code indexOf} scan.
+    */
+   private static final String FORBIDDEN_NAME_CHARS = "\\/*?\"<>|,# ";
 
    /**
     * Sorted by index name so two calls against an unchanged cluster produce the same order —

--- a/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticCatalog.java
+++ b/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticCatalog.java
@@ -242,12 +242,23 @@ final class ElasticCatalog {
       List<String> unaddressable = new ArrayList<>();
       List<String> arrays = new ArrayList<>();
       List<String> unrecognizedTypes = new ArrayList<>();
-      collect(properties, null, columns, unaddressable, arrays, unrecognizedTypes);
+      List<String> aliases = new ArrayList<>();
+      collect(properties, null, columns, unaddressable, arrays, unrecognizedTypes, aliases);
 
       if(columns.isEmpty()) {
-         throw new Exception("Elasticsearch index '" + datasetId + "' declares " +
-            properties.size() + " field(s), but none of them can be addressed as a column: " +
-            String.join(", ", unaddressable) + ".");
+         // aliases is deliberately folded in HERE ONLY, not into unaddressable itself: unaddressable
+         // is also the roster written into the dataset description (see datasetDescription below),
+         // and an alias is absent from _source entirely -- it isn't data the description needs to
+         // explain away, it simply isn't part of the data (fieldAliasIsNotAColumn pins this). But an
+         // index whose fields are ALL aliases still needs an exception that explains itself, so this
+         // one-off list is exactly the fields responsible for columns being empty, matching the
+         // count in the sentence that quotes it -- properties.size() would only count top-level
+         // fields and undercount whenever a declared object is in the mix.
+         List<String> reasons = new ArrayList<>(unaddressable);
+         reasons.addAll(aliases);
+         throw new Exception("Elasticsearch index '" + datasetId + "' declares " + reasons.size() +
+            " field(s), but none of them can be addressed as a column: " +
+            String.join(", ", reasons) + ".");
       }
 
       // Fully filled, with no empty value. Once the index is known a runnable query is completely
@@ -326,10 +337,17 @@ final class ElasticCatalog {
     * for the kinds of field that deliberately do not become an ordinary column, or whose type this
     * connector does not recognize. Recurses into a declared object with dotted names, which is what
     * {@code JsonTable.walkRecord} produces for the same document.
+    *
+    * <p>{@code aliases} is tracked separately from {@code unaddressable} on purpose: an alias is
+    * absent from {@code _source} entirely, so unlike an object/geo/range field it is not data the
+    * dataset description needs to name as excluded (see {@code datasetDescription}, which is never
+    * given this list) — it exists only so {@code describeDataset}'s "none of them can be addressed"
+    * exception can still explain itself for an index whose fields are all aliases, instead of
+    * rendering an empty list.
     */
    private static void collect(Map<?, ?> properties, String prefix, List<TabularColumn> columns,
                                List<String> unaddressable, List<String> arrays,
-                               List<String> unrecognizedTypes)
+                               List<String> unrecognizedTypes, List<String> aliases)
    {
       for(Map.Entry<?, ?> entry : properties.entrySet()) {
          String name = prefix == null ? String.valueOf(entry.getKey())
@@ -347,6 +365,7 @@ final class ElasticCatalog {
          // .keyword subfield the 'fields' key holds, which is never read at all.
          if(ALIAS.equals(type)) {
             LOG.debug("Skipping Elasticsearch field alias {}", name);
+            aliases.add(name + " (alias)");
             continue;
          }
 
@@ -358,7 +377,7 @@ final class ElasticCatalog {
          }
 
          if(sub != null) {
-            collect(sub, name, columns, unaddressable, arrays, unrecognizedTypes);
+            collect(sub, name, columns, unaddressable, arrays, unrecognizedTypes, aliases);
             continue;
          }
 

--- a/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticCatalog.java
+++ b/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticCatalog.java
@@ -1,0 +1,606 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.elasticrest;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Assembles {@link ElasticRestRuntime}'s {@link TabularCatalogProvider} answers out of two of the
+ * cluster's own REST endpoints. Mirrors {@code SharepointOnlineCatalog}'s role: package-private,
+ * static methods, no state of its own.
+ *
+ * <h2>One data source is one whole cluster</h2>
+ *
+ * <p>{@link ElasticRestDataSource} carries only a URL and credentials — no index, no scope. So
+ * unlike a connector whose target is pinned on the data source, this catalog genuinely enumerates:
+ * {@link #listDatasets} reads {@code GET /_cat/indices} and each open index becomes one dataset.
+ *
+ * <p>No Elasticsearch client library is used, deliberately. The connector's whole dependency set is
+ * {@code json-path} plus {@code inetsoft-tabular-util}, and requests go out through a bare
+ * {@link java.net.HttpURLConnection}; that is what lets it work against any server version whose
+ * REST API matches, and adding a client to implement the catalog would pin it to one.
+ *
+ * <h2>Why the mapping is authoritative</h2>
+ *
+ * <p>{@code GET /{index}/_mapping} returns a schema the user DECLARED when the index was created,
+ * not a sample of rows, so {@code columnsMayBeIncomplete} stays false and the connector needs no
+ * curated type table for names it could not otherwise classify — the server states each field's
+ * type itself.
+ *
+ * <h2>No relationships</h2>
+ *
+ * <p>Elasticsearch declares no edges between indexes. Its one intra-document relation, the
+ * {@code join} field type, relates a parent and a child document inside a SINGLE index, which this
+ * SPI has no way to express and which is not an edge between two datasets. So
+ * {@link TabularCatalog#relationships()} is always empty — legal, and the javadoc there says so.
+ *
+ * <h2>Three rules decide what becomes a column</h2>
+ *
+ * <p>All three were measured against Elasticsearch 7.9.2, not reasoned about, and each is a case of
+ * the same principle: <b>a name that cannot address a real runtime column must not be reported as
+ * one, and must still be described.</b> {@code JsonTable.walkRecord}
+ * ({@code inetsoft-tabular-util}) recurses into a Map and names each leaf {@code prefix + "." +
+ * key}; a List is not a Map, so it falls to the literal branch and the whole array lands in one
+ * cell. That behaviour is what "addressable" means below.
+ *
+ * <ol>
+ * <li><b>A {@code text} field's {@code .keyword} subfield is not a column.</b> Multi-fields live
+ *     under a {@code fields} key and exist on the index side for sorting and aggregation; they are
+ *     not in {@code _source}, so {@code runQuery} never produces a column by that name. The
+ *     {@code fields} key is ignored outright.</li>
+ * <li><b>A {@code type: "alias"} field is not a column</b> — same reason, measured: a field alias
+ *     is resolved at query time and never appears in {@code _source}.</li>
+ * <li><b>A field whose {@code _source} value is a JSON object the mapping does not describe is not
+ *     a column</b> — see {@link #UNADDRESSABLE_TYPES}. Its runtime column names are its own
+ *     sub-keys, dotted, and the mapping does not declare them, so no name derived from the mapping
+ *     can reach it. These are named in the dataset description instead.</li>
+ * </ol>
+ *
+ * <p>A field the mapping declares with sub-{@code properties} — a plain object, which carries no
+ * {@code type} at all, or an explicit {@code "type": "object"} — IS addressable, because the mapping
+ * declares the leaf names {@code walkRecord} will produce. It is flattened with dots.
+ *
+ * <h2>Arrays are one column, and that is one decision with {@code expanded}</h2>
+ *
+ * <p>A {@code nested} field is an array in {@code _source}, so it is reported as ONE column holding
+ * the raw array, and {@link #describeDataset} declares {@code expanded=false} to match. The column
+ * list and the {@code expanded} value are a single decision: with {@code expanded=true} the runtime
+ * builds an {@code ExpandedJsonTable} instead, which produces {@code items.sku} / {@code items.qty}
+ * columns and changes the grain from one row per document to one row per (document x array
+ * element), duplicating every scalar field across those rows so that any total over them is
+ * silently multiplied. {@code ExpandedJsonTable.expandMap} additionally starts every array in a row
+ * at the same row index, so two arrays in one document line up positionally and invent a
+ * relationship that is not there. The substructure still reaches the reader, through the column's
+ * own description.
+ *
+ * <h2>The declared type is reported even where the runtime coarsens it</h2>
+ *
+ * <p>{@code JsonTable.getTypeClass} maps every JSON number to {@code Double.class}, so a field the
+ * mapping calls {@code long} arrives in a worksheet as a Double. The type reported here is still
+ * {@code long}: the field-level COMMON extension's {@code "type"} key is documented as "the column's
+ * declared type as the source reports it", and the source reports {@code long}. The coarsening
+ * changes nothing about dimension-versus-measure or about charts, and is not worked around — seeding
+ * per-column types would mean an extra request inside every {@code runQuery} plus parsing the index
+ * name back out of a free-form {@code suffix}.
+ *
+ * <h2>{@code isDimension} is null on every column</h2>
+ *
+ * <p>{@link TabularColumn#isDimension()} is three-valued and may only be set when the source itself
+ * sorts a column into one of two disjoint dimension/measure lists — never inferred from a type. An
+ * Elasticsearch mapping declares no such split, so null ("the source did not say") is the true
+ * answer for every column. {@code TabularCatalogService.toDataset} separately marks a date-typed
+ * column a dimension on wiz's behalf; that is the caller's inference, not a claim about the source.
+ *
+ * <h2>Index names contain dots, and {@link TabularDatasetRef} says ids must not</h2>
+ *
+ * <p>Reported verbatim anyway. The standard shipping-agent naming convention is
+ * {@code logs-<something>-YYYY.MM.dd}, so a dot in an index name is normal rather than exceptional,
+ * and it is not this connector's to rename: the id is echoed back to {@link #describeDataset} and
+ * embedded in the {@code suffix} the binding runs, so any rewriting here would produce a dataset
+ * that cannot be described or queried.
+ *
+ * <p>The observed consequence is confined to one misleading warning on the wiz side, and is
+ * recorded rather than worked around. wiz reduces a table name to its last dot-separated segment
+ * when checking whether two stored documents describe the same table
+ * ({@code bareTableName} in {@code wiz-services/src/v1/services/tabularBinding.ts}), so
+ * {@code logs-2026.09.04} and {@code metrics-2025.01.04} both reduce to {@code 04} and are reported
+ * as duplicates of each other. Nothing branches on that result — it only prepends a sentence to a
+ * table summary. Fixing it properly means letting a connector state whether its id is a qualified
+ * name or an opaque one, which is a change to the shared contract and to every site that splits on
+ * the dot; that is its own round.
+ */
+final class ElasticCatalog {
+   private ElasticCatalog() {
+   }
+
+   /**
+    * @param ds the cluster to enumerate.
+    * @return one dataset per open, non-internal index, in index-name order.
+    * @throws Exception if {@code _cat/indices} could not be read or did not answer with a JSON
+    *                   array. Never an empty catalog on failure — an empty result would be
+    *                   indistinguishable from a cluster that genuinely holds no indexes.
+    */
+   static TabularCatalog listDatasets(ElasticRestDataSource ds) throws Exception {
+      Object parsed = parse(ElasticRestRuntime.getMetadata(ds, CAT_INDICES));
+
+      if(!(parsed instanceof List<?> rows)) {
+         throw new Exception("Elasticsearch answered " + CAT_INDICES + " with " +
+                             describeJson(parsed) + " instead of a JSON array.");
+      }
+
+      List<TabularDatasetRef> datasets = new ArrayList<>();
+
+      for(Object row : rows) {
+         Map<?, ?> entry = asMap(row);
+
+         if(entry == null) {
+            throw new Exception("Elasticsearch answered " + CAT_INDICES +
+                                " with an array entry that is not a JSON object.");
+         }
+
+         String index = str(entry.get("index"));
+
+         if(index == null || index.isBlank()) {
+            throw new Exception("Elasticsearch answered " + CAT_INDICES +
+                                " with an entry carrying no index name.");
+         }
+
+         // The cluster's own bookkeeping indexes (.kibana_1, .security-7, ...). _cat/indices does
+         // return them -- measured -- and leaving them in would put internal bookkeeping into the
+         // annotation list alongside the user's own data.
+         if(index.startsWith(".")) {
+            LOG.debug("Skipping internal Elasticsearch index {}", index);
+            continue;
+         }
+
+         // A closed index still answers _mapping, but POST /{index}/_search answers HTTP 400 with
+         // an index_closed_exception -- measured. Emitting it would produce a dataset whose own
+         // params are guaranteed to fail, so it is dropped and named in the log instead.
+         if(!"open".equals(str(entry.get("status")))) {
+            LOG.warn("Skipping Elasticsearch index {}: status is '{}', not 'open', so it cannot " +
+                     "be queried.", index, str(entry.get("status")));
+            continue;
+         }
+
+         datasets.add(new TabularDatasetRef(index));
+      }
+
+      return new TabularCatalog(datasets, List.of());
+   }
+
+   /**
+    * @param datasetId a concrete index name, as {@link #listDatasets} returned it.
+    * @throws Exception if the index is unknown, resolves to more than one index, or declares no
+    *                   addressable fields.
+    */
+   static TabularDatasetSchema describeDataset(ElasticRestDataSource ds, String datasetId)
+      throws Exception
+   {
+      if(datasetId == null || datasetId.isBlank()) {
+         throw new Exception("Elasticsearch was asked to describe a blank dataset id.");
+      }
+
+      Map<?, ?> byIndex = asMap(parse(ElasticRestRuntime.getMetadata(
+         ds, "/" + datasetId + "/_mapping")));
+
+      if(byIndex == null || byIndex.isEmpty()) {
+         throw new Exception("Elasticsearch returned no mapping for '" + datasetId + "'.");
+      }
+
+      // A wildcard or a multi-index alias answers with one key per concrete index -- measured, an
+      // alias spanning two indexes comes back with both. Which one the caller meant is not
+      // knowable, and taking the first would silently describe the wrong index, so this fails with
+      // the names it did get.
+      if(byIndex.size() > 1) {
+         throw new Exception("Elasticsearch resolved '" + datasetId + "' to " + byIndex.size() +
+            " indexes (" + String.join(", ", byIndex.keySet().stream().map(String::valueOf)
+            .sorted().toList()) + "). describeDataset needs exactly one — pass a concrete index " +
+            "name rather than an alias or a wildcard.");
+      }
+
+      Map<?, ?> mappings = asMap(asMap(byIndex.values().iterator().next()).get("mappings"));
+
+      if(mappings == null) {
+         throw new Exception("Elasticsearch returned a mapping for '" + datasetId +
+                             "' with no 'mappings' block.");
+      }
+
+      Map<?, ?> properties = asMap(mappings.get("properties"));
+
+      if(properties == null || properties.isEmpty()) {
+         throw new Exception("Elasticsearch index '" + datasetId + "' declares no fields — an " +
+            "index with an empty mapping has nothing to annotate.");
+      }
+
+      List<TabularColumn> columns = new ArrayList<>();
+      List<String> unaddressable = new ArrayList<>();
+      List<String> arrays = new ArrayList<>();
+      List<String> unrecognizedTypes = new ArrayList<>();
+      collect(properties, null, columns, unaddressable, arrays, unrecognizedTypes);
+
+      if(columns.isEmpty()) {
+         throw new Exception("Elasticsearch index '" + datasetId + "' declares " +
+            properties.size() + " field(s), but none of them can be addressed as a column: " +
+            String.join(", ", unaddressable) + ".");
+      }
+
+      // Fully filled, with no empty value. Once the index is known a runnable query is completely
+      // determined, so there is nothing left for the caller to choose from the column list. wiz's
+      // buildMetadataTableBinding filters queryParams for empty values and, finding none, takes the
+      // branch that tells the caller queryParams is exactly this map -- emitting an empty value
+      // here would turn that into an instruction to fill something that does not exist.
+      Map<String, String> params = new LinkedHashMap<>();
+      params.put("suffix", searchSuffix(datasetId));
+      params.put("jsonPath", ROW_PATH);
+      params.put("expanded", "false");
+
+      // keyColumns empty: a document's _id is its key, and _id is not in _source, so it is not one
+      // of the columns above and cannot be named here. columnsMayBeIncomplete false: _mapping is
+      // the schema the index declares, not a bounded scan.
+      return new TabularDatasetSchema(datasetId, columns, List.of(), params, false,
+         datasetDescription(ds, datasetId, mappings, columns, unaddressable, arrays,
+                            unrecognizedTypes));
+   }
+
+   /**
+    * Walks one {@code properties} block, appending a column per addressable field and a
+    * {@code name (type)} entry to {@code unaddressable} / {@code arrays} / {@code unrecognizedTypes}
+    * for the kinds of field that deliberately do not become an ordinary column, or whose type this
+    * connector does not recognize. Recurses into a declared object with dotted names, which is what
+    * {@code JsonTable.walkRecord} produces for the same document.
+    */
+   private static void collect(Map<?, ?> properties, String prefix, List<TabularColumn> columns,
+                               List<String> unaddressable, List<String> arrays,
+                               List<String> unrecognizedTypes)
+   {
+      for(Map.Entry<?, ?> entry : properties.entrySet()) {
+         String name = prefix == null ? String.valueOf(entry.getKey())
+            : prefix + "." + entry.getKey();
+         Map<?, ?> node = asMap(entry.getValue());
+
+         if(node == null) {
+            continue;
+         }
+
+         String type = str(node.get("type"));
+         Map<?, ?> sub = asMap(node.get("properties"));
+
+         // Resolved at query time, never present in _source -- measured. Same standing as the
+         // .keyword subfield the 'fields' key holds, which is never read at all.
+         if(ALIAS.equals(type)) {
+            LOG.debug("Skipping Elasticsearch field alias {}", name);
+            continue;
+         }
+
+         if(NESTED.equals(type)) {
+            arrays.add(name);
+            columns.add(new TabularColumn(name, XSchema.STRING,
+                                          description(node, arrayNote(name, sub)), null, null));
+            continue;
+         }
+
+         if(sub != null) {
+            collect(sub, name, columns, unaddressable, arrays, unrecognizedTypes);
+            continue;
+         }
+
+         if(type == null || UNADDRESSABLE_TYPES.contains(type)) {
+            unaddressable.add(name + " (" + (type == null ? "object" : type) + ")");
+            continue;
+         }
+
+         String xtype = TYPES.get(type);
+
+         if(xtype == null) {
+            // Not fatal, and deliberately so: Elasticsearch adds mapping types between versions,
+            // and refusing to describe a whole index because one field uses a newer one would
+            // break this connector against every future server. It is made loud instead -- a
+            // warning in the log, and a sentence in the DATASET description (never the column's
+            // own), so it reaches both an operator reading logs and whoever reads the annotated
+            // table. It is kept off the column's own description on purpose: a field can carry
+            // both a genuine source-declared meta.description AND an unrecognized type at once,
+            // and appending connector text there would make TabularColumn.description stop being
+            // verbatim, the one column-level place this connector keeps free of ambiguity about
+            // source text versus connector text.
+            xtype = XSchema.STRING;
+            unrecognizedTypes.add(name + " (" + type + ")");
+            LOG.warn("Unrecognized Elasticsearch field type '{}' on field '{}'; reporting it as " +
+                     "{}.", type, name, XSchema.STRING);
+         }
+
+         columns.add(new TabularColumn(name, xtype, description(node, null), null, null));
+      }
+   }
+
+   /**
+    * The column's description: the {@code meta.description} the index itself declares, verbatim,
+    * when there is one, plus this connector's own structural note when there is one.
+    *
+    * <p>Elasticsearch's field-level {@code meta} parameter is a real source-declared channel — it
+    * round-trips through {@code _mapping} unchanged, measured — and {@link TabularColumn#description()}
+    * asks for exactly that: the source's own words. Only {@code description} is read from it, since
+    * that is the one key with a counterpart in this SPI.
+    *
+    * <p>The connector's own note is appended rather than substituted, and it never invents what a
+    * field MEANS. It states only facts this connector knows for certain about its own reporting —
+    * that an array is returned as a single value, or that a type name was not recognized — the same
+    * boundary {@code FBAdInsightsCatalog}'s dataset description holds to.
+    */
+   private static String description(Map<?, ?> node, String connectorNote) {
+      Map<?, ?> meta = asMap(node.get("meta"));
+      String declared = meta == null ? null : str(meta.get("description"));
+
+      if(declared != null && declared.isBlank()) {
+         declared = null;
+      }
+
+      if(declared == null) {
+         return connectorNote;
+      }
+
+      return connectorNote == null ? declared : declared + " " + connectorNote;
+   }
+
+   private static String arrayNote(String name, Map<?, ?> sub) {
+      StringBuilder note = new StringBuilder("Elasticsearch 'nested' field, returned as one raw " +
+                                             "JSON array value in a single cell per document");
+
+      if(sub != null && !sub.isEmpty()) {
+         List<String> elements = new ArrayList<>();
+
+         for(Map.Entry<?, ?> entry : sub.entrySet()) {
+            Map<?, ?> child = asMap(entry.getValue());
+            String childType = child == null ? null : str(child.get("type"));
+            elements.add(entry.getKey() + " (" +
+                         (childType == null ? "object" : childType) + ")");
+         }
+
+         note.append("; each element has ").append(String.join(", ", elements));
+      }
+
+      note.append(". It is one column because this dataset's binding sets expanded=false; turning " +
+                  "array expansion on would flatten it into ").append(name)
+         .append(".<sub-field> columns and change the grain from one row per document to one row " +
+                 "per (document x array element), duplicating every other column's value across " +
+                 "those rows so that any total over them is multiplied.");
+      return note.toString();
+   }
+
+   /**
+    * The dataset-level description, which reaches wiz's annotation LLM as durable table context —
+    * {@code applyAnnotationToDoc} never overwrites it.
+    *
+    * <p>Opens with the index's own mapping-level {@code _meta.description} when it declares one,
+    * verbatim. Everything after it is this connector's own, and is confined to facts about the
+    * shape of what it reports: the row grain, the document count, the fields deliberately left out
+    * of the column list and why, and the page size the binding requests. It never describes what
+    * the data means — that is the annotation model's job and the source did not say.
+    */
+   private static String datasetDescription(ElasticRestDataSource ds, String datasetId,
+                                            Map<?, ?> mappings, List<TabularColumn> columns,
+                                            List<String> unaddressable, List<String> arrays,
+                                            List<String> unrecognizedTypes)
+   {
+      StringBuilder text = new StringBuilder();
+      Map<?, ?> meta = asMap(mappings.get("_meta"));
+      String declared = meta == null ? null : str(meta.get("description"));
+
+      if(declared != null && !declared.isBlank()) {
+         text.append(declared).append("\n\n");
+      }
+
+      text.append("Elasticsearch index '").append(datasetId).append("'");
+
+      Long count = documentCount(ds, datasetId);
+
+      if(count != null) {
+         text.append(" (").append(count).append(" documents)");
+      }
+
+      text.append(". One row per document, ").append(columns.size())
+         .append(" columns read from the index's own _mapping — the schema declared when the ")
+         .append("index was created, not a sample, so the column list is complete for the fields ")
+         .append("the mapping declares. Any field may hold an array in an individual document; ")
+         .append("Elasticsearch does not declare which do, and such a value arrives as one raw ")
+         .append("JSON array in its cell.");
+
+      if(!arrays.isEmpty()) {
+         text.append("\n\nDeclared array field(s) returned as a single raw JSON value: ")
+            .append(String.join(", ", arrays))
+            .append(". Each one's element structure is in that column's own description.");
+      }
+
+      if(!unaddressable.isEmpty()) {
+         text.append("\n\nThe mapping also declares ").append(unaddressable.size())
+            .append(" field(s) that are deliberately NOT columns: ")
+            .append(String.join(", ", unaddressable))
+            .append(". Each holds a JSON object in _source whose sub-keys the mapping does not ")
+            .append("declare, so the runtime splits it into dotted leaf columns (a geo_point ")
+            .append("written as an object becomes <field>.lat and <field>.lon; a range becomes ")
+            .append("<field>.gte and <field>.lte) — and which of the several accepted input forms ")
+            .append("a document used is a property of that document, not of the mapping. No ")
+            .append("single column name derived from the mapping can address them, so they are ")
+            .append("named here instead of reported as columns that would not exist.");
+      }
+
+      if(!unrecognizedTypes.isEmpty()) {
+         text.append("\n\nThis connector does not recognize the Elasticsearch mapping type ")
+            .append("declared for ").append(unrecognizedTypes.size()).append(" field(s), so ")
+            .append("each is reported as a string rather than its declared type: ")
+            .append(String.join(", ", unrecognizedTypes))
+            .append(". This is recorded here rather than on the field's own column, so it never ")
+            .append("collides with a verbatim source-declared description on the same field.");
+      }
+
+      text.append("\n\nThe binding reads this index with POST ").append(searchSuffix(datasetId))
+         .append(" and takes rows from ").append(ROW_PATH).append(". The size= is required: ")
+         .append("Elasticsearch returns 10 hits when a search does not ask for more, and nothing ")
+         .append("in this connector raises that — TabularQuery's own max-rows setting caps the ")
+         .append("table after the fact and is never sent to the server. ").append(SEARCH_SIZE)
+         .append(" is the server's own default index.max_result_window, the largest a from+size ")
+         .append("search can return at all; a larger value is rejected outright. Lower it in the ")
+         .append("query's URL Suffix to read fewer rows, and use the Filter body to select rows ")
+         .append("rather than raising it.");
+
+      return text.toString();
+   }
+
+   /**
+    * The index's searchable document count, or null if it could not be read.
+    *
+    * <p>Deliberately {@code _count} rather than the {@code docs.count} column {@code _cat/indices}
+    * already carries. {@code docs.count} counts Lucene documents, which includes every {@code
+    * nested} sub-document: measured on an index holding one document with a two-element nested
+    * array, {@code docs.count} reports 3 and {@code _count} reports 1. Only the second is the
+    * number of rows a query returns, and this text is read by a model that will reason about row
+    * counts.
+    *
+    * <p>A failure here degrades to omitting the sentence rather than failing the whole call — the
+    * column list is the substance of a schema, and losing it over a count would be the worse
+    * trade.
+    */
+   private static Long documentCount(ElasticRestDataSource ds, String datasetId) {
+      try {
+         Object number = asMap(parse(ElasticRestRuntime.getMetadata(
+            ds, "/" + datasetId + "/_count"))).get("count");
+         return number instanceof Number n ? n.longValue() : null;
+      }
+      catch(Exception ex) {
+         LOG.warn("Could not read the document count for Elasticsearch index {}", datasetId, ex);
+         return null;
+      }
+   }
+
+   private static String searchSuffix(String datasetId) {
+      return "/" + datasetId + "/_search?size=" + SEARCH_SIZE;
+   }
+
+   private static Object parse(String json) {
+      return JsonPath.using(PARSE_CONFIG).parse(json).json();
+   }
+
+   private static Map<?, ?> asMap(Object value) {
+      return value instanceof Map<?, ?> map ? map : null;
+   }
+
+   private static String str(Object value) {
+      return value == null ? null : String.valueOf(value);
+   }
+
+   private static String describeJson(Object value) {
+      return value == null ? "null" : value.getClass().getSimpleName();
+   }
+
+   /**
+    * Elasticsearch mapping type to {@link XSchema} constant, for the fields that become columns.
+    *
+    * <p>Every entry was checked against a live Elasticsearch 7.9.2 or is named in this SPI round's
+    * own specification. A type absent from here is NOT silently a string: {@link #collect} reports
+    * it as one but warns, so a server version that introduces a type reaches a human.
+    */
+   private static final Map<String, String> TYPES = Map.ofEntries(
+      Map.entry("text", XSchema.STRING),
+      Map.entry("keyword", XSchema.STRING),
+      Map.entry("constant_keyword", XSchema.STRING),
+      Map.entry("wildcard", XSchema.STRING),
+      Map.entry("search_as_you_type", XSchema.STRING),
+      Map.entry("ip", XSchema.STRING),
+      // _source always carries the base64 string the document was indexed with -- the only form
+      // Elasticsearch accepts for a binary field -- so unlike the geo types below this one has a
+      // single, predictable representation. Measured.
+      Map.entry("binary", XSchema.STRING),
+      Map.entry("long", XSchema.LONG),
+      Map.entry("integer", XSchema.INTEGER),
+      Map.entry("short", XSchema.SHORT),
+      Map.entry("byte", XSchema.BYTE),
+      Map.entry("double", XSchema.DOUBLE),
+      Map.entry("scaled_float", XSchema.DOUBLE),
+      // A plain JSON number in _source -- measured. Its plural, rank_features, is a map and is in
+      // UNADDRESSABLE_TYPES instead.
+      Map.entry("rank_feature", XSchema.DOUBLE),
+      Map.entry("float", XSchema.FLOAT),
+      Map.entry("half_float", XSchema.FLOAT),
+      Map.entry("boolean", XSchema.BOOLEAN),
+      Map.entry("date", XSchema.TIME_INSTANT),
+      Map.entry("date_nanos", XSchema.TIME_INSTANT));
+
+   /**
+    * Mapping types whose {@code _source} value is a JSON object whose sub-keys the mapping does not
+    * declare. A field of one of these types is described, never reported as a column — see this
+    * class's javadoc for the rule and the dataset description for where they surface.
+    *
+    * <p>{@code geo_point} is the clearest case and was measured both ways: written as
+    * {@code {"lat":42.35,"lon":-71.05}} it becomes two runtime columns {@code <field>.lat} and
+    * {@code <field>.lon}, and written as {@code "42.35,-71.05"} it becomes one column
+    * {@code <field>}. Elasticsearch accepts both, plus a geohash string and a {@code [lon, lat]}
+    * array, and {@code _source} preserves whichever the document used. The mapping says only
+    * {@code geo_point}, so the runtime column shape is a property of each document rather than of
+    * the schema, and no name taken from the mapping addresses it reliably. {@code geo_shape},
+    * {@code point} and {@code shape} carry the same object-or-WKT-string choice; {@code flattened},
+    * {@code histogram}, the {@code *_range} family, {@code percolator} and {@code rank_features}
+    * are always objects; {@code join} is a string or an object depending on whether the document is
+    * a parent or a child; and {@code completion} is a string or an
+    * {@code {"input": [...], "weight": n}} object.
+    *
+    * <p>{@code object} is here for the case where a mapping declares the type but no
+    * sub-{@code properties} — an object with {@code enabled: false}, say. An object that DOES
+    * declare its properties never reaches this set: {@link #collect} recurses into it, because
+    * there the mapping does name the leaves the runtime will produce.
+    */
+   private static final Set<String> UNADDRESSABLE_TYPES = Set.of(
+      "object", "geo_point", "geo_shape", "point", "shape", "flattened", "histogram",
+      "percolator", "join", "completion", "rank_features",
+      "integer_range", "long_range", "float_range", "double_range", "date_range", "ip_range");
+
+   private static final String ALIAS = "alias";
+   private static final String NESTED = "nested";
+
+   /**
+    * Sorted by index name so two calls against an unchanged cluster produce the same order —
+    * {@code _cat/indices} follows cluster-state iteration otherwise, which is not stable. Only the
+    * two columns this class reads are requested.
+    */
+   private static final String CAT_INDICES = "/_cat/indices?format=json&h=index,status&s=index";
+
+   /**
+    * The page size the binding's search asks for. Not arbitrary: it is Elasticsearch's own default
+    * {@code index.max_result_window}, so it is the largest a {@code from}+{@code size} search can
+    * return — 10001 is rejected with an illegal_argument_exception. Measured.
+    */
+   private static final int SEARCH_SIZE = 10000;
+
+   private static final String ROW_PATH = "$.hits.hits[*]._source";
+
+   /**
+    * The same provider {@link ElasticRestRuntime} already parses query results with, so the catalog
+    * adds no dependency of its own. It yields {@code LinkedHashMap}s, which is what preserves the
+    * server's own field order through {@link #collect}.
+    */
+   private static final Configuration PARSE_CONFIG =
+      Configuration.builder().jsonProvider(new JacksonJsonProvider()).build();
+
+   private static final Logger LOG = LoggerFactory.getLogger(ElasticCatalog.class.getName());
+}

--- a/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticRestRuntime.java
+++ b/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticRestRuntime.java
@@ -156,9 +156,18 @@ public class ElasticRestRuntime extends TabularRuntime implements TabularCatalog
     * Elasticsearch explains itself well in that body (an unknown index answers 404 with an
     * {@code index_not_found_exception}) and the SPI's callers surface the message to a user.
     *
-    * @param path already-encoded, and prefixed with {@code /}. Index names are safe to embed
-    *             directly: Elasticsearch forbids a space and {@code \/*?"<>|,#} in an index name,
-    *             so nothing reaching here needs percent-encoding beyond what {@link #joinURL} does.
+    * @param path already-encoded, and prefixed with {@code /}. This method does not itself
+    *             validate an index name embedded in {@code path} — it trusts the caller. For
+    *             {@link ElasticCatalog}, that trust is warranted only because
+    *             {@link ElasticCatalog#validateIndexName} rejects a {@code datasetId} containing a
+    *             character Elasticsearch itself forbids (space, {@code \/*?"<>|,#}), or shaped
+    *             like {@code .}/{@code ..}/a leading {@code +}, before ever building a path from
+    *             it. That check cannot and does not confirm the id came from this data source's
+    *             own {@code listDatasets} — the SPI does not let a connector verify that, and
+    *             {@code SharepointOnlineCatalog}'s class javadoc argues at length why that gap is
+    *             accepted SPI-wide rather than fixed per-connector. Percent-encoding beyond what
+    *             {@link #joinURL} already does is unnecessary only because of the character
+    *             restriction above, not because of anything about the caller.
     */
    static String getMetadata(ElasticRestDataSource ds, String path) throws Exception {
       String urlString = joinURL(ds.getURL(), path);

--- a/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticRestRuntime.java
+++ b/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticRestRuntime.java
@@ -36,7 +36,19 @@ import java.io.OutputStreamWriter;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 
-public class ElasticRestRuntime extends TabularRuntime {
+public class ElasticRestRuntime extends TabularRuntime implements TabularCatalogProvider {
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      return ElasticCatalog.listDatasets((ElasticRestDataSource) dataSource);
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      return ElasticCatalog.describeDataset((ElasticRestDataSource) dataSource, datasetId);
+   }
+
    public XTableNode runQuery(TabularQuery query0, VariableTable params) {
       ElasticRestQuery query = (ElasticRestQuery) query0;
       boolean expanded = query.isExpanded();
@@ -115,13 +127,70 @@ public class ElasticRestRuntime extends TabularRuntime {
       }
    }
 
-   private URLConnection getConnection(ElasticRestQuery query) throws Exception {
-      ElasticRestDataSource ds = (ElasticRestDataSource) query.getDataSource();
+   /**
+    * Reads one of the cluster's metadata endpoints with a GET and returns the response body.
+    *
+    * <p><b>This exists because {@link #getConnection} cannot be reused for a metadata read, and it
+    * must not be "simplified" back into it.</b> {@code getConnection} calls
+    * {@code conn.setDoOutput(true)} unconditionally, which makes {@link HttpURLConnection} issue a
+    * POST, and it writes {@code query.getFilter()} as the request body. {@code _search} accepts
+    * POST, so {@code runQuery} is unaffected — but neither endpoint {@link ElasticCatalog} reads
+    * does. Measured against Elasticsearch 7.9.2:
+    *
+    * <ul>
+    * <li>{@code POST /_cat/indices} answers HTTP 405. It is a GET-only endpoint.</li>
+    * <li>{@code POST /{index}/_mapping} with no body answers HTTP 400 — and <b>with</b> a body it
+    *     is not a read at all: it is the mapping-UPDATE API, answers 200, and adds the fields the
+    *     body names to the live index. A mapping addition cannot be undone without reindexing.
+    *     So routing a catalog read through {@code getConnection} would not merely fail; given a
+    *     query carrying a filter it would write to the user's index, which
+    *     {@link TabularCatalogProvider} forbids in as many words ("must not mutate the passed data
+    *     source beyond what a normal connection already does").</li>
+    * </ul>
+    *
+    * <p>Only the basic-auth header and the URL joining are shared, through {@link #applyBasicAuth}
+    * and {@link #joinURL}.
+    *
+    * <p>A non-2xx response is turned into an exception carrying the status and the server's own
+    * error body, rather than the bare {@code IOException} {@code getInputStream} throws on its own —
+    * Elasticsearch explains itself well in that body (an unknown index answers 404 with an
+    * {@code index_not_found_exception}) and the SPI's callers surface the message to a user.
+    *
+    * @param path already-encoded, and prefixed with {@code /}. Index names are safe to embed
+    *             directly: Elasticsearch forbids a space and {@code \/*?"<>|,#} in an index name,
+    *             so nothing reaching here needs percent-encoding beyond what {@link #joinURL} does.
+    */
+   static String getMetadata(ElasticRestDataSource ds, String path) throws Exception {
+      String urlString = joinURL(ds.getURL(), path);
+      HttpURLConnection conn = (HttpURLConnection) new URL(urlString).openConnection();
+      conn.setRequestMethod("GET");
+      conn.setRequestProperty("Accept", "application/json");
+      applyBasicAuth(conn, ds);
+
+      int status = conn.getResponseCode();
+
+      if(status < 200 || status >= 300) {
+         String body;
+
+         try(InputStream error = conn.getErrorStream()) {
+            body = error == null ? "" : IOUtils.toString(error, StandardCharsets.UTF_8);
+         }
+         catch(Exception ignore) {
+            body = "";
+         }
+
+         throw new Exception("Elasticsearch answered HTTP " + status + " for " + urlString +
+                             (body.isEmpty() ? "" : ": " + body));
+      }
+
+      try(InputStream input = conn.getInputStream()) {
+         return IOUtils.toString(input, StandardCharsets.UTF_8);
+      }
+   }
+
+   private static void applyBasicAuth(URLConnection conn, ElasticRestDataSource ds) {
       String user = ds.getUser();
       String password = ds.getPassword();
-
-      URL url = new URL(createURL(query));
-      URLConnection conn = url.openConnection();
 
       if(user != null && password != null) {
          String credential = new String(
@@ -129,6 +198,15 @@ public class ElasticRestRuntime extends TabularRuntime {
             StandardCharsets.US_ASCII);
          conn.setRequestProperty("Authorization", "Basic " + credential);
       }
+   }
+
+   private URLConnection getConnection(ElasticRestQuery query) throws Exception {
+      ElasticRestDataSource ds = (ElasticRestDataSource) query.getDataSource();
+
+      URL url = new URL(createURL(query));
+      URLConnection conn = url.openConnection();
+
+      applyBasicAuth(conn, ds);
 
       conn.setDoOutput(true);
 
@@ -146,9 +224,15 @@ public class ElasticRestRuntime extends TabularRuntime {
 
    private String createURL(ElasticRestQuery query) {
       ElasticRestDataSource ds = (ElasticRestDataSource) query.getDataSource();
-      String url = ds.getURL();
-      String suffix = query.getSuffix();
+      return joinURL(ds.getURL(), query.getSuffix());
+   }
 
+   /**
+    * Appends a suffix to the data source URL without doubling or dropping the separating slash.
+    * Extracted from {@link #createURL} so {@link #getMetadata} joins its paths the same way a query
+    * does, rather than growing a second, subtly different copy of this rule.
+    */
+   private static String joinURL(String url, String suffix) {
       if(suffix != null) {
           if(url.endsWith("/") && suffix.startsWith("/")) {
              url += suffix.substring(1);

--- a/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticCatalogTests.java
+++ b/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticCatalogTests.java
@@ -159,6 +159,21 @@ class ElasticCatalogTests {
       // rejects a dotted TabularDatasetRef.id.
       request("POST", "/logs-2026.09.04/_doc?refresh=true", """
          {"level": "INFO", "message": "service started"}""");
+
+      // CI review round 1 on #5041: describeDataset's "none of them can be addressed as a
+      // column" exception must still explain itself when a field alias is part of why. An alias
+      // can only ever point at a REAL, already-declared, non-alias field (Elasticsearch itself
+      // refuses a path to a nonexistent field or to another alias -- checked directly against
+      // this same 7.9.2 image before writing this fixture), so the minimal index that reproduces
+      // "columns ends up empty AND an alias is one of the reasons" needs one backing field whose
+      // own type is separately unaddressable (geo_point), plus alias(es) pointing to it. Two
+      // aliases, not one, so the fix is checked against more than a single-element list.
+      request("PUT", "/alias-only", """
+         {"mappings": {"properties": {
+            "loc":  {"type": "geo_point"},
+            "ref1": {"type": "alias", "path": "loc"},
+            "ref2": {"type": "alias", "path": "loc"}
+         }}}""");
    }
 
    @AfterAll
@@ -178,7 +193,7 @@ class ElasticCatalogTests {
       TabularCatalog catalog = runtime.listDatasets(dataSource);
       List<String> ids = catalog.datasets().stream().map(TabularDatasetRef::id).toList();
 
-      assertEquals(List.of("earthquakes", "logs-2026.09.04", "orders"), ids,
+      assertEquals(List.of("alias-only", "earthquakes", "logs-2026.09.04", "orders"), ids,
                    "only the open, non-internal indexes, sorted by name -- including the dotted, " +
                    "ILM-style index name (G1)");
       // The cluster's own bookkeeping indexes must not reach the annotation list, and a closed
@@ -447,6 +462,25 @@ class ElasticCatalogTests {
       // that rejected one here would be a silent regression of that, not a safety fix. A non-
       // leading, non-".."/"." dot must sail through untouched.
       assertDoesNotThrow(() -> runtime.describeDataset(dataSource, "logs-2026.09.04"));
+   }
+
+   @Test
+   void noAddressableColumnsExceptionNamesTheAliasesTooNotJustTheBackingField() throws Exception {
+      // CI review round 1 on #5041: before this fix, a field alias was skipped with only a debug
+      // log line, never recorded anywhere -- so this exception's "none of them can be addressed"
+      // explanation named the geo_point backing field but silently dropped both aliases that are
+      // equally a reason columns ended up empty, and its "N field(s)" count came from
+      // properties.size() (3 here) rather than from what the sentence actually lists.
+      Exception thrown = assertThrows(Exception.class,
+         () -> runtime.describeDataset(dataSource, "alias-only"));
+
+      assertTrue(thrown.getMessage().contains("loc (geo_point)"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("ref1 (alias)") &&
+                 thrown.getMessage().contains("ref2 (alias)"),
+                 "both aliases must be named, not just the backing field: " + thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("declares 3 field(s)"),
+                 "the count must match the 3 fields actually listed as the reason, not silently " +
+                 "undercount or overcount: " + thrown.getMessage());
    }
 
    @Test

--- a/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticCatalogTests.java
+++ b/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticCatalogTests.java
@@ -1,0 +1,643 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.elasticrest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.PropertiesEngine;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.XTableNode;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import inetsoft.uql.util.Config;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.credential.*;
+import inetsoft.util.swap.XSwapper;
+import inetsoft.web.wiz.service.TabularQueryContractSupport;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.LineIterator;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.context.ApplicationContext;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ElasticCatalog} against a real Elasticsearch, which is the reason this connector was
+ * chosen for the SPI round: every other implementer's tests can only check the shape of what the
+ * connector builds, and these can check it against what the server actually says and what
+ * {@code runQuery} actually returns.
+ *
+ * <p><b>Why a system property and not {@code @Disabled}.</b> These need a Docker daemon, so they
+ * must not run in a build that has none — which is why {@code ElasticRestRuntimeTests} beside them
+ * was written {@code @Disabled}. The cost of {@code @Disabled} is that the only way to run them at
+ * all is to edit the source first, so they rot unnoticed. A condition costs nothing extra to skip
+ * and leaves them runnable as they stand:
+ *
+ * <pre>./mvnw -pl connectors/inetsoft-elastic -am -Delastic.tests=true test</pre>
+ *
+ * <p>{@code @Tag("integration")} would NOT achieve this, though it looks like it should: this
+ * module's surefire configuration writes {@code <excludedGroups>integration,slow</excludedGroups>}
+ * into the POM, and POM configuration wins over the matching command-line property, so a tagged
+ * test cannot be re-enabled without editing the POM.
+ *
+ * <p>Every fact these tests pin was measured against Elasticsearch 7.9.2 while the catalog was
+ * written, rather than assumed from the mapping documentation.
+ */
+@Testcontainers
+@EnabledIfSystemProperty(named = "elastic.tests", matches = "true")
+class ElasticCatalogTests {
+   @Container
+   static final ElasticsearchContainer container =
+      new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.9.2");
+
+   private ElasticRestRuntime runtime = null;
+   private ElasticRestDataSource dataSource = null;
+
+   @BeforeAll
+   static void loadData() throws Exception {
+      CredentialService credentialService = mock(CredentialService.class);
+      when(credentialService.createCredential(CredentialType.PASSWORD))
+         .thenReturn(mock(LocalPasswordCredential.class));
+      when(credentialService.createCredential(CredentialType.PASSWORD, false))
+         .thenReturn(mock(LocalPasswordCredential.class));
+      ApplicationContext context = mock(ApplicationContext.class);
+      when(context.getBean(CredentialService.class)).thenReturn(credentialService);
+      // TabularSchemaExtractor, which runBinding uses to build the query schema the way
+      // WorksheetTableService does, reaches Config for a display-label resource bundle. A mock
+      // returns null for it, which is the branch that leaves the label alone.
+      when(context.getBean(Config.class)).thenReturn(mock(Config.class));
+      // runQuery (through XQuery.getMaxRows) reaches StyleFont.getDefaultFontFamily, which reads
+      // SreeEnv.getProperty -> PropertiesEngine.getInstance -> ConfigurationContext.getSpringBean.
+      // With no stub, the mocked ApplicationContext answers getBean(PropertiesEngine.class) with
+      // null, and ConfigurationContext's Caffeine bean cache rejects a null value outright --
+      // NullPointerException out of a static initializer, which permanently breaks
+      // inetsoft.report.internal.Util for the rest of the JVM (NoClassDefFoundError on every
+      // later reference). Stubbing getProperty to answer with its own "def" argument reproduces
+      // what a real PropertiesEngine holding no stored properties would do.
+      PropertiesEngine propertiesEngine = mock(PropertiesEngine.class);
+      when(propertiesEngine.getProperty(anyString(), anyString(), anyBoolean()))
+         .thenAnswer(invocation -> invocation.getArgument(1));
+      when(context.getBean(PropertiesEngine.class)).thenReturn(propertiesEngine);
+      // JsonTable.loadStreamed (runQuery's row loader) reaches XSwappableObjectList.add, which
+      // calls XSwapper.getSwapper() -- the same getSpringBean/Caffeine trap as PropertiesEngine
+      // above, one bean further down the same call path.
+      when(context.getBean(XSwapper.class)).thenReturn(mock(XSwapper.class));
+      ConfigurationContext.getContext().setApplicationContext(context);
+
+      loadEarthquakes();
+
+      // Every field shape the catalog has a rule for, in one index: a declared object (flattened
+      // with dots), a nested array (one column), a field alias and a geo_point (neither a column),
+      // a binary (a column), and a field carrying a source-declared meta.description.
+      request("PUT", "/orders", """
+         {"mappings": {
+            "_meta": {"description": "Customer orders, one document per placed order."},
+            "properties": {
+              "orderId":  {"type": "keyword"},
+              "orderRef": {"type": "alias", "path": "orderId"},
+              "placedAt": {"type": "date"},
+              "total":    {"type": "scaled_float", "scaling_factor": 100,
+                           "meta": {"description": "Order total in USD."}},
+              "shipTo":   {"properties": {"city": {"type": "keyword"},
+                                          "zip":  {"type": "keyword"},
+                                          "geo":  {"type": "geo_point"}}},
+              "items":    {"type": "nested", "properties": {"sku":   {"type": "keyword"},
+                                                            "qty":   {"type": "integer"},
+                                                            "price": {"type": "double"}}},
+              "region":   {"type": "geo_shape"},
+              "blob":     {"type": "binary"},
+              "active":   {"type": "boolean"},
+              "wordCount": {"type": "token_count", "analyzer": "standard"}
+            }}}""");
+      request("POST", "/orders/_doc?refresh=true", """
+         {"orderId": "A-1", "placedAt": "2026-03-04T10:00:00Z", "total": 123.45,
+          "shipTo": {"city": "Boston", "zip": "02110", "geo": {"lat": 42.35, "lon": -71.05}},
+          "items": [{"sku": "X1", "qty": 2, "price": 10.5},
+                    {"sku": "X2", "qty": 1, "price": 102.45}],
+          "blob": "U29tZSBieXRlcw==", "active": true,
+          "wordCount": "four little words here"}""");
+
+      request("PUT", "/.internal-probe", null);
+      request("PUT", "/parked", null);
+      request("POST", "/parked/_close", null);
+      request("POST", "/_aliases", """
+         {"actions": [{"add": {"index": "orders", "alias": "all-data"}},
+                      {"add": {"index": "earthquakes", "alias": "all-data"}}]}""");
+
+      // G1: an ILM/rollover-style index name -- Elastic's own documented convention -- must
+      // enumerate and describe like any other index now that TabularCatalogService no longer
+      // rejects a dotted TabularDatasetRef.id.
+      request("POST", "/logs-2026.09.04/_doc?refresh=true", """
+         {"level": "INFO", "message": "service started"}""");
+   }
+
+   @AfterAll
+   static void resetContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+   }
+
+   @BeforeEach
+   void createDataSource() {
+      runtime = new ElasticRestRuntime();
+      dataSource = new ElasticRestDataSource();
+      dataSource.setURL(getUrl());
+   }
+
+   @Test
+   void listDatasetsReturnsOpenUserIndexesInNameOrder() throws Exception {
+      TabularCatalog catalog = runtime.listDatasets(dataSource);
+      List<String> ids = catalog.datasets().stream().map(TabularDatasetRef::id).toList();
+
+      assertEquals(List.of("earthquakes", "logs-2026.09.04", "orders"), ids,
+                   "only the open, non-internal indexes, sorted by name -- including the dotted, " +
+                   "ILM-style index name (G1)");
+      // The cluster's own bookkeeping indexes must not reach the annotation list, and a closed
+      // index must not either -- POST /parked/_search answers 400 index_closed_exception, so
+      // emitting it would produce a dataset whose own params can never run.
+      assertFalse(ids.stream().anyMatch(id -> id.startsWith(".")),
+                  "no internal index should be reported: " + ids);
+      assertFalse(ids.contains("parked"), "a closed index should not be reported");
+      // Elasticsearch declares no edges between indexes.
+      assertEquals(List.of(), catalog.relationships());
+   }
+
+   @Test
+   void listDatasetsIsNotConfusedByAnAlias() throws Exception {
+      // 'all-data' spans two indexes but is not an index, so _cat/indices never mentions it.
+      assertFalse(runtime.listDatasets(dataSource).datasets().stream()
+                     .anyMatch(d -> "all-data".equals(d.id())),
+                  "an alias is not a dataset");
+   }
+
+   @Test
+   void earthquakeColumnsAndTypesComeFromTheServersOwnMapping() throws Exception {
+      Map<String, String> declared = serverFieldTypes("earthquakes");
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "earthquakes");
+
+      assertEquals("earthquakes", schema.datasetId(), "describeDataset must echo the id it was given");
+      assertFalse(schema.columnsMayBeIncomplete(),
+                  "_mapping is a declared schema, not a bounded scan");
+      assertEquals(List.of(), schema.keyColumns(), "_id is not in _source, so there is no key column");
+
+      // The column list, and its ORDER, is whatever the mapping response carried -- asserted
+      // against that response rather than against a list written here. Note this is NOT the order
+      // runQuery produces: _mapping returns its properties sorted by field name, while a row's
+      // columns follow _source's own field order. Both are correct; they are different questions.
+      assertEquals(new ArrayList<>(declared.keySet()),
+                   schema.columns().stream().map(TabularColumn::name).toList());
+
+      // ... and the same 12 fields the runtime test asserts runQuery produces, as a set.
+      assertEquals(Set.of("@timestamp", "latitude", "longitude", "depth", "magnitude", "magType",
+                          "nbStations", "gap", "distance", "rms", "source", "eventId"),
+                   new HashSet<>(declared.keySet()));
+
+      for(TabularColumn column : schema.columns()) {
+         String esType = declared.get(column.name());
+         assertEquals(EXPECTED_XSCHEMA.get(esType), column.type(),
+                      "column '" + column.name() + "', which the server types '" + esType + "'");
+         assertNull(column.isDimension(),
+                    "an Elasticsearch mapping declares no dimension/measure split, so '" +
+                    column.name() + "' must say nothing rather than guess");
+      }
+   }
+
+   @Test
+   void timestampIsMappedAsTextNotDate() throws Exception {
+      // Measured, not assumed. The fixture's timestamps read 2016/01/04T21:18:48.64Z -- slashes
+      // with a T separator -- which the server's default date detection does not recognize, so
+      // dynamic mapping makes the field text. A catalog that assumed 'date' here would report a
+      // type the index does not have, and toDataset would mark the column a dimension on the
+      // strength of it.
+      assertEquals("text", serverFieldTypes("earthquakes").get("@timestamp"));
+      assertEquals(XSchema.STRING, column(runtime.describeDataset(dataSource, "earthquakes"),
+                                          "@timestamp").type());
+   }
+
+   @Test
+   void keywordSubfieldIsNotAColumn() throws Exception {
+      // magType is text with a keyword multi-field. magType.keyword exists on the index side for
+      // sorting and aggregation but is not in _source, so runQuery never produces it.
+      assertTrue(serverMapping("earthquakes").path("magType").has("fields"),
+                 "the fixture must actually have a multi-field for this test to mean anything");
+      assertFalse(runtime.describeDataset(dataSource, "earthquakes").columns().stream()
+                     .anyMatch(c -> c.name().endsWith(".keyword")),
+                  "a multi-field is not in _source and must not be reported");
+   }
+
+   @Test
+   void declaredObjectFlattensWithDotsAndArrayStaysOneColumn() throws Exception {
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "orders");
+      List<String> names = schema.columns().stream().map(TabularColumn::name).toList();
+
+      // A declared object: the mapping names the leaves walkRecord will produce, so it is
+      // flattened the same way.
+      assertTrue(names.containsAll(List.of("shipTo.city", "shipTo.zip")), names.toString());
+      assertFalse(names.contains("shipTo"), "an object is not a column of its own");
+
+      // A nested array: one column holding the raw array, because expanded is false.
+      assertTrue(names.contains("items"), names.toString());
+      assertFalse(names.stream().anyMatch(n -> n.startsWith("items.")),
+                  "expanded=false means the array's sub-fields are not columns: " + names);
+      assertEquals("false", schema.params().get("expanded"),
+                   "the column list above is only correct while expansion is off");
+
+      String itemsDescription = column(schema, "items").description();
+      assertNotNull(itemsDescription);
+      assertTrue(itemsDescription.contains("sku") && itemsDescription.contains("qty") &&
+                 itemsDescription.contains("price"),
+                 "the substructure must still reach the reader: " + itemsDescription);
+   }
+
+   @Test
+   void arrayColumnIsOneCellAtRuntime() throws Exception {
+      // The claim the column list rests on, checked against runQuery rather than reasoned about.
+      XTableNode table = runBinding(runtime.describeDataset(dataSource, "orders"));
+      List<String> names = new ArrayList<>();
+
+      for(int i = 0; i < table.getColCount(); i++) {
+         names.add(table.getName(i));
+      }
+
+      assertTrue(names.contains("items"), names.toString());
+      assertFalse(names.stream().anyMatch(n -> n.startsWith("items.")), names.toString());
+      assertTrue(names.containsAll(List.of("shipTo.city", "shipTo.zip")), names.toString());
+   }
+
+   @Test
+   void fieldAliasIsNotAColumn() throws Exception {
+      // orderRef is declared 'alias' over orderId. It is resolved at query time and never appears
+      // in _source, so it is excluded for the same reason a .keyword subfield is.
+      assertEquals("alias", serverFieldTypes("orders").get("orderRef"));
+
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "orders");
+      List<String> names = schema.columns().stream().map(TabularColumn::name).toList();
+
+      assertFalse(names.contains("orderRef"), names.toString());
+      assertTrue(names.contains("orderId"), names.toString());
+      assertFalse(schema.description().contains("orderRef"),
+                  "an alias is absent from _source entirely, so it is not an excluded field to " +
+                  "explain -- it is simply not part of the data");
+   }
+
+   @Test
+   void objectShapedFieldsAreDescribedRatherThanColumned() throws Exception {
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "orders");
+      List<String> names = schema.columns().stream().map(TabularColumn::name).toList();
+
+      // geo_point/geo_shape accept several _source forms and the mapping does not say which a
+      // document used -- written as an object, shipTo.geo becomes shipTo.geo.lat and
+      // shipTo.geo.lon at runtime, so 'shipTo.geo' addresses nothing.
+      assertFalse(names.contains("shipTo.geo"), names.toString());
+      assertFalse(names.contains("region"), names.toString());
+      assertTrue(schema.description().contains("shipTo.geo (geo_point)"), schema.description());
+      assertTrue(schema.description().contains("region (geo_shape)"), schema.description());
+
+      // binary is the counter-case in the same family: _source always carries the base64 string
+      // the document was indexed with, so it has one predictable form and IS a column.
+      assertTrue(names.contains("blob"), names.toString());
+      assertEquals(XSchema.STRING, column(schema, "blob").type());
+   }
+
+   @Test
+   void objectShapedFieldsReallyDoSplitAtRuntime() throws Exception {
+      // The measurement the exclusion above rests on.
+      XTableNode table = runBinding(runtime.describeDataset(dataSource, "orders"));
+      List<String> names = new ArrayList<>();
+
+      for(int i = 0; i < table.getColCount(); i++) {
+         names.add(table.getName(i));
+      }
+
+      assertTrue(names.containsAll(List.of("shipTo.geo.lat", "shipTo.geo.lon")),
+                 "a geo_point written as an object splits into two columns the mapping never " +
+                 "named: " + names);
+      assertFalse(names.contains("shipTo.geo"), names.toString());
+   }
+
+   @Test
+   void sourceDeclaredDescriptionsArePassedThroughVerbatim() throws Exception {
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "orders");
+
+      // A field-level meta.description is the source's own words and survives _mapping unchanged.
+      assertTrue(column(schema, "total").description().startsWith("Order total in USD."),
+                 column(schema, "total").description());
+      // A mapping-level _meta.description opens the dataset description.
+      assertTrue(schema.description()
+                    .startsWith("Customer orders, one document per placed order."),
+                 schema.description());
+      // A field the index says nothing about, and that needs no note, says nothing.
+      assertNull(column(schema, "orderId").description());
+   }
+
+   @Test
+   void unrecognizedTypeIsReportedAsStringAndFlaggedInTheDatasetDescriptionNotTheColumn()
+      throws Exception
+   {
+      // wordCount is mapped token_count with an analyzer -- a type 7.9.2 genuinely accepts (M20)
+      // and this connector's TYPES table does not cover, so this is a live fixture for the A15
+      // default arm, not a hand-built type string.
+      assertEquals("token_count", serverFieldTypes("orders").get("wordCount"));
+
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "orders");
+      TabularColumn column = column(schema, "wordCount");
+
+      assertEquals(XSchema.STRING, column.type());
+      // The signal lives on the DATASET description, never on the column's own -- so it can never
+      // collide with a verbatim meta.description on the same field.
+      assertNull(column.description(),
+                 "wordCount has no meta.description, so its own column description must say " +
+                 "nothing rather than carry a connector-composed note");
+      assertTrue(schema.description().contains("wordCount") &&
+                 schema.description().contains("token_count"),
+                 "the dataset description must name the field and its unrecognized ES type: " +
+                 schema.description());
+   }
+
+   @Test
+   void describeDatasetColumnsAreASubsetOfWhatRunQueryProduces() throws Exception {
+      // N7 (clarified at P2/R4): describeDataset's column set is a SUBSET of runQuery's, never
+      // asserted equal -- A26's exclusions make runQuery a strict superset by design (shipTo.geo
+      // splits into shipTo.geo.lat/shipTo.geo.lon at runtime, neither of which describeDataset
+      // ever reports), so equality would fail a correct implementation on this exact fixture.
+      for(String index : List.of("earthquakes", "orders")) {
+         TabularDatasetSchema schema = runtime.describeDataset(dataSource, index);
+         Set<String> described = schema.columns().stream().map(TabularColumn::name)
+            .collect(Collectors.toSet());
+
+         XTableNode table = runBinding(schema);
+         Set<String> produced = new HashSet<>();
+
+         for(int i = 0; i < table.getColCount(); i++) {
+            produced.add(table.getName(i));
+         }
+
+         assertTrue(produced.containsAll(described),
+                    "'" + index + "': describeDataset reported a column runQuery never " +
+                    "produces -- described=" + described + ", produced=" + produced);
+      }
+   }
+
+   @Test
+   void dottedIndexNameIsEnumeratedAndDescribedEndToEnd() throws Exception {
+      // G1: an index whose name contains '.' -- Elastic's own documented ILM/rollover naming
+      // convention -- must work end to end now that TabularCatalogService.validateDatasetIds no
+      // longer rejects a dotted TabularDatasetRef.id (G2).
+      List<String> ids = runtime.listDatasets(dataSource).datasets().stream()
+         .map(TabularDatasetRef::id).toList();
+      assertTrue(ids.contains("logs-2026.09.04"), ids.toString());
+
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "logs-2026.09.04");
+      assertEquals("logs-2026.09.04", schema.datasetId(), "the dotted id must be echoed verbatim");
+      assertTrue(schema.columns().stream().anyMatch(c -> "level".equals(c.name())));
+   }
+
+   @Test
+   void paramsUseTheQueryBeansOwnPropertyNames() throws Exception {
+      // Derived, not written out: TabularUtil derives a property name from the getter through
+      // java.beans.Introspector, so a getter rename must break this assertion rather than leave a
+      // literal here green.
+      Set<String> beanProperties = TabularUtil.getPropertyMap(ElasticRestQuery.class).keySet();
+      Map<String, String> params = runtime.describeDataset(dataSource, "earthquakes").params();
+
+      assertTrue(beanProperties.containsAll(params.keySet()),
+                 params.keySet() + " must all be properties of ElasticRestQuery, which has " +
+                 beanProperties);
+      // Fully filled -- no empty value. wiz's buildMetadataTableBinding branches on that: with an
+      // empty value it would tell the caller to fill something, and there is nothing to fill.
+      params.forEach((key, value) -> assertFalse(value == null || value.isBlank(),
+                                                 "params['" + key + "'] must not be empty"));
+   }
+
+   @Test
+   void paramsRoundTripThroughTheBindingPathAndReturnEveryRow() throws Exception {
+      TabularDatasetSchema schema = runtime.describeDataset(dataSource, "earthquakes");
+      XTableNode table = runBinding(schema);
+      int rows = 0;
+
+      while(table.next()) {
+         rows++;
+      }
+
+      // The whole point of size= in the suffix. Elasticsearch answers a search that does not ask
+      // for more with 10 hits, and nothing in this connector raises that -- TabularQuery's own
+      // max-rows caps the table after the fact and is never sent to the server. Without size= this
+      // is permanently 10 no matter how many documents the index holds.
+      assertEquals(221, rows, "the fixture holds 221 documents and the binding must return them all");
+      assertTrue(schema.params().get("suffix").contains("size="), schema.params().toString());
+   }
+
+   @Test
+   void aMultiIndexAliasIsRefusedRatherThanResolvedToOne() throws Exception {
+      // GET /all-data/_mapping answers with one key per concrete index. Taking the first would
+      // silently describe the wrong index under the requested name.
+      Exception thrown = assertThrows(
+         Exception.class, () -> runtime.describeDataset(dataSource, "all-data"));
+
+      assertTrue(thrown.getMessage().contains("earthquakes") &&
+                 thrown.getMessage().contains("orders"),
+                 "the message must name what it did resolve to: " + thrown.getMessage());
+   }
+
+   @Test
+   void anUnknownIndexFailsWithTheServersOwnExplanation() {
+      Exception thrown = assertThrows(
+         Exception.class, () -> runtime.describeDataset(dataSource, "nosuchindex"));
+
+      assertTrue(thrown.getMessage().contains("404") &&
+                 thrown.getMessage().contains("index_not_found_exception"),
+                 thrown.getMessage());
+   }
+
+   @Test
+   void metadataEndpointsAreReadWithGet() throws Exception {
+      // The reason ElasticRestRuntime.getMetadata exists rather than reusing getConnection, which
+      // calls setDoOutput(true) -- forcing a POST -- and writes the query's filter as the body.
+      assertEquals(405, statusOf("POST", "/_cat/indices?format=json", null),
+                   "_cat/indices is GET-only");
+      assertEquals(400, statusOf("POST", "/earthquakes/_mapping", null),
+                   "a bodyless POST to _mapping is refused");
+
+      // And the sharper reason: POST to _mapping WITH a body is not a failed read, it is the
+      // mapping-update API, and it writes. Proven on a throwaway index so the fixture is
+      // untouched; the name starts with a dot only so listDatasets filters it and this test does
+      // not change what the other tests see.
+      request("PUT", "/.post-probe", null);
+      assertEquals(200, statusOf("POST", "/.post-probe/_mapping",
+                                 "{\"properties\":{\"writtenByPost\":{\"type\":\"keyword\"}}}"));
+      assertTrue(serverFieldTypes(".post-probe").containsKey("writtenByPost"),
+                 "a POST to _mapping modifies the index, so a catalog read must never use one");
+
+      // The catalog reads both endpoints anyway, which it could not do through getConnection.
+      assertFalse(runtime.listDatasets(dataSource).datasets().isEmpty());
+      assertFalse(runtime.describeDataset(dataSource, "earthquakes").columns().isEmpty());
+   }
+
+   /**
+    * Fills a query from a schema's own {@code params} through the same path
+    * {@code WorksheetTableService} uses to build a binding, then runs it. The point is that
+    * nothing here translates a name or a value: whatever {@code describeDataset} put in
+    * {@code params} is what the fill receives.
+    */
+   private XTableNode runBinding(TabularDatasetSchema schema) throws Exception {
+      ElasticRestQuery query = new ElasticRestQuery();
+      query.setDataSource(dataSource);
+
+      TabularQueryContractSupport.applyQueryContract(
+         query, TabularUtil.getPropertyMap(query.getClass()),
+         new TabularSchemaExtractor().extract(query, ElasticRestDataSource.TYPE),
+         new LinkedHashMap<>(schema.params()), "elastic-test");
+
+      assertEquals(schema.params().get("suffix"), query.getSuffix());
+      assertEquals(schema.params().get("jsonPath"), query.getJsonPath());
+      // params carries strings; the fill coerces this one back to the boolean the setter takes.
+      assertFalse(query.isExpanded(), "expanded=false must survive the round trip as a boolean");
+
+      XTableNode table = runtime.runQuery(query, new VariableTable());
+      assertNotNull(table, "the query built from the catalog's own params must run");
+      return table;
+   }
+
+   private static TabularColumn column(TabularDatasetSchema schema, String name) {
+      return schema.columns().stream().filter(c -> name.equals(c.name())).findFirst()
+         .orElseThrow(() -> new AssertionError(
+            "no column '" + name + "' in " +
+            schema.columns().stream().map(TabularColumn::name).toList()));
+   }
+
+   /** The {@code properties} block the server itself returns, in the order it returns it. */
+   private static JsonNode serverMapping(String index) throws Exception {
+      return MAPPER.readTree(request("GET", "/" + index + "/_mapping", null))
+         .path(index).path("mappings").path("properties");
+   }
+
+   private static Map<String, String> serverFieldTypes(String index) throws Exception {
+      JsonNode properties = serverMapping(index);
+      Map<String, String> types = new LinkedHashMap<>();
+      properties.fieldNames().forEachRemaining(
+         name -> types.put(name, properties.path(name).path("type").asText(null)));
+      return types;
+   }
+
+   private static void loadEarthquakes() throws IOException {
+      try(InputStream input =
+             ElasticCatalogTests.class.getResourceAsStream("earthquakes.ndjson")) {
+         assertNotNull(input);
+         StringBuilder bulk = new StringBuilder();
+
+         try(LineIterator it = IOUtils.lineIterator(input, StandardCharsets.UTF_8)) {
+            while(it.hasNext()) {
+               String line = it.next();
+
+               if(!line.trim().isEmpty()) {
+                  bulk.append("{\"index\":{}}\n").append(line).append('\n');
+               }
+            }
+         }
+
+         request("POST", "/earthquakes/_bulk?refresh=true", bulk.toString(),
+                 "application/x-ndjson");
+      }
+   }
+
+   private static String request(String method, String path, String body) throws IOException {
+      return request(method, path, body, "application/json");
+   }
+
+   private static String request(String method, String path, String body, String contentType)
+      throws IOException
+   {
+      HttpURLConnection conn = (HttpURLConnection) new URL(getUrl() + path).openConnection();
+      conn.setRequestMethod(method);
+      conn.setRequestProperty("Content-Type", contentType);
+
+      if(body != null) {
+         conn.setDoOutput(true);
+
+         try(OutputStream output = conn.getOutputStream()) {
+            output.write(body.getBytes(StandardCharsets.UTF_8));
+         }
+      }
+
+      int status = conn.getResponseCode();
+
+      try(InputStream input = status < 400 ? conn.getInputStream() : conn.getErrorStream()) {
+         String response = input == null ? "" : IOUtils.toString(input, StandardCharsets.UTF_8);
+         assertTrue(status < 400, method + " " + path + " answered " + status + ": " + response);
+         return response;
+      }
+   }
+
+   private static int statusOf(String method, String path, String body) throws IOException {
+      HttpURLConnection conn = (HttpURLConnection) new URL(getUrl() + path).openConnection();
+      conn.setRequestMethod(method);
+      conn.setRequestProperty("Content-Type", "application/json");
+
+      if(body != null) {
+         conn.setDoOutput(true);
+
+         try(OutputStream output = conn.getOutputStream()) {
+            output.write(body.getBytes(StandardCharsets.UTF_8));
+         }
+         catch(IOException ignore) {
+            // A refused method can fail on the write rather than the read; the status is what
+            // this method reports either way.
+         }
+      }
+
+      return conn.getResponseCode();
+   }
+
+   private static String getUrl() {
+      return "http://" + container.getHost() + ":" + container.getMappedPort(9200);
+   }
+
+   /**
+    * Elasticsearch type to expected {@link XSchema} constant, written here independently of
+    * {@code ElasticCatalog}'s own table so that a wrong entry there fails rather than agreeing
+    * with itself. Which field has which Elasticsearch type is never written down — that comes
+    * from the live mapping response.
+    */
+   private static final Map<String, String> EXPECTED_XSCHEMA = Map.of(
+      "text", XSchema.STRING,
+      "keyword", XSchema.STRING,
+      "long", XSchema.LONG,
+      "integer", XSchema.INTEGER,
+      "float", XSchema.FLOAT,
+      "double", XSchema.DOUBLE,
+      "scaled_float", XSchema.DOUBLE,
+      "boolean", XSchema.BOOLEAN,
+      "date", XSchema.TIME_INSTANT,
+      "binary", XSchema.STRING);
+
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+}

--- a/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticCatalogTests.java
+++ b/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticCatalogTests.java
@@ -422,6 +422,34 @@ class ElasticCatalogTests {
    }
 
    @Test
+   void malformedDatasetIdIsRejectedBeforeAnyHttpRequest() {
+      // I1: TabularCatalogService.describeTable passes a caller-supplied target straight through
+      // with no proof it ever came from listDatasets, so each of these would otherwise be
+      // embedded verbatim into a live request URL by ElasticRestRuntime.getMetadata. Asserting on
+      // OUR OWN message text (not just "it threw") is what proves validateIndexName caught this
+      // before any request went out -- a real round trip against a malformed URL would surface a
+      // connection-level or Elasticsearch-native error instead, never this literal phrase.
+      List<String> malformed = List.of(
+         "a/b", "a?b", "a#b", "a b", "a\"b", "a<b", "a>b", "a|b", "a,b", "a*b", "a\\b",
+         ".", "..", "+leading");
+
+      for(String id : malformed) {
+         Exception thrown = assertThrows(Exception.class,
+            () -> runtime.describeDataset(dataSource, id), "id='" + id + "'");
+         assertTrue(thrown.getMessage().contains("not a legal Elasticsearch index name"),
+                    "id='" + id + "': " + thrown.getMessage());
+      }
+   }
+
+   @Test
+   void aLegitimateDottedNameIsNotRejectedByValidation() throws Exception {
+      // The whole point of this round was to PERMIT a dot in a dataset id (G1) -- a validator
+      // that rejected one here would be a silent regression of that, not a safety fix. A non-
+      // leading, non-".."/"." dot must sail through untouched.
+      assertDoesNotThrow(() -> runtime.describeDataset(dataSource, "logs-2026.09.04"));
+   }
+
+   @Test
    void paramsUseTheQueryBeansOwnPropertyNames() throws Exception {
       // Derived, not written out: TabularUtil derives a property name from the getter through
       // java.beans.Introspector, so a getter rename must break this assertion rather than leave a

--- a/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticRestRuntimeTests.java
+++ b/connectors/inetsoft-elastic/src/test/java/inetsoft/uql/elasticrest/ElasticRestRuntimeTests.java
@@ -17,13 +17,16 @@
  */
 package inetsoft.uql.elasticrest;
 
+import inetsoft.sree.PropertiesEngine;
 import inetsoft.uql.VariableTable;
 import inetsoft.uql.XTableNode;
 import inetsoft.util.ConfigurationContext;
 import inetsoft.util.credential.*;
+import inetsoft.util.swap.XSwapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
@@ -38,11 +41,23 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Needs a Docker daemon, so it is off unless asked for:
+ *
+ * <pre>./mvnw -pl connectors/inetsoft-elastic -am -Delastic.tests=true test</pre>
+ *
+ * <p>This was {@code @Disabled}, which had the same effect on a normal build but could only be
+ * run after editing the source. It now shares {@link ElasticCatalogTests}'s condition, so the two
+ * Elasticsearch test classes are enabled the same way — see that class for why a JUnit condition
+ * rather than {@code @Tag("integration")}.
+ */
 @Testcontainers
-@Disabled
+@EnabledIfSystemProperty(named = "elastic.tests", matches = "true")
 class ElasticRestRuntimeTests {
    @Container
    static final ElasticsearchContainer container =
@@ -57,6 +72,16 @@ class ElasticRestRuntimeTests {
       when(credentialService.createCredential(CredentialType.PASSWORD, false)).thenReturn(mock(LocalPasswordCredential.class));
       ApplicationContext context = mock(ApplicationContext.class);
       when(context.getBean(CredentialService.class)).thenReturn(credentialService);
+      // See ElasticCatalogTests.loadData() for why this stub exists: without it,
+      // runQuery -> XQuery.getMaxRows -> ... -> PropertiesEngine.getInstance() puts a null bean
+      // into ConfigurationContext's Caffeine cache, which throws and permanently breaks
+      // inetsoft.report.internal.Util for the rest of the JVM.
+      PropertiesEngine propertiesEngine = mock(PropertiesEngine.class);
+      when(propertiesEngine.getProperty(anyString(), anyString(), anyBoolean()))
+         .thenAnswer(invocation -> invocation.getArgument(1));
+      when(context.getBean(PropertiesEngine.class)).thenReturn(propertiesEngine);
+      // See ElasticCatalogTests.loadData(): one bean further down the same runQuery call path.
+      when(context.getBean(XSwapper.class)).thenReturn(mock(XSwapper.class));
       ConfigurationContext.getContext().setApplicationContext(context);
 
       try(InputStream input = ElasticRestRuntimeTests.class.getResourceAsStream("earthquakes.ndjson")) {

--- a/core/src/main/java/inetsoft/uql/tabular/TabularDatasetRef.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularDatasetRef.java
@@ -20,41 +20,30 @@ package inetsoft.uql.tabular;
 /**
  * One dataset a tabular data source holds.
  *
- * @param id the connector's own handle for this dataset, opaque to core. It is the ONLY token that
- *           travels: the caller hands it back verbatim to
+ * @param id the connector's own handle for this dataset, fully opaque to core. It is the ONLY
+ *           token that travels: the caller hands it back verbatim to
  *           {@link TabularCatalogProvider#describeDataset}, and it is what identifies the dataset
  *           in every {@link TabularRelationship} of the same catalog. Must be non-blank and unique
  *           within one catalog, and must remain stable across calls for an unchanged source.
  *
- *           <p><b>Must not contain a {@code .} character.</b> This id is carried verbatim into
+ *           <p><b>May contain a {@code .} character.</b> A connector-native id is not a qualified
+ *           name, and a dot in it is not special — an Elasticsearch ILM/rollover index name
+ *           ({@code logs-2026.09.04}) is one ordinary example. This id is carried verbatim into
  *           {@code OsiDataset.source} on the wiz side ({@code TabularCatalogService.toDataset}
- *           does {@code dataset.setSource(schema.datasetId())}). wiz's own
- *           {@code bareTableName(source, category)}
- *           ({@code wiz-services/src/v1/services/tabularBinding.ts:68-71}) exempts only the
- *           {@code FILE} category from splitting {@code source} on {@code "."}. Every other
- *           category still has {@code source} split on {@code "."}, keeping only the last
- *           segment — {@code METADATA} included. <b>That has NOT been fixed.</b> Nothing in wiz
- *           exempts a METADATA id from the split today. Its sibling {@code sourceMatches}
- *           ({@code wiz-services/src/services/tableDocResolver.ts:27-33}) is worse: it takes no
- *           category parameter at all and always splits.
+ *           does {@code dataset.setSource(schema.datasetId())}), and wiz treats a METADATA
+ *           source as opaque end to end: {@code bareTableName}/{@code sourceMatches}
+ *           (wiz's {@code tabularBinding.ts}/{@code tableDocResolver.ts}) no longer split a
+ *           METADATA {@code source} on {@code "."} the way they still do for a JDBC source, whose
+ *           id genuinely is a qualified name meant to have its qualifier stripped.
  *
- *           <p>Splitting on {@code "."} is correct for a JDBC source, whose id genuinely is a
- *           qualified name meant to have its qualifier stripped. It is wrong for an opaque
- *           connector-native id, which was never a qualified name: two ids {@code "A.B"} and
- *           {@code "C.B"} would both bare-reduce to {@code "B"} and be reported as duplicates of
- *           each other, and a lookup could resolve to the wrong dataset. This javadoc constraint
- *           — no dot in the id — is the SPI's only defense against that today, and it holds only
- *           because OData's own EDM grammar happens to forbid a dot in an entity set name;
- *           nothing in this codebase enforces it for a connector that does not have that
- *           accident of grammar in its favor.
- *
- *           <p>A connector whose native identity is composite (e.g. SharePoint's
- *           {@code site → list}, named in this SPI's design doc as the first case expected to need
- *           one) must therefore either join its parts with something other than {@code .}, or this
- *           constraint has to be revisited together with making {@code bareTableName}/
- *           {@code sourceMatches} treat a METADATA id as opaque instead of qualified — the more
- *           correct fix, deliberately not done as a partial patch here, since
- *           {@code sourceMatches} has no category parameter and fixing only dedup while leaving
- *           resolution wrong would be worse than fixing neither.
+ *           <p>This used to be a hard constraint — "must not contain a {@code .} character" — and
+ *           {@code TabularCatalogService} enforced it by throwing, aborting an entire catalog for
+ *           any single dotted id. That was a producer-side guard against a consumer that could not
+ *           yet tell an opaque id from a qualified one; the consumer has since been fixed
+ *           directly (wiz's opaque-id handling above), so the guard was removed rather than kept
+ *           as a redundant, and now wrong, restriction on every connector. A connector whose
+ *           native identity is composite (e.g. SharePoint's {@code site → list}) may still choose
+ *           to join its parts with a separator other than {@code .} — nothing requires a dot — but
+ *           nothing in the SPI forbids one either.
  */
 public record TabularDatasetRef(String id) {}

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -96,13 +96,11 @@ public class TabularCatalogService {
          if(ref == null || ref.id() == null || ref.id().isBlank()) {
             throw new Exception("Data source '" + dsName + "' returned a dataset with a blank id.");
          }
-         if(ref.id().contains(".")) {
-            // TabularDatasetRef.id's javadoc: "Must not contain a '.' character" — wiz's own
-            // bareTableName/sourceMatches split a non-FILE source on '.', so a dotted id would
-            // silently collide two different datasets, or resolve to the wrong one, downstream.
-            throw new Exception("Data source '" + dsName + "' returned a dataset id '" + ref.id() +
-               "' containing '.', which TabularDatasetRef.id's contract forbids.");
-         }
+         // No '.'-containing check here: a TabularDatasetRef.id is opaque, and an id genuinely
+         // containing '.' (an Elasticsearch ILM/rollover index name, say) is legal. wiz's own
+         // bareTableName/sourceMatches now treat a METADATA source as opaque instead of splitting
+         // it, which is the fix this check used to stand in for -- see TabularDatasetRef.id's
+         // javadoc.
          if(!seen.add(ref.id())) {
             // TabularDatasetRef.id's javadoc: "must be non-blank and unique within one catalog."
             // A duplicate becomes two DatabaseTableInfo rows with an identical table field, and a

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceContractValidationTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.tabular.*;
+import inetsoft.web.wiz.model.DatasourceTablesResponse;
 import inetsoft.web.wiz.model.osi.OsiDataset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,14 +38,21 @@ import static org.mockito.Mockito.when;
  * Covers charter assertions C1-C3 and C6: {@link TabularCatalogService} must not trust a
  * connector's {@link TabularCatalog}/{@link TabularDatasetSchema} at face value — a null
  * relationships list, a relationship pointing at an unknown dataset, a blank id/column name, a
- * dotted dataset id, a blank relationship name, or a mismatched/empty column pairing must each
- * produce a named exception, not an NPE or a silently-broken wire response.
+ * blank relationship name, or a mismatched/empty column pairing must each produce a named
+ * exception, not an NPE or a silently-broken wire response.
+ *
+ * <p>The check that a dotted {@code TabularDatasetRef.id} must be rejected (once part of C6) was
+ * removed in the Elasticsearch SPI round: it was a producer-side guard against a downstream
+ * consumer (wiz's {@code bareTableName}/{@code sourceMatches}) that could not yet tell an opaque
+ * connector id from a qualified JDBC one. That consumer now treats a METADATA source as opaque
+ * directly, so the guard was deleted rather than kept as a redundant, and now wrong, restriction —
+ * see {@link TabularDatasetRef#id}'s javadoc. {@code listTables_dottedDatasetId_isAccepted} below
+ * pins the new behavior so this is not silently reintroduced.
  *
  * C6 was added after P5 review r1 (finding 1): the original C1-C3 pass checked only three of the
- * SPI's documented invariants, leaving the ones on {@code TabularDatasetRef.id} (no {@code .}) and
- * {@code TabularRelationship} (non-blank name, paired columns) unchecked — including the very
- * invariant ({@code id} must not contain {@code .}) that motivated {@code SharepointDatasetId}'s
- * whole escaping scheme in the sibling implementer. Extended again after P5 review r2 (finding 1):
+ * SPI's documented invariants, leaving the ones on {@code TabularDatasetRef.id} and
+ * {@code TabularRelationship} (non-blank name, paired columns) unchecked. Extended again after P5
+ * review r2 (finding 1):
  * C6 itself still missed the uniqueness half of both "non-blank and unique within one catalog"
  * ({@code TabularDatasetRef.id}) and "stable identifier ... within the catalog"
  * ({@code TabularRelationship.name}), plus (r2 nit 2) that {@code TabularDatasetSchema.keyColumns}
@@ -194,21 +202,26 @@ class TabularCatalogServiceContractValidationTest {
       assertTrue(ex.getMessage().toLowerCase().contains("column"));
    }
 
-   // ----- C6: TabularDatasetRef.id must not contain '.' -----
+   // ----- G2: TabularDatasetRef.id is opaque -- a '.' is no longer rejected on its own -----
 
    @Test
-   void listTables_dottedDatasetId_throwsNamedException() throws Exception {
-      TabularCatalog catalog =
-         new TabularCatalog(List.of(new TabularDatasetRef("contoso.sharepoint.com")), List.of());
+   void listTables_dottedDatasetId_isAccepted() throws Exception {
+      // An Elasticsearch ILM/rollover index name is exactly this shape. Before G2, this single
+      // dotted id would have aborted the ENTIRE catalog for the whole data source -- not just
+      // mislabeled one dataset -- which is why this is a listTables-level test, not a narrower
+      // unit test of validateDatasetIds alone.
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("logs-2026.09.04"), new TabularDatasetRef("orders")),
+         List.of());
       FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
       TabularCatalogService service = createService(dsName -> runtime);
 
-      Exception ex = assertThrows(Exception.class, () -> service.listTables(DS_NAME));
+      DatasourceTablesResponse response = service.listTables(DS_NAME);
 
-      assertFalse(ex instanceof UnsupportedDatasourceException);
-      assertTrue(ex.getMessage().contains(DS_NAME));
-      assertTrue(ex.getMessage().contains("contoso.sharepoint.com"),
-         "message must name the offending id: " + ex.getMessage());
+      assertEquals(2, response.getTables().size());
+      assertTrue(response.getTables().stream()
+                    .anyMatch(t -> "logs-2026.09.04".equals(t.getTable())),
+                 "the dotted id must be reported verbatim, not renamed or dropped");
    }
 
    // ----- C6: TabularRelationship.name must be non-blank -----


### PR DESCRIPTION
## Summary

- `ElasticRestRuntime` implements `TabularCatalogProvider` via a new `ElasticCatalog`: `listDatasets` enumerates open, non-internal indexes (`_cat/indices`, sorted by name); `describeDataset` reads `_mapping`/`_count`, flattens declared objects, keeps a `nested` field as one column, excludes fields whose `_source` shape the mapping does not commit to (`alias`, `.keyword` multi-fields, geo/range/`join`/`percolator`/`completion`), and reports an unrecognized mapping type as a string — flagged in the **dataset** description (never the column's own, so it can't collide with a verbatim `meta.description` on the same field) plus a WARN log.
- All metadata reads go through a dedicated GET-only helper (`ElasticRestRuntime.getMetadata`), distinct from the query path, so a catalog read can never fall through to Elasticsearch's mapping-**update** API.
- Fixed a test-only bug: the mocked `ApplicationContext` in both test classes didn't stub `PropertiesEngine`/`XSwapper`, so any test that called `runQuery` threw a `NullPointerException` out of a static initializer (Caffeine's bean cache rejects a `null` value), permanently breaking `inetsoft.report.internal.Util` for the rest of the JVM.
- `TabularCatalogService.validateDatasetIds` no longer rejects a dataset id for containing `.`. The check was a producer-side guard against wiz's dot-splitting of a `TabularDatasetRef.id`; wiz now treats a METADATA source's id as opaque directly instead (companion PR, see below), which is the real fix. Elasticsearch's own ILM/rollover index naming convention (`logs-2026.09.04`) is exactly the case the old check blocked outright — one such index aborted an entire data source's catalog, not just that one index. `TabularDatasetRef.id`'s javadoc is rewritten to say ids are opaque and a dot is permitted, not forbidden.
- Checked all ten pre-existing `TabularCatalogProvider` implementers' `listDatasets`: none emits a dotted id today (SharePoint Online and Google Sheets both already percent-escape a dot out of their composed ids defensively; Cassandra/Aerospike/Hive/OrientDB read an unqualified name from JDBC metadata; OData/Salesforce/GA4 read names whose own grammar excludes a dot). Removing the check is not a silent behavior change for any connector but this one.

## Test plan

- `./mvnw -pl connectors/inetsoft-elastic -am -Delastic.tests=true -Dtest=ElasticCatalogTests,ElasticRestRuntimeTests test` — 20/20 pass against a live `elasticsearch:7.9.2` container.
- `./mvnw -pl connectors/inetsoft-elastic -am -Dtest=ElasticCatalogTests,ElasticRestRuntimeTests test` (no property) — both classes skip cleanly, no Docker required.
- `./mvnw -pl core -am -Dtest=TabularCatalogServiceContractValidationTest,TabularCatalogServiceTest test` — 21 + 11 pass, including the new `listTables_dottedDatasetId_isAccepted`.

## Merge order

**This PR must merge after `feat/tabular-opaque-metadata-ids` in `stylebi-wiz`.** Merging this one first would start emitting dotted METADATA ids into a wiz that still splits a source on `.`, reintroducing the exact false-duplicate/wrong-resolution bug this round is fixing on the wiz side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)