### PR TITLE
fix(WSQ-006): differentiate parse-failure vs unresolved-column messages in add/edit_sql_query

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -2651,6 +2651,19 @@ public class WorksheetAgentController {
             scratchQuery, new VariableTable(), sqlTable, metaSession, null);
 
          if(columns == null || columns.getAttributeCount() == 0) {
+            if(sql.getParseResult() == UniformSQL.PARSE_FAILED) {
+               throw new PairingException(
+                  "SQL could not be parsed — check syntax (punctuation, keywords, clause structure).");
+            }
+
+            Exception driverError = scratchQuery.getLastQueryError();
+
+            if(driverError != null && driverError.getMessage() != null) {
+               throw new PairingException(
+                  "SQL is syntactically valid but could not be resolved against the datasource: "
+                  + driverError.getMessage() + " — check table/column references.");
+            }
+
             throw new PairingException(
                "SQL could not be parsed or no columns detected — check syntax and table references.");
          }
@@ -3539,6 +3552,19 @@ public class WorksheetAgentController {
             query, new VariableTable(), assembly, metaSession, null);
 
          if(columns == null || columns.getAttributeCount() == 0) {
+            if(sql.getParseResult() == UniformSQL.PARSE_FAILED) {
+               throw new PairingException(
+                  "SQL could not be parsed — check syntax (punctuation, keywords, clause structure).");
+            }
+
+            Exception driverError = query.getLastQueryError();
+
+            if(driverError != null && driverError.getMessage() != null) {
+               throw new PairingException(
+                  "SQL is syntactically valid but could not be resolved against the datasource: "
+                  + driverError.getMessage() + " — check table/column references.");
+            }
+
             throw new PairingException(
                "SQL could not be parsed or no columns detected — check syntax and table references.");
          }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -47,6 +47,8 @@ import inetsoft.uql.erm.XEntity;
 import inetsoft.uql.erm.XLogicalModel;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCQuery;
+import inetsoft.uql.jdbc.JDBCSelection;
+import inetsoft.uql.jdbc.UniformSQL;
 import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.web.wiz.model.DatabaseTableMeta;
 import inetsoft.uql.schema.UserVariable;
@@ -72,6 +74,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -247,6 +250,34 @@ class WorksheetAgentControllerTest {
          dataSourceService, securityEngine,
          mock(inetsoft.uql.asset.sync.RenameTransformHandler.class),
          mock(inetsoft.web.wiz.viewsheet.SheetOpenService.class));
+   }
+
+   /**
+    * WSQ-006: stubs a {@code mockConstruction}-produced {@code UniformSQL} so that
+    * {@code addSqlQuery}/{@code editSqlQuery}'s {@code new UniformSQL()} + real
+    * {@code setSQLString}/grammar-parse machinery is bypassed entirely -- {@code getParseResult()}
+    * is set directly to {@code parseResult} rather than left to a real SQL string's parse
+    * behavior (which, per two contested refute rounds on this bug, is not a reliable way to
+    * reach a particular branch; the lead's decision was to test via direct mocking instead).
+    * {@code getSelection()} is stubbed with an empty real {@code JDBCSelection} so
+    * {@code JDBCUtil.fixUniformSQLInfo}'s in-memory shortcut (which the mock's default
+    * {@code getTableCount() == 0} always takes) doesn't NPE. {@code setSQLString} spawns a
+    * background thread that acquires the mock's monitor and calls {@code notifyAll()} once the
+    * caller's {@code synchronized(sql) { ...; sql.wait(10_000); }} block actually starts
+    * waiting, so the call returns immediately instead of blocking for the real 10s timeout --
+    * {@code wait()} itself is {@code final} on {@code Object} and cannot be stubbed directly.
+    */
+   private static void stubUniformSqlConstruction(UniformSQL mock, int parseResult) {
+      when(mock.getParseResult()).thenReturn(parseResult);
+      when(mock.getSelection()).thenReturn(new JDBCSelection());
+      doAnswer(inv -> {
+         new Thread(() -> {
+            synchronized(mock) {
+               mock.notifyAll();
+            }
+         }).start();
+         return null;
+      }).when(mock).setSQLString(anyString(), anyBoolean());
    }
 
    /** Builds an {@code add_table} EditRequest that routes to addBoundTable() (no logicalModel). */
@@ -3925,6 +3956,174 @@ class WorksheetAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // editSqlQuery -- differentiated "no columns" guard message (bug #76500, WSQ-006)
+   // ---------------------------------------------------------------------------
+
+   /**
+    * WSQ-006: a genuine grammar failure should surface the syntax-specific message, not the old
+    * generic "SQL could not be parsed or no columns detected" wording. {@code sql.getParseResult()}
+    * is stubbed directly to {@code PARSE_FAILED} via {@code stubUniformSqlConstruction} -- see its
+    * javadoc for why real SQL-string-driven parsing is not used here.
+    */
+   @Test
+   void editSqlQueryThrowsParseFailedMessageForMalformedSql() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly sqlt = new SQLBoundTableAssembly(ws, "SqlTable1");
+      ((SQLBoundTableAssemblyInfo) sqlt.getInfo()).setQuery(new JDBCQuery());
+      ws.addAssembly(sqlt);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-EPF"), any())).thenReturn(session("TOK-EPF"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenReturn(new ColumnSelection());
+
+      WorksheetAgentController ctrl = securityController(editSvc, mock(DataSourceService.class),
+         securityEngine, mock(MetadataApiService.class), mock(XRepository.class),
+         queryManagerService);
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT 1");
+
+      try(MockedConstruction<UniformSQL> ignored = mockConstruction(UniformSQL.class,
+         (m, ctx) -> stubUniformSqlConstruction(m, UniformSQL.PARSE_FAILED)))
+      {
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.edit("TOK-EPF", req, agent));
+         assertTrue(ex.getMessage().contains("SQL could not be parsed — check syntax"),
+                    "should surface the parse-failed variant, got: " + ex.getMessage());
+      }
+   }
+
+   /**
+    * WSQ-006: when the SQL parses fine but the guard still fires (empty columns), a captured
+    * driver error should be surfaced instead of the generic message. {@code sql.getParseResult()}
+    * is stubbed to {@code PARSE_SUCCESS} via {@code stubUniformSqlConstruction}, and
+    * {@code lastQueryError} is set directly on the real {@code scratchQuery} instance the mocked
+    * {@code queryManagerService.getColumnSelection} is invoked with -- exactly mirroring what
+    * {@code QueryManagerService.getColumnSelection}'s real fallback branch does
+    * (QueryManagerService.java:1955). Per the lead's decision, no known real SQL shape reliably
+    * reaches this branch (per two contested refute rounds), so both signals are mocked directly.
+    */
+   @Test
+   void editSqlQueryThrowsDriverErrorMessageWhenLastQueryErrorIsSet() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly sqlt = new SQLBoundTableAssembly(ws, "SqlTable1");
+      ((SQLBoundTableAssemblyInfo) sqlt.getInfo()).setQuery(new JDBCQuery());
+      ws.addAssembly(sqlt);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-EDE"), any())).thenReturn(session("TOK-EDE"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenAnswer(inv -> {
+            JDBCQuery q = inv.getArgument(0);
+            q.setLastQueryError(new Exception("Column \"PRODUCT_ID\" not found in ORDERS"));
+            return new ColumnSelection();
+         });
+
+      WorksheetAgentController ctrl = securityController(editSvc, mock(DataSourceService.class),
+         securityEngine, mock(MetadataApiService.class), mock(XRepository.class),
+         queryManagerService);
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT 1");
+
+      try(MockedConstruction<UniformSQL> ignored = mockConstruction(UniformSQL.class,
+         (m, ctx) -> stubUniformSqlConstruction(m, UniformSQL.PARSE_SUCCESS)))
+      {
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.edit("TOK-EDE", req, agent));
+         assertTrue(ex.getMessage().contains("syntactically valid but could not be resolved"),
+                    "should surface the driver-error variant, got: " + ex.getMessage());
+         assertTrue(ex.getMessage().contains("Column \"PRODUCT_ID\" not found in ORDERS"),
+                    "should include the captured driver error text, got: " + ex.getMessage());
+      }
+   }
+
+   /**
+    * WSQ-006: if the guard fires but neither {@code parseResult} nor {@code lastQueryError}
+    * explain why, the original generic message must still be the fallback.
+    */
+   @Test
+   void editSqlQueryFallsBackToGenericMessageWhenNeitherSignalExplainsIt() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      SQLBoundTableAssembly sqlt = new SQLBoundTableAssembly(ws, "SqlTable1");
+      ((SQLBoundTableAssemblyInfo) sqlt.getInfo()).setQuery(new JDBCQuery());
+      ws.addAssembly(sqlt);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-EGEN"), any())).thenReturn(session("TOK-EGEN"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      // lastQueryError is left unset (defaults to null on a freshly-constructed JDBCQuery) --
+      // this is the "driver call succeeded but returned nothing" outcome, not exercised above.
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenReturn(new ColumnSelection());
+
+      WorksheetAgentController ctrl = securityController(editSvc, mock(DataSourceService.class),
+         securityEngine, mock(MetadataApiService.class), mock(XRepository.class),
+         queryManagerService);
+
+      EditRequest req = editSqlQueryRequest("SqlTable1", "SELECT 1");
+
+      try(MockedConstruction<UniformSQL> ignored = mockConstruction(UniformSQL.class,
+         (m, ctx) -> stubUniformSqlConstruction(m, UniformSQL.PARSE_SUCCESS)))
+      {
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.edit("TOK-EGEN", req, agent));
+         assertTrue(
+            ex.getMessage().contains("SQL could not be parsed or no columns detected"),
+            "should fall back to the original generic message, got: " + ex.getMessage());
+      }
+   }
+
+   // ---------------------------------------------------------------------------
    // addSqlQuery — FREE_FORM_SQL / ACCESS + datasource READ permission gates
    // ---------------------------------------------------------------------------
 
@@ -4069,6 +4268,184 @@ class WorksheetAgentControllerTest {
          () -> ctrl.addSqlQuery("TOK-SQ-CDATA", body, agent));
       assertTrue(ex.getMessage().contains("]]>"), ex.getMessage());
       assertNull(ws.getAssembly("bad]]>name"));
+   }
+
+   // ---------------------------------------------------------------------------
+   // addSqlQuery -- differentiated "no columns" guard message (bug #76500, WSQ-006)
+   // ---------------------------------------------------------------------------
+
+   /**
+    * WSQ-006: a genuine grammar failure should surface the syntax-specific message, not the old
+    * generic "SQL could not be parsed or no columns detected" wording. {@code sql.getParseResult()}
+    * is stubbed directly to {@code PARSE_FAILED} via {@code stubUniformSqlConstruction} -- see its
+    * javadoc for why real SQL-string-driven parsing is not used here.
+    */
+   @Test
+   void addSqlQueryThrowsParseFailedMessageForMalformedSql() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      JDBCDataSource jdbcDs = mock(JDBCDataSource.class);
+      when(xrepository.getDataSource("MyDatasource")).thenReturn(jdbcDs);
+
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      when(editSvc.applyOnRuntime(eq("TOK-SQ-PF"), eq(agent), any())).thenAnswer(inv -> {
+         WorksheetEditService.ThrowingFunction<RuntimeWorksheet, ?> fn = inv.getArgument(2);
+         return fn.apply(rws);
+      });
+
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenReturn(new ColumnSelection());
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, queryManagerService);
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", null);
+
+      try(MockedConstruction<UniformSQL> ignored = mockConstruction(UniformSQL.class,
+         (m, ctx) -> stubUniformSqlConstruction(m, UniformSQL.PARSE_FAILED)))
+      {
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.addSqlQuery("TOK-SQ-PF", body, agent));
+         assertTrue(ex.getMessage().contains("SQL could not be parsed — check syntax"),
+                    "should surface the parse-failed variant, got: " + ex.getMessage());
+      }
+   }
+
+   /**
+    * WSQ-006: when the SQL parses fine but the guard still fires (empty columns), a captured
+    * driver error should be surfaced instead of the generic message. {@code sql.getParseResult()}
+    * is stubbed to {@code PARSE_SUCCESS} via {@code stubUniformSqlConstruction}, and
+    * {@code lastQueryError} is set directly on the real {@code JDBCQuery} instance the mocked
+    * {@code queryManagerService.getColumnSelection} is invoked with, exactly mirroring what
+    * {@code QueryManagerService.getColumnSelection}'s real fallback branch does
+    * (QueryManagerService.java:1955). Per the lead's decision, no known real SQL shape reliably
+    * reaches this branch (per two contested refute rounds), so both signals are mocked directly.
+    */
+   @Test
+   void addSqlQueryThrowsDriverErrorMessageWhenLastQueryErrorIsSet() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      JDBCDataSource jdbcDs = mock(JDBCDataSource.class);
+      when(xrepository.getDataSource("MyDatasource")).thenReturn(jdbcDs);
+
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      when(editSvc.applyOnRuntime(eq("TOK-SQ-DE"), eq(agent), any())).thenAnswer(inv -> {
+         WorksheetEditService.ThrowingFunction<RuntimeWorksheet, ?> fn = inv.getArgument(2);
+         return fn.apply(rws);
+      });
+
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenAnswer(inv -> {
+            JDBCQuery q = inv.getArgument(0);
+            q.setLastQueryError(new Exception("Column \"PRODUCT_ID\" not found in ORDERS"));
+            return new ColumnSelection();
+         });
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, queryManagerService);
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", null);
+
+      try(MockedConstruction<UniformSQL> ignored = mockConstruction(UniformSQL.class,
+         (m, ctx) -> stubUniformSqlConstruction(m, UniformSQL.PARSE_SUCCESS)))
+      {
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.addSqlQuery("TOK-SQ-DE", body, agent));
+         assertTrue(ex.getMessage().contains("syntactically valid but could not be resolved"),
+                    "should surface the driver-error variant, got: " + ex.getMessage());
+         assertTrue(ex.getMessage().contains("Column \"PRODUCT_ID\" not found in ORDERS"),
+                    "should include the captured driver error text, got: " + ex.getMessage());
+      }
+   }
+
+   /**
+    * WSQ-006: if the guard fires but neither {@code parseResult} nor {@code lastQueryError}
+    * explain why (the "driver call succeeded but returned nothing" case both refute rounds
+    * identified), the original generic message must still be the fallback.
+    */
+   @Test
+   void addSqlQueryFallsBackToGenericMessageWhenNeitherSignalExplainsIt() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(agent), eq(ResourceType.FREE_FORM_SQL),
+                                          eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      JDBCDataSource jdbcDs = mock(JDBCDataSource.class);
+      when(xrepository.getDataSource("MyDatasource")).thenReturn(jdbcDs);
+
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      when(editSvc.applyOnRuntime(eq("TOK-SQ-GEN"), eq(agent), any())).thenAnswer(inv -> {
+         WorksheetEditService.ThrowingFunction<RuntimeWorksheet, ?> fn = inv.getArgument(2);
+         return fn.apply(rws);
+      });
+
+      // lastQueryError is left unset (defaults to null on a freshly-constructed JDBCQuery) --
+      // this is the "driver call succeeded but returned nothing" outcome, not exercised above.
+      QueryManagerService queryManagerService = mock(QueryManagerService.class);
+      when(queryManagerService.getColumnSelection(any(), any(), any(), any(), any()))
+         .thenReturn(new ColumnSelection());
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, securityEngine, mock(MetadataApiService.class),
+         xrepository, queryManagerService);
+
+      WorksheetAgentController.SqlQueryRequest body =
+         new WorksheetAgentController.SqlQueryRequest("MyDatasource", "SELECT 1", null);
+
+      try(MockedConstruction<UniformSQL> ignored = mockConstruction(UniformSQL.class,
+         (m, ctx) -> stubUniformSqlConstruction(m, UniformSQL.PARSE_SUCCESS)))
+      {
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.addSqlQuery("TOK-SQ-GEN", body, agent));
+         assertTrue(
+            ex.getMessage().contains("SQL could not be parsed or no columns detected"),
+            "should fall back to the original generic message, got: " + ex.getMessage());
+      }
    }
 
    // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Redmine #76500 (consolidated), sub-item WSQ-006. `addSqlQuery`/`editSqlQuery` threw the same generic message ("SQL could not be parsed or no columns detected -- check syntax and table references.") whether the SQL was genuinely malformed (grammar failure) or syntactically valid but referencing a table/column that couldn't be resolved against the datasource. Both signals needed to tell these apart -- `sql.getParseResult()` and `query`/`scratchQuery.getLastQueryError()` -- were already computed and in local scope at the throw site, but never read.

## Fix

At both throw sites (`addSqlQuery`, `editSqlQuery`), read the two signals before falling back to the generic message:
1. `sql.getParseResult() == UniformSQL.PARSE_FAILED` -> a syntax-specific message.
2. Otherwise, a non-null `getLastQueryError()` with a message -> a resolution-specific message including the driver's own error text.
3. Otherwise -> the original generic message (covers the "driver call succeeded but returned nothing" case).

## Review history and an open question this PR does not resolve

This fix went through two rounds of adversarial review (diagnosis + refute, `stylebi-wiz` repo, `docs/teams/2026-09-07-bugs-76500-wsq-pcb/bug-WSQ-006/`). Both rounds unanimously agree the fix code itself is correct and sound. What was contested across both rounds was narrower: which hand-crafted SQL string's real ANTLR2 grammar parse would actually exercise the fallback/`lastQueryError` branch for a live repro. The refuter traced the code precisely and found that **no bad-column-name-only repro (in an ON clause or in the SELECT list) reliably reaches the fallback branch** -- reaching it requires either a genuine grammar failure or a bad *table* reference, not a bad column name against an otherwise-valid table. This means the bug's own original historical repro (WSQ-006) most likely hit this guard for a reason not fully traced by either round (see `01-diagnosis.md`'s "wrinkle" section and `02-refute.md`'s two recheck rounds for the full trace).

This is a live-verification-pending question, not a defect in the fix: the two signals (`parseResult`, `lastQueryError`) are real, in-scope, and were being discarded regardless of which path any particular SQL shape takes. Per the lead's decision, this PR's regression tests mock `parseResult`/`lastQueryError` directly (via `mockConstruction<UniformSQL>` and a `queryManagerService` stub that sets `lastQueryError` on the real query instance) rather than relying on a specific SQL string to naturally trigger a given branch, sidestepping that open question entirely.

Full context: `docs/teams/2026-09-07-bugs-76500-wsq-pcb/bug-WSQ-006/01-diagnosis.md`, `02-refute.md`, `03-fix.md` in the `stylebi-wiz` repo.

## Test plan

- [x] `WorksheetAgentControllerTest` -- 6 new tests (3 per throw site): `PARSE_FAILED` -> syntax message, `lastQueryError` set -> resolution message including driver text, neither signal set -> generic fallback message.
- [x] Full `WorksheetAgentControllerTest` suite green: `./mvnw.cmd -pl community/core test -Dtest=WorksheetAgentControllerTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false` -- 138 tests, 0 failures, 0 errors.
- [ ] Live StyleBI verification -- not done, out of scope per task instructions (handled separately).

Not merging -- awaiting review.