### PR TITLE
test(core): WBS-003 condition-tree JVM regression fixtures (#76449)

### DIFF
--- a/core/src/test/java/inetsoft/uql/jdbc/util/TreeToLevelCompilerRegressionTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/util/TreeToLevelCompilerRegressionTest.java
@@ -1,0 +1,410 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc.util;
+
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.HierarchyItem;
+import inetsoft.uql.jdbc.*;
+import inetsoft.util.Queue;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression insurance for the P4 builder of Redmine #76449 WBS-003's condition-tree redesign
+ * (docs/teams/2026-09-05-bug-wbs003-condition-tree-redesign in stylebi-wiz), ported from
+ * investigator-wireformat's throwaway {@code TreeToLevelCompilerPrototypeTest.java} prototype
+ * (01-hypothesis-wireformat.md steps 1-2) as a permanent fixture.
+ *
+ * <p>These 12 cases are NOT the bug -- every one of them already passes against unmodified
+ * {@link ConditionListHandler} today (that's the point: this file proves the derivation rule
+ * "each nested group's own junction level = enclosing group's level + 1, regardless of whether
+ * relation type matches its parent's" produces a flat (condition, junction, level) array that
+ * both of StyleBI's independent condition-tree algorithms already interpret correctly). Once a
+ * real compiler function exists in stylebi-wiz's {@code worksheetTools.ts} (P4), its own
+ * plugin-side unit tests should assert its output against the same 12 tree shapes' expected
+ * flat arrays; this file is the JVM-side half confirming those arrays, once produced, land on
+ * already-correct ground.
+ *
+ * <p>{@code compile(Node, int)} below is test-fixture code (a tree-to-level compiler local to
+ * this test), not a port of any production compiler -- none exists yet in the plugin; writing
+ * one is P4's job.
+ */
+@Tag("core")
+public class TreeToLevelCompilerRegressionTest {
+
+   private ConditionListHandler handler;
+
+   @org.junit.jupiter.api.BeforeEach
+   void setUp() {
+      handler = new ConditionListHandler();
+   }
+
+   // -----------------------------------------------------------------------
+   // Tree DSL + compiler under test (fixture code, mirrors 01-hypothesis-wireformat.md step 1-2)
+   // -----------------------------------------------------------------------
+
+   private interface Node {}
+
+   private record Leaf(String name) implements Node {}
+
+   private record Group(String relation, List<Node> children) implements Node {}
+
+   private static Node leaf(String name) {
+      return new Leaf(name);
+   }
+
+   private static Node group(String relation, Node... children) {
+      return new Group(relation, List.of(children));
+   }
+
+   private XBinaryCondition makeCond(String name) {
+      return new XBinaryCondition(
+         new XExpression(name, XExpression.FIELD),
+         new XExpression("'x'", XExpression.EXPRESSION), "=");
+   }
+
+   /**
+    * Compiles a tree into a fresh (condition, junction, level) node list. Called once per
+    * algorithm run (never shared) so the two algorithm invocations below never mutate each
+    * other's node objects -- the exact pitfall investigator-wireformat's own harness hit and
+    * documented (walk()'s calc() mutates XSetItem.level and XSet's child list in place).
+    */
+   private List<HierarchyItem> compile(Node root) {
+      List<HierarchyItem> out = new ArrayList<>();
+      compileInto(root, 0, out);
+      return out;
+   }
+
+   private void compileInto(Node node, int level, List<HierarchyItem> out) {
+      if(node instanceof Leaf leaf) {
+         out.add(new XFilterNodeItem(makeCond(leaf.name()), level));
+         return;
+      }
+
+      Group group = (Group) node;
+
+      for(int i = 0; i < group.children().size(); i++) {
+         Node child = group.children().get(i);
+
+         if(child instanceof Group) {
+            // Every nested group's own junctions/leaf-children go one level deeper than the
+            // enclosing group's, regardless of whether the relation matches.
+            compileInto(child, level + 1, out);
+         }
+         else {
+            out.add(new XFilterNodeItem(makeCond(((Leaf) child).name()), level));
+         }
+
+         if(i < group.children().size() - 1) {
+            out.add(new XSetItem(new XSet(group.relation()), level));
+         }
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // Canonical form for comparing a resolved XFilterNode tree against the caller's intent,
+   // independent of sibling order and of AND/OR's own associativity (a same-relation group
+   // nested inside an identical-relation group is not a distinguishable shape).
+   // -----------------------------------------------------------------------
+
+   private sealed interface Canon {}
+
+   private record CLeaf(String name) implements Canon {}
+
+   private record CRel(String relation, List<Canon> children) implements Canon {}
+
+   private static Canon cleaf(String name) {
+      return new CLeaf(name);
+   }
+
+   private static Canon crel(String relation, Canon... children) {
+      List<Canon> flat = new ArrayList<>();
+
+      for(Canon child : children) {
+         if(child instanceof CRel r && r.relation().equals(relation)) {
+            flat.addAll(r.children());
+         }
+         else {
+            flat.add(child);
+         }
+      }
+
+      flat.sort(Comparator.comparing(Object::toString));
+      return new CRel(relation, flat);
+   }
+
+   private Canon canon(XFilterNode node) {
+      if(node instanceof XBinaryCondition c) {
+         return cleaf((String) c.getExpression1().getValue());
+      }
+
+      XSet set = (XSet) node;
+      List<Canon> children = new ArrayList<>();
+
+      for(int i = 0; i < set.getChildCount(); i++) {
+         children.add(canon((XFilterNode) set.getChild(i)));
+      }
+
+      return crel(set.getRelation(), children.toArray(new Canon[0]));
+   }
+
+   // -----------------------------------------------------------------------
+   // Algorithm runners
+   // -----------------------------------------------------------------------
+
+   private XFilterNode runWalk(Node tree) throws Exception {
+      Method m = ConditionListHandler.class.getDeclaredMethod("walk", Queue.class);
+      m.setAccessible(true);
+      Queue<HierarchyItem> queue = new Queue<>();
+
+      for(HierarchyItem item : compile(tree)) {
+         queue.enqueue(item);
+      }
+
+      return (XFilterNode) m.invoke(handler, queue);
+   }
+
+   private XFilterNode runParseClause(Node tree) {
+      ConditionList list = new ConditionList();
+
+      for(HierarchyItem item : compile(tree)) {
+         list.append(item);
+      }
+
+      return handler.createXFilterNode(list);
+   }
+
+   private void assertBothAlgorithmsMatch(Node tree, Canon expected) throws Exception {
+      assertEquals(expected, canon(runWalk(tree)), "walk() mismatch");
+      assertEquals(expected, canon(runParseClause(tree)), "createXFilterNode(HierarchyList) mismatch");
+   }
+
+   // -----------------------------------------------------------------------
+   // The 12 cases (docs/teams/2026-09-05-bug-wbs003-condition-tree-redesign/
+   // 01-hypothesis-wireformat.md, "Final result" table)
+   // -----------------------------------------------------------------------
+
+   @Test
+   void singleLeaf_bareCondition() throws Exception {
+      assertBothAlgorithmsMatch(leaf("A"), cleaf("A"));
+   }
+
+   @Test
+   void flatAndChain_threeLeaves() throws Exception {
+      assertBothAlgorithmsMatch(
+         group(XSet.AND, leaf("A"), leaf("B"), leaf("C")),
+         crel(XSet.AND, cleaf("A"), cleaf("B"), cleaf("C"))
+      );
+   }
+
+   @Test
+   void flatOrChain_threeLeaves() throws Exception {
+      assertBothAlgorithmsMatch(
+         group(XSet.OR, leaf("A"), leaf("B"), leaf("C")),
+         crel(XSet.OR, cleaf("A"), cleaf("B"), cleaf("C"))
+      );
+   }
+
+   @Test
+   void canonicalRepro_andOuter_orInner_withSibling() throws Exception {
+      // (A1 AND A2) OR (B1 AND B2), ANDed with sibling C -- WBS-003's own literal repro shape.
+      Node tree = group(XSet.AND,
+         group(XSet.OR,
+            group(XSet.AND, leaf("A1"), leaf("A2")),
+            group(XSet.AND, leaf("B1"), leaf("B2"))
+         ),
+         leaf("C")
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR,
+            crel(XSet.AND, cleaf("A1"), cleaf("A2")),
+            crel(XSet.AND, cleaf("B1"), cleaf("B2"))
+         ),
+         cleaf("C")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void mirrorImage_orOuter_andInner_withSibling() throws Exception {
+      // (A1 OR A2) AND (B1 OR B2), OR'd with sibling C -- the direction-inverted mirror family.
+      Node tree = group(XSet.OR,
+         group(XSet.AND,
+            group(XSet.OR, leaf("A1"), leaf("A2")),
+            group(XSet.OR, leaf("B1"), leaf("B2"))
+         ),
+         leaf("C")
+      );
+      Canon expected = crel(XSet.OR,
+         crel(XSet.AND,
+            crel(XSet.OR, cleaf("A1"), cleaf("A2")),
+            crel(XSet.OR, cleaf("B1"), cleaf("B2"))
+         ),
+         cleaf("C")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void threeAndGroups_orChained_wrappedByAndWithSibling() throws Exception {
+      // N=3 AND-groups OR-chained, wrapped by an outer AND with sibling D.
+      Node tree = group(XSet.AND,
+         group(XSet.OR,
+            group(XSet.AND, leaf("A1"), leaf("A2")),
+            group(XSet.AND, leaf("B1"), leaf("B2")),
+            group(XSet.AND, leaf("C1"), leaf("C2"))
+         ),
+         leaf("D")
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR,
+            crel(XSet.AND, cleaf("A1"), cleaf("A2")),
+            crel(XSet.AND, cleaf("B1"), cleaf("B2")),
+            crel(XSet.AND, cleaf("C1"), cleaf("C2"))
+         ),
+         cleaf("D")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void twoOrGroups_andedTogether_noOuterWrapper() throws Exception {
+      // Two OR-groups ANDed together, no further outer junction.
+      Node tree = group(XSet.AND,
+         group(XSet.OR, leaf("A1"), leaf("A2")),
+         group(XSet.OR, leaf("B1"), leaf("B2"))
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR, cleaf("A1"), cleaf("A2")),
+         crel(XSet.OR, cleaf("B1"), cleaf("B2"))
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void threeLevelNesting_mixedRelations() throws Exception {
+      // ((A-grp OR B-grp) AND C) OR D
+      Node tree = group(XSet.OR,
+         group(XSet.AND,
+            group(XSet.OR, leaf("A"), leaf("B")),
+            leaf("C")
+         ),
+         leaf("D")
+      );
+      Canon expected = crel(XSet.OR,
+         crel(XSet.AND,
+            crel(XSet.OR, cleaf("A"), cleaf("B")),
+            cleaf("C")
+         ),
+         cleaf("D")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void asymmetricBranchDepth_sameRelationNestedInsideItself() throws Exception {
+      // One AND branch has an extra same-relation nesting level its OR-sibling doesn't:
+      // (A AND (A2 AND A3)) OR B, ANDed with sibling C.
+      Node tree = group(XSet.AND,
+         group(XSet.OR,
+            group(XSet.AND, leaf("A1"), group(XSet.AND, leaf("A2"), leaf("A3"))),
+            leaf("B")
+         ),
+         leaf("C")
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR,
+            crel(XSet.AND, cleaf("A1"), cleaf("A2"), cleaf("A3")),
+            cleaf("B")
+         ),
+         cleaf("C")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void fourLevelAlternatingNesting() throws Exception {
+      // 4 levels of strictly alternating AND/OR/AND/OR:
+      // ((( A OR B ) AND C) OR D) AND E
+      Node tree = group(XSet.AND,
+         group(XSet.OR,
+            group(XSet.AND,
+               group(XSet.OR, leaf("A"), leaf("B")),
+               leaf("C")
+            ),
+            leaf("D")
+         ),
+         leaf("E")
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR,
+            crel(XSet.AND,
+               crel(XSet.OR, cleaf("A"), cleaf("B")),
+               cleaf("C")
+            ),
+            cleaf("D")
+         ),
+         cleaf("E")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void mixedLeafAndGroupSiblings() throws Exception {
+      // One AND with 3 operands: an OR-group plus two plain leaves.
+      Node tree = group(XSet.AND,
+         group(XSet.OR, leaf("A1"), leaf("A2")),
+         leaf("B"),
+         leaf("C")
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR, cleaf("A1"), cleaf("A2")),
+         cleaf("B"),
+         cleaf("C")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+
+   @Test
+   void doubleRelationSwitchOneBranch() throws Exception {
+      // One OR branch relation-switches twice (AND containing an OR containing a leaf sibling)
+      // down one path while the other branch stays shallow: (( A AND ( B OR C )) OR D) AND E
+      Node tree = group(XSet.AND,
+         group(XSet.OR,
+            group(XSet.AND, leaf("A"), group(XSet.OR, leaf("B"), leaf("C"))),
+            leaf("D")
+         ),
+         leaf("E")
+      );
+      Canon expected = crel(XSet.AND,
+         crel(XSet.OR,
+            crel(XSet.AND, cleaf("A"), crel(XSet.OR, cleaf("B"), cleaf("C"))),
+            cleaf("D")
+         ),
+         cleaf("E")
+      );
+      assertBothAlgorithmsMatch(tree, expected);
+   }
+}

--- a/core/src/test/java/inetsoft/uql/jdbc/util/Wbs003CapabilityGapReproTest.java
+++ b/core/src/test/java/inetsoft/uql/jdbc/util/Wbs003CapabilityGapReproTest.java
@@ -1,0 +1,167 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.jdbc.util;
+
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.HierarchyItem;
+import inetsoft.uql.jdbc.*;
+import inetsoft.util.Queue;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Confirmed-red repro for Redmine #76449 WBS-003's condition-tree scope defect, ported from
+ * stylebi-wiz's docs/teams/2026-09-05-bug-wbs003-condition-tree-redesign/03-repro.md (P3,
+ * verifier-wbs003). This is the StyleBI-side half of the confirmed-red demonstration; the
+ * plugin-side half (the same node sequence's level assignment is accepted silently, with no
+ * error, by set_conditions/set_post_conditions's own validation) is
+ * plugin/composer/test/tools/worksheetTools.test.ts's "silently accepts the exact broken
+ * trigger..." case in the stylebi-wiz repo.
+ *
+ * <p>Both fixed node sequences below are byte-for-byte the array
+ * investigator-plugin-boundary's falsifiable claim describes
+ * (docs/teams/2026-09-05-bug-wbs003-condition-tree-redesign/01-hypothesis-plugin-boundary.md):
+ * "(A1 AND A2) OR (B1 AND B2), ANDed with a sibling C", with the OR junction given the SAME
+ * level (0) as the outer AND and C, instead of its own distinct level -- the exact trigger
+ * set_conditions's own (corrected) worked example now names in prose but does not, and cannot,
+ * enforce.
+ *
+ * <p>No product code is changed by this file -- it is a regression/characterization fixture
+ * confirming unmodified {@link ConditionListHandler} still exhibits the reported defect, per
+ * this ticket's own convergence (docs/teams/2026-09-05-bug-wbs003-condition-tree-redesign/
+ * 02-root-cause.md): "No StyleBI Java change is required or beneficial here."
+ */
+@Tag("core")
+public class Wbs003CapabilityGapReproTest {
+
+   private ConditionListHandler handler;
+
+   @org.junit.jupiter.api.BeforeEach
+   void setUp() {
+      handler = new ConditionListHandler();
+   }
+
+   private XBinaryCondition cond(String name) {
+      return new XBinaryCondition(
+         new XExpression(name, XExpression.FIELD),
+         new XExpression("'x'", XExpression.EXPRESSION), "=");
+   }
+
+   /**
+    * Builds the broken node sequence fresh (new XSet/XSetItem/XFilterNodeItem instances every
+    * call) so the two algorithm runs below never share mutable node objects -- the exact pitfall
+    * investigator-wireformat hit and documented in 01-hypothesis-wireformat.md step 2 (walk()'s
+    * calc() mutates XSetItem.level and XSet's child list in place).
+    */
+   private List<HierarchyItem> brokenSequence() {
+      return List.of(
+         new XFilterNodeItem(cond("A1"), 2),
+         new XSetItem(new XSet(XSet.AND), 2),
+         new XFilterNodeItem(cond("A2"), 2),
+         new XSetItem(new XSet(XSet.OR), 0),
+         new XFilterNodeItem(cond("B1"), 2),
+         new XSetItem(new XSet(XSet.AND), 2),
+         new XFilterNodeItem(cond("B2"), 2),
+         new XSetItem(new XSet(XSet.AND), 0),
+         new XFilterNodeItem(cond("C"), 0)
+      );
+   }
+
+   @SuppressWarnings("unchecked")
+   private XFilterNode runWalk(List<HierarchyItem> items) throws Exception {
+      Method m = ConditionListHandler.class.getDeclaredMethod("walk", Queue.class);
+      m.setAccessible(true);
+      Queue<HierarchyItem> queue = new Queue<>();
+
+      for(HierarchyItem item : items) {
+         queue.enqueue(item);
+      }
+
+      return (XFilterNode) m.invoke(handler, queue);
+   }
+
+   private XFilterNode runParseClause(List<HierarchyItem> items) {
+      ConditionList list = new ConditionList();
+
+      for(HierarchyItem item : items) {
+         list.append(item);
+      }
+
+      return handler.createXFilterNode(list);
+   }
+
+   /** Returns the field name of a leaf condition, for identifying which leaf ended up where. */
+   private String leafName(XFilterNode node) {
+      return (String) ((XBinaryCondition) node).getExpression1().getValue();
+   }
+
+   @Test
+   void walk_brokenTrigger_bindsOrToOnlyBGroup_stealingScopeFromFinalAnd() throws Exception {
+      XFilterNode result = runWalk(brokenSequence());
+
+      assertNotNull(result);
+      assertInstanceOf(XSet.class, result);
+      XSet root = (XSet) result;
+      // The caller's actual intent is an outer AND (( A1 AND A2 ) OR ( B1 AND B2 )) AND C -- i.e.
+      // the ROOT should be AND, with C as a direct sibling operand. Confirmed-red: it is not.
+      assertEquals(
+         XSet.OR, root.getRelation(),
+         "walk() resolved the broken level assignment to an OR root -- confirming the reported " +
+         "defect (A_group OR (B_group AND C)) rather than the caller's intended " +
+         "(A_group OR B_group) AND C. C has silently zero effect on rows satisfying A_group alone."
+      );
+      assertFalse(
+         directChildIsLeafNamed(root, "C"),
+         "C ended up nested under an AND with only the B-group, not as a sibling operand of the " +
+         "whole tree -- exactly the silent-scope-loss this ticket reports."
+      );
+   }
+
+   @Test
+   void createXFilterNode_brokenTrigger_bindsOrToOnlyBGroup_stealingScopeFromFinalAnd() {
+      XFilterNode result = runParseClause(brokenSequence());
+
+      assertNotNull(result);
+      assertInstanceOf(XSet.class, result);
+      XSet root = (XSet) result;
+      assertEquals(
+         XSet.OR, root.getRelation(),
+         "createXFilterNode(HierarchyList) (parseClause/splitAndParseClause) independently " +
+         "resolves the same broken level assignment to an OR root too -- the defect is not " +
+         "specific to walk()'s stack-shunting mechanism."
+      );
+      assertFalse(directChildIsLeafNamed(root, "C"));
+   }
+
+   private boolean directChildIsLeafNamed(XSet set, String name) {
+      for(int i = 0; i < set.getChildCount(); i++) {
+         XFilterNode child = (XFilterNode) set.getChild(i);
+
+         if(child instanceof XBinaryCondition && leafName(child).equals(name)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+}


### PR DESCRIPTION
## Summary
- Test-only commit, cherry-picked cleanly (no conflicts) from an earlier, undocumented pass on
  this same investigation (`C:\src\agent\1\se-wt-wbs003-verifier`, branch
  `verifier-wbs003/bug-wbs003-repro`, commit `40dc1cd49`), rebased onto current
  `stylebi-wiz-main-rebase` tip.
- Adds two files under `core/src/test/java/inetsoft/uql/jdbc/util/`:
  - `Wbs003CapabilityGapReproTest` — confirms the literal WBS-003 broken-trigger level assignment
    still resolves wrong (OR-rooted, C scoped only under the B-group) on unmodified
    `ConditionListHandler`, via both `walk(Queue)` and `createXFilterNode(HierarchyList)`.
  - `TreeToLevelCompilerRegressionTest` — a tree-to-level compiler fixture implementing the rule
    "each nested group's own junction/leaf-children sit at the enclosing group's level + 1,
    unconditionally", asserting 12 tree shapes compile to a flat array both of StyleBI's
    independent condition-tree algorithms resolve identically to the caller's intended tree. This
    is the JVM ground truth the companion `stylebi-wiz` plugin PR's `compileConditionTree()` is
    built and tested against (see
    `docs/teams/2026-09-05-bug-wbs003-condition-tree-redesign/02-schema-redesign-plan.md` in that
    repo, and PR https://github.com/inetsoft-technology/stylebi-wiz/pull/2277).
- No production code changed — `ConditionListHandler` stays untouched; the actual fix lives
  entirely on the plugin side.

## Test plan
- [x] `./mvnw -pl core -Dtest=TreeToLevelCompilerRegressionTest,Wbs003CapabilityGapReproTest test`
      re-run fresh post-cherry-pick: `Tests run: 14, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)