### PR TITLE
Fix Bug #76499: Custom Log Level checkbox cross-selects rows sharing the same name

### DIFF
--- a/web/projects/em/src/app/settings/logging/logging-level-table/logging-level-table.component.html
+++ b/web/projects/em/src/app/settings/logging/logging-level-table/logging-level-table.component.html
@@ -15,9 +15,9 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
-<em-table-view [dataSource]="loggingLevels"
+<em-table-view [dataSource]="keyedLoggingLevels"
                [tableInfo]="tableInfo"
-               [trackByProp]="'name'"
+               [trackByProp]="'rowKey'"
                (add)="addLevel()"
                (editSelected)="editLevel($event)"
                (removeSelection)="removeLevels($event)">

--- a/web/projects/em/src/app/settings/logging/logging-level-table/logging-level-table.component.spec.ts
+++ b/web/projects/em/src/app/settings/logging/logging-level-table/logging-level-table.component.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
+import { MatCheckboxModule } from "@angular/material/checkbox";
+import { MatTableModule } from "@angular/material/table";
+import { LoggingLevelTableComponent } from "./logging-level-table.component";
+import { TableView } from "../../../common/util/table/table-view.component";
+import { LogLevelDTO } from "../LogLevelDTO";
+
+describe("LoggingLevelTableComponent", () => {
+   let fixture: ComponentFixture<LoggingLevelTableComponent>;
+   let component: LoggingLevelTableComponent;
+
+   const hostOrgLevel: LogLevelDTO = {
+      context: "DASHBOARD", name: "dashboard1", orgName: "Host Organization", level: "info"
+   };
+   const selfOrgLevel: LogLevelDTO = {
+      context: "DASHBOARD", name: "dashboard1", orgName: "Self Organization", level: "debug"
+   };
+
+   beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+         imports: [
+            LoggingLevelTableComponent,
+            TableView,
+            NoopAnimationsModule,
+            MatTableModule,
+            MatCheckboxModule,
+            MatCardModule,
+            MatButtonModule
+         ]
+      }).compileComponents();
+   }));
+
+   beforeEach(() => {
+      fixture = TestBed.createComponent(LoggingLevelTableComponent);
+      component = fixture.componentInstance;
+      component.enterprise = true;
+      component.isMultiTenant = true;
+      component.loggingLevels = [hostOrgLevel, selfOrgLevel];
+      fixture.detectChanges();
+   });
+
+   it("should create", () => {
+      expect(component).toBeTruthy();
+   });
+
+   // Bug #76499: two rows can share the same `name` while differing in orgName/level (the
+   // backend identity is context+name+orgName, per LogLevelSetting.equals()/hashCode()).
+   // Checking one such row must not select its sibling.
+   //
+   // Drives TableView.ngOnChanges()/refreshDataSource() directly (rather than through
+   // fixture.detectChanges(), which fights MatTableDataSource's own async internals in this
+   // harness) since that is the exact code path the diagnosis identified as the bug site.
+   it("does not cross-select rows that share name but differ in orgName (bug #76499)", () => {
+      const tableView = fixture.debugElement.query(By.directive(TableView))
+         .componentInstance as TableView<LogLevelDTO>;
+
+      const hostRow = component.keyedLoggingLevels
+         .find((row) => row.orgName === "Host Organization");
+      tableView.selection.select(hostRow as any);
+
+      // Simulate logging-settings-view.component.html's
+      // `[loggingLevels]="getLevels(model.logLevels)"`, which re-supplies a fresh array
+      // reference (same underlying row objects) on every change-detection cycle and
+      // re-triggers TableView.ngOnChanges -> refreshDataSource().
+      const previousDataSource = tableView.dataSource;
+      const freshDataSource = [...component.keyedLoggingLevels];
+      tableView.dataSource = freshDataSource as any;
+      tableView.ngOnChanges({
+         dataSource: {
+            previousValue: previousDataSource,
+            currentValue: freshDataSource,
+            firstChange: false,
+            isFirstChange: () => false
+         }
+      } as any);
+
+      expect(tableView.selection.selected.length).toBe(1);
+      expect((tableView.selection.selected[0] as unknown as LogLevelDTO).orgName)
+         .toBe("Host Organization");
+   });
+});

--- a/web/projects/em/src/app/settings/logging/logging-level-table/logging-level-table.component.ts
+++ b/web/projects/em/src/app/settings/logging/logging-level-table/logging-level-table.component.ts
@@ -44,6 +44,28 @@ export class LoggingLevelTableComponent {
          actions: [TableAction.EDIT, TableAction.ADD, TableAction.DELETE]
       };
    }
+
+   /**
+    * `name` alone is not a unique row identity: in multi-tenant setups two rows can share the
+    * same context+name but differ in orgName/level (see LogLevelSetting.equals() server-side).
+    * TableView's trackByProp only supports a single flat field, so each row is stamped with a
+    * non-enumerable composite key (kept off the object's enumerable properties so it is not
+    * picked up by JSON.stringify when the row is later POSTed back to the server) and
+    * trackByProp points at that key instead of "name".
+    */
+   get keyedLoggingLevels(): LogLevelDTO[] {
+      for(const level of this.loggingLevels) {
+         if(level != null && !Object.prototype.hasOwnProperty.call(level, "rowKey")) {
+            Object.defineProperty(level, "rowKey", {
+               value: `${level.context}_${level.name}_${level.orgName}`,
+               enumerable: false,
+               configurable: true
+            });
+         }
+      }
+
+      return this.loggingLevels;
+   }
    private getTableColumns() {
       if(!this.enterprise || !this.isMultiTenant) {
          return [
@@ -133,7 +155,8 @@ export class LoggingLevelTableComponent {
       this.loggingLevels = this.loggingLevels.filter(
          (loggingLevel) => !loggingLevels.some((level) =>
             level.name === loggingLevel.name &&
-            level.context === loggingLevel.context));
+            level.context === loggingLevel.context &&
+            level.orgName === loggingLevel.orgName));
       this.loggingLevelsChange.emit(this.loggingLevels);
    }
 }


### PR DESCRIPTION
## Summary
- `TableView.refreshDataSource()` rebuilds row selection by matching only on `row[trackByProp]`. `LoggingLevelTableComponent` hardcoded `[trackByProp]="'name'"`, which is not unique once multi-tenant orgs are involved — two rows can share `name` while differing in `orgName`/`level` (backend identity is `context+name+orgName`, per `LogLevelSetting.equals()`/`hashCode()`).
- Fix: stamp each row with a non-enumerable composite key (`context_name_orgName`) via a `keyedLoggingLevels` getter, and point `trackByProp` at that key instead of `'name'`. The key is non-enumerable so it is not picked up by `JSON.stringify` when the row is POSTed back to the server — no change needed to `LogLevelDTO`'s wire model, and no change to the shared `TableView`/`trackByProp` mechanism (so the other 6 `trackByProp` consumers in the `em` app are unaffected).
- Also fixed `removeLevels()`, which had the same non-unique-identity defect (matched only on `name`+`context`) on the Remove-button path — selecting one row and clicking Remove would have deleted both same-name rows.

Fixes Bug #76499.

## Test plan
- [x] Added `logging-level-table.component.spec.ts` (no prior spec existed) with a regression test: two rows sharing `name` but differing in `orgName`, select one, simulate the parent's per-change-detection-cycle re-render (`getLevels()` returning a fresh array of the same row objects), assert only the originally-selected row remains selected.
- [x] Verified the test is load-bearing on the fix: stashing the `.ts`/`.html` change (keeping the new spec) makes it fail to compile (`keyedLoggingLevels` does not exist).
- [x] `npx ng test em --include "**/logging-level-table.component.spec.ts"` — 2/2 passed.
- [x] `npx ng test em` scoped to the 5 directly-related files (logging-level-table, logging-settings-view, logging-settings-page, table-view, regular-table) — 9/9 passed.
- [x] Full `npm run test:em` suite — 106 files / 376 tests, all passed, no regressions.
- [ ] Live-browser end-to-end confirmation (checking one row does not select its sibling; Remove only removes the selected row) — pending, needs two rows in EM > Settings > Logging > Custom Log Levels sharing `name` with different `orgName` (multi-tenant only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)