### PR TITLE
wiz: seed fresh print-layout defaults, validate device-layout names, refuse negative layout-object positions

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutMutationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutMutationService.java
@@ -223,6 +223,7 @@ public class LayoutMutationService {
                   (currentSize != null ? currentSize.width : 0);
                int height = object.containsKey("height") ? toInt(object.get("height")) :
                   (currentSize != null ? currentSize.height : 0);
+               requireNonNegativePosition(x, y);
                Point position = new Point(x, y);
                Dimension size = new Dimension(width, height);
                assemblyLayout.setPosition(position);
@@ -257,10 +258,13 @@ public class LayoutMutationService {
             for(Map<String, Object> object : objects) {
                String name = requireName(object);
                AddVSLayoutObjectEvent event = new AddVSLayoutObjectEvent();
+               int xOffset = toInt(object.getOrDefault("x", 0));
+               int yOffset = toInt(object.getOrDefault("y", 0));
+               requireNonNegativePosition(xOffset, yOffset);
                event.setLayoutName(layoutName);
                event.setRegion(region);
-               event.setxOffset(toInt(object.getOrDefault("x", 0)));
-               event.setyOffset(toInt(object.getOrDefault("y", 0)));
+               event.setxOffset(xOffset);
+               event.setyOffset(yOffset);
                event.setNames(new String[] { name });
 
                VSAssembly assembly = masterVs.getAssembly(name);
@@ -366,6 +370,23 @@ public class LayoutMutationService {
          .orElseThrow(() -> new IllegalArgumentException(
             "\"" + objectName + "\" is not placed in layout \"" + layoutName + "\" -- add it " +
             "first with edit_layout_objects (op: \"add\")."));
+   }
+
+   /**
+    * VSLayoutControllerService.moveResizeLayoutObjects (the human UI's own controller path)
+    * already refuses a negative left/top -- but it does so by silently skipping the update,
+    * which is a poor fit for an agent-facing API (a caller has no way to tell "nothing changed
+    * because the input was invalid" from "nothing changed for some other reason"). This enforces
+    * the same StyleBI-wide invariant (a layout object's position is clamped to the page origin;
+    * no on-screen equivalent exists for a negative one) but fails loud instead, matching every
+    * other validation in this class.
+    */
+   private static void requireNonNegativePosition(int x, int y) {
+      if(x < 0 || y < 0) {
+         throw new IllegalArgumentException(
+            "edit_layout_objects: x/y must be non-negative -- got (" + x + ", " + y + "). " +
+            "StyleBI clamps a layout object's position to the page origin.");
+      }
    }
 
    private static String requireName(Map<String, Object> object) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.internal.PaperSize;
+import inetsoft.util.Catalog;
 import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
 import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
 import inetsoft.web.composer.model.vs.*;
@@ -200,6 +201,19 @@ public class PrintDeviceLayoutPropertyService {
             throw new IllegalArgumentException(
                "manage_device_layout: \"name\" cannot be \"Master\" -- that name is reserved " +
                "for the viewsheet's own Master view.");
+         }
+
+         // The dialog's reservedName() blocks a second reserved literal too: the print layout's
+         // own display name, "_#(js:Print Layout)" in Angular -- resolved through the same
+         // Catalog mechanism server-side, so this stays correct if a translation for the key is
+         // ever added (today it falls back to the literal "Print Layout", matching what the
+         // dialog currently shows in every locale this community edition ships).
+         String reservedPrintLayoutName = Catalog.getCatalog(user).getString("Print Layout");
+
+         if(reservedPrintLayoutName.equals(name)) {
+            throw new IllegalArgumentException(
+               "manage_device_layout: \"name\" cannot be \"" + name + "\" -- that name is " +
+               "reserved for the viewsheet's print layout.");
          }
 
          if(DEVICE_LAYOUT_INVALID_NAME_CHARS.matcher(name).find()) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
@@ -105,12 +105,27 @@ public class PrintDeviceLayoutPropertyService {
          VSPrintLayoutDialogModel printLayout = screensPane.getPrintLayout();
 
          if(printLayout == null) {
-            // No print layout configured on this viewsheet yet: seed scaleFont at the safe
-            // default BEFORE applying the patch, so an omitted "scaleFont" key lands on 1.0f
-            // rather than the bare-field 0.0f a freshly-constructed model would otherwise carry
-            // through to the write untouched (the Hazard-3 regression this class exists to
-            // close).
+            // No print layout configured on this viewsheet yet: seed every field at the same
+            // default viewsheet-print-layout-dialog.component.ts's own ngOnInit() uses for a
+            // brand-new model, BEFORE applying the caller's patch, so an omitted key lands on
+            // that default rather than the bare Java field default (0.0/0.0f/null) a
+            // freshly-constructed model would otherwise carry through to the write untouched.
+            // scaleFont was the first field this class closed this gap for (the Hazard-3
+            // regression); paperSize/margins/header-footer-from-edge are the same shape of bug --
+            // an omitted paperSize in particular resolves to PaperSize.getSize(null) => null,
+            // which persists a degenerate 0x0 page.
             printLayout = new VSPrintLayoutDialogModel();
+            // Matches viewsheet-print-layout-dialog.component.ts's ngOnInit() default verbatim,
+            // not PaperSize.getSizeStrs()[0] -- the dialog's default is a product choice, not
+            // "whichever size happens to be first in this enum", and the two should not be
+            // allowed to drift apart just because the array order changed.
+            printLayout.setPaperSize("Letter [8.5x11 in]");
+            printLayout.setMarginTop(1);
+            printLayout.setMarginBottom(1);
+            printLayout.setMarginLeft(1);
+            printLayout.setMarginRight(1);
+            printLayout.setHeaderFromEdge(0.5f);
+            printLayout.setFooterFromEdge(0.75f);
             printLayout.setScaleFont(1.0f);
          }
 
@@ -173,6 +188,25 @@ public class PrintDeviceLayoutPropertyService {
       if(name == null || name.isBlank()) {
          throw new IllegalArgumentException(
             "manage_device_layout needs a \"name\" identifying the device layout.");
+      }
+
+      // viewsheet-device-layout-dialog.component.ts's own duplicateName() and
+      // form-validators.ts's validLayoutName refuse these client-side, but neither backend path
+      // re-checks them, so a non-Angular caller could otherwise write either. Create-only,
+      // matching the dialog: this tool cannot rename an existing layout (name IS its identity),
+      // so update/delete never introduce a new name value.
+      if("create".equals(normalizedAction)) {
+         if("Master".equals(name)) {
+            throw new IllegalArgumentException(
+               "manage_device_layout: \"name\" cannot be \"Master\" -- that name is reserved " +
+               "for the viewsheet's own Master view.");
+         }
+
+         if(DEVICE_LAYOUT_INVALID_NAME_CHARS.matcher(name).find()) {
+            throw new IllegalArgumentException(
+               "manage_device_layout: \"name\" contains a character StyleBI does not allow in " +
+               "a layout name (/ \\ % ^ ~ < > * | ? \" ,) -- got \"" + name + "\".");
+         }
       }
 
       List<String> selectedDevices = asStringList(safePatch.get("selectedDevices"));
@@ -400,6 +434,10 @@ public class PrintDeviceLayoutPropertyService {
    }
 
    private static final Set<String> VALID_ACTIONS = Set.of("create", "update", "delete");
+
+   // Mirrors form-validators.ts's validLayoutName exactly.
+   private static final java.util.regex.Pattern DEVICE_LAYOUT_INVALID_NAME_CHARS =
+      java.util.regex.Pattern.compile("[/\\\\%^~<>*|?\",]");
 
    private final ViewsheetSessionService sessions;
    private final ViewsheetPropertyDialogService dialogService;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutMutationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutMutationServiceTest.java
@@ -132,6 +132,42 @@ class LayoutMutationServiceTest {
    }
 
    /**
+    * A negative left/top has no on-screen equivalent a human could produce -- the interactive
+    * Composer's own controller path silently skips such an update rather than applying it, but
+    * this agent-facing entry point refuses it loudly instead, so a caller can tell an invalid
+    * input apart from a no-op.
+    */
+   @Test
+   void moveResizeRefusesANegativePosition() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize",
+            VSLayoutService.CONTENT, List.of(Map.of("name", "Table1", "x", -5, "y", 10)), false));
+
+      assertTrue(thrown.getMessage().contains("-5"), thrown.getMessage());
+      LayoutObjectModelHolder table = fx.readTableObject();
+      assertEquals(300, table.layoutX(), "a refused move must leave the object's position untouched");
+      assertEquals(400, table.layoutY());
+   }
+
+   @Test
+   void addRefusesANegativePosition() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      int objectCountBefore = fx.printLayoutObjectNames().size();
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "add", VSLayoutService.CONTENT,
+            List.of(Map.of("name", "NewCaption", "type", "text", "x", 10, "y", -5)), false));
+
+      assertTrue(thrown.getMessage().contains("-5"), thrown.getMessage());
+      assertEquals(objectCountBefore, fx.printLayoutObjectNames().size(),
+                   "a refused add must not place a new object in the layout");
+   }
+
+   /**
     * The Hazard-1 exit criterion again, from this task's own entry point (not just
     * {@code LayoutSessionServiceTest}'s unit test in isolation) -- a full {@code
     * edit_layout_objects} call through {@code LayoutMutationService} leaves the master runtime's

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
@@ -432,6 +432,21 @@ class PrintDeviceLayoutPropertyServiceTest {
    }
 
    @Test
+   void refusesCreatingADeviceLayoutNamedPrintLayout() throws Exception {
+      // The dialog's reservedName() blocks this literal too (resolved through Catalog from
+      // "_#(js:Print Layout)" in Angular) -- not just "Master".
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile");
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.manageDeviceLayout(
+         "tok", h.principal, "create", Map.of("name", "Print Layout"), ""));
+
+      assertTrue(thrown.getMessage().contains("Print Layout"), thrown.getMessage());
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
+   }
+
+   @Test
    void allowsMasterAsAnUpdateOrDeleteTargetSinceOnlyCreateIsReserved() throws Exception {
       VSDeviceLayoutDialogModel existing = new VSDeviceLayoutDialogModel();
       existing.setName("Master");

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
@@ -87,6 +87,30 @@ class PrintDeviceLayoutPropertyServiceTest {
    }
 
    @Test
+   void aFreshPrintLayoutSeedsPaperSizeMarginsAndHeaderFooterFromEdgeLikeTheDialogsDefault()
+      throws Exception
+   {
+      // Same shape as the scaleFont/units seeding above, extended to every other field the
+      // print-layout dialog's own ngOnInit() default covers -- an omitted paperSize in
+      // particular resolves to PaperSize.getSize(null) => null, persisting a degenerate 0x0
+      // page, not merely a cosmetic difference from the dialog's default.
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      h.service.setPrintLayout("tok", h.principal, Map.of("scaleFont", 0.8f), "");
+
+      VSPrintLayoutDialogModel written = writtenPrintLayout(h);
+      assertEquals("Letter [8.5x11 in]", written.getPaperSize());
+      assertEquals(1, written.getMarginTop(), 0.0001);
+      assertEquals(1, written.getMarginBottom(), 0.0001);
+      assertEquals(1, written.getMarginLeft(), 0.0001);
+      assertEquals(1, written.getMarginRight(), 0.0001);
+      assertEquals(0.5f, written.getHeaderFromEdge(), 0.0001f);
+      assertEquals(0.75f, written.getFooterFromEdge(), 0.0001f);
+      assertEquals("inches", written.getUnits());
+      assertEquals(0.8f, written.getScaleFont(), 0.0001f);
+   }
+
+   @Test
    void paperSizeBareShortNamesCanonicalizeCaseInsensitively() throws Exception {
       Harness h = new Harness(screensPaneWithNoPrintLayout());
 
@@ -392,6 +416,47 @@ class PrintDeviceLayoutPropertyServiceTest {
       verify(h.dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
                                         anyString(), any());
       assertTrue(captor.getValue().screensPane().getDeviceLayouts().isEmpty());
+   }
+
+   @Test
+   void refusesCreatingADeviceLayoutNamedMaster() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile");
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.manageDeviceLayout(
+         "tok", h.principal, "create", Map.of("name", "Master"), ""));
+
+      assertTrue(thrown.getMessage().contains("Master"), thrown.getMessage());
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
+   }
+
+   @Test
+   void allowsMasterAsAnUpdateOrDeleteTargetSinceOnlyCreateIsReserved() throws Exception {
+      VSDeviceLayoutDialogModel existing = new VSDeviceLayoutDialogModel();
+      existing.setName("Master");
+      ScreensPaneModel screensPane = screensPaneWithNoPrintLayout();
+      screensPane.getDeviceLayouts().add(existing);
+      Harness h = new Harness(screensPane);
+      h.registerDevices("wiz-mobile");
+
+      h.service.manageDeviceLayout("tok", h.principal, "delete", Map.of("name", "Master"), "");
+
+      verify(h.dialog).setViewsheetInfo(eq("rt1"), any(), any(Principal.class), any(),
+                                        anyString(), any());
+   }
+
+   @Test
+   void refusesADeviceLayoutNameContainingADisallowedCharacter() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile");
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.manageDeviceLayout(
+         "tok", h.principal, "create", Map.of("name", "Phones/2"), ""));
+
+      assertTrue(thrown.getMessage().contains("Phones/2"), thrown.getMessage());
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
    }
 
    @Test


### PR DESCRIPTION
## Summary

Companion StyleBI-side fixes for the L11 (Print & Device Layout) parity audit run in `inetsoft-technology/stylebi-wiz` (see linked plugin PR for the full report):

- `PrintDeviceLayoutPropertyService.setPrintLayout`: a freshly-configured print layout now seeds `paperSize`, all four margins, and `headerFromEdge`/`footerFromEdge` to the same defaults `viewsheet-print-layout-dialog.component.ts`'s `ngOnInit()` uses for a brand-new model, generalizing the seeding this method already did for `scaleFont`/`units`. An omitted `paperSize` previously resolved to `PaperSize.getSize(null) => null`, persisting a degenerate 0x0 page.
- `PrintDeviceLayoutPropertyService.manageDeviceLayout`: `create` now refuses the reserved name `"Master"` and any character `form-validators.ts`'s `validLayoutName` disallows, mirroring the Angular dialog's own `duplicateName()`/`reservedName()` checks, which previously had no backend equivalent on either path.
- `LayoutMutationService.moveResize`/`addObjects`: both now refuse a negative `x`/`y` outright instead of relying on `VSLayoutControllerService`'s own silent-skip behavior, which has no equivalent on this class's own code path.

The print-layout seeding fix was live-verified against a running instance through the wiz plugin's own tools; the device-layout name and negative-position guards are covered only by the unit tests below (the plugin's own client-side guards for the same inputs make them unreachable live through the plugin).

## Test plan

- [x] `.\mvnw.cmd -pl core -am compile` — BUILD SUCCESS
- [x] `.\mvnw.cmd -pl core test -Dtest=PrintDeviceLayoutPropertyServiceTest,LayoutMutationServiceTest` — 34/34 passing (28 pre-existing + 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)