### PR TITLE
fix(WSQ-002): editSqlQuery now reports undeclaredVariables

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -395,7 +395,7 @@ public class WorksheetAgentController {
 
       // edit_sql_query needs RuntimeWorksheet for SQL parsing and column re-init.
       if("edit_sql_query".equals(req.op())) {
-         editSqlQuery(sessionToken, req, user);
+         editSqlQuery(sessionToken, req.table(), req.expression(), user);
          return;
       }
 
@@ -2549,8 +2549,12 @@ public class WorksheetAgentController {
 
    /**
     * Replace the SQL on an existing {@link SQLBoundTableAssembly}.
+    *
+    * @return the assembly name and any undeclared {@code $(name)} variables the new SQL
+    *         references, mirroring {@link #addSqlQuery}'s response shape.
     */
-   private void editSqlQuery(String sessionToken, EditRequest req, Principal user)
+   private SqlQueryResponse editSqlQuery(String sessionToken, String table, String expression,
+                                          Principal user)
       throws Exception
    {
       // Verify ACCESS permission on freeform SQL ("Visual Composer -> Free Form SQL"),
@@ -2561,27 +2565,27 @@ public class WorksheetAgentController {
             Catalog.getCatalog().getString("composer.authorization.permissionDenied"));
       }
 
-      if(req.table() == null || req.table().isBlank()) {
+      if(table == null || table.isBlank()) {
          throw new PairingException("table is required for edit_sql_query.");
       }
 
-      if(req.expression() == null || req.expression().isBlank()) {
+      if(expression == null || expression.isBlank()) {
          throw new PairingException("expression (SQL string) is required for edit_sql_query.");
       }
 
-      editService.applyOnRuntime(sessionToken, user, rws -> {
+      return editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
-         Assembly a = ws.getAssembly(req.table());
+         Assembly a = ws.getAssembly(table);
 
          if(!(a instanceof SQLBoundTableAssembly sqlTable)) {
-            throw new PairingException("Not a SQL-bound table: " + req.table());
+            throw new PairingException("Not a SQL-bound table: " + table);
          }
 
          SQLBoundTableAssemblyInfo info =
             (SQLBoundTableAssemblyInfo) sqlTable.getInfo();
 
          if(info.getQuery() == null) {
-            throw new PairingException("Table has no query: " + req.table());
+            throw new PairingException("Table has no query: " + table);
          }
 
          // Verify READ permission on the datasource this SQL executes against, mirroring
@@ -2630,7 +2634,7 @@ public class WorksheetAgentController {
          try {
             synchronized(sql) {
                sql.setParseSQL(true);
-               sql.setSQLString(req.expression(), true);
+               sql.setSQLString(expression, true);
                sql.wait(10_000);
             }
          }
@@ -2674,11 +2678,12 @@ public class WorksheetAgentController {
          // TableAssembly by name, including a SQL-bound one) -- unbounded here had the same hang
          // shape as refreshData's own single-table branch (3a) above.
          RenderWaitSupport.awaitOrRetry(() -> {
-            WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
+            WorksheetEventUtil.refreshColumnSelection(rws, table, true);
             return null;
          }, TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS,
             (int) Math.max(1, (TABLE_WARM_MAX_ATTEMPTS * TABLE_WARM_RETRY_SLEEP_MS) / 1000));
-         return null;
+
+         return new SqlQueryResponse(table, detectUndeclaredVariables(rws));
       });
    }
 
@@ -3550,6 +3555,42 @@ public class WorksheetAgentController {
 
          return new SqlQueryResponse(tableName, detectUndeclaredVariables(rws));
       });
+   }
+
+   /**
+    * Request body for editing a SQL query table's SQL text.
+    *
+    * @param table      the assembly name of the existing SQL-bound table to edit
+    * @param expression the new SQL string
+    */
+   public record EditSqlQueryRequest(String table, String expression) {}
+
+   /**
+    * Replace the SQL query on an existing SQL-bound table assembly.
+    *
+    * <p>Own bespoke endpoint mirroring {@link #addSqlQuery}'s shape, rather than going through
+    * the shared void {@link #edit} dispatcher, so the response can carry
+    * {@code undeclaredVariables} back to the caller. {@code edit_sql_query} was already
+    * dispatched to {@link #editSqlQuery} via its own early-return branch in {@link #editOp}
+    * rather than the generic Editor/dispatch pipeline, so this adds no risk to the other ops
+    * still served by {@link #edit}.</p>
+    *
+    * @param sessionToken the token obtained at join time
+    * @param body         the existing SQL-bound assembly name and the new SQL string
+    * @param user         the authenticated agent principal
+    * @return the assembly name and any undeclared {@code $(name)} variables the new SQL
+    *         references
+    * @throws PairingException if the session is invalid, the table is not SQL-bound, or the
+    *                          SQL cannot be parsed
+    */
+   @PutMapping("/api/wiz/v1/agent/worksheet/{sessionToken}/sql-query")
+   public SqlQueryResponse editSqlQuery(@PathVariable String sessionToken,
+                                         @RequestBody EditSqlQueryRequest body,
+                                         Principal user) throws Exception
+   {
+      requireEnabled();
+      requireWholeSheetSession(sessionToken, user);
+      return editSqlQuery(sessionToken, body.table(), body.expression(), user);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -57,6 +57,9 @@ import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.assembly.VariableAssemblyModelInfo;
+import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
+import inetsoft.web.composer.ws.command.WSCollectVariablesCommand;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
@@ -3922,6 +3925,84 @@ class WorksheetAgentControllerTest {
 
       assertThrows(RenderNotReadyException.class,
          () -> ctrl.edit("TOK-ES4", req, agent));
+   }
+
+   /**
+    * Bug #76500 (WSQ-002): {@code editSqlQuery} used to end its {@code applyOnRuntime} lambda
+    * with a bare {@code return null;}, never calling {@code detectUndeclaredVariables} the way
+    * {@code addSqlQuery} does -- so an unresolved {@code $(name)} placeholder in an edited SQL
+    * string was silently accepted with no signal, unlike {@code add_sql_query}. Exercises the
+    * new bespoke {@code PUT .../sql-query} endpoint (mirroring {@code addSqlQuery}'s shape)
+    * rather than the shared void {@code /edit} dispatcher, since only the bespoke endpoint can
+    * carry a typed response back to the caller.
+    */
+   @Test
+   void editSqlQueryEndpointReturnsUndeclaredVariables() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly sqlt = new SQLBoundTableAssembly(ws, "SqlTable1");
+      ((SQLBoundTableAssemblyInfo) sqlt.getInfo()).setQuery(new JDBCQuery());
+      ws.addAssembly(sqlt);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+      // No sleep this time -- refreshColumnSelection completes immediately so execution reaches
+      // the tail of the lambda instead of timing out (contrast
+      // editSqlQueryThrowsRenderNotReadyWhenColumnSelectionIsSlow).
+      doNothing().when(box).refreshColumnSelection(eq("SqlTable1"), anyBoolean());
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-ES5"), any())).thenReturn(session("TOK-ES5"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      ColumnSelection newColumns = new ColumnSelection();
+      newColumns.addAttribute(new ColumnRef(new AttributeRef(null, "a")));
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenReturn(newColumns);
+
+      WorksheetAgentController ctrl = securityController(editSvc, mock(DataSourceService.class),
+         securityEngine, mock(MetadataApiService.class), mock(XRepository.class),
+         queryManagerService);
+
+      VariableAssemblyModelInfo undeclared = new VariableAssemblyModelInfo();
+      undeclared.setName("MV.ORDER_DATE.Max");
+      WSCollectVariablesCommand command = WSCollectVariablesCommand.builder()
+         .varInfos(List.of(undeclared))
+         .build();
+
+      // Table-less "SELECT 1" (no FROM clause), same as editSqlQueryThrowsRenderNotReadyWhenColumn-
+      // SelectionIsSlow above -- fixUniformSQLInfo's in-memory shortcut (sql.getTableCount() <= 0)
+      // fires without a live datasource/Config bean, which this lightweight test context does not
+      // provide. WorksheetEventUtil.refreshVariables is mocked below regardless of SQL content, so
+      // detecting a $(name) placeholder in the real SQL text is not what this test is verifying --
+      // that detection is detectUndeclaredVariables'/VarSQL's own job, already covered elsewhere.
+      WorksheetAgentController.EditSqlQueryRequest body =
+         new WorksheetAgentController.EditSqlQueryRequest("SqlTable1", "SELECT 1");
+
+      try(MockedStatic<WorksheetEventUtil> eventUtil =
+             mockStatic(WorksheetEventUtil.class, CALLS_REAL_METHODS)) {
+         eventUtil.when(() -> WorksheetEventUtil.refreshVariables(eq(rws), any(), eq(false)))
+            .thenReturn(command);
+
+         WorksheetAgentController.SqlQueryResponse response =
+            ctrl.editSqlQuery("TOK-ES5", body, agent);
+
+         assertEquals("SqlTable1", response.tableName());
+         assertEquals(List.of("MV.ORDER_DATE.Max"), response.undeclaredVariables());
+      }
    }
 
    // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `editSqlQuery` ended its `applyOnRuntime` lambda with a bare `return null;` and never called `detectUndeclaredVariables` the way `addSqlQuery` does — an unresolved `$(name)` placeholder introduced by an edit was silently accepted with no signal.
- Since `edit_sql_query` was already dispatched to `editSqlQuery` via its own early-return branch in `editOp`, outside the generic ~50-op Editor/dispatch pipeline, this gives it its own bespoke `PUT .../sql-query` endpoint (mirroring `addSqlQuery`'s shape: own typed `SqlQueryResponse`, own `@PutMapping`) rather than changing the shared void `/edit` architecture. No risk to the other ops still served by `/edit`.

Root-caused and fix direction confirmed via `docs/teams/2026-09-07-bugs-76500-wsq-pcb/bug-WSQ-002/01-diagnosis.md` and `02-refute.md` in the companion `stylebi-wiz` repo (Redmine #76500).

## Test plan
- [x] `WorksheetAgentControllerTest` — new `editSqlQueryEndpointReturnsUndeclaredVariables` test (mocks `WorksheetEventUtil.refreshVariables` to return an undeclared-variable command, asserts the new bespoke endpoint's response carries it)
- [x] Full `WorksheetAgentControllerTest` suite: 133 tests passed (`./mvnw -pl community/core test -Dtest=WorksheetAgentControllerTest`)
- [ ] Live StyleBI verification — not done this session (stack was down); pending separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)