### PR TITLE
feat(tabular): scaled annotation target selection -- contract, threshold, paging route

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalog.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalog.java
@@ -22,7 +22,15 @@ import java.util.List;
 /**
  * A tabular data source's whole catalog.
  *
- * @param datasets      every dataset in the source; never null, in the source's own order.
+ * @param datasets      every dataset in the source; never null, in the source's own order. This
+ *                      order MUST be stable across repeated calls against an unchanged source --
+ *                      not merely stable within one call -- so that
+ *                      {@link TabularCatalogProvider}'s default paging (and any override built the
+ *                      same way) does not skip or repeat a dataset while a caller pages through an
+ *                      unchanged catalog. A connector whose native order can vary between two calls
+ *                      (e.g. hash-based iteration) MUST impose its own stable secondary order (such
+ *                      as sorting by {@link TabularDatasetRef#id()}) before returning -- there is no
+ *                      separate ordering hook for the paged method to use instead.
  * @param relationships edges the source declares between datasets in {@code datasets}. Never null;
  *                      empty when the source declares none, or declares none this SPI can express.
  *                      Every fromDataset/toDataset MUST be an id in {@code datasets}.

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogPage.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogPage.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import java.util.List;
+
+/**
+ * One page of {@link TabularDatasetRef}s, in answer to
+ * {@link TabularCatalogProvider#listDatasets(TabularDataSource, TabularCatalogRequest)}.
+ *
+ * @param datasets   this page's datasets. Never null; may be empty. In a stable relative order.
+ * @param nextCursor the cursor to pass back as {@link TabularCatalogRequest#cursor()} to fetch the
+ *                   following page. {@code null} means this was the LAST page. Opaque.
+ */
+public record TabularCatalogPage(List<TabularDatasetRef> datasets, String nextCursor) {}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
@@ -17,6 +17,13 @@
  */
 package inetsoft.uql.tabular;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * A tabular connector's description of its own catalog: which datasets a data source holds, and
  * what one dataset looks like.
@@ -97,4 +104,169 @@ public interface TabularCatalogProvider {
     */
    TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
       throws Exception;
+
+   /**
+    * A filtered, paged view of the same catalog {@link #listDatasets(TabularDataSource)} returns in
+    * full -- for a caller that wants to browse or search rather than receive everything.
+    *
+    * This default implementation calls the full {@link #listDatasets(TabularDataSource)}, filters
+    * it in memory by {@code request.nameContains()}, and slices out one page. That is CORRECT for
+    * every connector -- the two calls describe the same catalog -- but it is NOT CHEAP: every page,
+    * including the first, re-enumerates the whole source. A connector that can push
+    * {@code nameContains} and paging down to its own source (a {@code WHERE ... LIKE} clause, a
+    * REST API's own cursor/query parameters, ...) should override this method rather than rely on
+    * the default -- the smaller the source, the less this matters, which is why no community
+    * connector needs to today.
+    *
+    * <p><b>Order.</b> Paging is only coherent if {@link #listDatasets(TabularDataSource)} returns
+    * the same datasets in the same relative order across repeated calls against an unchanged source
+    * -- not merely a stable order within one call. Every existing implementer already satisfies this
+    * incidentally (a SQL dictionary query, a REST list endpoint, and a metadata document all return
+    * a deterministic order in practice); a connector whose native order can vary between two calls
+    * (e.g. hash-based iteration) MUST impose its own stable secondary order (such as sorting by
+    * {@link TabularDatasetRef#id()}) before returning from {@link #listDatasets(TabularDataSource)}
+    * -- there is no separate ordering hook for the paged method to use instead.
+    *
+    * <p><b>Filtering.</b> {@code nameContains} matches a {@link TabularDatasetRef} id as a
+    * case-insensitive substring ({@link Locale#ROOT}, not the platform default locale, so
+    * this does not depend on where the JVM runs) -- not a prefix, not a whole-name match. {@code
+    * null} or blank means every dataset matches; it never means match nothing.
+    *
+    * <p><b>Paging.</b> {@code request.cursor()} is opaque; the caller passes back exactly the
+    * {@link TabularCatalogPage#nextCursor()} a previous call returned, together with the SAME
+    * {@code nameContains} it was minted under. This default implementation's cursor happens to be a
+    * decimal offset into the filtered list, but that is an implementation detail an overriding
+    * connector is free to ignore -- nothing in this contract lets a caller tell which kind of cursor
+    * it is holding, or exploit that if it could. A cursor this default implementation cannot parse
+    * throws {@link IllegalArgumentException}; a syntactically valid cursor that no longer lands
+    * inside the (possibly re-filtered) list -- because the underlying catalog changed, or the caller
+    * mixed up two browsing sessions -- is answered with an empty, exhausted page rather than an
+    * exception, the same answer a caller gets from simply over-paging past the real end.
+    *
+    * <p><b>Stated residual.</b> Because this default implementation re-runs
+    * {@link #listDatasets(TabularDataSource)} on every call, its cursor is, structurally, an offset
+    * into a freshly recomputed list -- the same shape of weakness an offset-based contract would
+    * have had: a dataset added or removed between two page calls can be skipped or repeated. This is
+    * not a regression this method introduces; {@link #listDatasets(TabularDataSource)} never
+    * promised a snapshot across two separate calls either. What paging through an opaque cursor buys
+    * over a literal offset in the CONTRACT is that an overriding connector is not committed to the
+    * same weakness: a keyset-style cursor over a source with a stable native ordering (SAP's last
+    * TABNAME seen, say) is NOT vulnerable to insertions or deletions elsewhere in the keyspace the
+    * way an integer offset is. This default implementation does not need that extra robustness --
+    * see the class javadoc's cost argument -- so it does not build it.
+    *
+    * @param request never null.
+    * @return never null. {@link TabularCatalogPage#nextCursor()} is null exactly on the last page.
+    * @throws Exception whatever {@link #listDatasets(TabularDataSource)} throws, unchanged, plus
+    *         {@link IllegalArgumentException} for an unparseable cursor.
+    */
+   default TabularCatalogPage listDatasets(TabularDataSource<?> dataSource,
+                                           TabularCatalogRequest request) throws Exception
+   {
+      TabularCatalog catalog = listDatasets(dataSource);
+      List<TabularDatasetRef> all = catalog.datasets() == null ? List.of() : catalog.datasets();
+
+      List<TabularDatasetRef> filtered = all.stream()
+         .filter(ref -> matchesNameContains(ref, request.nameContains()))
+         .collect(Collectors.toUnmodifiableList());
+
+      int start = decodeCursor(request.cursor());
+
+      if(start < 0 || start >= filtered.size()) {
+         // Over-paged, or a cursor from a browsing session whose filter/underlying catalog has
+         // since moved on -- answered the same way as genuine exhaustion. See "Paging" above.
+         return new TabularCatalogPage(List.of(), null);
+      }
+
+      int end = Math.min(start + request.limit(), filtered.size());
+      List<TabularDatasetRef> page = List.copyOf(filtered.subList(start, end));
+      String nextCursor = end < filtered.size() ? encodeCursor(end) : null;
+
+      return new TabularCatalogPage(page, nextCursor);
+   }
+
+   private static boolean matchesNameContains(TabularDatasetRef ref, String nameContains) {
+      if(nameContains == null || nameContains.isBlank()) {
+         return true;
+      }
+
+      return ref.id() != null &&
+         ref.id().toUpperCase(Locale.ROOT).contains(nameContains.toUpperCase(Locale.ROOT));
+   }
+
+   private static int decodeCursor(String cursor) {
+      if(cursor == null) {
+         return 0;
+      }
+
+      try {
+         int index = Integer.parseInt(cursor);
+
+         if(index < 0) {
+            throw new NumberFormatException("negative cursor");
+         }
+
+         return index;
+      }
+      catch(NumberFormatException e) {
+         throw new IllegalArgumentException(
+            "TabularCatalogRequest.cursor '" + cursor + "' was not minted by this default " +
+            "TabularCatalogProvider.listDatasets(TabularDataSource, TabularCatalogRequest) and " +
+            "cannot be resumed from.", e);
+      }
+   }
+
+   private static String encodeCursor(int nextStart) {
+      return Integer.toString(nextStart);
+   }
+
+   /**
+    * The relationships the source declares that lie entirely within {@code datasetIds} -- both
+    * endpoints. An edge with one endpoint inside {@code datasetIds} and one outside is dropped, not
+    * just the outside endpoint; an edge with neither endpoint inside is dropped too. See
+    * {@code TabularCatalogService.validateRelationshipEndpoints} -- this method's whole reason to
+    * exist both-endpoints-only is that it is what keeps that unchanged validation correct by
+    * construction for a caller that annotates a chosen SUBSET of a source's datasets rather than the
+    * whole catalog: a relationship into a dataset the caller never selected has no home to attach to.
+    *
+    * This default implementation calls the full {@link #listDatasets(TabularDataSource)} and
+    * filters its relationships -- correct, and no more expensive than the paging default above, but
+    * for a connector whose relationships can ONLY be produced by describing every dataset one at a
+    * time (Salesforce's {@code describeGlobal} is the motivating case: today it has to
+    * describe every sobject just to report the lookup fields between them), overriding this
+    * method to describe only {@code datasetIds} is a real cost win that overriding the paging method
+    * above is not.
+    *
+    * <p>No directional promise: some connectors can report an edge cheaply when it points OUT of a
+    * dataset in {@code datasetIds} (a lookup field is visible on the referencing object's own
+    * description) but not when it points IN from outside; this contract only promises "the edges the
+    * source declares with both endpoints in {@code datasetIds}", not that both directions cost the
+    * same to discover.
+    *
+    * @param datasetIds the caller's chosen subset. A null or empty collection is treated
+    *                    identically -- both yield an empty relationship list, never every edge and
+    *                    never an exception.
+    * @return never null; empty when the source declares no relationship satisfying the
+    *         both-endpoints rule, or none at all.
+    */
+   default List<TabularRelationship> listRelationships(TabularDataSource<?> dataSource,
+                                                        Collection<String> datasetIds) throws Exception
+   {
+      if(datasetIds == null || datasetIds.isEmpty()) {
+         return List.of();
+      }
+
+      TabularCatalog catalog = listDatasets(dataSource);
+      List<TabularRelationship> relationships = catalog.relationships();
+
+      if(relationships == null || relationships.isEmpty()) {
+         return List.of();
+      }
+
+      Set<String> ids = datasetIds instanceof Set<String> set ? set : new HashSet<>(datasetIds);
+
+      return relationships.stream()
+         .filter(rel -> rel != null && ids.contains(rel.fromDataset()) && ids.contains(rel.toDataset()))
+         .collect(Collectors.toUnmodifiableList());
+   }
 }

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogProvider.java
@@ -166,8 +166,11 @@ public interface TabularCatalogProvider {
       TabularCatalog catalog = listDatasets(dataSource);
       List<TabularDatasetRef> all = catalog.datasets() == null ? List.of() : catalog.datasets();
 
+      String normalizedNameContains = request.nameContains() == null || request.nameContains().isBlank()
+         ? null : request.nameContains().toUpperCase(Locale.ROOT);
+
       List<TabularDatasetRef> filtered = all.stream()
-         .filter(ref -> matchesNameContains(ref, request.nameContains()))
+         .filter(ref -> matchesNameContains(ref, normalizedNameContains))
          .collect(Collectors.toUnmodifiableList());
 
       int start = decodeCursor(request.cursor());
@@ -178,20 +181,21 @@ public interface TabularCatalogProvider {
          return new TabularCatalogPage(List.of(), null);
       }
 
-      int end = Math.min(start + request.limit(), filtered.size());
-      List<TabularDatasetRef> page = List.copyOf(filtered.subList(start, end));
-      String nextCursor = end < filtered.size() ? encodeCursor(end) : null;
+      // start + request.limit() as int arithmetic can overflow -- limit has no upper bound, only
+      // limit > 0 -- so the addition is done as long before clamping back down to filtered.size().
+      long end = Math.min((long) start + request.limit(), filtered.size());
+      List<TabularDatasetRef> page = List.copyOf(filtered.subList(start, (int) end));
+      String nextCursor = end < filtered.size() ? encodeCursor((int) end) : null;
 
       return new TabularCatalogPage(page, nextCursor);
    }
 
-   private static boolean matchesNameContains(TabularDatasetRef ref, String nameContains) {
-      if(nameContains == null || nameContains.isBlank()) {
+   private static boolean matchesNameContains(TabularDatasetRef ref, String normalizedNameContains) {
+      if(normalizedNameContains == null) {
          return true;
       }
 
-      return ref.id() != null &&
-         ref.id().toUpperCase(Locale.ROOT).contains(nameContains.toUpperCase(Locale.ROOT));
+      return ref.id() != null && ref.id().toUpperCase(Locale.ROOT).contains(normalizedNameContains);
    }
 
    private static int decodeCursor(String cursor) {

--- a/core/src/main/java/inetsoft/uql/tabular/TabularCatalogRequest.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularCatalogRequest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+/**
+ * One page of a {@link TabularCatalogProvider#listDatasets(TabularDataSource, TabularCatalogRequest)}
+ * request.
+ *
+ * @param nameContains a substring of a {@link TabularDatasetRef#id()}, matched case-insensitively.
+ *                      {@code null} or blank means no filtering -- every dataset matches. This is
+ *                      deliberately the ONLY filter dimension this contract carries.
+ * @param limit         the maximum number of datasets one page may hold. Must be greater than 0 --
+ *                      enforced by this record's compact constructor.
+ * @param cursor        the exact {@code nextCursor} a previous call returned, or {@code null} for
+ *                      the first page. Opaque to every caller.
+ */
+public record TabularCatalogRequest(String nameContains, int limit, String cursor) {
+   public TabularCatalogRequest {
+      if(limit <= 0) {
+         throw new IllegalArgumentException(
+            "TabularCatalogRequest.limit must be > 0, got " + limit);
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -142,16 +142,28 @@ public class DatasourceMetaApiController {
    /**
     * Gets all tables and FK relationships for the specified datasource.
     *
-    * @param dsPath the datasource name or path.
+    * <p>{@code nameContains}/{@code limit}/{@code cursor} are all optional; omitting all three
+    * is byte-identical to this endpoint's pre-paging behavior. Supplying {@code limit} switches
+    * to the paged path (see {@link MetadataApiService#getDatabaseTables}), whose response never
+    * carries relationships and, for a JDBC data source, is rejected rather than silently
+    * returning an unpaged full listing.
+    *
+    * @param dsPath       the datasource name or path.
+    * @param nameContains optional case-insensitive substring filter on the dataset/table id.
+    * @param limit        optional page size; presence is what triggers paging.
+    * @param cursor       the exact {@code nextCursor} a previous paged call returned.
     * @return tables (with catalog/schema/type) and OSI relationships.
     */
    @GetMapping("/datasource/tables")
    public DatasourceTablesResponse getDatabaseTables(
       @RequestParam("dsPath") String dsPath,
+      @RequestParam(value = "nameContains", required = false) String nameContains,
+      @RequestParam(value = "limit", required = false) Integer limit,
+      @RequestParam(value = "cursor", required = false) String cursor,
       XPrincipal principal)
       throws Exception
    {
-      return metadataService.getDatabaseTables(dsPath, principal);
+      return metadataService.getDatabaseTables(dsPath, nameContains, limit, cursor, principal);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -1179,9 +1179,9 @@ public class WizDatabaseController {
       }
 
       return new WizDatasourceEntry(info.name(), info.path(), nodeType, folder, sourceType,
-                                    databaseType, annotationClass, info.createdBy(),
-                                    info.createdDate(), info.editable(), info.deletable(),
-                                    info.hasSubFolder());
+                                    databaseType, annotationClass, ANNOTATION_TARGET_THRESHOLD,
+                                    info.createdBy(), info.createdDate(), info.editable(),
+                                    info.deletable(), info.hasSubFolder());
    }
 
    /**
@@ -1675,4 +1675,12 @@ public class WizDatabaseController {
 
    /** Named rather than imported: it lives in a connector module core does not depend on. */
    private static final String REST_QUERY_CLASS = "inetsoft.uql.rest.AbstractRestQuery";
+
+   /**
+    * See {@link WizDatasourceEntry#annotationTargetThreshold()}. Global for every connector: of the
+    * connectors this threshold can affect, only Salesforce on a large org has enough sobjects to
+    * cross it, and a typical JDBC schema stays well under it, so annotating a source that size today
+    * sees no behavior change.
+    */
+   static final int ANNOTATION_TARGET_THRESHOLD = 500;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/DatasourceTablesResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DatasourceTablesResponse.java
@@ -39,6 +39,20 @@ public class DatasourceTablesResponse {
       this.relationships = relationships;
    }
 
+   /**
+    * The cursor to pass back to fetch the next page of a paged {@code GET /datasource/tables}
+    * request. {@code null} means either this response is not paged (no {@code limit} was
+    * requested) or it is the last page of one that was.
+    */
+   public String getNextCursor() {
+      return nextCursor;
+   }
+
+   public void setNextCursor(String nextCursor) {
+      this.nextCursor = nextCursor;
+   }
+
    private List<DatabaseTableInfo> tables;
    private List<OsiRelationship> relationships;
+   private String nextCursor;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
@@ -72,6 +72,20 @@ package inetsoft.web.wiz.model;
  *                     <dd>classification failed, usually a connector plugin that did not load. Kept
  *                     distinct from the others so the cause is not mistaken for a verdict.</dd>
  *                     </dl>
+ * @param annotationTargetThreshold
+ *                     the most annotation targets wiz may list without asking the user to narrow
+ *                     the selection first. Wiz's first listing request must use
+ *                     {@code limit = annotationTargetThreshold + 1}: getting back that many means
+ *                     the source has more, so wiz has to ask before annotating everything;
+ *                     otherwise it proceeds unchanged. It cannot be learned from the listing
+ *                     response, since it decides what {@code limit} to put on the request that
+ *                     produces that response — this entry is wiz's only chance to learn it first.
+ *                     Currently the same global value ({@code 500}, see
+ *                     {@code WizDatabaseController.ANNOTATION_TARGET_THRESHOLD}) on every entry, not
+ *                     overridable per connector; carried per-entry rather than hardcoded in wiz so
+ *                     that changing it later — including making it per-connector — needs no new
+ *                     channel. Not meaningful for a folder entry, which is never annotated, but
+ *                     still carries the same global value for record simplicity.
  * @param createdBy    the alias of the creating user, may be null.
  * @param createdDate  creation time in epoch millis, 0 when unknown. Not formatted.
  * @param editable     whether the caller holds WRITE on this entry.
@@ -86,6 +100,7 @@ public record WizDatasourceEntry(
    String sourceType,
    String databaseType,
    String annotationClass,
+   int annotationTargetThreshold,
    String createdBy,
    long createdDate,
    boolean editable,

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1196,16 +1196,37 @@ public class MetadataApiService {
    /**
     * Gets all tables and their FK relationships for the specified datasource.
     *
-    * @param dsName    the datasource name/path.
-    * @param principal the current user.
-    * @return tables with catalog/schema/type, plus foreign key relationships.
+    * @param dsName       the datasource name/path.
+    * @param nameContains optional case-insensitive substring filter on the dataset/table id.
+    *                      {@code null} or blank matches everything. Ignored (as if {@code null})
+    *                      when {@code limit} is {@code null}.
+    * @param limit         optional page size. {@code null} means "no paging" -- this method
+    *                      returns the full table list, exactly as it did before this parameter
+    *                      existed. A non-null value switches to the paged path, which for a
+    *                      tabular data source never returns relationships (see
+    *                      {@link TabularCatalogService#listTables(String, String, int, String)})
+    *                      and for a JDBC data source is rejected -- see below.
+    * @param cursor        the exact {@code nextCursor} a previous paged call returned, or
+    *                      {@code null} for the first page. Ignored when {@code limit} is
+    *                      {@code null}.
+    * @param principal     the current user.
+    * @return tables with catalog/schema/type, plus foreign key relationships (paged responses
+    *         carry none).
+    * @throws IllegalArgumentException if {@code limit} is non-null for a JDBC data source: JDBC
+    *         paging is not implemented yet (see
+    *         {@code docs/teams/2026-09-07-tabular-catalog-paging-contract/09-design-dialog-and-persistence.md}
+    *         A.5 in the wiz repo) -- a JDBC caller must omit {@code limit}/{@code cursor}/
+    *         {@code nameContains} today rather than silently receiving an unpaged full listing.
     */
-   public DatasourceTablesResponse getDatabaseTables(String dsName, Principal principal)
+   public DatasourceTablesResponse getDatabaseTables(
+      String dsName, String nameContains, Integer limit, String cursor, Principal principal)
       throws Exception
    {
       if(!dataSourceService.checkPermission(dsName, ResourceAction.READ, principal)) {
          throw new SecurityException("Access denied to data source: " + dsName);
       }
+
+      boolean paged = limit != null;
 
       // getJDBCDatasource throws clearly if the source doesn't exist or isn't JDBC; call it
       // first so we fail fast before the more expensive metadata connection is opened.
@@ -1218,7 +1239,19 @@ public class MetadataApiService {
          // Not relational, but the connector may still be able to describe its own catalog
          // through TabularCatalogProvider. No line below this branch runs for a non-JDBC source,
          // and none of it changed.
-         return tabularCatalogService.listTables(dsName);
+         return paged
+            ? tabularCatalogService.listTables(dsName, nameContains, limit, cursor)
+            : tabularCatalogService.listTables(dsName);
+      }
+
+      if(paged) {
+         // JDBC paging is a separate, larger change (skipping the per-table
+         // buildRelationships/populatePrimaryKeys calls below, which today run unconditionally)
+         // that this round does not implement. Failing loudly here keeps that a documented gap
+         // rather than a silent degradation to the unpaged full listing.
+         throw new IllegalArgumentException(
+            "Paging (nameContains/limit/cursor) is not supported yet for JDBC data source '" +
+            dsName + "'; omit these parameters to get the full, unpaged table list.");
       }
 
       DefaultMetaDataProvider metaDataProvider = getMetaDataProvider(dsName);
@@ -2015,7 +2048,8 @@ public class MetadataApiService {
                continue;
             }
 
-            DatasourceTablesResponse tablesResponse = getDatabaseTables(dsName, principal);
+            DatasourceTablesResponse tablesResponse =
+               getDatabaseTables(dsName, null, null, null, principal);
 
             for(DatabaseTableInfo tableInfo : tablesResponse.getTables()) {
                boolean tableMatches = queryLower != null && tableNameMatches(

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -87,6 +87,29 @@ public class TabularCatalogService {
       return toTablesResponse(dsName, catalog);
    }
 
+   /**
+    * The paged counterpart of {@link #listTables(String)}, for a caller that wants to browse or
+    * search a large catalog rather than receive everything (spec §3.1/§7). Unlike the full
+    * listing, a page never carries relationships: a {@link TabularCatalogPage} has no
+    * relationships field to validate, so {@link #validateRelationshipEndpoints} is not called
+    * here -- see spec §5, which argues that check does not need relaxing precisely because the
+    * paged path never feeds it a relationship whose endpoint could fall outside the caller's
+    * current page.
+    */
+   public DatasourceTablesResponse listTables(String dsName, String nameContains, int limit,
+                                              String cursor) throws Exception
+   {
+      TabularCatalogProvider provider = resolveProvider(dsName);
+      TabularDataSource<?> tds = resolveTabularDataSource(dsName);
+
+      TabularCatalogPage page =
+         provider.listDatasets(tds, new TabularCatalogRequest(nameContains, limit, cursor));
+
+      validateDatasetIds(dsName, page.datasets());
+
+      return toPagedTablesResponse(dsName, page);
+   }
+
    private static void validateDatasetIds(String dsName, List<TabularDatasetRef> datasets)
       throws Exception
    {
@@ -335,6 +358,23 @@ public class TabularCatalogService {
       DatasourceTablesResponse response = new DatasourceTablesResponse();
       response.setTables(tables);
       response.setRelationships(relationships);
+      return response;
+   }
+
+   static DatasourceTablesResponse toPagedTablesResponse(String dsName, TabularCatalogPage page) {
+      List<DatabaseTableInfo> tables = new ArrayList<>();
+
+      for(TabularDatasetRef ref : page.datasets()) {
+         DatabaseTableInfo info = new DatabaseTableInfo();
+         info.setDatabase(dsName);
+         info.setTable(ref.id());
+         tables.add(info);
+      }
+
+      DatasourceTablesResponse response = new DatasourceTablesResponse();
+      response.setTables(tables);
+      response.setRelationships(List.of());
+      response.setNextCursor(page.nextCursor());
       return response;
    }
 

--- a/core/src/test/java/inetsoft/uql/tabular/FixedCatalogProvider.java
+++ b/core/src/test/java/inetsoft/uql/tabular/FixedCatalogProvider.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import java.util.List;
+
+/**
+ * The minimal test double for {@link TabularCatalogProvider}'s two new default methods: a fixed
+ * catalog, and NOTHING ELSE overridden. {@link TabularCatalogProvider} does not depend on
+ * {@link TabularRuntime}, so unlike {@code FakeCatalogRuntime} this does not need to extend it —
+ * exercising the interface's default methods needs only the interface itself.
+ *
+ * Deliberately overrides neither {@code listDatasets(TabularDataSource, TabularCatalogRequest)} nor
+ * {@code listRelationships}: that is what makes a test built on this double a test of the DEFAULT
+ * implementation (charter A1/A5), and, combined with never being used as a production
+ * implementation, part of the constructive argument behind charter A9.
+ */
+class FixedCatalogProvider implements TabularCatalogProvider {
+   FixedCatalogProvider(List<TabularDatasetRef> datasets) {
+      this(datasets, List.of());
+   }
+
+   FixedCatalogProvider(List<TabularDatasetRef> datasets, List<TabularRelationship> relationships) {
+      this.catalog = new TabularCatalog(datasets, relationships);
+   }
+
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) {
+      return catalog;
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId) {
+      throw new UnsupportedOperationException("not used by these tests");
+   }
+
+   private final TabularCatalog catalog;
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderImplementerCanaryTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderImplementerCanaryTest.java
@@ -29,16 +29,16 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Covers charter assertions A9 and B5.
  *
- * <p>A9's reflection check, honestly scoped: {@code core}'s test classpath cannot see ANY of the 12
- * production {@link TabularCatalogProvider} implementers — not just the 3 that live in the separate
+ * <p>A9's reflection check, honestly scoped: {@code core}'s test classpath cannot see ANY of the 13
+ * production {@link TabularCatalogProvider} implementers — not just the 4 that live in the separate
  * enterprise reactor, but all 9 community connectors too, because the dependency direction is
  * connector to {@code core}, never the reverse. Running this from {@code core} therefore verifies
- * zero implementers by reflection today; what makes A9 true for all 12 is the constructive argument
+ * zero implementers by reflection today; what makes A9 true for all 13 is the constructive argument
  * in the design doc (the two methods are new, and no connector file changes this round), not this
  * test.
  *
  * <p>This test exists so that fact is asserted, not silently assumed:
- * {@code knownImplementersAreNotOnClasspath_documentedLimitOfThisModule} pins the 12 names and
+ * {@code knownImplementersAreNotOnClasspath_documentedLimitOfThisModule} pins the 13 names and
  * fails loudly the day one becomes loadable from {@code core} — at which point
  * {@code resolvesToInterfaceDefaultWhenLoadable} (which already loops over the same list and skips
  * whatever it cannot load) starts actually checking that one, with no code change needed here.
@@ -58,7 +58,8 @@ class TabularCatalogProviderImplementerCanaryTest {
       "inetsoft.uql.sharepoint.SharepointOnlineRuntime",
       "inetsoft.uql.facebook.marketing.FBAdInsightsRuntime",
       "inetsoft.uql.googleanalyticsga4.AnalyticsRuntime",
-      "inetsoft.uql.sforce.SForceRuntime");
+      "inetsoft.uql.sforce.SForceRuntime",
+      "inetsoft.uql.sapjco2.table.SAPTableRuntime");
 
    @Test
    void knownImplementersAreNotOnClasspath_documentedLimitOfThisModule() {

--- a/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderImplementerCanaryTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderImplementerCanaryTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers charter assertions A9 and B5.
+ *
+ * <p>A9's reflection check, honestly scoped: {@code core}'s test classpath cannot see ANY of the 12
+ * production {@link TabularCatalogProvider} implementers — not just the 3 that live in the separate
+ * enterprise reactor, but all 9 community connectors too, because the dependency direction is
+ * connector to {@code core}, never the reverse. Running this from {@code core} therefore verifies
+ * zero implementers by reflection today; what makes A9 true for all 12 is the constructive argument
+ * in the design doc (the two methods are new, and no connector file changes this round), not this
+ * test.
+ *
+ * <p>This test exists so that fact is asserted, not silently assumed:
+ * {@code knownImplementersAreNotOnClasspath_documentedLimitOfThisModule} pins the 12 names and
+ * fails loudly the day one becomes loadable from {@code core} — at which point
+ * {@code resolvesToInterfaceDefaultWhenLoadable} (which already loops over the same list and skips
+ * whatever it cannot load) starts actually checking that one, with no code change needed here.
+ */
+@Tag("core")
+class TabularCatalogProviderImplementerCanaryTest {
+
+   private static final List<String> KNOWN_PRODUCTION_IMPLEMENTERS = List.of(
+      "inetsoft.uql.aerospike.AerospikeRuntime",
+      "inetsoft.uql.cassandra.CassandraRuntime",
+      "inetsoft.uql.elasticrest.ElasticRestRuntime",
+      "inetsoft.uql.gdata.GDataRuntime",
+      "inetsoft.uql.hive.HiveRuntime",
+      "inetsoft.uql.mongodb.MongoRuntime",
+      "inetsoft.uql.odata.ODataRuntime",
+      "inetsoft.uql.orientdb.OrientDBRuntime",
+      "inetsoft.uql.sharepoint.SharepointOnlineRuntime",
+      "inetsoft.uql.facebook.marketing.FBAdInsightsRuntime",
+      "inetsoft.uql.googleanalyticsga4.AnalyticsRuntime",
+      "inetsoft.uql.sforce.SForceRuntime");
+
+   @Test
+   void knownImplementersAreNotOnClasspath_documentedLimitOfThisModule() {
+      for(String fqcn : KNOWN_PRODUCTION_IMPLEMENTERS) {
+         assertThrows(ClassNotFoundException.class, () -> Class.forName(fqcn),
+            () -> fqcn + " is now loadable from core -- promote it into the assertion below, " +
+                  "this is the signal this canary exists to give.");
+      }
+   }
+
+   @Test
+   void resolvesToInterfaceDefaultWhenLoadable() throws Exception {
+      for(String fqcn : KNOWN_PRODUCTION_IMPLEMENTERS) {
+         Class<?> implClass;
+
+         try {
+            implClass = Class.forName(fqcn);
+         }
+         catch(ClassNotFoundException e) {
+            continue;   // Not on this module's classpath -- covered by construction, see design doc.
+         }
+
+         Method listDatasetsPaged = implClass.getMethod(
+            "listDatasets", TabularDataSource.class, TabularCatalogRequest.class);
+         assertEquals(TabularCatalogProvider.class, listDatasetsPaged.getDeclaringClass(),
+            fqcn + " overrides the new paged listDatasets -- re-verify A1/A2/A4 equivalence for it.");
+
+         Method listRelationships = implClass.getMethod(
+            "listRelationships", TabularDataSource.class, Collection.class);
+         assertEquals(TabularCatalogProvider.class, listRelationships.getDeclaringClass(),
+            fqcn + " overrides listRelationships -- re-verify A5/A6 equivalence for it.");
+      }
+   }
+
+   // ----- B5 -----
+
+   @Test
+   void bothNewMethods_areDefault_notAbstract() throws Exception {
+      Method listDatasetsPaged = TabularCatalogProvider.class.getMethod(
+         "listDatasets", TabularDataSource.class, TabularCatalogRequest.class);
+      Method listRelationships = TabularCatalogProvider.class.getMethod(
+         "listRelationships", TabularDataSource.class, Collection.class);
+
+      assertTrue(listDatasetsPaged.isDefault(),
+         "listDatasets(TabularDataSource, TabularCatalogRequest) must be default, or it would " +
+         "break every existing implementer at compile time");
+      assertTrue(listRelationships.isDefault(),
+         "listRelationships must be default, or it would break every existing implementer at " +
+         "compile time");
+   }
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderPagingTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderPagingTest.java
@@ -1,0 +1,302 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import inetsoft.web.wiz.service.FakeTabularDataSource;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers charter assertions A1, A2, A3, A4, A8, B2, B3, B8 for
+ * {@link TabularCatalogProvider#listDatasets(TabularDataSource, TabularCatalogRequest)}'s default
+ * implementation. Uses {@link FixedCatalogProvider}, which overrides neither new default method —
+ * exercising the default implementation itself is the point of these assertions (see charter A9).
+ */
+@Tag("core")
+class TabularCatalogProviderPagingTest {
+
+   private static final int LIMIT = 3;
+   private static final TabularDataSource<?> DS = new FakeTabularDataSource();
+
+   // A1/A2 fixture: a Chinese id (订单), a pair differing only by case (orders/Orders — both are
+   // independent, legal, distinct ids; A1 does not fold on case), and a dotted id
+   // (customers.archive — legal per TabularDatasetRef's javadoc, and the subject of wiz#2252).
+   private static final List<TabularDatasetRef> NINE_DATASETS =
+      refs("orders", "Orders", "订单", "customers.archive", "A", "B", "C", "D", "E");
+
+   // ----- A1 / A2 -----
+
+   @ParameterizedTest(name = "catalog size {0}")
+   @ValueSource(ints = {0, 1, 2, 3, 4, 7, 9})
+   void pagingThroughEveryPage_withNoFilter_yieldsExactlyTheFullDatasetSet(int size) throws Exception {
+      List<TabularDatasetRef> datasets = NINE_DATASETS.subList(0, size);
+      FixedCatalogProvider provider = new FixedCatalogProvider(datasets);
+
+      List<TabularCatalogPage> pages = collectAllPages(provider, DS, null, LIMIT, size);
+
+      List<TabularDatasetRef> paged = pages.stream()
+         .flatMap(p -> p.datasets().stream())
+         .collect(Collectors.toList());
+
+      // Set equality AND size equality -- set equality alone would let a duplicate id hide behind
+      // Set's de-duplication.
+      assertEquals(idSet(datasets), idSet(paged), "size=" + size + ": id set mismatch");
+      assertEquals(datasets.size(), paged.size(), "size=" + size + ": total count mismatch");
+
+      // A2: every non-final page holds exactly LIMIT entries, and has a non-null nextCursor; the
+      // page carrying the last batch of data -- and only it -- has a null nextCursor, with no extra
+      // empty page even when size is an exact multiple of LIMIT (size=9 here).
+      for(int i = 0; i < pages.size() - 1; i++) {
+         assertEquals(LIMIT, pages.get(i).datasets().size(),
+            "size=" + size + ": page " + i + " is not the last page but lacks exactly " + LIMIT +
+            " entries");
+         assertNotNull(pages.get(i).nextCursor(),
+            "size=" + size + ": page " + i + " is not the last page but has a null nextCursor");
+      }
+      assertNull(pages.get(pages.size() - 1).nextCursor(),
+         "size=" + size + ": last page must have a null nextCursor");
+
+      int expectedPageCount = size == 0 ? 1 : (int) Math.ceil(size / (double) LIMIT);
+      assertEquals(expectedPageCount, pages.size(), "size=" + size + ": unexpected page count");
+   }
+
+   // ----- A3 -----
+
+   /**
+    * This loop is itself the A3 evidence: it only ever stores the exact {@code nextCursor} a
+    * previous call returned and compares it to {@code null} — never {@code equals}, {@code parse},
+    * {@code substring}, or {@code length} on the cursor string. A review pass over this file
+    * confirms that discipline was not violated anywhere else in it either.
+    */
+   private static List<TabularCatalogPage> collectAllPages(TabularCatalogProvider provider,
+      TabularDataSource<?> ds, String nameContains, int limit, int datasetCountBound)
+      throws Exception
+   {
+      List<TabularCatalogPage> pages = new java.util.ArrayList<>();
+      String cursor = null;
+      int iterations = 0;
+
+      while(true) {
+         if(iterations++ > datasetCountBound + 2) {
+            fail("paging loop exceeded " + (datasetCountBound + 2) +
+               " iterations without terminating -- the implementation under test is likely stuck " +
+               "in a loop rather than genuinely failing");
+         }
+
+         TabularCatalogPage page =
+            provider.listDatasets(ds, new TabularCatalogRequest(nameContains, limit, cursor));
+         pages.add(page);
+
+         if(page.nextCursor() == null) {
+            break;
+         }
+
+         cursor = page.nextCursor();
+      }
+
+      return pages;
+   }
+
+   /**
+    * D1's resolution, recorded rather than forbidden: the default implementation's cursor is,
+    * structurally, an offset into a freshly recomputed list ({@link TabularCatalogProvider}'s
+    * "Stated residual" javadoc says so explicitly). When the underlying source legitimately changes
+    * between two page calls — nothing in the SPI ever promised a snapshot across calls — the
+    * default implementation can skip or repeat an entry. This test pins that EXACT, ACCEPTED
+    * behavior; it must NOT be read as a bug report. A future keyset-based rewrite of the default
+    * implementation would legitimately turn this test red — whoever does that should update this
+    * test to match the new (stronger) contract, not treat a red run here as a regression to revert.
+    */
+   @Test
+   void cursorAcrossUnderlyingListShift_recordsTheStatedResidualWeakness() throws Exception {
+      ShiftingCatalogProvider provider = new ShiftingCatalogProvider(refs("A", "B", "C", "D"));
+
+      TabularCatalogPage page1 =
+         provider.listDatasets(DS, new TabularCatalogRequest(null, 2, null));
+      assertEquals(List.of("A", "B"), idList(page1.datasets()));
+      String cursor1 = page1.nextCursor();
+      assertNotNull(cursor1);
+
+      // Between the two calls, an element is inserted ahead of everything already delivered -- a
+      // legitimate change the SPI never forbade.
+      provider.setCurrent(refs("E", "A", "B", "C", "D"));
+
+      TabularCatalogPage page2 =
+         provider.listDatasets(DS, new TabularCatalogRequest(null, 2, cursor1));
+
+      // Offset 2 into the shifted list is now [B, C]: B is repeated (already delivered in page1)
+      // and D is skipped entirely. This is the residual the javadoc names, not a bug this test is
+      // trying to catch.
+      assertEquals(List.of("B", "C"), idList(page2.datasets()));
+   }
+
+   private static class ShiftingCatalogProvider implements TabularCatalogProvider {
+      ShiftingCatalogProvider(List<TabularDatasetRef> initial) {
+         this.current = initial;
+      }
+
+      void setCurrent(List<TabularDatasetRef> current) {
+         this.current = current;
+      }
+
+      @Override
+      public TabularCatalog listDatasets(TabularDataSource<?> dataSource) {
+         return new TabularCatalog(current, List.of());
+      }
+
+      @Override
+      public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId) {
+         throw new UnsupportedOperationException("not used by this test");
+      }
+
+      private List<TabularDatasetRef> current;
+   }
+
+   // ----- A4 / B8 -----
+
+   private static final List<TabularDatasetRef> NAME_FILTER_DATASETS = refs(
+      "Orders", "orders_2025", "CustomerOrders", "订单汇总", "Invoices", "customers.archive");
+
+   @Test
+   void nameContains_substringNotPrefix_matchesMidStringCaseInsensitively() throws Exception {
+      assertFilterYields("rder", Set.of("Orders", "orders_2025", "CustomerOrders"));
+   }
+
+   @Test
+   void nameContains_upperCaseFilter_stillMatchesLowerCaseId() throws Exception {
+      assertFilterYields("ORDERS", Set.of("Orders", "orders_2025", "CustomerOrders"));
+   }
+
+   @Test
+   void nameContains_chineseSubstring_matchesById() throws Exception {
+      assertFilterYields("订单", Set.of("订单汇总"));
+   }
+
+   @Test
+   void nameContains_dotDoesNotActAsWildcardOrSeparator() throws Exception {
+      assertFilterYields("archive", Set.of("customers.archive"));
+   }
+
+   @Test
+   void nameContains_noSubstringMatches_yieldsEmptySet_notEveryDataset() throws Exception {
+      // Paired with the null/blank cases below: this is what "really matches nothing" looks like,
+      // so the two outcomes are told apart rather than assumed different (charter B8).
+      assertFilterYields("ZZZ_NO_MATCH", Set.of());
+   }
+
+   @Test
+   void blankOrNullNameContains_meansNoFiltering_notMatchNothing() throws Exception {
+      Set<String> all = idSet(NAME_FILTER_DATASETS);
+      assertFilterYields(null, all);
+      assertFilterYields("", all);
+      assertFilterYields("   ", all);
+   }
+
+   @Test
+   void pagingAFilteredListing_satisfiesA1AndA2OverTheFilteredSet() throws Exception {
+      FixedCatalogProvider provider = new FixedCatalogProvider(NAME_FILTER_DATASETS);
+
+      List<TabularCatalogPage> pages = collectAllPages(provider, DS, "rder", 2, 3);
+
+      List<TabularDatasetRef> paged = pages.stream()
+         .flatMap(p -> p.datasets().stream()).collect(Collectors.toList());
+      assertEquals(Set.of("Orders", "orders_2025", "CustomerOrders"), idSet(paged));
+      assertEquals(3, paged.size());
+
+      assertEquals(2, pages.size());
+      assertNotNull(pages.get(0).nextCursor());
+      assertEquals(2, pages.get(0).datasets().size());
+      assertNull(pages.get(1).nextCursor());
+      assertEquals(1, pages.get(1).datasets().size());
+   }
+
+   private static void assertFilterYields(String nameContains, Set<String> expectedIds)
+      throws Exception
+   {
+      FixedCatalogProvider provider = new FixedCatalogProvider(NAME_FILTER_DATASETS);
+      // limit set above the fixture size: this method only checks the filtered SET, paging itself
+      // is covered separately above.
+      List<TabularCatalogPage> pages =
+         collectAllPages(provider, DS, nameContains, NAME_FILTER_DATASETS.size() + 1,
+            NAME_FILTER_DATASETS.size());
+
+      List<TabularDatasetRef> matched = pages.stream()
+         .flatMap(p -> p.datasets().stream()).collect(Collectors.toList());
+      assertEquals(expectedIds, idSet(matched), "nameContains='" + nameContains + "'");
+   }
+
+   // ----- A8 -----
+
+   @Test
+   void limitZero_throwsNamingTheField() {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> new TabularCatalogRequest(null, 0, null));
+      assertTrue(ex.getMessage().toLowerCase().contains("limit"),
+         "exception must name the offending field: " + ex.getMessage());
+   }
+
+   @Test
+   void limitNegative_throwsNamingTheField() {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> new TabularCatalogRequest(null, -1, null));
+      assertTrue(ex.getMessage().toLowerCase().contains("limit"),
+         "exception must name the offending field: " + ex.getMessage());
+   }
+
+   // ----- B2 / B3 -----
+
+   @Test
+   void tabularCatalogPage_carriesExactlyDatasetsAndNextCursor_noRelationshipsField() {
+      RecordComponent[] comps = TabularCatalogPage.class.getRecordComponents();
+      assertEquals(Set.of("datasets", "nextCursor"),
+         Arrays.stream(comps).map(RecordComponent::getName).collect(Collectors.toSet()));
+      assertEquals(2, comps.length);
+   }
+
+   @Test
+   void tabularCatalogRequest_carriesExactlyThreeFields_noReservedFilterDimension() {
+      RecordComponent[] comps = TabularCatalogRequest.class.getRecordComponents();
+      assertEquals(Set.of("nameContains", "limit", "cursor"),
+         Arrays.stream(comps).map(RecordComponent::getName).collect(Collectors.toSet()));
+      assertEquals(3, comps.length);
+   }
+
+   // ----- shared fixture helpers -----
+
+   private static List<TabularDatasetRef> refs(String... ids) {
+      return Arrays.stream(ids).map(TabularDatasetRef::new).collect(Collectors.toList());
+   }
+
+   private static List<String> idList(List<TabularDatasetRef> refs) {
+      return refs.stream().map(TabularDatasetRef::id).collect(Collectors.toList());
+   }
+
+   private static Set<String> idSet(List<TabularDatasetRef> refs) {
+      return refs.stream().map(TabularDatasetRef::id).collect(Collectors.toSet());
+   }
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderPagingTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderPagingTest.java
@@ -177,6 +177,51 @@ class TabularCatalogProviderPagingTest {
       private List<TabularDatasetRef> current;
    }
 
+   // ----- overflow guard for start + limit -----
+
+   @Test
+   void limitLargerThanRemainingCount_doesNotOverflowStartPlusLimit() throws Exception {
+      List<TabularDatasetRef> datasets = NINE_DATASETS.subList(0, 5);
+      FixedCatalogProvider provider = new FixedCatalogProvider(datasets);
+
+      TabularCatalogPage page1 =
+         provider.listDatasets(DS, new TabularCatalogRequest(null, 2, null));
+      String cursor = page1.nextCursor();
+      assertNotNull(cursor);
+
+      // A compliant caller may raise limit on a later page -- nothing in the contract requires it to
+      // stay constant across a browsing session, only that the cursor is replayed with the same
+      // nameContains. start + limit here is 2 + Integer.MAX_VALUE, which overflows int arithmetic.
+      TabularCatalogPage page2 =
+         provider.listDatasets(DS, new TabularCatalogRequest(null, Integer.MAX_VALUE, cursor));
+
+      assertEquals(idList(datasets.subList(2, datasets.size())), idList(page2.datasets()));
+      assertNull(page2.nextCursor());
+   }
+
+   // ----- decodeCursor edge cases -----
+
+   @ParameterizedTest(name = "cursor ''{0}''")
+   @ValueSource(strings = {"not-a-cursor", "-1"})
+   void cursorNotMintedByThisImplementation_throwsIllegalArgumentException(String cursor) {
+      FixedCatalogProvider provider = new FixedCatalogProvider(NINE_DATASETS);
+
+      assertThrows(IllegalArgumentException.class,
+         () -> provider.listDatasets(DS, new TabularCatalogRequest(null, LIMIT, cursor)));
+   }
+
+   @Test
+   void cursorPastTheEnd_returnsEmptyExhaustedPage_notException() throws Exception {
+      List<TabularDatasetRef> datasets = NINE_DATASETS.subList(0, 3);
+      FixedCatalogProvider provider = new FixedCatalogProvider(datasets);
+
+      TabularCatalogPage page =
+         provider.listDatasets(DS, new TabularCatalogRequest(null, LIMIT, "999"));
+
+      assertEquals(List.of(), page.datasets());
+      assertNull(page.nextCursor());
+   }
+
    // ----- A4 / B8 -----
 
    private static final List<TabularDatasetRef> NAME_FILTER_DATASETS = refs(

--- a/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderRelationshipsTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderRelationshipsTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import inetsoft.web.wiz.service.FakeTabularDataSource;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers charter assertions A5 and A6 for
+ * {@link TabularCatalogProvider#listRelationships(TabularDataSource, java.util.Collection)}'s
+ * default implementation. Uses {@link FixedCatalogProvider}, which overrides neither new default
+ * method (see charter A9).
+ */
+@Tag("core")
+class TabularCatalogProviderRelationshipsTest {
+
+   private static final TabularDataSource<?> DS = new FakeTabularDataSource();
+
+   // Four datasets, one edge per endpoint shape, selected ids = {A, B}. Names double as the
+   // expected/rejected assertion labels.
+   private static final List<TabularDatasetRef> DATASETS =
+      List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B"),
+         new TabularDatasetRef("C"), new TabularDatasetRef("D"));
+
+   private static final TabularRelationship R_BOTH_IN =
+      edge("R_both_in", "A", "B");   // both endpoints in {A, B} -- must be kept
+   private static final TabularRelationship R_FROM_IN =
+      edge("R_from_in", "A", "C");   // from in, to out -- must be dropped
+   private static final TabularRelationship R_TO_IN =
+      edge("R_to_in", "C", "A");     // from out, to in -- the "at-least-one-endpoint" trap
+   private static final TabularRelationship R_BOTH_OUT =
+      edge("R_both_out", "C", "D");  // neither endpoint in -- must be dropped
+
+   private static final FixedCatalogProvider PROVIDER = new FixedCatalogProvider(
+      DATASETS, List.of(R_BOTH_IN, R_FROM_IN, R_TO_IN, R_BOTH_OUT));
+
+   @Test
+   void listRelationships_keepsOnlyTheEdgeWithBothEndpointsInSelection() throws Exception {
+      List<TabularRelationship> result = PROVIDER.listRelationships(DS, Set.of("A", "B"));
+
+      // Exact set equality, not "contains at least" -- an implementation wrongly written with
+      // ids.contains(from) || ids.contains(to) would keep R_from_in and R_to_in too (both have A
+      // as one endpoint) and this would report 3 edges instead of 1.
+      assertEquals(Set.of("R_both_in"), nameSet(result));
+   }
+
+   @Test
+   void listRelationships_emptyDatasetIds_yieldsEmptyList_notEveryEdge() throws Exception {
+      List<TabularRelationship> result = PROVIDER.listRelationships(DS, Set.of());
+
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void listRelationships_nullDatasetIds_treatedIdenticallyToEmpty() throws Exception {
+      List<TabularRelationship> result = PROVIDER.listRelationships(DS, null);
+
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+   }
+
+   private static TabularRelationship edge(String name, String from, String to) {
+      return new TabularRelationship(name, from, to, List.of("x"), List.of("y"));
+   }
+
+   private static Set<String> nameSet(List<TabularRelationship> relationships) {
+      return relationships.stream().map(TabularRelationship::name).collect(Collectors.toSet());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceAnnotationTargetThresholdTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceAnnotationTargetThresholdTest.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.util.Config;
+import inetsoft.web.admin.content.database.DatabaseTypeService;
+import inetsoft.web.admin.content.repository.DatabaseDatasourcesService;
+import inetsoft.web.admin.model.NameLabelTuple;
+import inetsoft.web.portal.data.DataSourceBrowserService;
+import inetsoft.web.portal.data.DataSourceInfo;
+import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.portal.service.datasource.DataSourceStatusService;
+import inetsoft.web.wiz.model.WizDatasourceBrowserModel;
+import inetsoft.web.wiz.model.WizDatasourceEntry;
+import inetsoft.web.wiz.service.EndpointCatalogReader;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins design spec §3.3 (scaled annotation target selection): the annotation-target threshold
+ * reaches {@link WizDatasourceEntry} through the real browse path, not just as a constant sitting
+ * unused in the controller. Wiz issues its first paged listing request with
+ * {@code limit = annotationTargetThreshold + 1} <em>before</em> that first request, so this is its
+ * only chance to learn the value.
+ */
+@Tag("core")
+class WizDatasourceAnnotationTargetThresholdTest {
+   @Test
+   void browseEntryCarriesTheGlobalAnnotationTargetThreshold() throws Exception {
+      DataSourceInfo info = DataSourceInfo.builder()
+         .name("ds1")
+         .path("Test/ds1")
+         .type(NameLabelTuple.builder().name("DATA_SOURCE").label("ds1").build())
+         .createdBy("admin")
+         .createdDateLabel("")
+         .dateFormat("")
+         .editable(true)
+         .deletable(true)
+         .hasSubFolder(false)
+         .build();
+
+      DataSourceBrowserService browserService = mock(DataSourceBrowserService.class);
+      when(browserService.getDataSources(anyString(), eq(false), any(), any(Principal.class)))
+         .thenReturn(List.of(info));
+      when(browserService.getBreadcrumbs(anyString(), eq(true), any(Principal.class)))
+         .thenReturn(List.of());
+
+      // A bare mock, not a real JDBCDataSource -- constructing one needs a live Spring context
+      // (CredentialService) this plain unit test does not stand up, and this test cares about the
+      // threshold reaching the entry, not about which annotationClass a real JDBC source gets.
+      XDataSource dataSource = mock(XDataSource.class);
+      when(dataSource.getType()).thenReturn("TEST");
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource("Test/ds1")).thenReturn(dataSource);
+
+      Config uqlConfig = mock(Config.class);
+      when(uqlConfig.getQueryClass("TEST")).thenReturn(null); // classifies as UNKNOWN -- irrelevant here
+
+      WizDatabaseController controller = new WizDatabaseController(
+         browserService, mock(DataSourceStatusService.class),
+         mock(DatabaseDatasourcesService.class), mock(DatabaseTypeService.class),
+         mock(SecurityEngine.class), uqlConfig, xrepository,
+         mock(EndpointCatalogReader.class), mock(DatasourcesService.class));
+
+      WizDatasourceBrowserModel model = controller.getDatasourceBrowser("Test", mock(Principal.class));
+
+      assertEquals(1, model.entries().size());
+      WizDatasourceEntry entry = model.entries().get(0);
+      assertEquals(WizDatabaseController.ANNOTATION_TARGET_THRESHOLD,
+                   entry.annotationTargetThreshold(),
+                   "the threshold must reach the entry wiz reads before its first paged " +
+                      "listing request, not just exist as an unused constant");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceNonJdbcBranchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceNonJdbcBranchTest.java
@@ -94,7 +94,7 @@ class MetadataApiServiceNonJdbcBranchTest {
          tabularCatalogService);
 
       assertThrows(Exception.class,
-         () -> service.getDatabaseTables("Examples/Orders", mock(Principal.class)));
+         () -> service.getDatabaseTables("Examples/Orders", null, null, null, mock(Principal.class)));
 
       verifyNoInteractions(tabularCatalogService);
    }
@@ -119,7 +119,7 @@ class MetadataApiServiceNonJdbcBranchTest {
          tabularCatalogService);
 
       DatasourceTablesResponse response =
-         service.getDatabaseTables("OData Source", mock(Principal.class));
+         service.getDatabaseTables("OData Source", null, null, null, mock(Principal.class));
 
       assertNotNull(response);
       verify(tabularCatalogService).listTables("OData Source");

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePagingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePagingTest.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.DatasourceTablesResponse;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers 09-design-dialog-and-persistence.md A.1/A.2: {@code GET /datasource/tables}'s new
+ * {@code nameContains}/{@code limit}/{@code cursor} parameters, dispatched through
+ * {@link MetadataApiService#getDatabaseTables}.
+ *
+ * The JDBC-with-paging-params case is a guard, not a feature -- see A.5: JDBC paging is a
+ * separate, larger change this round does not implement, so a paging request against a JDBC
+ * source must fail loudly rather than silently fall back to the unpaged full listing.
+ */
+@Tag("core")
+class MetadataApiServicePagingTest {
+
+   private static final String JDBC_DS = "Examples/Orders";
+   private static final String TABULAR_DS = "OData Source";
+
+   @Test
+   void getDatabaseTables_pagedParamsAgainstJdbcSource_throwsNamedGuardError() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(JDBC_DS)).thenReturn(mock(JDBCDataSource.class));
+
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq(JDBC_DS), eq(ResourceAction.READ), any()))
+         .thenReturn(true);
+
+      TabularCatalogService tabularCatalogService = mock(TabularCatalogService.class);
+      MetadataApiService service = new MetadataApiService(xrepository, dataSourceService,
+         mock(AssetRepository.class), mock(AssetTreeService.class), new ObjectMapper(),
+         tabularCatalogService);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.getDatabaseTables(JDBC_DS, null, 50, null, mock(Principal.class)));
+
+      assertNotNull(ex.getMessage());
+      assertTrue(ex.getMessage().contains(JDBC_DS), "message must name the offending data source");
+      assertTrue(ex.getMessage().toLowerCase().contains("jdbc"),
+         "message must say why -- paging is not supported for JDBC sources yet");
+      verifyNoInteractions(tabularCatalogService);
+   }
+
+   /**
+    * The single most important property of this change: omitting all three paging parameters
+    * against a JDBC source must still reach the full, pre-paging code path (and never touch
+    * {@link TabularCatalogService}) -- i.e. the guard above must only fire when paging was
+    * actually requested.
+    */
+   @Test
+   void getDatabaseTables_noPagingParamsAgainstJdbcSource_doesNotThrowTheGuard() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(JDBC_DS)).thenReturn(mock(JDBCDataSource.class));
+
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq(JDBC_DS), eq(ResourceAction.READ), any()))
+         .thenReturn(true);
+
+      TabularCatalogService tabularCatalogService = mock(TabularCatalogService.class);
+      MetadataApiService service = new MetadataApiService(xrepository, dataSourceService,
+         mock(AssetRepository.class), mock(AssetTreeService.class), new ObjectMapper(),
+         tabularCatalogService);
+
+      // getMetaDataProvider() fails further down against a mock DataSourceService with no
+      // stubbed model -- same seam MetadataApiServiceNonJdbcBranchTest relies on. The point here
+      // is that the failure comes from THAT plumbing, not from the paging guard: an
+      // IllegalArgumentException naming JDBC paging would mean the guard mis-fired.
+      Exception ex = assertThrows(Exception.class,
+         () -> service.getDatabaseTables(JDBC_DS, null, null, null, mock(Principal.class)));
+      assertFalse(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("paging"));
+
+      verifyNoInteractions(tabularCatalogService);
+   }
+
+   @Test
+   void getDatabaseTables_pagedParamsAgainstTabularSource_delegatesToPagedListTables()
+      throws Exception
+   {
+      XRepository xrepository = mock(XRepository.class);
+      XDataSource odataLikeDataSource = mock(XDataSource.class);
+      when(odataLikeDataSource.getType()).thenReturn("OData");
+      when(xrepository.getDataSource(TABULAR_DS)).thenReturn(odataLikeDataSource);
+
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq(TABULAR_DS), eq(ResourceAction.READ), any()))
+         .thenReturn(true);
+
+      TabularCatalogService tabularCatalogService = mock(TabularCatalogService.class);
+      DatasourceTablesResponse canned = new DatasourceTablesResponse();
+      canned.setNextCursor("3");
+      when(tabularCatalogService.listTables(TABULAR_DS, "ord", 25, "prevCursor"))
+         .thenReturn(canned);
+
+      MetadataApiService service = new MetadataApiService(xrepository, dataSourceService,
+         mock(AssetRepository.class), mock(AssetTreeService.class), new ObjectMapper(),
+         tabularCatalogService);
+
+      DatasourceTablesResponse response = service.getDatabaseTables(
+         TABULAR_DS, "ord", 25, "prevCursor", mock(Principal.class));
+
+      assertSame(canned, response);
+      verify(tabularCatalogService).listTables(TABULAR_DS, "ord", 25, "prevCursor");
+      verify(tabularCatalogService, never()).listTables(TABULAR_DS);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceSchemaSearchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceSchemaSearchTest.java
@@ -134,7 +134,8 @@ class MetadataApiServiceSchemaSearchTest {
          xrepository, dataSourceService, mock(AssetRepository.class),
          mock(AssetTreeService.class), new ObjectMapper()));
 
-      doReturn(tablesResponse).when(service).getDatabaseTables(anyString(), any());
+      doReturn(tablesResponse).when(service)
+         .getDatabaseTables(anyString(), any(), any(), any(), any());
 
       if(tableMeta != null) {
          doReturn(tableMeta).when(service)

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceRelationshipEndpointFilterTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceRelationshipEndpointFilterTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.tabular.*;
+import inetsoft.web.wiz.model.DatasourceTablesResponse;
+import inetsoft.web.wiz.model.osi.OsiRelationship;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers charter assertion A7: filtering relationships to both-endpoints-in-selection, per
+ * {@link TabularCatalogProvider#listRelationships}'s default implementation, makes the untouched
+ * {@code TabularCatalogService.validateRelationshipEndpoints} pass by construction for a caller
+ * that annotates a chosen subset of a source's datasets.
+ *
+ * <p>New file rather than an addition to {@code TabularCatalogServiceContractValidationTest} —
+ * charter B1 requires that file (and {@code TabularCatalogService.java} itself) to see zero changed
+ * lines this round; its own two existing negative-path tests
+ * ({@code listTables_relationshipFromDatasetMissing_throwsNamingTheViolation}/
+ * {@code _ToDatasetMissing_}) already carry the B1 regression evidence — see charter B1 and
+ * {@code 03-reconcile.md} §D5 for why no new negative-path test is added here.
+ */
+@Tag("core")
+class TabularCatalogServiceRelationshipEndpointFilterTest {
+
+   private static final String DS_NAME = "Fake Paging Source";
+
+   @Test
+   void filteredRelationships_feedIntoListTables_withoutTrippingEndpointValidation() throws Exception {
+      // A three-dataset, two-edge full catalog: A->B has both endpoints in the caller's chosen
+      // subset {A, B}; A->C does not (C is never selected).
+      TabularCatalog fullCatalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B"), new TabularDatasetRef("C")),
+         List.of(
+            new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of("y")),
+            new TabularRelationship("R_A_C", "A", "C", List.of("x"), List.of("y"))));
+
+      FakeCatalogRuntime fullProvider = new FakeCatalogRuntime(fullCatalog, Map.of());
+
+      // This is the real default listRelationships call, not a hand-copied edge list -- if A5's
+      // implementation had a bug, this test would fail along with it rather than masking it.
+      List<TabularRelationship> filtered = fullProvider.listRelationships(
+         new FakeTabularDataSource(), Set.of("A", "B"));
+      assertEquals(1, filtered.size());
+      assertEquals("R_A_B", filtered.get(0).name());
+
+      TabularCatalog selectedCatalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")), filtered);
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(selectedCatalog, Map.of());
+
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource(DS_NAME)).thenReturn(new FakeTabularDataSource());
+      TabularCatalogService service =
+         new TabularCatalogService(xrepository, new ObjectMapper(), dsName -> runtime);
+
+      DatasourceTablesResponse response = service.listTables(DS_NAME);
+
+      List<OsiRelationship> relationships = response.getRelationships();
+      assertEquals(1, relationships.size());
+      assertEquals("A", relationships.get(0).getFrom());
+      assertEquals("B", relationships.get(0).getTo());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceTest.java
@@ -96,6 +96,49 @@ class TabularCatalogServiceTest {
       assertEquals(List.of("ID"), rel.getToColumns());
    }
 
+   // ----- paging: listTables(dsName, nameContains, limit, cursor) -----
+
+   /**
+    * Charter-successor assertion (09-design-dialog-and-persistence.md A.3): a paged response must
+    * never carry relationships, even for a source whose full {@code listDatasets} declares one --
+    * the paged {@link TabularCatalogPage} that {@code FakeCatalogRuntime}'s inherited default
+    * {@code listDatasets(ds, request)} derives from this same {@code catalog} has no relationships
+    * field to carry one in the first place.
+    */
+   @Test
+   void listTables_paged_neverReturnsRelationshipsEvenWhenFullCatalogDeclaresOne() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("Products"), new TabularDatasetRef("Categories")),
+         List.of(new TabularRelationship("Products_Category", "Products", "Categories",
+            List.of("CategoryID"), List.of("ID"))));
+
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service =
+         createService(repositoryWithFakeDataSource(), dsName -> runtime);
+
+      DatasourceTablesResponse response = service.listTables(DS_NAME, null, 10, null);
+
+      assertEquals(2, response.getTables().size());
+      assertEquals(List.of(), response.getRelationships());
+      assertNull(response.getNextCursor(), "both datasets fit in one page of 10");
+   }
+
+   @Test
+   void listTables_paged_duplicateDatasetId_isValidatedTheSameAsTheFullListing() throws Exception {
+      // validateDatasetIds is shared between the full and paged paths -- this pins that the
+      // paged path did not quietly drop that check while adding its own toPagedTablesResponse
+      // mapping.
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("A")), List.of());
+      FakeCatalogRuntime runtime = new FakeCatalogRuntime(catalog, Map.of());
+      TabularCatalogService service =
+         createService(repositoryWithFakeDataSource(), dsName -> runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.listTables(DS_NAME, null, 10, null));
+      assertTrue(ex.getMessage().contains("A"));
+   }
+
    @Test
    void listTables_emptyCatalog_throwsInsteadOfSilentlyEmptyResult() throws Exception {
       FakeCatalogRuntime runtime = new FakeCatalogRuntime(


### PR DESCRIPTION
Steps 1-3 and 5 of `docs/superpowers/specs/2026-09-07-scaled-annotation-target-selection-design.md`, on the community side. The SAP connector is a separate PR in the enterprise repo; the portal dialog, the wiz-services forwarding route and selection persistence are in stylebi-wiz.

## What this contains

**The SPI contract (§3.1 / §3.2).** Two `default` methods on `TabularCatalogProvider` — a filtered, paged `listDatasets` returning `TabularCatalogPage`, and `listRelationships(dataSource, datasetIds)` returning only edges with **both** endpoints inside the given set. Both are `default`, so all 12 production implementers are unchanged and none had to be touched. Plus two neutral records, and a javadoc addition making `TabularCatalog.datasets()`'s ordering guarantee explicit across calls — something paging silently depended on that had never been written down.

The default cursor is a decimal index by design: the opaque-cursor contract exists so an overriding connector is not bound to an offset's weakness, not to force the in-memory default to be keyset. Its residual — an insert or delete between two page calls can skip or repeat an entry — is stated in the method's own javadoc rather than engineered away.

**The threshold channel (§3.3).** `WizDatasourceEntry` carries `annotationTargetThreshold` (500, global). It has to live there rather than in a list response, because the first request is sent with `limit = threshold + 1` and must know the threshold before making it. The first page *is* the over-the-line probe, which is why no count operation was added.

**The paging route (§7 backend).** `GET /datasource/tables` gains optional `nameContains` / `limit` / `cursor`. Omitting all three is byte-identical to its previous behaviour, which matters because it has an existing caller. The presence of `limit` is what selects paged mode.

`TabularCatalogService`'s relationship-endpoint validation is **unchanged**. A paged response carries no relationships — not because the check is bypassed, but because `TabularCatalogPage` has no relationships field at all, so that path never produces an input for it.

A paging request against a JDBC source fails with a named error rather than quietly returning an unpaged listing.

## Review

The contract went through two review rounds plus two independent CI reviews. Round one found an integer overflow in the paging slice — `start + limit` wrapping negative for a caller that raises `limit` after the first page, throwing out of `subList` — and that neither documented `decodeCursor` behaviour had a test. Both fixed; the overflow regression test was confirmed red against the unfixed line before the fix was restored. Round two was clean.

The scope extension had its own review: unescaped single quotes in the SAP RFC conditions (fixed in the enterprise PR), `SAPTableRuntime` missing from the catalog-provider canary list (fixed here), and a missing empty-page test (fixed there).

## What this does not do

**JDBC paging is out of scope**, and not for lack of a UI. `MetadataApiService.getDatabaseTables` runs `buildRelationships` and `populatePrimaryKeys` once per table on every full listing, so a 600-table schema issues roughly 1200 catalog queries on a single click today — the same cost shape as SAP's per-table describe, never previously recognised as the same problem. It needs the same surgery, and judging its priority needs timing against a real database rather than H2. Recorded for a separate round.

The argument that no implementer overrides the new defaults is **constructive, not observed**: the methods are new, so nothing could have overridden them, and no connector file changed. `core`'s test classpath reaches none of the 12 implementers — connectors depend on `inetsoft-core`, never the reverse, and the enterprise connectors are a separate Maven reactor — so the canary test verifies zero of them today, and says so in its own javadoc.

Full run archive: `docs/teams/2026-09-07-tabular-catalog-paging-contract/` in stylebi-wiz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
