### PR TITLE
fix(PCB-007): explicit Year/Hour date-level default instead of forwarding the unset -1 sentinel

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactory.java
@@ -18,8 +18,10 @@
 package inetsoft.web.binding.service.graph;
 
 import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.asset.SNamedGroupInfo;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.web.binding.VSDataController;
@@ -149,7 +151,18 @@ public abstract class ChartDimensionInfoFactory<M extends ChartDimensionRef>
 
          ref.setCaption(model.getCaption());
          ref.setManualOrderList(VSDataController.fixNull(model.getManualOrder()));
-         ref.setDateLevelValue(model.getDateLevel());
+
+         String dlevel = model.getDateLevel();
+
+         if("-1".equals(dlevel) && ref.getDataRef() != null &&
+            XSchema.isDateType(ref.getDataRef().getDataType()))
+         {
+            dlevel = XSchema.TIME.equals(ref.getDataRef().getDataType())
+               ? String.valueOf(DateRangeRef.HOUR_INTERVAL)
+               : String.valueOf(DateRangeRef.YEAR_INTERVAL);
+         }
+
+         ref.setDateLevelValue(dlevel);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactoryTest.java
@@ -30,6 +30,7 @@ import inetsoft.uql.XCondition;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
@@ -184,5 +185,77 @@ class ChartDimensionInfoFactoryTest {
       factory.pasteChartRef(null, model, ref);
 
       assertNull(ref.getNamedGroupInfo());
+   }
+
+   /**
+    * PCB-007: a {@code ChartDimensionRefModel} built via the wiz layer's no-arg constructor
+    * (e.g. {@code FieldRefFactory.toChartRef}) that never had a date level set carries the
+    * class-level sentinel {@code dlevel == "-1"} verbatim -- not {@code null}. Forwarded
+    * unconditionally into {@code setDateLevelValue}, that sentinel is not a member of
+    * {@code VSDimensionRef}'s date-level restriction list, so {@code DynamicValue}'s generic
+    * "unmatched value" fallback silently resolves it to the first restriction entry
+    * ({@code YEAR_INTERVAL}) -- an accidental default, not an intentional one. These cases
+    * assert the write is now an explicit, intentional Year/Hour default that mirrors
+    * {@code BDimensionRefModel}'s own "date default to year if not set" convention.
+    */
+   @Test
+   void defaultsToYearForAnUnsetDateLevelOnADateDimension() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_ASC);
+
+      AttributeRef dateAttr = new AttributeRef("ORDER_DATE");
+      dateAttr.setDataType(XSchema.DATE);
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setDataRef(new ColumnRef(dateAttr));
+
+      factory.pasteChartRef(null, model, ref);
+
+      assertEquals(String.valueOf(DateRangeRef.YEAR_INTERVAL), ref.getDateLevelValue());
+   }
+
+   @Test
+   void defaultsToHourForAnUnsetDateLevelOnATimeDimension() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_ASC);
+
+      AttributeRef timeAttr = new AttributeRef("LOGIN_TIME");
+      timeAttr.setDataType(XSchema.TIME);
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setDataRef(new ColumnRef(timeAttr));
+
+      factory.pasteChartRef(null, model, ref);
+
+      assertEquals(String.valueOf(DateRangeRef.HOUR_INTERVAL), ref.getDateLevelValue());
+   }
+
+   @Test
+   void passesThroughAnExplicitDateLevelOnADateDimensionUnchanged() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_ASC);
+      model.setDateLevel(String.valueOf(DateRangeRef.MONTH_INTERVAL));
+
+      AttributeRef dateAttr = new AttributeRef("ORDER_DATE");
+      dateAttr.setDataType(XSchema.DATE);
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setDataRef(new ColumnRef(dateAttr));
+
+      factory.pasteChartRef(null, model, ref);
+
+      assertEquals(String.valueOf(DateRangeRef.MONTH_INTERVAL), ref.getDateLevelValue());
+   }
+
+   @Test
+   void leavesTheUnsetSentinelAloneForANonDateDimension() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_ASC);
+
+      AttributeRef stringAttr = new AttributeRef("REGION");
+      stringAttr.setDataType(XSchema.STRING);
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setDataRef(new ColumnRef(stringAttr));
+
+      factory.pasteChartRef(null, model, ref);
+
+      assertEquals("-1", ref.getDateLevelValue());
    }
 }


### PR DESCRIPTION
## Summary
- `VSChartDimensionInfoFactory.pasteChartRef` (`ChartDimensionInfoFactory.java`) forwarded a freshly-bound `ChartDimensionRefModel`'s `dlevel` unconditionally into `ref.setDateLevelValue()`, including the class-level `"-1"` unset sentinel (`BDimensionRefModel.java:518`) a model carries when no date level was ever set.
- `"-1"` is not a member of `VSDimensionRef`'s date-level restriction list, so `DynamicValue.findValue()`'s generic "unmatched value" fallback silently resolved it to `restriction[0]` = `YEAR_INTERVAL` — an accidental default, not the deliberate one `BDimensionRefModel.java:97-105` already documents elsewhere in the same class ("date default to year if not set").
- Fix: when `dlevel == "-1"` and the ref's underlying column is date-typed, write an explicit `YEAR_INTERVAL`/`HOUR_INTERVAL` before the paste, mirroring the existing convention. This makes the write intentional and traceable; it does not, by itself, change the rendered Year outcome for an already-curated (e.g. month-truncated) column — that half of the reported symptom is addressed independently on the `stylebi-wiz` side (a companion PR makes `set_chart_shelf` refuse a date-typed dimension with no `dateLevel` rather than silently posting one).

## Root cause
Traced end-to-end from `BindingAgentController.setChartShelf` (a `dateLevel`-omitting agent write) through `FieldRefFactory.toChartRef` (skips `setDateLevel`, leaving the model's class-level `"-1"` default) to `VSChartDimensionInfoFactory.pasteChartRef:152` (forwards `"-1"` verbatim) to `DynamicValue.findValue()` (resolves any unrecognized value, including `"-1"`, `null`, or "never set", to `restriction[0]`).

Blast radius: `pasteChartRef` is also reached by the ordinary Composer UI's chart-edit gesture via `ChangeChartRefService`, but that gesture always builds its model through `BDimensionRefModel`'s ref-based constructor, which already resolves an unset date level to an explicit Year/Hour value before reaching this method — so this fix is inert for that gesture (never fires), except when re-editing a chart already tainted by this exact pre-fix bug, where it is self-healing (produces the identical resolved Year/Hour outcome, not a behavior change).

## Test plan
- [x] `ChartDimensionInfoFactoryTest`: added 4 cases — unset `"-1"` on a `date`-typed dimension → explicit `YEAR_INTERVAL`; unset `"-1"` on a `time`-typed dimension → explicit `HOUR_INTERVAL`; an explicit date level passes through unchanged; a non-date-typed dimension's `"-1"` is left alone.
- [x] `./mvnw.cmd -pl community/core test -Dtest=ChartDimensionInfoFactoryTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false` — 8/8 passed (4 pre-existing + 4 new).

Redmine #76500, finding PCB-007.