### PR TITLE
L9 Scripting parity: fix Group A findings (G1-1, G1-2, G3-1, G3-2)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/CalcFieldService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/CalcFieldService.java
@@ -28,6 +28,7 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.DataVSAssemblyInfo;
 import inetsoft.util.script.ScriptEnv;
+import inetsoft.util.script.ScriptEnvRepository;
 import inetsoft.web.wiz.pairing.PairingException;
 import org.springframework.stereotype.Service;
 
@@ -148,11 +149,25 @@ public class CalcFieldService {
    }
 
    /**
-    * Mirrors {@code ModifyCalculateFieldService.checkScriptValid}'s syntax check, not the method
-    * itself: that method is wired to a {@code CommandDispatcher}/{@code MessageCommand} pair --
-    * a WebSocket-session concept this session-token-based agent path has none of -- and also
-    * handles the cube-measure (MDX) branch, which {@link #calcRefOf} never returns (every ref
-    * this Tier 2a path resolves is a plain {@link ExpressionRef}-backed field).
+    * Mirrors the INTENT of {@code ModifyCalculateFieldService.checkScriptValid}'s syntax check,
+    * not its JS implementation: that method (and the shared {@code ExpressionDialogService.check}
+    * the native "Edit Expression" dialog also uses) validates JS via {@code ScriptEnv.compile()},
+    * which -- confirmed live -- does NOT actually parse anything under the Graal engine; it only
+    * builds a lazy {@code Source} literal, so a syntax error like an unbalanced paren is silently
+    * accepted and only surfaces later at render time (reproduced live: the native Formula Editor
+    * dialog accepts it too, then `FormulaTableLens` logs a `SyntaxError` at data-refresh time).
+    * That is a pre-existing StyleBI-side gap in {@code checkScriptValid}/{@code
+    * ExpressionDialogService.check} themselves, out of scope for this lane (operator decision:
+    * fix only this path, not the shared dialog method). {@link ScriptEnv#checkFunction} is the
+    * primitive that actually parses eagerly (`context.parse("js", cmd)`, throwing on a real
+    * syntax error) -- the same one StyleBI's own Composer script-editor "check script" endpoint
+    * (`OpenScriptController`) already uses for an equivalent syntax-only check.
+    *
+    * <p>Also does not reuse {@code checkScriptValid} itself for another reason: that method is
+    * wired to a {@code CommandDispatcher}/{@code MessageCommand} pair -- a WebSocket-session
+    * concept this session-token-based agent path has none of -- and also handles the cube-measure
+    * (MDX) branch, which {@link #calcRefOf} never returns (every ref this Tier 2a path resolves
+    * is a plain {@link ExpressionRef}-backed field).
     */
    private void validateExpression(RuntimeViewsheet rvs, CalculateRef cref, String expression)
       throws PairingException
@@ -172,11 +187,14 @@ public class CalcFieldService {
       ScriptEnv env = scriptEnvOf(rvs);
 
       if(env == null) {
+         // ScriptEnvRepository.getScriptEnv() (scriptEnvOf's fallback) can only fail if the
+         // Graal engine class itself is missing from the deployment -- not a case worth
+         // silently skipping validation for, but also not one this path can recover from.
          return;
       }
 
       try {
-         env.compile(str);
+         env.checkFunction(cref.getName(), str);
       }
       catch(Exception ex) {
          String suggestion = env.getSuggestion(ex, null);
@@ -186,19 +204,40 @@ public class CalcFieldService {
       }
    }
 
+   /**
+    * Prefers the live runtime's own {@link ScriptEnv} when one is wired up, but calc fields are
+    * only ever reachable through a pane-scoped session ({@code PaneScopeService} requires it for
+    * every real call) -- and that session's {@code RuntimeViewsheet} is StyleBI's own preview
+    * copy backing the Formula Editor dialog, which is never given a live {@link ViewsheetSandbox}
+    * the way the dialog's own OK-button controller's runtime is
+    * ({@code ModifyCalculateFieldService} resolves a different, non-preview runtime). Relying on
+    * {@code rvs}'s own sandbox alone made this validation a no-op on every real call -- confirmed
+    * live, not just suspected: {@code rvs.getViewsheetSandbox()} returns {@code Optional.empty()}
+    * for that preview runtime.
+    *
+    * <p>Falls back to {@link ScriptEnvRepository#getScriptEnv()} -- a standalone engine with no
+    * data-sandbox dependency, the same mechanism {@code AssetQuerySandbox}/{@code ViewsheetScope}
+    * lazily create their own env from, and what {@code OpenScriptController} already uses for a
+    * comparable syntax-only check. Compiling doesn't need a live data context: referencing an
+    * undeclared {@code field} is a runtime {@code ReferenceError}, not a compile-time syntax
+    * error, so a bare engine still catches the failure mode this check exists for (e.g. an
+    * unbalanced paren).
+    */
    private ScriptEnv scriptEnvOf(RuntimeViewsheet rvs) {
-      if(rvs == null) {
-         return null;
+      if(rvs != null) {
+         Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+         if(box.isPresent()) {
+            AssetQuerySandbox wbox = box.get().getAssetQuerySandbox();
+            ScriptEnv env = wbox == null ? null : wbox.getScriptEnv();
+
+            if(env != null) {
+               return env;
+            }
+         }
       }
 
-      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
-
-      if(box.isEmpty()) {
-         return null;
-      }
-
-      AssetQuerySandbox wbox = box.get().getAssetQuerySandbox();
-      return wbox == null ? null : wbox.getScriptEnv();
+      return ScriptEnvRepository.getScriptEnv();
    }
 
    private ExpressionRef expressionOf(Viewsheet vs, String table, String name)

--- a/core/src/main/java/inetsoft/web/wiz/script/CalcFieldService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/CalcFieldService.java
@@ -17,18 +17,24 @@
  */
 package inetsoft.web.wiz.script;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.erm.ExpressionRef;
+import inetsoft.uql.util.XUtil;
 import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.DataVSAssemblyInfo;
+import inetsoft.util.script.ScriptEnv;
 import inetsoft.web.wiz.pairing.PairingException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -115,18 +121,100 @@ public class CalcFieldService {
     * <p>Refuses a name that is not already there. Creating one is 2b, and silently creating it here
     * would hand the caller an unregistered field with no dependent-column invalidation -- which
     * looks like success and is not.
+    *
+    * <p>Validates the new text before storing it -- the same JS-compile/SQL-validity check the
+    * native Formula Editor dialog's OK button runs ({@code ModifyCalculateFieldService
+    * .checkScriptValid}) -- so a caller gets a loud, actionable rejection instead of an
+    * {@code {ok:true}} that silently persists an uncompilable expression, only surfacing later as
+    * a broken render.
     */
-   public void write(Viewsheet vs, String table, String name, String expression)
+   public void write(RuntimeViewsheet rvs, String table, String name, String expression)
       throws PairingException
    {
       if(expression == null) {
          throw new PairingException("A calc field's expression text is required.");
       }
 
-      expressionOf(vs, table, name).setExpression(expression);
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      CalculateRef cref = calcRefOf(vs, table, name);
+
+      if(!(cref.getDataRef() instanceof ExpressionRef ref)) {
+         throw new PairingException(
+            "Calculated field '" + name + "' on '" + table + "' holds no expression.");
+      }
+
+      validateExpression(rvs, cref, expression);
+      ref.setExpression(expression);
+   }
+
+   /**
+    * Mirrors {@code ModifyCalculateFieldService.checkScriptValid}'s syntax check, not the method
+    * itself: that method is wired to a {@code CommandDispatcher}/{@code MessageCommand} pair --
+    * a WebSocket-session concept this session-token-based agent path has none of -- and also
+    * handles the cube-measure (MDX) branch, which {@link #calcRefOf} never returns (every ref
+    * this Tier 2a path resolves is a plain {@link ExpressionRef}-backed field).
+    */
+   private void validateExpression(RuntimeViewsheet rvs, CalculateRef cref, String expression)
+      throws PairingException
+   {
+      boolean issql = cref.isSQL();
+      String str = ExpressionRef.getSQLExpression(issql, expression);
+
+      if(issql) {
+         if(!XUtil.isSQLExpressionValid(str)) {
+            throw new PairingException(
+               "Invalid SQL expression for calculated field '" + cref.getName() + "'.");
+         }
+
+         return;
+      }
+
+      ScriptEnv env = scriptEnvOf(rvs);
+
+      if(env == null) {
+         return;
+      }
+
+      try {
+         env.compile(str);
+      }
+      catch(Exception ex) {
+         String suggestion = env.getSuggestion(ex, null);
+         throw new PairingException(
+            "Script error in calculated field '" + cref.getName() + "': " + ex.getMessage() +
+            (suggestion != null ? "\nTo fix: " + suggestion : ""));
+      }
+   }
+
+   private ScriptEnv scriptEnvOf(RuntimeViewsheet rvs) {
+      if(rvs == null) {
+         return null;
+      }
+
+      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+      if(box.isEmpty()) {
+         return null;
+      }
+
+      AssetQuerySandbox wbox = box.get().getAssetQuerySandbox();
+      return wbox == null ? null : wbox.getScriptEnv();
    }
 
    private ExpressionRef expressionOf(Viewsheet vs, String table, String name)
+      throws PairingException
+   {
+      CalculateRef cref = calcRefOf(vs, table, name);
+
+      if(!(cref.getDataRef() instanceof ExpressionRef expression)) {
+         throw new PairingException(
+            "Calculated field '" + name + "' on '" + table + "' holds no expression.");
+      }
+
+      return expression;
+   }
+
+   private CalculateRef calcRefOf(Viewsheet vs, String table, String name)
       throws PairingException
    {
       if(vs == null) {
@@ -143,12 +231,7 @@ public class CalcFieldService {
 
       for(CalculateRef ref : refs) {
          if(name.equals(ref.getName())) {
-            if(!(ref.getDataRef() instanceof ExpressionRef expression)) {
-               throw new PairingException(
-                  "Calculated field '" + name + "' on '" + table + "' holds no expression.");
-            }
-
-            return expression;
+            return ref;
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptApiService.java
@@ -26,8 +26,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Best-effort "Layer A" static metadata lookup (the generated Tern {@code js-functions} JSON the
@@ -93,12 +95,45 @@ public class ScriptApiService {
             functions.set(e.getKey(), e.getValue());
          }
 
+         // Report/Sree-scoped globals aren't valid in a viewsheet script -- the script editor's
+         // own autocomplete (VSScriptableService.createStaticDefinitions) hides them the same way.
+         functions.remove(SREE_ONLY);
+
+         // Excel-style CALC functions (day, eomonth, ...) are nested under "CALC" in the source
+         // file but are callable bare, unqualified, in a viewsheet script -- mirrors
+         // VSScriptableService.createStaticDefinitions, the UI script editor's own resolution of
+         // this same static metadata, so a bare lookup here matches what a human actually sees.
+         JsonNode calc = functions.get("CALC");
+
+         if(calc != null && calc.isObject()) {
+            ObjectNode merged = MAPPER.createObjectNode();
+            merged.setAll((ObjectNode) calc);
+            merged.setAll(functions);
+            return merged;
+         }
+
          return functions;
       }
       catch(Exception e) {
          LOG.warn("Failed to load script API metadata", e);
          return MAPPER.createObjectNode();
       }
+   }
+
+   private static final Set<String> SREE_ONLY = new HashSet<>();
+
+   static {
+      SREE_ONLY.add("showReplet");
+      SREE_ONLY.add("showReport");
+      SREE_ONLY.add("showURL");
+      SREE_ONLY.add("promptParameters");
+      SREE_ONLY.add("sendRequest");
+      SREE_ONLY.add("refresh");
+      SREE_ONLY.add("reprint");
+      SREE_ONLY.add("setChanged");
+      SREE_ONLY.add("scrollTo");
+      SREE_ONLY.add("showStatus");
+      SREE_ONLY.add("dataBinding");
    }
 
    private JsonNode readResource(String path) throws Exception {

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
@@ -172,7 +172,7 @@ public class ScriptEditService {
             VSAssemblyInfo info = ScriptReadService.requireAssemblyInfo(vs, target.assemblyName());
             ScriptReadService.setOnClick(info, text);
          }
-         case CALC_FIELD -> calcFields.write(vs, target.assemblyName(), target.name(), text);
+         case CALC_FIELD -> calcFields.write(rvs, target.assemblyName(), target.name(), text);
          // This is a switch STATEMENT, not an expression -- with no `default`, a Location this
          // switch does not name would silently fall through and do NOTHING (the dangerous half
          // of the trap this package has hit before: a no-op that reports success). A worksheet

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -58,6 +58,7 @@ import java.security.Principal;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Session-resolved edit service for worksheets.
@@ -135,16 +136,19 @@ public class WorksheetEditService {
       // through. Falling back to ScriptEnvRepository.getScriptEnv() -- the same standalone,
       // sandbox-independent engine CalcFieldService.scriptEnvOf falls back to, and what
       // AssetQuerySandbox itself lazily creates its own env from -- keeps the check from being
-      // silently skipped.
-      AssetQuerySandbox wbox = rws.getAssetQuerySandbox();
-      ScriptEnv scriptEnv = wbox == null ? null : wbox.getScriptEnv();
-
-      if(scriptEnv == null) {
-         scriptEnv = ScriptEnvRepository.getScriptEnv();
-      }
+      // silently skipped. Resolved lazily (only inside validateExpressionSyntax, and only when it
+      // actually reaches the JS branch): apply() is the single entry point for every mutator, not
+      // just the two expression-editing ones, and this resolution is a reflective
+      // ScriptEnvRepository.getScriptEnv() call with no caching at that layer when the sandbox
+      // path comes up empty -- not worth paying on every removeColumn/addFilter/setSort/... call.
+      Supplier<ScriptEnv> scriptEnvSupplier = () -> {
+         AssetQuerySandbox wbox = rws.getAssetQuerySandbox();
+         ScriptEnv env = wbox == null ? null : wbox.getScriptEnv();
+         return env != null ? env : ScriptEnvRepository.getScriptEnv();
+      };
 
       Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine, innerJoinService,
-         expressionDialogService, scriptEnv);
+         expressionDialogService, scriptEnvSupplier);
 
       try {
          mutation.accept(editor);
@@ -406,13 +410,13 @@ public class WorksheetEditService {
 
       Editor(Worksheet ws, Principal agent, SecurityEngine securityEngine,
              InnerJoinService innerJoinService, ExpressionDialogService expressionDialogService,
-             ScriptEnv scriptEnv) {
+             Supplier<ScriptEnv> scriptEnvSupplier) {
          this.ws = ws;
          this.agent = agent;
          this.securityEngine = securityEngine;
          this.innerJoinService = innerJoinService;
          this.expressionDialogService = expressionDialogService;
-         this.scriptEnv = scriptEnv;
+         this.scriptEnvSupplier = scriptEnvSupplier;
       }
 
       /**
@@ -657,8 +661,9 @@ public class WorksheetEditService {
        * @param expression the expression body
        * @param type       the data type string, or {@code null}
        * @param sql        {@code true} if the expression is SQL rather than script
-       * @throws PairingException if no {@link TableAssembly} with {@code table} exists, or
-       *                          if a column named {@code name} already exists on the table
+       * @throws PairingException if no {@link TableAssembly} with {@code table} exists, if a
+       *                          column named {@code name} already exists on the table, or if
+       *                          {@code expression} fails syntax validation
        */
       public void addExpressionColumn(String table, String name, String expression,
                                       String type, boolean sql)
@@ -678,6 +683,7 @@ public class WorksheetEditService {
                "'. Use edit_expression to modify an existing expression column.");
          }
 
+         validateExpressionSyntax(table, name, expression, sql);
          WorksheetMutationSupport.addExpressionColumn(t, name, expression, type, sql);
       }
 
@@ -1889,7 +1895,13 @@ public class WorksheetEditService {
       }
 
       /**
-       * SQL mode still delegates to the native "Edit Expression" dialog's own check
+       * Shared by {@link #addExpressionColumn} and {@link #editExpression} -- both are separate,
+       * directly wire-exposed ops (`add_expression_column`/`edit_expression`) that can each create
+       * a brand-new expression column with no other write path in between, so both need the same
+       * gate: an uncompilable expression created via {@code add_expression_column} is exactly the
+       * same failure mode this validation exists to close for {@code edit_expression}.
+       *
+       * <p>SQL mode still delegates to the native "Edit Expression" dialog's own check
        * ({@link ExpressionDialogService#check}) -- its SQL branch (a real {@code SQLLexer}/
        * {@code SQLParser} parse) genuinely works. JS mode does NOT: {@code check()}'s JS branch
        * validates via {@code ScriptEnv.compile()}, which -- confirmed live -- does not actually
@@ -1920,10 +1932,14 @@ public class WorksheetEditService {
 
          try {
             if(sql) {
-               expressionDialogService.check(str, scriptEnv, true);
+               expressionDialogService.check(str, scriptEnvSupplier.get(), true);
             }
-            else if(scriptEnv != null) {
-               scriptEnv.checkFunction(name, str);
+            else {
+               ScriptEnv env = scriptEnvSupplier.get();
+
+               if(env != null) {
+                  env.checkFunction(name, str);
+               }
             }
          }
          catch(Exception ex) {
@@ -3387,6 +3403,6 @@ public class WorksheetEditService {
       private final SecurityEngine securityEngine;
       private final InnerJoinService innerJoinService;
       private final ExpressionDialogService expressionDialogService;
-      private final ScriptEnv scriptEnv;
+      private final Supplier<ScriptEnv> scriptEnvSupplier;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -40,6 +40,7 @@ import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.util.script.ScriptEnv;
+import inetsoft.util.script.ScriptEnvRepository;
 import java.awt.Point;
 import java.util.Enumeration;
 import inetsoft.web.composer.ws.WorksheetControllerService;
@@ -126,8 +127,22 @@ public class WorksheetEditService {
          SheetType.WORKSHEET, session.runtimeId(), agent);
       applySocketSession(rws, session);
 
+      // Confirmed live: a session paired from the expression column's OWN editor (required for
+      // every real editExpression call -- PaneScopeService demands a pane-scoped session for
+      // worksheetExpression) resolves a RuntimeWorksheet whose getAssetQuerySandbox()/
+      // getScriptEnv() can come back null, silently no-op'ing ExpressionDialogService.check()'s
+      // JS branch (`if(env != null) env.compile(text)`) and letting an uncompilable expression
+      // through. Falling back to ScriptEnvRepository.getScriptEnv() -- the same standalone,
+      // sandbox-independent engine CalcFieldService.scriptEnvOf falls back to, and what
+      // AssetQuerySandbox itself lazily creates its own env from -- keeps the check from being
+      // silently skipped.
       AssetQuerySandbox wbox = rws.getAssetQuerySandbox();
       ScriptEnv scriptEnv = wbox == null ? null : wbox.getScriptEnv();
+
+      if(scriptEnv == null) {
+         scriptEnv = ScriptEnvRepository.getScriptEnv();
+      }
+
       Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine, innerJoinService,
          expressionDialogService, scriptEnv);
 
@@ -1874,13 +1889,25 @@ public class WorksheetEditService {
       }
 
       /**
-       * Mirrors the native "Edit Expression" dialog's own syntax check
-       * ({@link ExpressionDialogService#check}) -- before this, the wiz agent path skipped it
-       * entirely, silently persisting an uncompilable JS expression or unparseable SQL one, only
-       * surfacing later as a broken render. {@code expressionDialogService} is {@code null} only
-       * for an {@code Editor} built via {@code WorksheetEditService}'s 5-arg legacy constructor
-       * (this package's own tests), which skips validation deliberately rather than requiring
-       * every existing test to supply a real {@link ExpressionDialogService}.
+       * SQL mode still delegates to the native "Edit Expression" dialog's own check
+       * ({@link ExpressionDialogService#check}) -- its SQL branch (a real {@code SQLLexer}/
+       * {@code SQLParser} parse) genuinely works. JS mode does NOT: {@code check()}'s JS branch
+       * validates via {@code ScriptEnv.compile()}, which -- confirmed live -- does not actually
+       * parse anything under the Graal engine (it only builds a lazy {@code Source} literal), so
+       * a real syntax error like an unbalanced paren is silently accepted and only surfaces later
+       * at render time. Reproduced live: the native Formula/Expression editor dialog accepts the
+       * same broken text too, then `FormulaTableLens` logs a `SyntaxError` at data-refresh time --
+       * a pre-existing StyleBI-side gap in {@code check()} itself, out of scope for this lane
+       * (operator decision: fix only this path, not the shared dialog method). JS mode instead
+       * calls {@link ScriptEnv#checkFunction} directly -- the primitive that actually parses
+       * eagerly (`context.parse("js", cmd)`, throwing on a real syntax error), the same one
+       * StyleBI's own Composer script-editor "check script" endpoint ({@code OpenScriptController})
+       * already uses for an equivalent syntax-only check.
+       *
+       * <p>{@code expressionDialogService} is {@code null} only for an {@code Editor} built via
+       * {@code WorksheetEditService}'s 5-arg legacy constructor (this package's own tests), which
+       * skips validation deliberately rather than requiring every existing test to supply a real
+       * {@link ExpressionDialogService} -- both branches below honor that by returning early.
        */
       private void validateExpressionSyntax(String table, String name, String expression, boolean sql)
          throws PairingException
@@ -1892,7 +1919,12 @@ public class WorksheetEditService {
          String str = ExpressionRef.getSQLExpression(sql, expression);
 
          try {
-            expressionDialogService.check(str, scriptEnv, sql);
+            if(sql) {
+               expressionDialogService.check(str, scriptEnv, true);
+            }
+            else if(scriptEnv != null) {
+               scriptEnv.checkFunction(name, str);
+            }
          }
          catch(Exception ex) {
             String message = sql

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.event.AssetEventUtil;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.report.internal.binding.BaseField;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
@@ -35,12 +36,15 @@ import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.util.script.ScriptEnv;
 import java.awt.Point;
 import java.util.Enumeration;
 import inetsoft.web.composer.ws.WorksheetControllerService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
+import inetsoft.web.composer.ws.dialog.ExpressionDialogService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.service.RenderWaitSupport;
@@ -64,18 +68,39 @@ import java.util.Set;
 @Service
 public class WorksheetEditService {
 
-   @Autowired
    public WorksheetEditService(SheetSessionService sessions,
                                SheetRuntimeAccess runtimeAccess,
                                SheetAgentBroadcastService broadcast,
                                SecurityEngine securityEngine,
                                InnerJoinService innerJoinService)
    {
+      this(sessions, runtimeAccess, broadcast, securityEngine, innerJoinService, null);
+   }
+
+   /**
+    * @param expressionDialogService validates a new expression column's syntax before it is
+    *                                stored -- the same check {@link ExpressionDialogService
+    *                                #validateExpression} runs for the native "Edit Expression"
+    *                                dialog's OK button. {@code null} (the 5-arg constructor
+    *                                above, used throughout this package's own tests) skips that
+    *                                validation rather than failing to construct -- mirrors
+    *                                {@code ScriptEditService}'s optional-{@code CalcFieldService}
+    *                                shape.
+    */
+   @Autowired
+   public WorksheetEditService(SheetSessionService sessions,
+                               SheetRuntimeAccess runtimeAccess,
+                               SheetAgentBroadcastService broadcast,
+                               SecurityEngine securityEngine,
+                               InnerJoinService innerJoinService,
+                               ExpressionDialogService expressionDialogService)
+   {
       this.sessions = sessions;
       this.runtimeAccess = runtimeAccess;
       this.broadcast = broadcast;
       this.securityEngine = securityEngine;
       this.innerJoinService = innerJoinService;
+      this.expressionDialogService = expressionDialogService;
    }
 
    /**
@@ -101,7 +126,10 @@ public class WorksheetEditService {
          SheetType.WORKSHEET, session.runtimeId(), agent);
       applySocketSession(rws, session);
 
-      Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine, innerJoinService);
+      AssetQuerySandbox wbox = rws.getAssetQuerySandbox();
+      ScriptEnv scriptEnv = wbox == null ? null : wbox.getScriptEnv();
+      Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine, innerJoinService,
+         expressionDialogService, scriptEnv);
 
       try {
          mutation.accept(editor);
@@ -346,6 +374,7 @@ public class WorksheetEditService {
    private final SheetAgentBroadcastService broadcast;
    private final SecurityEngine securityEngine;
    private final InnerJoinService innerJoinService;
+   private final ExpressionDialogService expressionDialogService;
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetEditService.class);
 
    // =========================================================================
@@ -361,11 +390,14 @@ public class WorksheetEditService {
    public static final class Editor {
 
       Editor(Worksheet ws, Principal agent, SecurityEngine securityEngine,
-             InnerJoinService innerJoinService) {
+             InnerJoinService innerJoinService, ExpressionDialogService expressionDialogService,
+             ScriptEnv scriptEnv) {
          this.ws = ws;
          this.agent = agent;
          this.securityEngine = securityEngine;
          this.innerJoinService = innerJoinService;
+         this.expressionDialogService = expressionDialogService;
+         this.scriptEnv = scriptEnv;
       }
 
       /**
@@ -1837,7 +1869,37 @@ public class WorksheetEditService {
          throws PairingException, SecurityException
       {
          requirePermission(ResourceType.WORKSHEET_EXPRESSION_COLUMN);
+         validateExpressionSyntax(table, name, expression, sql);
          WorksheetMutationSupport.editExpression(requireTable(table), name, expression, type, sql);
+      }
+
+      /**
+       * Mirrors the native "Edit Expression" dialog's own syntax check
+       * ({@link ExpressionDialogService#check}) -- before this, the wiz agent path skipped it
+       * entirely, silently persisting an uncompilable JS expression or unparseable SQL one, only
+       * surfacing later as a broken render. {@code expressionDialogService} is {@code null} only
+       * for an {@code Editor} built via {@code WorksheetEditService}'s 5-arg legacy constructor
+       * (this package's own tests), which skips validation deliberately rather than requiring
+       * every existing test to supply a real {@link ExpressionDialogService}.
+       */
+      private void validateExpressionSyntax(String table, String name, String expression, boolean sql)
+         throws PairingException
+      {
+         if(expressionDialogService == null || expression == null || expression.isBlank()) {
+            return;
+         }
+
+         String str = ExpressionRef.getSQLExpression(sql, expression);
+
+         try {
+            expressionDialogService.check(str, scriptEnv, sql);
+         }
+         catch(Exception ex) {
+            String message = sql
+               ? Catalog.getCatalog().getString("viewer.viewsheet.sqlFailed", ex.getMessage())
+               : Catalog.getCatalog().getString("viewer.worksheet.scriptFailed", name, table);
+            throw new PairingException(message);
+         }
       }
 
       /**
@@ -3292,5 +3354,7 @@ public class WorksheetEditService {
       private final Principal agent;
       private final SecurityEngine securityEngine;
       private final InnerJoinService innerJoinService;
+      private final ExpressionDialogService expressionDialogService;
+      private final ScriptEnv scriptEnv;
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/CalcFieldServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/CalcFieldServiceTest.java
@@ -107,7 +107,13 @@ class CalcFieldServiceTest {
                    service.read(vsWithCalcFields(), "Query1", "Margin"));
    }
 
-   /** No {@code ViewsheetSandbox} available (unstubbed mock) -- validation is skipped, not blocked. */
+   /**
+    * No {@code ViewsheetSandbox} available (unstubbed mock) -- mirrors the real pane-scoped
+    * preview runtime a calcField's formula editor pairs to in production, which never gets one
+    * wired up. {@code scriptEnvOf} falls back to a real {@code ScriptEnvRepository} engine in
+    * this case, so validation still runs -- see
+    * {@link #writingAnUncompilableExpressionWithNoSandboxStillGetsRejectedViaTheFallbackEngine}.
+    */
    private static RuntimeViewsheet rvsFor(Viewsheet vs) {
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
@@ -146,7 +152,8 @@ class CalcFieldServiceTest {
    void writingAnExpressionThatFailsToCompileIsRejectedRatherThanStored() throws Exception {
       Viewsheet vs = vsWithCalcFields();
       ScriptEnv env = mock(ScriptEnv.class);
-      when(env.compile(anyString())).thenThrow(new RuntimeException("missing ) after argument list"));
+      doThrow(new RuntimeException("missing ) after argument list"))
+         .when(env).checkFunction(anyString(), anyString());
       when(env.getSuggestion(any(), any())).thenReturn("check the parentheses");
 
       PairingException ex = assertThrows(PairingException.class, () -> service.write(
@@ -159,6 +166,26 @@ class CalcFieldServiceTest {
       assertEquals("field['PRICE'] - field['COST']", service.read(vs, "Query1", "Margin"));
    }
 
+   /**
+    * The exact live bug this fix closes: a calcField's real-world caller is ALWAYS the pane-scoped
+    * preview runtime (PaneScopeService requires it), which has no {@code ViewsheetSandbox} --
+    * confirmed live, not just suspected. Before {@code scriptEnvOf} fell back to
+    * {@code ScriptEnvRepository.getScriptEnv()}, {@code rvsFor}'s null sandbox meant validation
+    * was skipped entirely and a broken expression like this one was persisted verbatim. No mocked
+    * {@link ScriptEnv} here -- this is the real Graal engine, the same one
+    * {@code ScriptEnvRepository} lazily hands to {@code AssetQuerySandbox}/{@code ViewsheetScope}
+    * elsewhere in this codebase.
+    */
+   @Test
+   void writingAnUncompilableExpressionWithNoSandboxStillGetsRejectedViaTheFallbackEngine() {
+      Viewsheet vs = vsWithCalcFields();
+
+      PairingException ex = assertThrows(PairingException.class, () -> service.write(
+         rvsFor(vs), "Query1", "Margin", "field['PRICE'] - ("));
+
+      assertTrue(ex.getMessage().contains("Script error"), ex.getMessage());
+   }
+
    /** A SQL-mode field's write is validated too, on the SQL-validity path, not the JS compile path. */
    @Test
    void aSqlModeWriteNeverCallsTheJavaScriptCompiler() throws Exception {
@@ -169,6 +196,7 @@ class CalcFieldServiceTest {
 
       assertEquals("0.25", service.read(vs, "Query1", "TaxRate"));
       verify(env, never()).compile(anyString());
+      verify(env, never()).checkFunction(anyString(), anyString());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/script/CalcFieldServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/CalcFieldServiceTest.java
@@ -17,16 +17,21 @@
  */
 package inetsoft.web.wiz.script;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.util.script.ScriptEnv;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -102,13 +107,68 @@ class CalcFieldServiceTest {
                    service.read(vsWithCalcFields(), "Query1", "Margin"));
    }
 
+   /** No {@code ViewsheetSandbox} available (unstubbed mock) -- validation is skipped, not blocked. */
+   private static RuntimeViewsheet rvsFor(Viewsheet vs) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   private static RuntimeViewsheet rvsWithScriptEnv(Viewsheet vs, ScriptEnv env) {
+      AssetQuerySandbox wbox = mock(AssetQuerySandbox.class);
+      when(wbox.getScriptEnv()).thenReturn(env);
+
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(box.getAssetQuerySandbox()).thenReturn(wbox);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      return rvs;
+   }
+
    @Test
    void writesAnExpressionThroughToTheInnerRef() throws Exception {
       Viewsheet vs = vsWithCalcFields();
 
-      service.write(vs, "Query1", "Margin", "field['PRICE'] * 2");
+      service.write(rvsFor(vs), "Query1", "Margin", "field['PRICE'] * 2");
 
       assertEquals("field['PRICE'] * 2", service.read(vs, "Query1", "Margin"));
+   }
+
+   /**
+    * The gap this fix closes: before it, `write` never compiled the new text at all, so an
+    * uncompilable expression was persisted silently ({@code {ok:true}}) and only surfaced later as
+    * a broken render. Mirrors ModifyCalculateFieldService.checkScriptValid's JS branch -- same
+    * "compile before storing" contract the native Formula Editor dialog already enforces.
+    */
+   @Test
+   void writingAnExpressionThatFailsToCompileIsRejectedRatherThanStored() throws Exception {
+      Viewsheet vs = vsWithCalcFields();
+      ScriptEnv env = mock(ScriptEnv.class);
+      when(env.compile(anyString())).thenThrow(new RuntimeException("missing ) after argument list"));
+      when(env.getSuggestion(any(), any())).thenReturn("check the parentheses");
+
+      PairingException ex = assertThrows(PairingException.class, () -> service.write(
+         rvsWithScriptEnv(vs, env), "Query1", "Margin", "field['PRICE'] - ("));
+
+      assertTrue(ex.getMessage().contains("missing ) after argument list"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("check the parentheses"), ex.getMessage());
+      // The original expression must survive a rejected write -- this is a validate-before-store
+      // gate, not a partial write.
+      assertEquals("field['PRICE'] - field['COST']", service.read(vs, "Query1", "Margin"));
+   }
+
+   /** A SQL-mode field's write is validated too, on the SQL-validity path, not the JS compile path. */
+   @Test
+   void aSqlModeWriteNeverCallsTheJavaScriptCompiler() throws Exception {
+      Viewsheet vs = vsWithCalcFields();
+      ScriptEnv env = mock(ScriptEnv.class);
+
+      service.write(rvsWithScriptEnv(vs, env), "Query1", "TaxRate", "0.25");
+
+      assertEquals("0.25", service.read(vs, "Query1", "TaxRate"));
+      verify(env, never()).compile(anyString());
    }
 
    @Test
@@ -152,7 +212,7 @@ class CalcFieldServiceTest {
 
       PairingException ex = assertThrows(
          PairingException.class,
-         () -> service.write(vs, "Query1", "BrandNew", "1"));
+         () -> service.write(rvsFor(vs), "Query1", "BrandNew", "1"));
       assertTrue(ex.getMessage().toLowerCase().contains("create"),
                  "must say creation is out of scope, not just 'not found': " + ex.getMessage());
       verify(vs, never()).addCalcField(anyString(), any());

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptApiServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptApiServiceTest.java
@@ -57,4 +57,27 @@ class ScriptApiServiceTest {
       assertNull(signature.type());
       assertNull(signature.url());
    }
+
+   @Test
+   void looksUpCalcFunctionUnqualified() {
+      // CALC.day/eomonth are nested under "CALC" in js-functions.json but are callable bare in a
+      // viewsheet script, same as VSScriptableService.createStaticDefinitions resolves them for
+      // the script editor's own autocomplete.
+      FunctionSignature day = service.lookup("day");
+      assertTrue(day.found());
+      assertNotNull(day.type());
+
+      FunctionSignature eomonth = service.lookup("eomonth");
+      assertTrue(eomonth.found());
+      assertNotNull(eomonth.type());
+   }
+
+   @Test
+   void hidesSreeOnlyReportingFunctions() {
+      // showReport/reprint are Report/Sree-scoped globals the viewsheet script editor's own
+      // autocomplete never offers (VSScriptableService.createStaticDefinitions strips them);
+      // this lookup must agree, not just relay whatever the raw metadata file contains.
+      assertFalse(service.lookup("showReport").found());
+      assertFalse(service.lookup("reprint").found());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -38,6 +38,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.web.composer.ws.dialog.ExpressionDialogService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
 import org.junit.jupiter.api.*;
@@ -94,6 +95,38 @@ class WorksheetEditServiceMutatorsTest {
          .thenReturn(rws);
 
       return new WorksheetEditService(sessions, runtimeAccess, broadcast, securityEngine, mock(InnerJoinService.class));
+   }
+
+   /**
+    * Same as {@link #service(RuntimeWorksheet, String, Principal, String)} but wires a real
+    * {@link ExpressionDialogService} mock through, so {@code editExpression}'s syntax-validation
+    * gate is actually exercised -- every other {@code service(...)} overload builds a
+    * {@code WorksheetEditService} via the 5-arg legacy constructor, which deliberately skips
+    * that validation (see the constructor's own javadoc).
+    */
+   private WorksheetEditService serviceWithExpressionValidation(
+      RuntimeWorksheet rws, String runtimeId, Principal agent, String token,
+      ExpressionDialogService expressionDialogService)
+      throws PairingException, inetsoft.sree.security.SecurityException
+   {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         any(), any(ResourceType.class), any(String.class), any(ResourceAction.class)))
+         .thenReturn(true);
+
+      SheetSessionService sessions       = mock(SheetSessionService.class);
+      SheetRuntimeAccess  runtimeAccess  = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      JoinSession s = new JoinSession(token, runtimeId, "alice~;~host-org",
+                                      SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq(token), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq(runtimeId), eq(agent)))
+         .thenReturn(rws);
+
+      return new WorksheetEditService(sessions, runtimeAccess, broadcast, securityEngine,
+         mock(InnerJoinService.class), expressionDialogService);
    }
 
    private RuntimeWorksheet rws(Worksheet ws) {
@@ -2722,6 +2755,62 @@ class WorksheetEditServiceMutatorsTest {
       ColumnRef cr = (ColumnRef) ref;
       assertInstanceOf(ExpressionRef.class, cr.getDataRef());
       assertEquals("field['a'] * 2", ((ExpressionRef) cr.getDataRef()).getExpression());
+   }
+
+   /**
+    * Before this fix, `editExpression` never validated the new text at all -- an uncompilable
+    * expression was persisted silently ({@code {ok:true}}), only surfacing later as a broken
+    * render. Mirrors the native "Edit Expression" dialog's own gate
+    * (ExpressionDialogService.check), which the wiz agent path simply never called.
+    */
+   @Test
+   void editExpressionRejectsAnUncompilableScriptRatherThanStoringIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      ExpressionDialogService dialogService = mock(ExpressionDialogService.class);
+      doThrow(new Exception("missing ) after argument list"))
+         .when(dialogService).check(anyString(), any(), eq(false));
+
+      WorksheetEditService svc = serviceWithExpressionValidation(
+         rws(ws), "Worksheet/ws1", agent, "TOK", dialogService);
+
+      svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "calc", "field['a'] * 1", "integer", false));
+
+      assertThrows(PairingException.class, () -> svc.apply("TOK", agent, ed ->
+         ed.editExpression("T", "calc", "field['a'] - (", "integer", false)));
+
+      // The rejected write must not have taken -- the original expression survives.
+      ColumnRef cr = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertEquals("field['a'] * 1", ((ExpressionRef) cr.getDataRef()).getExpression());
+   }
+
+   /** A SQL-mode edit is routed to the SQL branch of the same validation gate, not skipped. */
+   @Test
+   void editExpressionValidatesSqlModeTextTooNotJustJavaScript() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      ExpressionDialogService dialogService = mock(ExpressionDialogService.class);
+      doThrow(new Exception("Unexpected token: )"))
+         .when(dialogService).check(anyString(), any(), eq(true));
+
+      WorksheetEditService svc = serviceWithExpressionValidation(
+         rws(ws), "Worksheet/ws1", agent, "TOK", dialogService);
+
+      svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "calc", "1", "integer", true));
+
+      assertThrows(PairingException.class, () -> svc.apply("TOK", agent, ed ->
+         ed.editExpression("T", "calc", "a b c )", "integer", true)));
+
+      verify(dialogService).check(anyString(), any(), eq(true));
+      verify(dialogService, never()).check(anyString(), any(), eq(false));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.worksheet;
 
+import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.ResourceAction;
@@ -37,7 +38,9 @@ import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.web.binding.VSScriptableController;
 import inetsoft.web.composer.ws.dialog.ExpressionDialogService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
@@ -2770,9 +2773,9 @@ class WorksheetEditServiceMutatorsTest {
       ws.addAssembly(t);
       Principal agent = TestPrincipals.user("alice", "host-org");
 
+      // JS mode validates via ScriptEnv.checkFunction directly, not expressionDialogService.check
+      // -- the mock only needs to be non-null to clear validateExpressionSyntax's gate.
       ExpressionDialogService dialogService = mock(ExpressionDialogService.class);
-      doThrow(new Exception("missing ) after argument list"))
-         .when(dialogService).check(anyString(), any(), eq(false));
 
       WorksheetEditService svc = serviceWithExpressionValidation(
          rws(ws), "Worksheet/ws1", agent, "TOK", dialogService);
@@ -2784,6 +2787,43 @@ class WorksheetEditServiceMutatorsTest {
          ed.editExpression("T", "calc", "field['a'] - (", "integer", false)));
 
       // The rejected write must not have taken -- the original expression survives.
+      ColumnRef cr = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
+      assertEquals("field['a'] * 1", ((ExpressionRef) cr.getDataRef()).getExpression());
+   }
+
+   /**
+    * The exact live bug this fix closes: a worksheetExpression's real-world caller is ALWAYS a
+    * session paired from the column's own expression editor (PaneScopeService requires it), and
+    * that pane-scoped {@code RuntimeWorksheet}'s {@code getAssetQuerySandbox()} can come back
+    * with no {@link inetsoft.util.script.ScriptEnv} -- confirmed live, not just suspected. Before
+    * {@code WorksheetEditService.apply} fell back to {@code ScriptEnvRepository.getScriptEnv()},
+    * a null env made {@code ExpressionDialogService.check}'s own JS branch
+    * (`if(env != null) env.compile(text)`) silently no-op, and a broken expression like this one
+    * was persisted verbatim. Uses a REAL {@link ExpressionDialogService} (mocked-out unrelated
+    * constructor deps only) so {@code check()} genuinely runs the real Graal engine -- a mocked
+    * dialog service, as the other tests in this file use, would hide exactly the bug this proves
+    * is fixed.
+    */
+   @Test
+   void editExpressionWithNoSandboxStillGetsRejectedViaTheFallbackEngine() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      ExpressionDialogService realDialogService = new ExpressionDialogService(
+         mock(ViewsheetService.class), mock(VSScriptableController.class),
+         mock(DataSourceRegistry.class));
+
+      WorksheetEditService svc = serviceWithExpressionValidation(
+         rws(ws), "Worksheet/ws1", agent, "TOK", realDialogService);
+
+      svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "calc", "field['a'] * 1", "integer", false));
+
+      assertThrows(PairingException.class, () -> svc.apply("TOK", agent, ed ->
+         ed.editExpression("T", "calc", "field['a'] - (", "integer", false)));
+
       ColumnRef cr = (ColumnRef) t.getColumnSelection(false).getAttribute("calc");
       assertEquals("field['a'] * 1", ((ExpressionRef) cr.getDataRef()).getExpression());
    }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2503,6 +2503,35 @@ class WorksheetEditServiceMutatorsTest {
       assertTrue(ex2.getMessage().contains("already exists"));
    }
 
+   /**
+    * Same bug class as {@code editExpressionRejectsAnUncompilableScriptRatherThanStoringIt} --
+    * `add_expression_column` is a separate, directly wire-exposed op from `edit_expression`, and
+    * before this test's fix it had no syntax validation at all: an agent could create a brand-new
+    * expression column with an unbalanced paren and it would be silently persisted. Uses the same
+    * real-fallback-engine {@code rws(ws)} (no sandbox stubbed) as the `editExpression` fallback
+    * test, so this proves the real {@code ScriptEnv.checkFunction()} path, not a mock.
+    */
+   @Test
+   void addExpressionColumnRejectsAnUncompilableScriptRatherThanCreatingIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      ExpressionDialogService realDialogService = new ExpressionDialogService(
+         mock(ViewsheetService.class), mock(VSScriptableController.class),
+         mock(DataSourceRegistry.class));
+
+      WorksheetEditService svc = serviceWithExpressionValidation(
+         rws(ws), "Worksheet/ws1", agent, "TOK", realDialogService);
+
+      assertThrows(PairingException.class, () -> svc.apply("TOK", agent, ed ->
+         ed.addExpressionColumn("T", "calc", "field['a'] - (", "integer", false)));
+
+      assertNull(t.getColumnSelection(false).getAttribute("calc"),
+         "the rejected column must not have been created at all");
+   }
+
    // =========================================================================
    // Sort test
    // =========================================================================
@@ -2836,9 +2865,12 @@ class WorksheetEditServiceMutatorsTest {
       ws.addAssembly(t);
       Principal agent = TestPrincipals.user("alice", "host-org");
 
+      // Stubbed on the specific failing text only, not anyString() -- addExpressionColumn now
+      // validates too (this test's own setup call below), so a blanket throw-on-any-SQL-call
+      // stub would fail the setup itself rather than the intended second call.
       ExpressionDialogService dialogService = mock(ExpressionDialogService.class);
       doThrow(new Exception("Unexpected token: )"))
-         .when(dialogService).check(anyString(), any(), eq(true));
+         .when(dialogService).check(eq("a b c )"), any(), eq(true));
 
       WorksheetEditService svc = serviceWithExpressionValidation(
          rws(ws), "Worksheet/ws1", agent, "TOK", dialogService);
@@ -2849,7 +2881,9 @@ class WorksheetEditServiceMutatorsTest {
       assertThrows(PairingException.class, () -> svc.apply("TOK", agent, ed ->
          ed.editExpression("T", "calc", "a b c )", "integer", true)));
 
-      verify(dialogService).check(anyString(), any(), eq(true));
+      // Called twice now (setup's addExpressionColumn + the failing editExpression), since
+      // addExpressionColumn validates too.
+      verify(dialogService, times(2)).check(anyString(), any(), eq(true));
       verify(dialogService, never()).check(anyString(), any(), eq(false));
    }
 


### PR DESCRIPTION
## Summary

Fixes the "Group A" clear-cut findings from the wiz-agent L9 (Scripting)
parity audit (see `stylebi-wiz`'s `docs/parity/L9-scripting/L9-parity-report.md`),
all live-verified against a real running instance built from this branch:

- **G1-1** — `CalcFieldService.write` never validated a calc field's new
  expression before storing it, unlike the native Formula Editor dialog's OK
  button (`ModifyCalculateFieldService.checkScriptValid`). Now runs a real
  syntax check (SQL: `XUtil.isSQLExpressionValid`; JS: `ScriptEnv.checkFunction`)
  before mutating, raising a clear error with the write left untouched on
  failure.
- **G1-2** — `WorksheetEditService.Editor.editExpression` had the identical
  gap for a worksheet expression column. Same fix shape; SQL mode delegates to
  `ExpressionDialogService.check()` (its SQL branch already works correctly),
  JS mode calls `ScriptEnv.checkFunction()` directly.
- **G3-1 / G3-2** — `get_function_signature`'s backing `ScriptApiService`
  couldn't resolve any CALC-namespace function (`day`, `eomonth`, ...) and
  leaked 11 report-only `sreeOnly` functions a viewsheet script should never
  see. `load()` now mirrors `VSScriptableService.createStaticDefinitions()`'s
  CALC-unwrap and `sreeOnly` filter.

**A real bug found only by live-testing, not unit tests**: the first attempt
at G1-1/G1-2 used `ScriptEnv.compile()` for JS validation, mirroring what
`ModifyCalculateFieldService.checkScriptValid()`/`ExpressionDialogService.check()`
already do. Live testing showed `compile()` does not actually parse anything
under the Graal engine (`GraalJavaScriptEngine.compile()` only builds a lazy
`Source` literal) — a real syntax error was silently accepted and only
surfaced later at render time. **This is a pre-existing platform gap in
`checkScriptValid()`/`check()` themselves, reproduced live in the native
Formula Editor/Edit Expression dialogs too** (confirmed: the native UI
accepts the same broken input, then `FormulaTableLens` logs a `SyntaxError`
only at data-refresh time). This PR fixes only the two wiz-agent call sites
(using `ScriptEnv.checkFunction()`, which parses eagerly via
`context.parse("js", cmd)` — the same primitive `OpenScriptController`'s own
"check script" endpoint already uses) — it does **not** touch
`ExpressionDialogService.check()`/`checkScriptValid()` itself, so the native
UI's own gap remains open as a separate, out-of-scope platform issue.

## Test plan
- [x] `CalcFieldServiceTest`, `WorksheetEditServiceMutatorsTest`,
      `WorksheetEditServiceTest`, `WorksheetAgentControllerTest`,
      `WorksheetScriptControllerTest`, `WorksheetScriptServiceTest`,
      `ScriptEditServiceTest`, `ScriptApiServiceTest` all pass (451 tests)
- [x] Two new regression tests exercise the real `ScriptEnvRepository`
      fallback engine (not a mocked `ScriptEnv`) to prove the fallback path
      itself catches a real syntax error
- [x] Live-verified both arms on a real running instance (reject broken
      input + read-back unchanged; accept valid input + read-back applied)
      for all four findings — see `stylebi-wiz`'s
      `docs/parity/L9-scripting/L9-parity-report.md` for the recorded arms

Paired plugin PR: inetsoft-technology/stylebi-wiz#2255