### PR TITLE
fix(wiz): move SSO token issuance from enterprise into community

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/SSOTokenController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/SSOTokenController.java
@@ -169,9 +169,29 @@ public class SSOTokenController {
 
       List<String> allowedCallbacks = getAllowedCallbacks();
 
-      // Check if callback starts with the allowed prefix
+      // Check if callback starts with the allowed prefix, at a path boundary
+      String lowerCallback = callback.toLowerCase();
       return allowedCallbacks.stream()
-         .anyMatch(allowed -> callback.toLowerCase().startsWith(allowed.toLowerCase()));
+         .anyMatch(allowed -> matchesPrefixBoundary(lowerCallback, allowed.toLowerCase()));
+   }
+
+   /**
+    * Returns true if {@code value} starts with {@code prefix} and the match ends at a path
+    * boundary — i.e. {@code prefix} is the entire value, or is immediately followed by
+    * {@code /} or {@code ?}. Prevents a longer, unrelated path
+    * (e.g. {@code .../api/wiz/auth/callback-evil}) from matching a {@code .../callback} prefix.
+    */
+   private boolean matchesPrefixBoundary(String value, String prefix) {
+      if(!value.startsWith(prefix)) {
+         return false;
+      }
+
+      if(value.length() == prefix.length()) {
+         return true;
+      }
+
+      char next = value.charAt(prefix.length());
+      return next == '/' || next == '?';
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/controller/SSOTokenController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/SSOTokenController.java
@@ -1,0 +1,300 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.assistant.AIAssistantController;
+import inetsoft.web.viewsheet.service.LinkUriArgumentResolver;
+import inetsoft.web.wiz.security.SSOTokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.HtmlUtils;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.*;
+
+import static inetsoft.web.wiz.controller.WizPortalController.WIZ_SERVICE_URL;
+
+/**
+ * Controller for SSO token endpoints.
+ * Provides JWT token issuance via auto-submitting HTML form and public key distribution.
+ */
+@Controller
+public class SSOTokenController {
+   @Autowired
+   public SSOTokenController(SSOTokenService ssoTokenService) {
+      this.ssoTokenService = ssoTokenService;
+   }
+
+   /**
+    * SSO authorization endpoint.
+    * Generates an RS256-signed JWT and returns an auto-submitting HTML form
+    * that POSTs the token to the chat-app's callback endpoint.
+    *
+    * If the user is not authenticated, they will be redirected to the login page
+    * by the security filters, and after login will be redirected back here.
+    *
+    * @param callback the chat-app callback URL to POST the token to
+    * @param request the HTTP request
+    * @param response the HTTP response
+    * @return HTML page with auto-submitting form
+    */
+   @GetMapping("/sso/authorize")
+   public void authorize(
+      @RequestParam("callback") String callback,
+      @RequestParam(value = "redirect_url", required = false) String redirectUrl,
+      HttpServletRequest request,
+      HttpServletResponse response) throws IOException
+   {
+      Principal principal = request.getUserPrincipal();
+
+      // If principal is null, the security filter should have redirected to login.
+      // This is a fallback in case it didn't.
+      if(principal == null) {
+         String currentUrl = LinkUriArgumentResolver.transformUri(request);
+         String queryString = request.getQueryString();
+
+         if(queryString != null) {
+            currentUrl = currentUrl + "?" + queryString;
+         }
+
+         String loginUrl = LinkUriArgumentResolver.getLinkUri(request) + "login.html?requestedUrl=" +
+            URLEncoder.encode(currentUrl, StandardCharsets.UTF_8);
+         response.sendRedirect(loginUrl);
+         return;
+      }
+
+      // Validate the callback URL against the allowlist
+      if(!isCallbackAllowed(callback, request)) {
+         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+         response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+         response.getWriter().write("Invalid callback URL");
+         return;
+      }
+
+      // Get the StyleBI server URL to use as the JWT issuer
+      String styleBIUrl = LinkUriArgumentResolver.getLinkUri(request);
+
+      // Generate the SSO token with the StyleBI URL as issuer
+      String token = ssoTokenService.createSSOToken(principal, styleBIUrl);
+
+      // Embed the CSRF token only for proxy-mode callbacks that POST back to StyleBI's own
+      // /api/assistant/proxy/** path — the CSRF filter requires it for those POSTs.
+      // Direct-mode callbacks target the external assistant server, which ignores the token;
+      // forwarding the session CSRF credential to a third-party is unnecessary and undesirable.
+      String normalizedStyleBIUrl = styleBIUrl.endsWith("/")
+         ? styleBIUrl.substring(0, styleBIUrl.length() - 1) : styleBIUrl;
+      boolean proxyCallback = callback.toLowerCase().startsWith(
+         (normalizedStyleBIUrl + AIAssistantController.PROXY_PATH_PREFIX).toLowerCase());
+
+      String csrfToken = null;
+
+      if(proxyCallback) {
+         Cookie[] cookies = request.getCookies();
+
+         if(cookies != null) {
+            for(Cookie cookie : cookies) {
+               if("XSRF-TOKEN".equals(cookie.getName())) {
+                  csrfToken = cookie.getValue();
+                  break;
+               }
+            }
+         }
+      }
+
+      String html = buildAutoSubmitForm(callback, token, redirectUrl, csrfToken);
+
+      response.setStatus(HttpServletResponse.SC_OK);
+      response.setContentType(MediaType.TEXT_HTML_VALUE);
+      response.setHeader(HttpHeaders.CACHE_CONTROL, CacheControl.noStore().getHeaderValue());
+      response.getWriter().write(html);
+   }
+
+   /**
+    * JWKS endpoint.
+    * Returns the public key for JWT verification in JWKS format.
+    * This endpoint is public (no authentication required).
+    *
+    * @return JWKS JSON document
+    */
+   @GetMapping(value = "/sso/jwks", produces = MediaType.APPLICATION_JSON_VALUE)
+   @ResponseBody
+   public Map<String, Object> jwks() {
+      return ssoTokenService.getJWKS();
+   }
+
+   /**
+    * Validates the callback URL against the allowlist.
+    * Accepts callbacks under {@code {chat.app.server.url}} (direct) or under
+    * {@code {styleBIUrl}/api/assistant/proxy} (proxy mode).
+    */
+   private boolean isCallbackAllowed(String callback, HttpServletRequest request) {
+      if(callback == null || callback.isEmpty()) {
+         return false;
+      }
+
+      // Always allow callbacks back to StyleBI's own origin (same scheme+host+port+context-path).
+      String styleBIBase = LinkUriArgumentResolver.getLinkUri(request);
+
+      if(!styleBIBase.endsWith("/")) {
+         styleBIBase = styleBIBase + "/";
+      }
+
+      if(callback.toLowerCase().startsWith(styleBIBase.toLowerCase())) {
+         return true;
+      }
+
+      List<String> allowedCallbacks = getAllowedCallbacks();
+
+      // Check if callback starts with the allowed prefix
+      return allowedCallbacks.stream()
+         .anyMatch(allowed -> callback.toLowerCase().startsWith(allowed.toLowerCase()));
+   }
+
+   /**
+    * Gets the allowed callback URL prefix from the assistant.base.url configuration.
+    */
+   private List<String> getAllowedCallbacks() {
+      List<String> list = new ArrayList<>();
+      String assistantCallBack = getAllowedCallback(
+         SreeEnv.getProperty(AIAssistantController.CHAT_APP_SERVER_URL));
+
+      if(assistantCallBack != null) {
+         list.add(assistantCallBack.toLowerCase());
+      }
+
+      String wizCallBack = getAllowedCallback(SreeEnv.getProperty(WIZ_SERVICE_URL));
+
+      if(wizCallBack != null) {
+         list.add(wizCallBack.toLowerCase());
+      }
+
+      return list;
+   }
+
+   private String getAllowedCallback(String baseUrl) {
+      if(baseUrl == null || baseUrl.trim().isEmpty()) {
+         return null;
+      }
+
+      baseUrl = baseUrl.trim();
+
+      if(baseUrl.endsWith("/")) {
+         baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+      }
+
+      return baseUrl + SSO_CALLBACK_PATH;
+   }
+
+
+   /**
+    * Builds an HTML page with an auto-submitting form that POSTs the JWT to the callback URL.
+    */
+   private String buildAutoSubmitForm(String callback, String token, String redirectUrl,
+                                      String csrfToken)
+   {
+      String escapedCallback = HtmlUtils.htmlEscape(callback);
+      String escapedToken = HtmlUtils.htmlEscape(token);
+      String redirectUrlInput = "";
+
+      if(redirectUrl != null && !redirectUrl.isEmpty()) {
+         String escapedRedirectUrl = HtmlUtils.htmlEscape(redirectUrl);
+         redirectUrlInput = "<input type=\"hidden\" name=\"redirect_url\" value=\"" + escapedRedirectUrl + "\" />";
+      }
+
+      String csrfInput = "";
+
+      if(csrfToken != null && !csrfToken.isEmpty()) {
+         csrfInput = "<input type=\"hidden\" name=\"_csrf\" value=\"" + HtmlUtils.htmlEscape(csrfToken) + "\" />";
+      }
+
+      return """
+         <!DOCTYPE html>
+         <html>
+         <head>
+            <meta charset="UTF-8">
+            <title>Authorize StyleBI Access</title>
+            <style>
+               * { box-sizing: border-box; margin: 0; padding: 0; }
+               body {
+                  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+                  background: #f5f5f5;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  min-height: 100vh;
+               }
+               .card {
+                  background: #fff;
+                  border-radius: 12px;
+                  box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+                  padding: 48px 40px;
+                  max-width: 420px;
+                  width: 100%%;
+                  text-align: center;
+               }
+               .logo { font-size: 40px; margin-bottom: 16px; }
+               h1 { font-size: 22px; font-weight: 600; color: #1a1a1a; margin-bottom: 8px; }
+               p { font-size: 14px; color: #666; margin-bottom: 32px; line-height: 1.5; }
+               .btn {
+                  display: inline-block;
+                  background: #ed711c;
+                  color: #fff;
+                  border: none;
+                  border-radius: 8px;
+                  padding: 14px 40px;
+                  font-size: 16px;
+                  font-weight: 600;
+                  cursor: pointer;
+                  width: 100%%;
+                  transition: background 0.2s;
+               }
+               .btn:hover { background: #d25f11; }
+               .hint { margin-top: 20px; font-size: 12px; color: #999; }
+            </style>
+         </head>
+         <body>
+            <div class="card">
+               <div class="logo"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#ed711c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
+               <h1>Authorize StyleBI Access</h1>
+               <p>An AI agent is requesting access to your StyleBI session.<br>
+                  Click <strong>Authorize</strong> to connect, or close this tab to cancel.</p>
+               <form method="POST" action="%s">
+                  <input type="hidden" name="token" value="%s" />
+                  %s
+                  %s
+                  <button type="submit" class="btn">Authorize</button>
+               </form>
+               <p class="hint">You can copy this page's URL into another browser or incognito window before clicking.</p>
+            </div>
+         </body>
+         </html>
+         """.formatted(escapedCallback, escapedToken, redirectUrlInput, csrfInput);
+   }
+
+   private final SSOTokenService ssoTokenService;
+   private static final String SSO_CALLBACK_PATH = "/api/wiz/auth/callback";
+}

--- a/core/src/main/java/inetsoft/web/wiz/security/SSOTokenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/security/SSOTokenService.java
@@ -1,0 +1,229 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.security;
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import inetsoft.sree.ClientInfo;
+import inetsoft.sree.security.*;
+import inetsoft.util.PasswordEncryption;
+import inetsoft.util.Tool;
+import inetsoft.web.wiz.AppDomainUtils;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.security.*;
+import java.security.interfaces.RSAPublicKey;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+/**
+ * Service for creating RS256-signed JWT tokens for cross-app SSO.
+ * This service generates tokens that can be verified by external applications
+ * using the public key exposed via the JWKS endpoint.
+ */
+@Component
+public class SSOTokenService {
+   @Autowired
+   public SSOTokenService(SecurityProvider securityProvider) {
+      this.securityProvider = securityProvider;
+   }
+
+   @PostConstruct
+   public void init() throws IOException {
+      ssoKeyPair = PasswordEncryption.newInstance().getSSOKeyPair();
+   }
+
+   /**
+    * Creates an RS256-signed SSO JWT token for the given principal.
+    *
+    * @param principal the authenticated user principal
+    * @param issuerUrl the StyleBI server URL to use as the JWT issuer
+    * @return the serialized JWT token string
+    */
+   public String createSSOToken(Principal principal, String issuerUrl) {
+      SRPrincipal srPrincipal = convertPrincipal(principal);
+
+      try {
+         long expirationSeconds = ZonedDateTime.now(ZoneOffset.UTC)
+            .plusHours(SSO_TOKEN_EXPIRATION_HOURS)
+            .toEpochSecond();
+         Date expirationTime = new Date(expirationSeconds * 1000L);
+         Date issueTime = new Date();
+
+         String[] roles = Arrays.stream(srPrincipal.getRoles())
+            .map(IdentityID::convertToKey)
+            .toArray(String[]::new);
+
+         ClientInfo clientInfo = srPrincipal.getUser();
+         String clientAddress = clientInfo != null ? clientInfo.getIPAddress() : null;
+         String clientSession = clientInfo != null ? clientInfo.getSession() : null;
+         Locale clientLocale = clientInfo != null ? clientInfo.getLocale() : null;
+         IdentityID loginUserID = clientInfo != null ? clientInfo.getLoginUserID() : null;
+
+         JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder()
+            .issuer(normalizeIssuerUrl(issuerUrl))
+            .audience(SSO_AUDIENCE)
+            .subject(srPrincipal.getName())
+            .issueTime(issueTime)
+            .expirationTime(expirationTime)
+            .claim("roles", roles)
+            .claim("groups", srPrincipal.getGroups())
+            .claim("organizationId", srPrincipal.getOrgId())
+            .claim("appDomain", AppDomainUtils.getAppDomain(srPrincipal))
+            .claim("secureId", srPrincipal.getSecureID())
+            .claim("clientAddress", clientAddress)
+            .claim("clientSession", clientSession)
+            .claim("clientLoginUser", loginUserID != null ? loginUserID.convertToKey() : null);
+
+         // Add email if available
+         String email = getUserEmail(srPrincipal);
+
+         if(email != null && !email.isEmpty()) {
+            claimsBuilder.claim("email", email);
+         }
+
+         // Add locale from ClientInfo (use toString() for Java locale format: zh_CN)
+         if(clientLocale != null) {
+            claimsBuilder.claim("locale", clientLocale.toString());
+         }
+
+         claimsBuilder.claim("version", Tool.getReportVersion());
+
+         JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(getKeyId())
+            .build();
+
+         SignedJWT jwt = new SignedJWT(header, claimsBuilder.build());
+         JWSSigner signer = new RSASSASigner(ssoKeyPair.getPrivate());
+         jwt.sign(signer);
+
+         return jwt.serialize();
+      }
+      catch(JOSEException e) {
+         throw new RuntimeException("Failed to create SSO token", e);
+      }
+   }
+
+   /**
+    * Gets the JWKS (JSON Web Key Set) containing the public key for JWT verification.
+    *
+    * @return the JWKS as a Map that can be serialized to JSON
+    */
+   public Map<String, Object> getJWKS() {
+      try {
+         RSAPublicKey publicKey = (RSAPublicKey) ssoKeyPair.getPublic();
+
+         RSAKey rsaKey = new RSAKey.Builder(publicKey)
+            .keyID(getKeyId())
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .build();
+
+         JWKSet jwkSet = new JWKSet(rsaKey);
+         return jwkSet.toJSONObject();
+      }
+      catch(Exception e) {
+         throw new RuntimeException("Failed to generate JWKS", e);
+      }
+   }
+
+   /**
+    * Gets a stable key ID for the RSA key pair.
+    * Uses the SHA-256 thumbprint of the public key.
+    */
+   private String getKeyId() {
+      try {
+         RSAPublicKey publicKey = (RSAPublicKey) ssoKeyPair.getPublic();
+         RSAKey rsaKey = new RSAKey.Builder(publicKey).build();
+         return rsaKey.computeThumbprint().toString();
+      }
+      catch(JOSEException e) {
+         // Fallback to a simple hash if thumbprint fails
+         return Integer.toHexString(ssoKeyPair.getPublic().hashCode());
+      }
+   }
+
+   private SRPrincipal convertPrincipal(Principal principal) {
+      if(principal instanceof SRPrincipal) {
+         return (SRPrincipal) principal;
+      }
+
+      IdentityID userID = IdentityID.getIdentityIDFromKey(principal.getName());
+      return createPrincipal(userID);
+   }
+
+   private SRPrincipal createPrincipal(IdentityID username) {
+      IdentityID[] roles = securityProvider.getRoles(username);
+      User user = securityProvider.getUser(username);
+      String[] groups = user == null ? new String[0] : user.getGroups();
+      String orgID = user == null ? Organization.getDefaultOrganizationID() :
+         securityProvider.getOrganization(user.getOrganizationID()).getId();
+
+      if(roles == null) {
+         roles = new IdentityID[0];
+      }
+
+      if(groups == null) {
+         groups = new String[0];
+      }
+
+      return new SRPrincipal(username, roles, groups, orgID,
+         inetsoft.util.Tool.getSecureRandom().nextLong());
+   }
+
+   private String getUserEmail(SRPrincipal principal) {
+      try {
+         IdentityID userID = principal.getIdentityID();
+         User user = securityProvider.getUser(userID);
+         String[] emails = user != null ? user.getEmails() : null;
+         return emails != null && emails.length > 0 ? emails[0] : null;
+      }
+      catch(Exception e) {
+         return null;
+      }
+   }
+
+   /**
+    * Normalizes the issuer URL by removing trailing slashes.
+    */
+   private String normalizeIssuerUrl(String url) {
+      if(url == null || url.isEmpty()) {
+         return url;
+      }
+
+      // Remove trailing slashes for consistency
+      while(url.endsWith("/")) {
+         url = url.substring(0, url.length() - 1);
+      }
+
+      return url;
+   }
+
+   private KeyPair ssoKeyPair;
+   private final SecurityProvider securityProvider;
+
+   private static final List<String> SSO_AUDIENCE = Arrays.asList("chat-app", "wiz-service");
+   private static final long SSO_TOKEN_EXPIRATION_HOURS = 8L;
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/SSOTokenControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/SSOTokenControllerTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.assistant.AIAssistantController;
+import inetsoft.web.wiz.security.SSOTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link SSOTokenController}'s own logic — callback allowlist matching, the
+ * unauthenticated-principal login redirect, and HTML escaping in the auto-submit form. JWT
+ * claim encoding is covered separately by {@code SSOTokenServiceTest}.
+ */
+@Tag("core")
+class SSOTokenControllerTest {
+
+   private SSOTokenController controller;
+   private MockedStatic<SreeEnv> sreeEnvMock;
+
+   @BeforeEach
+   void setUp() {
+      controller = new SSOTokenController(mock(SSOTokenService.class));
+
+      sreeEnvMock = mockStatic(SreeEnv.class);
+      sreeEnvMock.when(() -> SreeEnv.getProperty(AIAssistantController.CHAT_APP_SERVER_URL))
+         .thenReturn("https://chat.example.com");
+      sreeEnvMock.when(() -> SreeEnv.getProperty(WizPortalController.WIZ_SERVICE_URL))
+         .thenReturn("https://wiz.example.com");
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvMock.close();
+   }
+
+   private HttpServletRequest mockRequest() {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getScheme()).thenReturn("https");
+      when(request.getServerName()).thenReturn("stylebi.example.com");
+      when(request.getServerPort()).thenReturn(443);
+      when(request.getHeader("X-Inetsoft-Remote-Uri")).thenReturn(null);
+      when(request.getContextPath()).thenReturn("");
+      return request;
+   }
+
+   private boolean isCallbackAllowed(String callback, HttpServletRequest request) {
+      return ReflectionTestUtils.invokeMethod(controller, "isCallbackAllowed", callback, request);
+   }
+
+   @Test
+   void isCallbackAllowed_sameOrigin_allowed() {
+      assertTrue(isCallbackAllowed(
+         "https://stylebi.example.com/api/assistant/proxy/foo", mockRequest()));
+   }
+
+   @Test
+   void isCallbackAllowed_chatAppPrefix_allowed() {
+      assertTrue(isCallbackAllowed(
+         "https://chat.example.com/api/wiz/auth/callback", mockRequest()));
+   }
+
+   @Test
+   void isCallbackAllowed_wizServicePrefix_withQueryString_allowed() {
+      assertTrue(isCallbackAllowed(
+         "https://wiz.example.com/api/wiz/auth/callback?nonce=abc", mockRequest()));
+   }
+
+   @Test
+   void isCallbackAllowed_pathBoundaryGap_rejected() {
+      // Regression test for the boundary gap flagged in review: a longer, unrelated path must
+      // not match just because it shares the callback path as a literal string prefix.
+      assertFalse(isCallbackAllowed(
+         "https://chat.example.com/api/wiz/auth/callback-evil", mockRequest()));
+   }
+
+   @Test
+   void isCallbackAllowed_unrelatedOrigin_rejected() {
+      assertFalse(isCallbackAllowed("https://attacker.example.com/steal", mockRequest()));
+   }
+
+   @Test
+   void isCallbackAllowed_nullOrEmpty_rejected() {
+      assertFalse(isCallbackAllowed(null, mockRequest()));
+      assertFalse(isCallbackAllowed("", mockRequest()));
+   }
+
+   @Test
+   void authorize_nullPrincipal_redirectsToLogin() throws Exception {
+      HttpServletRequest request = mockRequest();
+      when(request.getUserPrincipal()).thenReturn(null);
+      when(request.getServletPath()).thenReturn("/sso/authorize");
+      when(request.getPathInfo()).thenReturn(null);
+      when(request.getQueryString())
+         .thenReturn("callback=https://chat.example.com/api/wiz/auth/callback");
+
+      HttpServletResponse response = mock(HttpServletResponse.class);
+
+      controller.authorize(
+         "https://chat.example.com/api/wiz/auth/callback", null, request, response);
+
+      ArgumentCaptor<String> redirectCaptor = ArgumentCaptor.forClass(String.class);
+      verify(response).sendRedirect(redirectCaptor.capture());
+      assertTrue(redirectCaptor.getValue()
+         .startsWith("https://stylebi.example.com/login.html?requestedUrl="),
+         "Unauthenticated requests must be redirected to login with the original URL preserved");
+   }
+
+   @Test
+   void buildAutoSubmitForm_escapesHtmlInAllFields() {
+      String html = ReflectionTestUtils.invokeMethod(controller, "buildAutoSubmitForm",
+         "https://chat.example.com/cb\"><script>alert(1)</script>",
+         "token\"><script>alert(2)</script>",
+         "https://example.com/redirect\"><script>alert(3)</script>",
+         "csrf\"><script>alert(4)</script>");
+
+      assertNotNull(html);
+      assertFalse(html.contains("<script>"), "Raw <script> must never appear unescaped");
+      assertTrue(html.contains("&lt;script&gt;"), "Interpolated values must be HTML-escaped");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/security/SSOTokenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/security/SSOTokenServiceTest.java
@@ -1,0 +1,347 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.security;
+
+/*
+ * Cases deferred - require additional static-constructor isolation:
+ *
+ * init() -> calls PasswordEncryption.newInstance().getSSOKeyPair()
+ *           and is covered indirectly here by injecting a test key pair.
+ *           A direct unit test would need an extra mockStatic tier for
+ *           PasswordEncryption and adds little value beyond the existing
+ *           createSSOToken()/getJWKS() key-usage assertions.
+ */
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.FSUser;
+import inetsoft.sree.security.*;
+import inetsoft.uql.util.XSessionService;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Principal;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for SSOTokenService JWT claim encoding.
+ * Verifies that principal attributes are correctly encoded into outbound SSO tokens.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class SSOTokenServiceTest {
+
+   @Mock
+   private SecurityProvider securityProvider;
+
+   private SSOTokenService service;
+   private MockedStatic<XSessionService> xSessionServiceMock;
+   private MockedStatic<SreeEnv> sreeEnvMock;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      // XPrincipal constructor calls XSessionService.getService().createSessionID()
+      // which requires a Spring context. Mock it to avoid that dependency.
+      XSessionService mockSessionService = mock(XSessionService.class);
+      AtomicLong counter = new AtomicLong(0);
+      when(mockSessionService.createSessionID(anyString(), any()))
+         .thenAnswer(inv -> inv.getArgument(0, String.class) + counter.incrementAndGet());
+
+      xSessionServiceMock = mockStatic(XSessionService.class);
+      xSessionServiceMock.when(XSessionService::getService).thenReturn(mockSessionService);
+
+      // createSSOToken() calls AppDomainUtils.getAppDomain() -> SreeEnv.getProperty(),
+      // which requires a Spring context. Mock it to avoid that dependency; individual
+      // tests may override this stub to exercise the appDomain claim.
+      sreeEnvMock = mockStatic(SreeEnv.class);
+      sreeEnvMock.when(() -> SreeEnv.getProperty(anyString(), eq(false), eq(true))).thenReturn(null);
+
+      service = new SSOTokenService(securityProvider);
+      // Bypass @PostConstruct — inject a test RSA key pair directly
+      KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+      gen.initialize(2048);
+      ReflectionTestUtils.setField(service, "ssoKeyPair", gen.generateKeyPair());
+   }
+
+   @AfterEach
+   void tearDown() {
+      if(xSessionServiceMock != null) {
+         xSessionServiceMock.close();
+      }
+      if(sreeEnvMock != null) {
+         sreeEnvMock.close();
+      }
+   }
+
+   private SRPrincipal principal(String name, String orgId, IdentityID... roles) {
+      return new SRPrincipal(new IdentityID(name, orgId), roles, new String[0], orgId, 1L);
+   }
+
+   private FSUser user(String name, String orgId) {
+      FSUser user = new FSUser(new IdentityID(name, orgId));
+      user.setOrganization(orgId);
+      return user;
+   }
+
+   @Test
+   void createSSOToken_principalWithRoles_tokenContainsRoles() throws Exception {
+      SRPrincipal p = principal("alice", "orgA",
+         new IdentityID("Viewer", "orgA"), new IdentityID("Analyst", "orgA"));
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      List<String> tokenRoles = claims.getStringListClaim("roles");
+      assertNotNull(tokenRoles, "'roles' claim must be present");
+      assertEquals(
+         List.of(new IdentityID("Viewer", "orgA").convertToKey(),
+            new IdentityID("Analyst", "orgA").convertToKey()),
+         tokenRoles,
+         "Token must encode role identity keys");
+   }
+
+   @Test
+   void createSSOToken_srPrincipal_encodesSubjectAudienceGroupsAndVersion() throws Exception {
+      SRPrincipal p = new SRPrincipal(
+         new IdentityID("alice", "orgA"),
+         new IdentityID[] { new IdentityID("Viewer", "orgA") },
+         new String[] { "finance", "ops" },
+         "orgA",
+         1L);
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertAll(
+         () -> assertEquals(new IdentityID("alice", "orgA").convertToKey(), claims.getSubject(),
+            "Token subject must be the principal identity key"),
+         () -> assertEquals(List.of("chat-app", "wiz-service"), claims.getAudience(),
+            "Token audience must target the chat app and wiz service"),
+         () -> assertEquals(List.of("finance", "ops"), claims.getStringListClaim("groups"),
+            "SRPrincipal groups must be copied into the token"),
+         () -> assertEquals(Tool.getReportVersion(), claims.getStringClaim("version"),
+            "Token must include the current report version")
+      );
+   }
+
+   @Test
+   void createSSOToken_principalWithOrg_tokenContainsOrganization() throws Exception {
+      SRPrincipal p = principal("bob", "acme");
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertEquals("acme", claims.getStringClaim("organizationId"),
+         "Token must encode the principal's orgId");
+   }
+
+   @Test
+   void createSSOToken_issuerUrl_isNormalizedWithoutTrailingSlash() throws Exception {
+      SRPrincipal p = principal("user", "org");
+
+      String token = service.createSSOToken(p, "https://example.com///");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertEquals("https://example.com", claims.getIssuer(),
+         "Trailing slashes must be stripped from issuer URL");
+   }
+
+   @Test
+   void createSSOToken_producesRS256SignedToken() throws Exception {
+      SRPrincipal p = principal("user", "org");
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      SignedJWT jwt = SignedJWT.parse(token);
+      assertEquals("RS256", jwt.getHeader().getAlgorithm().getName(),
+         "Token must be signed with RS256");
+   }
+
+   @Test
+   void createSSOToken_tokenHasExpiration() throws Exception {
+      SRPrincipal p = principal("user", "org");
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertNotNull(claims.getExpirationTime(), "Token must have an expiration time");
+      long now = System.currentTimeMillis();
+      long exp = claims.getExpirationTime().getTime();
+      assertTrue(exp > now, "Token expiration must be in the future");
+      assertTrue(exp > now + 7 * 3600 * 1000L, "Expiration must be at least 7 hours away");
+      assertTrue(exp < now + 9 * 3600 * 1000L, "Expiration must be at most 9 hours away");
+   }
+
+   @Test
+   void createSSOToken_userWithEmail_tokenContainsFirstEmail() throws Exception {
+      SRPrincipal p = principal("carol", "orgA");
+      FSUser user = user("carol", "orgA");
+      user.setEmails(new String[] { "carol@example.com", "carol@backup.example.com" });
+      when(securityProvider.getUser(new IdentityID("carol", "orgA"))).thenReturn(user);
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertEquals("carol@example.com", claims.getStringClaim("email"),
+         "Token must include the first available email address");
+   }
+
+   @Test
+   void createSSOToken_userWithoutEmail_tokenOmitsEmailClaim() throws Exception {
+      SRPrincipal p = principal("dave", "orgA");
+      FSUser user = user("dave", "orgA");
+      user.setEmails(new String[0]);
+      when(securityProvider.getUser(new IdentityID("dave", "orgA"))).thenReturn(user);
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertNull(claims.getClaim("email"),
+         "Token must omit the email claim when the provider returns no email");
+   }
+
+   @Test
+   void createSSOToken_userLookupThrows_tokenOmitsEmailClaimInsteadOfFailing() throws Exception {
+      SRPrincipal p = principal("erin", "orgA");
+      when(securityProvider.getUser(new IdentityID("erin", "orgA")))
+         .thenThrow(new RuntimeException("lookup failed"));
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertNull(claims.getClaim("email"),
+         "Email lookup failures must be swallowed so token creation can continue");
+   }
+
+   @Test
+   void createSSOToken_principalWithLocale_tokenContainsLanguageTag() throws Exception {
+      SRPrincipal p = principal("frank", "orgA");
+      p.getUser().setLocale(Locale.CANADA_FRENCH);
+
+      String token = service.createSSOToken(p, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertEquals("fr_CA", claims.getStringClaim("locale"),
+         "Token must encode the client locale in Java locale format");
+   }
+
+   @Test
+   void createSSOToken_nonSrPrincipal_usesSecurityProviderToBuildClaims() throws Exception {
+      Principal principal = () -> new IdentityID("grace", "orgB").convertToKey();
+      IdentityID[] roles = {
+         new IdentityID("Viewer", "orgB"),
+         new IdentityID("Analyst", "orgB")
+      };
+      FSUser user = user("grace", "orgB");
+      user.setGroups(new String[] { "finance", "north-america" });
+      when(securityProvider.getRoles(new IdentityID("grace", "orgB"))).thenReturn(roles);
+      when(securityProvider.getUser(new IdentityID("grace", "orgB"))).thenReturn(user);
+      Organization org = mock(Organization.class);
+      when(org.getId()).thenReturn("resolved-orgB");
+      when(securityProvider.getOrganization("orgB")).thenReturn(org);
+
+      String token = service.createSSOToken(principal, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertAll(
+         () -> assertEquals(new IdentityID("grace", "orgB").convertToKey(), claims.getSubject(),
+            "Non-SRPrincipal inputs must be converted into the identity-key subject"),
+         () -> assertEquals("resolved-orgB", claims.getStringClaim("organizationId"),
+            "Organization must come from the provider-backed principal reconstruction"),
+         () -> assertEquals(List.of("finance", "north-america"), claims.getStringListClaim("groups"),
+            "Provider groups must be copied into the token claims"),
+         () -> assertEquals(
+            List.of(new IdentityID("Viewer", "orgB").convertToKey(),
+               new IdentityID("Analyst", "orgB").convertToKey()),
+            claims.getStringListClaim("roles"),
+            "Provider roles must be copied into the token claims")
+      );
+   }
+
+   @Test
+   void createSSOToken_nonSrPrincipal_nullRolesAndGroups_fallBackToEmptyArrays() throws Exception {
+      Principal principal = () -> new IdentityID("harry", "orgC").convertToKey();
+      FSUser user = user("harry", "orgC");
+      user.setGroups(null);
+      when(securityProvider.getRoles(new IdentityID("harry", "orgC"))).thenReturn(null);
+      when(securityProvider.getUser(new IdentityID("harry", "orgC"))).thenReturn(user);
+      Organization org = mock(Organization.class);
+      when(org.getId()).thenReturn("orgC");
+      when(securityProvider.getOrganization("orgC")).thenReturn(org);
+
+      String token = service.createSSOToken(principal, "https://test.example.com");
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertAll(
+         () -> assertEquals(List.of(), claims.getStringListClaim("roles"),
+            "Null provider roles must become an empty roles claim"),
+         () -> assertEquals(List.of(), claims.getStringListClaim("groups"),
+            "Null provider groups must become an empty groups claim")
+      );
+   }
+
+   @Test
+   void createSSOToken_nullIssuer_preservesNullIssuer() throws Exception {
+      SRPrincipal p = principal("user", "org");
+
+      String token = service.createSSOToken(p, null);
+
+      JWTClaimsSet claims = SignedJWT.parse(token).getJWTClaimsSet();
+      assertNull(claims.getIssuer(), "Null issuer input must remain null");
+   }
+
+   @Test
+   void getJwks_containsSingleRsaSigningKeyWithStableKid() throws Exception {
+      SRPrincipal p = principal("ivy", "orgA");
+      String token = service.createSSOToken(p, "https://test.example.com");
+      SignedJWT jwt = SignedJWT.parse(token);
+
+      Map<String, Object> jwks = service.getJWKS();
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> keys = (List<Map<String, Object>>) jwks.get("keys");
+
+      assertNotNull(keys, "JWKS must contain a keys array");
+      assertEquals(1, keys.size(), "JWKS must expose exactly one signing key");
+
+      Map<String, Object> key = keys.get(0);
+      assertAll(
+         () -> assertEquals("RSA", key.get("kty"),
+            "JWKS must expose an RSA key"),
+         () -> assertEquals("sig", key.get("use"),
+            "JWKS key use must be signing"),
+         () -> assertEquals("RS256", key.get("alg"),
+            "JWKS algorithm must match the token signing algorithm"),
+         () -> assertEquals(jwt.getHeader().getKeyID(), key.get("kid"),
+            "JWKS key id must match the token header kid")
+      );
+   }
+}


### PR DESCRIPTION
## Summary

- `SSOTokenController`/`SSOTokenService` implement `/sso/authorize` and `/sso/jwks` — the login flow the `stylebi-admin-chat` (and other wiz) plugins use to sign in. They previously lived under `enterprise/`, even though the flow's other half (`WizServiceAuthenticationFilter`, `WizAuthCallbackController`) is already here in `community/core`, and every dependency they use (`SecurityProvider`, `PasswordEncryption`, `SRPrincipal`, `AppDomainUtils`, `nimbus-jose-jwt`) is already community-only.
- Net effect: a Community-edition deployment could never complete plugin login at all — `/sso/authorize` 404s with no fallback path. Confirmed live against a real Community build, and documented in `stylebi-wiz`'s plugin-admin test plan (Stage 1 · 0.3), which also lists the downstream items this blocked (S-4.1, M-3.2, I-6.4, A-5.2, D-4.2, C-3.3, V-5.2, L-1.1).
- Moves `SSOTokenController` into `inetsoft.web.wiz.controller` (alongside `WizAuthCallbackController`) and `SSOTokenService` into `inetsoft.web.wiz.security` (alongside `WizServiceAuthenticationFilter`, which validates the tokens this service signs). Pure move — package declaration, one import, and license header updated to match community's AGPL convention; no logic changes.
- Companion enterprise PR removes the old classes and bumps the submodule pointer to this commit (linked once this PR is up).

## Test plan
- [x] `./mvnw -pl core compile` — community/core compiles cleanly
- [x] `./mvnw -pl core test -Dtest=SSOTokenServiceTest` — all 14 tests pass in the new location
- [x] Confirmed no remaining references to `inetsoft.enterprise.sso.SSOTokenService` / `inetsoft.enterprise.web.sso.SSOTokenController` anywhere in the tree