### PR TITLE
feat(admin-ai): pin the reviewed task narrative into the applied audit record

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
@@ -129,7 +129,7 @@ public class AdminAiController {
    {
       return Map.of("status", "conflict",
                     "error", String.valueOf(ex.getMessage()),
-                    "plan", ex.current());
+                    "plan", withoutTaskToken(ex.current()));
    }
 
    /**
@@ -146,7 +146,12 @@ public class AdminAiController {
    {
       return Map.of("status", "conflict",
                     "error", String.valueOf(ex.getMessage()),
-                    "plan", ex.current());
+                    "plan", withoutTaskToken(ex.current()));
+   }
+
+   private static ResolvedPlan withoutTaskToken(ResolvedPlan plan) {
+      return new ResolvedPlan(plan.task(), plan.changes(), plan.requiresStorageBackup(),
+                              plan.requiresAgentSignoff(), plan.planHash(), null);
    }
 
    private final AdminBackupService backupService;

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
@@ -132,6 +132,23 @@ public class AdminAiController {
                     "plan", ex.current());
    }
 
+   /**
+    * Maps a missing/invalid/foreign {@code taskToken} to {@code 409} carrying the current plan,
+    * the same shape {@link #handlePlanHashMismatch} uses - a caller cannot pin an audit record to
+    * a narrative it cannot prove was reviewed, so this forces a re-preview rather than accepting
+    * whatever task text (if any) the apply request itself carries.
+    */
+   @ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handleTaskTokenMismatch(
+      AdminChangesetApplyService.TaskTokenMismatchException ex)
+   {
+      return Map.of("status", "conflict",
+                    "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
    private final AdminBackupService backupService;
    private final AdminChangePlanService planService;
    private final AdminChangesetApplyService applyService;

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
@@ -129,7 +129,7 @@ public class AdminAiController {
    {
       return Map.of("status", "conflict",
                     "error", String.valueOf(ex.getMessage()),
-                    "plan", withoutTaskToken(ex.current()));
+                    "plan", ex.current());
    }
 
    /**
@@ -146,12 +146,7 @@ public class AdminAiController {
    {
       return Map.of("status", "conflict",
                     "error", String.valueOf(ex.getMessage()),
-                    "plan", withoutTaskToken(ex.current()));
-   }
-
-   private static ResolvedPlan withoutTaskToken(ResolvedPlan plan) {
-      return new ResolvedPlan(plan.task(), plan.changes(), plan.requiresStorageBackup(),
-                              plan.requiresAgentSignoff(), plan.planHash(), null);
+                    "plan", ex.current());
    }
 
    private final AdminBackupService backupService;

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -178,11 +178,12 @@ public class AdminChangePlanService {
     * refused with 409) but forces operators to re-review.
     *
     * <p>{@code task} is deliberately excluded from the hash: it is a free-text narrative that is
-    * never compared or parsed. A reviewer reads the {@code task} at preview, and it is embedded in
-    * the {@code taskToken} issued for that plan, which is what reaches the audit record. The apply
-    * request's own {@code task} field is now vestigial (not read for the audit record). Excluding
-    * {@code task} from the hash lets two equivalent narratives describing the identical change list
-    * be reviewed separately, each valid on its own planHash.
+    * never compared or parsed. {@code preview}'s own {@code task} is what a caller sees and what
+    * {@code taskToken} embeds; the apply request's own {@code task} field is now vestigial (not read
+    * for the audit record). Excluding {@code task} means two equivalent narratives describing the
+    * identical change list produce the same planHash, so a caller paraphrasing {@code task} between
+    * preview and apply never trips a spurious re-review (a false {@code PlanHashMismatchException})
+    * even though nothing the gate protects has changed.
     */
    private static String hash(List<PlanChange> changes) {
       StringBuilder canonical = new StringBuilder();

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -166,8 +166,10 @@ public class AdminChangePlanService {
       boolean signoff = changes.stream()
          .anyMatch(c -> AdminChangeRecord.RISK_HIGH.equals(c.risk()));
 
-      return new ResolvedPlan(req.getTask().trim(), Collections.unmodifiableList(changes),
-                              backup, signoff, hash(changes));
+      String planHash = hash(changes);
+      String task = req.getTask().trim();
+      return new ResolvedPlan(task, Collections.unmodifiableList(changes),
+                              backup, signoff, planHash, TaskAuditToken.issue(planHash, task));
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -177,12 +177,12 @@ public class AdminChangePlanService {
     * contract: changing them invalidates every outstanding preview, which is safe (an apply is
     * refused with 409) but forces operators to re-review.
     *
-    * <p>{@code task} is deliberately excluded: it is a free-text narrative that is never compared
-    * or parsed, only carried through to {@code AdminChangesetApplyService}'s {@code writeAudit}
-    * call as {@link AdminChangeRecord#setTaskDescription}, a write-only audit label. Including it
-    * here would let two equivalent narratives describing the identical change list hash
-    * differently, forcing a spurious re-review (a false {@code PlanHashMismatchException}) even
-    * though nothing the gate actually protects has changed.
+    * <p>{@code task} is deliberately excluded from the hash: it is a free-text narrative that is
+    * never compared or parsed. A reviewer reads the {@code task} at preview, and it is embedded in
+    * the {@code taskToken} issued for that plan, which is what reaches the audit record. The apply
+    * request's own {@code task} field is now vestigial (not read for the audit record). Excluding
+    * {@code task} from the hash lets two equivalent narratives describing the identical change list
+    * be reviewed separately, each valid on its own planHash.
     */
    private static String hash(List<PlanChange> changes) {
       StringBuilder canonical = new StringBuilder();

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
@@ -76,6 +76,21 @@ public class AdminChangesetApplyService {
       private final transient ResolvedPlan current;
    }
 
+   /** Thrown when {@code apply} carries a missing, invalid, or foreign {@code taskToken}. */
+   public static class TaskTokenMismatchException extends RuntimeException {
+      public TaskTokenMismatchException(ResolvedPlan current, String message) {
+         super(message);
+         this.current = current;
+      }
+
+      /** The plan as it stands now, so the caller can show the operator what to re-review. */
+      public ResolvedPlan current() {
+         return current;
+      }
+
+      private final transient ResolvedPlan current;
+   }
+
    /**
     * Resolves, gates on the plan hash, then executes.
     *
@@ -90,6 +105,15 @@ public class AdminChangesetApplyService {
 
          if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
             throw new PlanHashMismatchException(plan);
+         }
+
+         String reviewedTask;
+
+         try {
+            reviewedTask = TaskAuditToken.verify(req.getTaskToken(), plan.planHash());
+         }
+         catch(TaskAuditToken.TaskTokenException e) {
+            throw new TaskTokenMismatchException(plan, e.getMessage());
          }
 
          // Finding 5b: requiresAgentSignoff was computed by AdminChangePlanService but never
@@ -119,7 +143,7 @@ public class AdminChangesetApplyService {
             // attempted - exactly the failure mode this method exists to prevent.
             try {
                AdminChangeResult applied = changeService.applyChange(
-                  request(txId, plan.task(), change, AdminChangeRecord.ACTION_APPLY,
+                  request(txId, reviewedTask, change, AdminChangeRecord.ACTION_APPLY,
                           change.proposedValue(), backupRef, req.getReviewOutcome()),
                   user);
 
@@ -191,7 +215,7 @@ public class AdminChangesetApplyService {
          }
 
          List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
-         failures.addAll(rollback(txId, plan.task(), undoable, undoableBefore, backupRef,
+         failures.addAll(rollback(txId, reviewedTask, undoable, undoableBefore, backupRef,
                                   req.getReviewOutcome(), user));
 
          if(failures.isEmpty()) {

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
@@ -65,7 +65,7 @@ public class AdminChangesetApplyService {
    public static class PlanHashMismatchException extends RuntimeException {
       public PlanHashMismatchException(ResolvedPlan current) {
          super("planHash: does not match the current plan; re-review before applying");
-         this.current = current;
+         this.current = withoutTaskToken(current);
       }
 
       /** The plan as it stands now, so the caller can show the operator what changed. */
@@ -80,7 +80,7 @@ public class AdminChangesetApplyService {
    public static class TaskTokenMismatchException extends RuntimeException {
       public TaskTokenMismatchException(ResolvedPlan current, String message) {
          super(message);
-         this.current = current;
+         this.current = withoutTaskToken(current);
       }
 
       /** The plan as it stands now, so the caller can show the operator what to re-review. */
@@ -89,6 +89,17 @@ public class AdminChangesetApplyService {
       }
 
       private final transient ResolvedPlan current;
+   }
+
+   /**
+    * A 409 conflict response exists to show the operator what the CURRENT plan looks like so they can
+    * re-review — it must never hand back a taskToken, which would let a caller retry with an
+    * unreviewed narrative and silently defeat the whole audit-pinning mechanism this exception exists
+    * to protect.
+    */
+   private static ResolvedPlan withoutTaskToken(ResolvedPlan plan) {
+      return new ResolvedPlan(plan.task(), plan.changes(), plan.requiresStorageBackup(),
+                              plan.requiresAgentSignoff(), plan.planHash(), null);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/ai/ApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/ApplyRequest.java
@@ -24,8 +24,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ApplyRequest extends PlanRequest {
    public String getPlanHash() { return planHash; }
    public void setPlanHash(String v) { this.planHash = v; }
+   public String getTaskToken() { return taskToken; }
+   public void setTaskToken(String v) { this.taskToken = v; }
    public String getReviewOutcome() { return reviewOutcome; }
    public void setReviewOutcome(String v) { this.reviewOutcome = v; }
 
-   private String planHash, reviewOutcome;
+   private String planHash, taskToken, reviewOutcome;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/ResolvedPlan.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/ResolvedPlan.java
@@ -26,8 +26,11 @@ import java.util.List;
  * @param requiresAgentSignoff  true when any change is high risk.
  * @param planHash              SHA-256 over the canonical plan, including CURRENT values, so an
  *                              apply after drift is refused.
+ * @param taskToken binds {@code task} to {@code planHash} (see {@link TaskAuditToken}) so a
+ *                  caller cannot substitute a different narrative at apply time without also
+ *                  re-previewing.
  */
 public record ResolvedPlan(String task, List<PlanChange> changes, boolean requiresStorageBackup,
-                           boolean requiresAgentSignoff, String planHash)
+                           boolean requiresAgentSignoff, String planHash, String taskToken)
 {
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/TaskAuditToken.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/TaskAuditToken.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+import inetsoft.util.Tool;
+
+/**
+ * Issues and verifies the token that pins a plan's reviewed {@code task} narrative to the
+ * {@code planHash} a caller must echo at apply. {@code AdminChangePlanService#hash} deliberately
+ * excludes {@code task} so a caller paraphrasing it between preview and apply never trips a false
+ * conflict - but that also means apply's own {@code task} request field is never required to
+ * match what a reviewer actually read at preview. This token closes that gap without reopening
+ * the one {@code hash} avoids: a caller is never required to resend a matching {@code task}
+ * string, but whatever text is embedded in a valid token is what actually reaches the audit
+ * record, not whatever text (if any) the apply request itself carries.
+ *
+ * <p>Stateless by design: the token embeds both the reviewed {@code task} and the
+ * {@code planHash} it was issued for, encrypted with {@link Tool#encryptPassword}, which every
+ * node in a cluster can decrypt (the same master key a cluster shares to keep encrypted
+ * credentials portable between nodes). No cache, no TTL, no clustering gap.
+ */
+public final class TaskAuditToken {
+   private TaskAuditToken() {
+   }
+
+   /** Issues a token binding {@code task} to {@code planHash}, for a preview response. */
+   public static String issue(String planHash, String task) {
+      return Tool.encryptPassword(planHash + SEP + task);
+   }
+
+   /**
+    * Recovers the reviewed {@code task} embedded in {@code taskToken}, requiring it to have been
+    * issued for exactly {@code planHash}.
+    *
+    * @throws TaskTokenException if {@code taskToken} is missing, undecryptable, malformed, or was
+    *                           issued for a different {@code planHash}.
+    */
+   public static String verify(String taskToken, String planHash) {
+      if(taskToken == null || taskToken.isBlank()) {
+         throw new TaskTokenException(
+            "taskToken: required - the token returned by preview for this plan");
+      }
+
+      String decoded;
+
+      try {
+         decoded = Tool.decryptPassword(taskToken);
+      }
+      catch(Exception e) {
+         throw new TaskTokenException(
+            "taskToken: does not match the current plan; re-review before applying");
+      }
+
+      int idx = decoded == null ? -1 : decoded.indexOf(SEP);
+
+      if(idx < 0 || !planHash.equals(decoded.substring(0, idx))) {
+         throw new TaskTokenException(
+            "taskToken: does not match the current plan; re-review before applying");
+      }
+
+      return decoded.substring(idx + 1);
+   }
+
+   /** Thrown by {@link #verify} on a missing, undecryptable, malformed, or foreign token. */
+   public static class TaskTokenException extends RuntimeException {
+      public TaskTokenException(String message) {
+         super(message);
+      }
+   }
+
+   /** Same unit-separator {@code AdminChangePlanService#hash} uses; task/planHash cannot contain it. */
+   private static final char SEP = '';
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/TaskAuditToken.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/TaskAuditToken.java
@@ -83,6 +83,10 @@ public final class TaskAuditToken {
       }
    }
 
-   /** Same unit-separator {@code AdminChangePlanService#hash} uses; task/planHash cannot contain it. */
-   private static final char SEP = '';
+   /**
+    * Same unit-separator {@code AdminChangePlanService#hash} uses. {@code indexOf} finds the FIRST
+    * separator, which is always the planHash boundary, so even if {@code task} contains a stray
+    * separator, it cannot be exploited to forge a different split.
+    */
+   private static final char SEP = '\u001f';
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java
@@ -20,6 +20,7 @@ package inetsoft.web.admin.ai.cluster;
 import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import inetsoft.web.admin.cluster.ClusterService;
 import inetsoft.web.cluster.ServerClusterClient;
 import inetsoft.web.cluster.ServerClusterStatus;
@@ -118,8 +119,9 @@ public class ClusterChangePlanService {
       requirePauseEnabled();
 
       String task = req.getTask().trim();
+      String planHash = hash(changes);
       return new ResolvedPlan(task, Collections.unmodifiableList(changes), false, true,
-                              hash(changes));
+                              planHash, TaskAuditToken.issue(planHash, task));
    }
 
    private PlanChange resolveOne(String server, String verb) {

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanService.java
@@ -23,6 +23,7 @@ import inetsoft.report.internal.license.LicenseType;
 import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -131,8 +132,9 @@ public class LicenseChangePlanService {
       }
 
       String task = req.getTask().trim();
+      String planHash = hash(changes, installed.size());
       return new ResolvedPlan(task, Collections.unmodifiableList(changes), true, true,
-                              hash(changes, installed.size()));
+                              planHash, TaskAuditToken.issue(planHash, task));
    }
 
    // ---------------------------------------------------------------- add

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -85,7 +86,9 @@ public class PresentationChangePlanService {
 
       String task = req.getTask().trim();
       List<PlanChange> immutableChanges = Collections.unmodifiableList(changes);
-      return new ResolvedPlan(task, immutableChanges, true, true, hash(immutableChanges));
+      String planHash = hash(immutableChanges);
+      return new ResolvedPlan(task, immutableChanges, true, true,
+                              planHash, TaskAuditToken.issue(planHash, task));
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
@@ -25,6 +25,7 @@ import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.RollbackFailure;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +93,8 @@ public class PresentationChangesetApplyService {
 
          if(req.getPlanHash() == null || !currentHash.equals(req.getPlanHash())) {
             throw new AdminChangesetApplyService.PlanHashMismatchException(
-               new inetsoft.web.admin.ai.ResolvedPlan(task, planChanges, true, true, currentHash));
+               new inetsoft.web.admin.ai.ResolvedPlan(task, planChanges, true, true,
+                  currentHash, TaskAuditToken.issue(currentHash, task)));
          }
 
          if(req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()) {

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
@@ -24,6 +24,7 @@ import inetsoft.uql.XPrincipal;
 import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import inetsoft.web.admin.security.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -122,8 +123,9 @@ public class ProviderChangePlanService {
       }
 
       String task = req.getTask().trim();
+      String planHash = hash(changes, chainProjections);
       return new ResolvedPlan(task, Collections.unmodifiableList(changes), true, true,
-                              hash(changes, chainProjections));
+                              planHash, TaskAuditToken.issue(planHash, task));
    }
 
    // ---------------------------------------------------------------- create

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
@@ -235,7 +235,10 @@ class AdminAiControllerTest {
 
       assertEquals("conflict", actual.get("status"));
       assertEquals(ex.getMessage(), actual.get("error"));
-      assertSame(current, actual.get("plan"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) actual.get("plan");
+      assertEquals(current.task(), returnedPlan.task());
+      assertEquals(current.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
    }
 
    @Test void handlePlanHashMismatchIsAnnotatedConflict() throws NoSuchMethodException {
@@ -259,7 +262,10 @@ class AdminAiControllerTest {
 
       assertEquals("conflict", actual.get("status"));
       assertEquals(ex.getMessage(), actual.get("error"));
-      assertSame(current, actual.get("plan"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) actual.get("plan");
+      assertEquals(current.task(), returnedPlan.task());
+      assertEquals(current.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
    }
 
    @Test void handleTaskTokenMismatchIsAnnotatedConflict() throws NoSuchMethodException {
@@ -270,5 +276,19 @@ class AdminAiControllerTest {
 
       assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
       assertEquals(HttpStatus.CONFLICT, annotation.value());
+   }
+
+   @Test void handlePlanHashMismatchScrubsTheTaskTokenFromTheReturnedPlan() {
+      ResolvedPlan current = new ResolvedPlan("t", List.of(), false, false, "hash456", "unreviewed-token");
+      Map<String, Object> actual = controller.handlePlanHashMismatch(
+         new AdminChangesetApplyService.PlanHashMismatchException(current));
+      assertNull(((ResolvedPlan) actual.get("plan")).taskToken());
+   }
+
+   @Test void handleTaskTokenMismatchScrubsTheTaskTokenFromTheReturnedPlan() {
+      ResolvedPlan current = new ResolvedPlan("t", List.of(), false, false, "hash456", "unreviewed-token");
+      Map<String, Object> actual = controller.handleTaskTokenMismatch(
+         new AdminChangesetApplyService.TaskTokenMismatchException(current, "msg"));
+      assertNull(((ResolvedPlan) actual.get("plan")).taskToken());
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
@@ -247,4 +247,28 @@ class AdminAiControllerTest {
       assertNotNull(annotation, "handlePlanHashMismatch must be annotated @ResponseStatus");
       assertEquals(HttpStatus.CONFLICT, annotation.value());
    }
+
+   @Test void handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan() {
+      ResolvedPlan current = new ResolvedPlan("raise max rows", List.of(), false, false,
+                                              "hash456", "token456");
+      AdminChangesetApplyService.TaskTokenMismatchException ex =
+         new AdminChangesetApplyService.TaskTokenMismatchException(current,
+            "taskToken: does not match the current plan; re-review before applying");
+
+      Map<String, Object> actual = controller.handleTaskTokenMismatch(ex);
+
+      assertEquals("conflict", actual.get("status"));
+      assertEquals(ex.getMessage(), actual.get("error"));
+      assertSame(current, actual.get("plan"));
+   }
+
+   @Test void handleTaskTokenMismatchIsAnnotatedConflict() throws NoSuchMethodException {
+      ResponseStatus annotation = AdminAiController.class
+         .getMethod("handleTaskTokenMismatch",
+                    AdminChangesetApplyService.TaskTokenMismatchException.class)
+         .getAnnotation(ResponseStatus.class);
+
+      assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
+      assertEquals(HttpStatus.CONFLICT, annotation.value());
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
@@ -164,7 +164,7 @@ class AdminAiControllerTest {
       PlanRequest req = new PlanRequest();
       req.setTask("raise max rows");
       ResolvedPlan expected =
-         new ResolvedPlan("raise max rows", List.of(), false, false, "hash123");
+         new ResolvedPlan("raise max rows", List.of(), false, false, "hash123", "token123");
       when(planService.resolve(req)).thenReturn(expected);
 
       ResolvedPlan actual = controller.preview(req, principal);
@@ -226,7 +226,8 @@ class AdminAiControllerTest {
    // -------------------------------------------------------------------------
 
    @Test void handlePlanHashMismatchReturnsConflictStatusWithCurrentPlan() {
-      ResolvedPlan current = new ResolvedPlan("raise max rows", List.of(), false, false, "hash456");
+      ResolvedPlan current = new ResolvedPlan("raise max rows", List.of(), false, false,
+                                              "hash456", "token456");
       AdminChangesetApplyService.PlanHashMismatchException ex =
          new AdminChangesetApplyService.PlanHashMismatchException(current);
 

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
@@ -277,18 +277,4 @@ class AdminAiControllerTest {
       assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
       assertEquals(HttpStatus.CONFLICT, annotation.value());
    }
-
-   @Test void handlePlanHashMismatchScrubsTheTaskTokenFromTheReturnedPlan() {
-      ResolvedPlan current = new ResolvedPlan("t", List.of(), false, false, "hash456", "unreviewed-token");
-      Map<String, Object> actual = controller.handlePlanHashMismatch(
-         new AdminChangesetApplyService.PlanHashMismatchException(current));
-      assertNull(((ResolvedPlan) actual.get("plan")).taskToken());
-   }
-
-   @Test void handleTaskTokenMismatchScrubsTheTaskTokenFromTheReturnedPlan() {
-      ResolvedPlan current = new ResolvedPlan("t", List.of(), false, false, "hash456", "unreviewed-token");
-      Map<String, Object> actual = controller.handleTaskTokenMismatch(
-         new AdminChangesetApplyService.TaskTokenMismatchException(current, "msg"));
-      assertNull(((ResolvedPlan) actual.get("plan")).taskToken());
-   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeFaultInjectionIntegrationTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeFaultInjectionIntegrationTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.ai;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
 import inetsoft.util.audit.*;
 import inetsoft.web.admin.properties.PropertyChangeSideEffects;
 import org.junit.jupiter.api.*;
@@ -55,6 +56,7 @@ class AdminChangeFaultInjectionIntegrationTest {
    @Mock private PropertyChangeSideEffects sideEffects;
    private MockedStatic<SreeEnv> sreeEnv;
    private MockedStatic<Audit> auditStatic;
+   private MockedStatic<Tool> tool;
    private AdminChangesetApplyService service;
    private AdminChangePlanService planService;
    /**
@@ -80,6 +82,23 @@ class AdminChangeFaultInjectionIntegrationTest {
              .thenAnswer(inv -> store.put(inv.getArgument(0), inv.getArgument(1)));
       auditStatic = mockStatic(Audit.class, withSettings().strictness(Strictness.LENIENT));
       auditStatic.when(Audit::getInstance).thenReturn(mock(Audit.class));
+      // resolve() now issues a TaskAuditToken (Task 2), and apply() now verifies one (Task 4) -
+      // both reach Tool.encryptPassword/decryptPassword, which need a live Spring context outside
+      // this mock. Same reversible TKN: stand-in AdminChangesetApplyServiceTest uses.
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
       AdminPropertyCatalog catalog = new AdminPropertyCatalog();
       planService = new AdminChangePlanService(catalog, new AdminRiskClassifier(catalog));
       // The REAL AdminChangeService - the whole point of this test class.
@@ -90,6 +109,7 @@ class AdminChangeFaultInjectionIntegrationTest {
    @AfterEach void tearDown() {
       sreeEnv.close();
       auditStatic.close();
+      tool.close();
       System.clearProperty(FAULT_INJECTION_ENABLED_PROPERTY);
    }
 
@@ -111,7 +131,9 @@ class AdminChangeFaultInjectionIntegrationTest {
       PlanRequest probe = new PlanRequest();
       probe.setTask(task);
       probe.setChanges(changes);
-      req.setPlanHash(planService.resolve(probe).planHash());
+      ResolvedPlan resolved = planService.resolve(probe);
+      req.setPlanHash(resolved.planHash());
+      req.setTaskToken(resolved.taskToken());
       return req;
    }
 

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -20,6 +20,7 @@ package inetsoft.web.admin.ai;
 import inetsoft.sree.SreeEnv;
 import inetsoft.util.Tool;
 import org.junit.jupiter.api.*;
+import org.mockito.Answers;
 import org.mockito.MockedStatic;
 import org.mockito.quality.Strictness;
 
@@ -43,15 +44,21 @@ class AdminChangePlanServiceTest {
    private final AdminChangePlanService service =
       new AdminChangePlanService(catalog, new AdminRiskClassifier(catalog));
    private MockedStatic<SreeEnv> sreeEnv;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach
    void setUp() {
       sreeEnv = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
    }
 
    @AfterEach
    void tearDown() {
       sreeEnv.close();
+      tool.close();
    }
 
    private static PlanRequest request(String task, String property, String value) {
@@ -161,6 +168,14 @@ class AdminChangePlanServiceTest {
          .thenReturn("100");
       String base = service.resolve(request("t", "max.rows", "500")).planHash();
       assertEquals(base, service.resolve(request("other", "max.rows", "500")).planHash());
+   }
+
+   @Test
+   void issuesATaskTokenBoundToThePlanHash() {
+      sreeEnv.when(() -> SreeEnv.getProperty("query.runtime.maxrow", false, false))
+         .thenReturn("100");
+      ResolvedPlan plan = service.resolve(request("t", "max.rows", "500"));
+      assertEquals("TKN:" + plan.planHash() + "\u001ft", plan.taskToken());
    }
 
    @Test
@@ -322,16 +337,11 @@ class AdminChangePlanServiceTest {
 
    @Test void refusesACredentialWhenCloudSecretsAreConfigured() {
       // In that mode the property holds the NAME of a secret, not the secret, so writing a literal
-      // value would store something nothing downstream can resolve. Scoped to this test: a
-      // class-wide Tool mock would silently change every other test's environment.
-      try(MockedStatic<Tool> tool = mockStatic(Tool.class, withSettings().strictness(
-             Strictness.LENIENT)))
-      {
-         tool.when(Tool::isCloudSecrets).thenReturn(true);
-         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-            () -> service.resolve(request("set it", "openid.client.secret", "s3cret")));
-         assertTrue(ex.getMessage().contains("cloud secrets"));
-      }
+      // value would store something nothing downstream can resolve.
+      tool.when(Tool::isCloudSecrets).thenReturn(true);
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("set it", "openid.client.secret", "s3cret")));
+      assertTrue(ex.getMessage().contains("cloud secrets"));
    }
 
    @Test void refusesAnEmptyValueForACredentialAndSaysWhatToUseInstead() {
@@ -357,27 +367,23 @@ class AdminChangePlanServiceTest {
       // The guard became reachable for mail and logging credentials when they joined the
       // allow-list. Its message used to say "Settings > Security > SSO", which is the wrong page
       // for every one of them - and a wrong page is worse guidance than none.
-      try(MockedStatic<Tool> tool = mockStatic(Tool.class, withSettings().strictness(
-             Strictness.LENIENT)))
-      {
-         tool.when(Tool::isCloudSecrets).thenReturn(true);
+      tool.when(Tool::isCloudSecrets).thenReturn(true);
 
-         for(String prop : new String[] { "mail.smtp.pass", "log.fluentd.security.sharedkey",
-                                          "openid.client.secret" })
-         {
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-               () -> service.resolve(request("set it", prop, "value")));
-            assertTrue(ex.getMessage().contains(prop), "message should name " + prop);
-            assertTrue(ex.getMessage().contains("cloud secrets"));
-            // The message must describe only what admin-chat will not do. Every claim about how a
-            // property is configured elsewhere is a claim per property, and this is one string for
-            // seven of them - two review rounds caught exactly that, first the page name and then
-            // the Secret ID field, which only three of the seven actually have.
-            assertFalse(ex.getMessage().contains("Security > SSO"),
-                        "message must not name an SSO page for " + prop);
-            assertFalse(ex.getMessage().contains("Secret ID"),
-                        "message must not promise a Secret ID field for " + prop);
-         }
+      for(String prop : new String[] { "mail.smtp.pass", "log.fluentd.security.sharedkey",
+                                       "openid.client.secret" })
+      {
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> service.resolve(request("set it", prop, "value")));
+         assertTrue(ex.getMessage().contains(prop), "message should name " + prop);
+         assertTrue(ex.getMessage().contains("cloud secrets"));
+         // The message must describe only what admin-chat will not do. Every claim about how a
+         // property is configured elsewhere is a claim per property, and this is one string for
+         // seven of them - two review rounds caught exactly that, first the page name and then
+         // the Secret ID field, which only three of the seven actually have.
+         assertFalse(ex.getMessage().contains("Security > SSO"),
+                     "message must not name an SSO page for " + prop);
+         assertFalse(ex.getMessage().contains("Secret ID"),
+                     "message must not promise a Secret ID field for " + prop);
       }
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
@@ -770,4 +770,72 @@ class AdminChangesetApplyServiceTest {
       assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, applied.status());
       assertEquals("query.runtime.maxrow", applied.rollbackFailures().get(0).property());
    }
+
+   /**
+    * PlanHashMismatchException constructor must scrub taskToken from the plan it carries
+    * in current(), even when the original plan has a non-null taskToken, to prevent leaking
+    * the token in a 409 response.
+    */
+   @Test
+   void planHashMismatchExceptionScrubsTaskTokenFromCurrent() {
+      List<AdminChangeRequest> changes = List.of(
+         change("property", "old", "new"));
+      ResolvedPlan planWithToken = new ResolvedPlan(
+         "original task",
+         changes,
+         false,
+         false,
+         "hash123",
+         "TKN:value");
+
+      AdminChangesetApplyService.PlanHashMismatchException ex =
+         new AdminChangesetApplyService.PlanHashMismatchException(
+            planWithToken, "hash456");
+
+      assertNull(ex.current().taskToken(),
+         "PlanHashMismatchException must scrub taskToken");
+      assertEquals(new ResolvedPlan(
+         "original task",
+         changes,
+         false,
+         false,
+         "hash123",
+         null),
+         ex.current(),
+         "All other plan fields must be preserved");
+   }
+
+   /**
+    * TaskTokenMismatchException constructor must scrub taskToken from the plan it carries
+    * in current(), even when the original plan has a non-null taskToken, to prevent leaking
+    * the token in a 409 response.
+    */
+   @Test
+   void taskTokenMismatchExceptionScrubsTaskTokenFromCurrent() {
+      List<AdminChangeRequest> changes = List.of(
+         change("property", "old", "new"));
+      ResolvedPlan planWithToken = new ResolvedPlan(
+         "original task",
+         changes,
+         false,
+         false,
+         "hash123",
+         "TKN:value");
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex =
+         new AdminChangesetApplyService.TaskTokenMismatchException(
+            planWithToken);
+
+      assertNull(ex.current().taskToken(),
+         "TaskTokenMismatchException must scrub taskToken");
+      assertEquals(new ResolvedPlan(
+         "original task",
+         changes,
+         false,
+         false,
+         "hash123",
+         null),
+         ex.current(),
+         "All other plan fields must be preserved");
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
@@ -72,6 +72,16 @@ class AdminChangesetApplyServiceTest {
          .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
       AdminPropertyCatalog catalog = new AdminPropertyCatalog();
       planService = new AdminChangePlanService(catalog, new AdminRiskClassifier(catalog));
       service = new AdminChangesetApplyService(planService, changeService, backupService);
@@ -107,7 +117,40 @@ class AdminChangesetApplyServiceTest {
       PlanRequest probe = new PlanRequest();
       probe.setTask(task);
       probe.setChanges(changes);
-      req.setPlanHash(planService.resolve(probe).planHash());
+      ResolvedPlan resolved = planService.resolve(probe);
+      req.setPlanHash(resolved.planHash());
+      req.setTaskToken(resolved.taskToken());
+      return req;
+   }
+
+   /**
+    * Builds an apply request whose taskToken was issued for a DIFFERENT task string than the one
+    * this request's own {@code task} field carries — the shape a caller previewing an honest
+    * description then applying with different text produces.
+    */
+   private ApplyRequest requestWithDivergentApplyTask(String previewTask, String applyTask,
+                                                       String... propertyValuePairs)
+   {
+      List<PlanRequest.Change> changes = new ArrayList<>();
+
+      for(int i = 0; i < propertyValuePairs.length; i += 2) {
+         PlanRequest.Change change = new PlanRequest.Change();
+         change.setProperty(propertyValuePairs[i]);
+         change.setValue(propertyValuePairs[i + 1]);
+         changes.add(change);
+      }
+
+      PlanRequest preview = new PlanRequest();
+      preview.setTask(previewTask);
+      preview.setChanges(changes);
+      ResolvedPlan previewed = planService.resolve(preview);
+
+      ApplyRequest req = new ApplyRequest();
+      req.setTask(applyTask);
+      req.setChanges(changes);
+      req.setReviewOutcome("approved");
+      req.setPlanHash(previewed.planHash());
+      req.setTaskToken(previewed.taskToken());
       return req;
    }
 
@@ -181,6 +224,49 @@ class AdminChangesetApplyServiceTest {
          argThat(r -> "approved".equals(r.getReviewOutcome())), eq(principal));
    }
 
+   @Test
+   void auditsThePreviewedTaskEvenWhenApplyTaskDiffers() throws Exception {
+      stub("query.runtime.maxrow", "100");
+      when(changeService.applyChange(any(), eq(principal)))
+         .thenReturn(result("query.runtime.maxrow", "100", "500",
+                            AdminChangeRecord.STATUS_VERIFIED, null));
+
+      ApplyRequest req = requestWithDivergentApplyTask(
+         "raise the row limit", "totally different apply-time text", "max.rows", "500");
+
+      ApplyResult applied = service.apply(req, principal);
+
+      // The core regression proof: apply still succeeds. Task text diverging must never be
+      // treated as drift — only `changes` is hash-protected.
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, applied.status());
+      verify(changeService).applyChange(
+         argThat(r -> "raise the row limit".equals(r.getTaskDescription())), eq(principal));
+   }
+
+   @Test
+   void rejectsAMissingTaskToken() {
+      stub("query.runtime.maxrow", "100");
+      ApplyRequest req = request("t", "max.rows", "500");
+      req.setTaskToken(null);
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex = assertThrows(
+         AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, principal));
+      assertTrue(ex.getMessage().startsWith("taskToken:"));
+      assertNotNull(ex.current());
+   }
+
+   @Test
+   void rejectsATaskTokenIssuedForADifferentPlan() {
+      stub("query.runtime.maxrow", "100");
+      ApplyRequest req = request("t", "max.rows", "500");
+      ApplyRequest otherPlan = request("other task", "max.rows", "600");
+      req.setTaskToken(otherPlan.getTaskToken());
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, principal));
+   }
+
    // ── concurrency ──────────────────────────────────────────────────────────
 
    /**
@@ -198,7 +284,7 @@ class AdminChangesetApplyServiceTest {
       PlanChange change = new PlanChange("query.runtime.maxrow", null, "100", "500",
          AdminChangeRecord.RISK_LOW, AdminChangeRecord.SCOPE_VALUE, true, null);
       ResolvedPlan plan = new ResolvedPlan("t", List.of(change), false, false,
-                                           "fixed-hash", "fixed-token");
+                                           "fixed-hash", TaskAuditToken.issue("fixed-hash", "t"));
       when(mockPlanService.resolve(any())).thenReturn(plan);
       AdminChangesetApplyService concurrentService =
          new AdminChangesetApplyService(mockPlanService, changeService, backupService);
@@ -224,13 +310,14 @@ class AdminChangesetApplyServiceTest {
       req.setTask("t");
       req.setChanges(List.of());
       req.setPlanHash("fixed-hash");
+      req.setTaskToken(TaskAuditToken.issue("fixed-hash", "t"));
 
       ExecutorService pool = Executors.newFixedThreadPool(2);
 
       try {
          List<Future<ApplyResult>> futures = List.of(
-            pool.submit(() -> concurrentService.apply(req, principal)),
-            pool.submit(() -> concurrentService.apply(req, principal)));
+            pool.submit(() -> applyOnThisThread(concurrentService, req)),
+            pool.submit(() -> applyOnThisThread(concurrentService, req)));
 
          for(Future<ApplyResult> future : futures) {
             assertEquals(AdminChangesetApplyService.STATUS_APPLIED, future.get(5, TimeUnit.SECONDS).status());
@@ -241,6 +328,36 @@ class AdminChangesetApplyServiceTest {
       }
 
       assertEquals(1, maxConcurrent.get(), "two applies ran their critical section concurrently");
+   }
+
+   /**
+    * {@code apply} now calls {@code TaskAuditToken.verify}, which reaches {@code Tool}. Mockito's
+    * {@code mockStatic} registration is thread-local, so the executor's worker threads do not see
+    * the {@code tool} mock installed in {@code setUp} on the main test thread - without this, they
+    * would fall through to the real crypto implementation, which cannot decode the fake
+    * {@code "TKN:"} token this test class uses. Each worker thread needs its own registration.
+    */
+   private ApplyResult applyOnThisThread(AdminChangesetApplyService svc, ApplyRequest req)
+      throws Exception
+   {
+      try(MockedStatic<Tool> threadTool = mockStatic(Tool.class,
+         withSettings().strictness(Strictness.LENIENT).defaultAnswer(Answers.CALLS_REAL_METHODS)))
+      {
+         threadTool.when(() -> Tool.encryptPassword(anyString()))
+            .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+         threadTool.when(() -> Tool.decryptPassword(anyString()))
+            .thenAnswer(inv -> {
+               String s = inv.getArgument(0);
+
+               if(!s.startsWith("TKN:")) {
+                  throw new IllegalArgumentException("not a token");
+               }
+
+               return s.substring(4);
+            });
+
+         return svc.apply(req, principal);
+      }
    }
 
    // ── review gate ──────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
@@ -778,11 +778,9 @@ class AdminChangesetApplyServiceTest {
     */
    @Test
    void planHashMismatchExceptionScrubsTaskTokenFromCurrent() {
-      List<AdminChangeRequest> changes = List.of(
-         change("property", "old", "new"));
       ResolvedPlan planWithToken = new ResolvedPlan(
          "original task",
-         changes,
+         List.of(),
          false,
          false,
          "hash123",
@@ -790,13 +788,13 @@ class AdminChangesetApplyServiceTest {
 
       AdminChangesetApplyService.PlanHashMismatchException ex =
          new AdminChangesetApplyService.PlanHashMismatchException(
-            planWithToken, "hash456");
+            planWithToken);
 
       assertNull(ex.current().taskToken(),
          "PlanHashMismatchException must scrub taskToken");
       assertEquals(new ResolvedPlan(
          "original task",
-         changes,
+         List.of(),
          false,
          false,
          "hash123",
@@ -812,11 +810,9 @@ class AdminChangesetApplyServiceTest {
     */
    @Test
    void taskTokenMismatchExceptionScrubsTaskTokenFromCurrent() {
-      List<AdminChangeRequest> changes = List.of(
-         change("property", "old", "new"));
       ResolvedPlan planWithToken = new ResolvedPlan(
          "original task",
-         changes,
+         List.of(),
          false,
          false,
          "hash123",
@@ -824,13 +820,14 @@ class AdminChangesetApplyServiceTest {
 
       AdminChangesetApplyService.TaskTokenMismatchException ex =
          new AdminChangesetApplyService.TaskTokenMismatchException(
-            planWithToken);
+            planWithToken,
+            "taskToken: does not match the current plan; re-review before applying");
 
       assertNull(ex.current().taskToken(),
          "TaskTokenMismatchException must scrub taskToken");
       assertEquals(new ResolvedPlan(
          "original task",
-         changes,
+         List.of(),
          false,
          false,
          "hash123",

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
@@ -18,9 +18,11 @@
 package inetsoft.web.admin.ai;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
 import inetsoft.util.audit.AdminChangeRecord;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -61,10 +63,15 @@ class AdminChangesetApplyServiceTest {
    private MockedStatic<SreeEnv> sreeEnv;
    private AdminChangesetApplyService service;
    private AdminChangePlanService planService;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach
    void setUp() {
       sreeEnv = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
       AdminPropertyCatalog catalog = new AdminPropertyCatalog();
       planService = new AdminChangePlanService(catalog, new AdminRiskClassifier(catalog));
       service = new AdminChangesetApplyService(planService, changeService, backupService);
@@ -73,6 +80,7 @@ class AdminChangesetApplyServiceTest {
    @AfterEach
    void tearDown() {
       sreeEnv.close();
+      tool.close();
    }
 
    /**
@@ -189,7 +197,8 @@ class AdminChangesetApplyServiceTest {
       AdminChangePlanService mockPlanService = mock(AdminChangePlanService.class);
       PlanChange change = new PlanChange("query.runtime.maxrow", null, "100", "500",
          AdminChangeRecord.RISK_LOW, AdminChangeRecord.SCOPE_VALUE, true, null);
-      ResolvedPlan plan = new ResolvedPlan("t", List.of(change), false, false, "fixed-hash");
+      ResolvedPlan plan = new ResolvedPlan("t", List.of(change), false, false,
+                                           "fixed-hash", "fixed-token");
       when(mockPlanService.resolve(any())).thenReturn(plan);
       AdminChangesetApplyService concurrentService =
          new AdminChangesetApplyService(mockPlanService, changeService, backupService);

--- a/core/src/test/java/inetsoft/web/admin/ai/TaskAuditTokenCryptoTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/TaskAuditTokenCryptoTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+/*
+ * Test strategy
+ *
+ * TaskAuditTokenTest stubs Tool.encryptPassword/decryptPassword so its assertions pin
+ * TaskAuditToken's own logic without depending on a master key - that proves which methods are
+ * called, not that the two are actually inverses. This test runs the real encryption once, under
+ * the Spring/SreeHome harness the crypto needs, to hold the two halves together, mirroring
+ * LogSettingServiceCryptoTest's own strategy for the same primitive.
+ */
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class TaskAuditTokenCryptoTest {
+   @Test
+   void issuedTokenIsVerifiableByTheRealCrypto() {
+      String token = TaskAuditToken.issue("hash123", "raise the row limit");
+
+      assertNotEquals("hash123raise the row limit", token,
+         "the plan hash and task must not be stored in clear text");
+      assertEquals("raise the row limit", TaskAuditToken.verify(token, "hash123"));
+   }
+
+   @Test
+   void verifyRejectsARealTokenIssuedForADifferentPlanHash() {
+      String token = TaskAuditToken.issue("hash123", "raise the row limit");
+      assertThrows(TaskAuditToken.TaskTokenException.class,
+         () -> TaskAuditToken.verify(token, "hash456"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/TaskAuditTokenTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/TaskAuditTokenTest.java
@@ -89,6 +89,6 @@ class TaskAuditTokenTest {
       // Pins the wire format one layer down from verify(), so a future change to the delimiter
       // or field order is caught here even if verify() happened to still round-trip correctly.
       String token = TaskAuditToken.issue("hash123", "t");
-      assertEquals("TKN:hash123t", token);
+      assertEquals("TKN:hash123" + (char) 0x1F + "t", token);
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/TaskAuditTokenTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/TaskAuditTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Stubs Tool.encryptPassword/decryptPassword so these tests pin TaskAuditToken's own issue/verify
+ * logic (delimiter handling, hash binding, error cases) without depending on the master-key crypto
+ * those methods wrap. TaskAuditTokenCryptoTest runs the real round trip once, under the
+ * Spring/SreeHome harness the crypto needs, to hold the two halves together.
+ */
+@Tag("core")
+class TaskAuditTokenTest {
+   private MockedStatic<Tool> tool;
+
+   @BeforeEach
+   void setUp() {
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
+   }
+
+   @AfterEach
+   void tearDown() {
+      tool.close();
+   }
+
+   @Test
+   void verifyRecoversTheIssuedTask() {
+      String token = TaskAuditToken.issue("hash123", "raise the row limit");
+      assertEquals("raise the row limit", TaskAuditToken.verify(token, "hash123"));
+   }
+
+   @Test
+   void verifyRejectsATokenIssuedForADifferentPlanHash() {
+      String token = TaskAuditToken.issue("hash123", "raise the row limit");
+      assertThrows(TaskAuditToken.TaskTokenException.class,
+         () -> TaskAuditToken.verify(token, "hash456"));
+   }
+
+   @Test
+   void verifyRejectsAMissingToken() {
+      assertTrue(assertThrows(TaskAuditToken.TaskTokenException.class,
+         () -> TaskAuditToken.verify(null, "hash123")).getMessage().startsWith("taskToken:"));
+      assertThrows(TaskAuditToken.TaskTokenException.class,
+         () -> TaskAuditToken.verify("   ", "hash123"));
+   }
+
+   @Test
+   void verifyRejectsAnUndecryptableToken() {
+      assertThrows(TaskAuditToken.TaskTokenException.class,
+         () -> TaskAuditToken.verify("not-a-real-token", "hash123"));
+   }
+
+   @Test
+   void issueEmbedsTaskAfterTheSeparator() {
+      // Pins the wire format one layer down from verify(), so a future change to the delimiter
+      // or field order is caught here even if verify() happened to still round-trip correctly.
+      String token = TaskAuditToken.issue("hash123", "t");
+      assertEquals("TKN:hash123t", token);
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin.ai.cluster;
 
+import inetsoft.util.Tool;
 import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
@@ -26,8 +27,11 @@ import inetsoft.web.cluster.ServerClusterClient;
 import inetsoft.web.cluster.ServerClusterStatus;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Set;
@@ -47,11 +51,20 @@ class ClusterChangePlanServiceTest {
    @Mock private ClusterService clusterService;
    @Mock private ServerClusterClient client;
    private ClusterChangePlanService service;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach void setUp() {
       service = new ClusterChangePlanService(clusterService, client);
       lenient().when(clusterService.getClusterEnabled())
          .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(true).build());
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach void tearDown() {
+      tool.close();
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
@@ -56,6 +56,7 @@ class ClusterChangesetApplyServiceTest {
 
    private ClusterChangePlanService planService;
    private ClusterChangesetApplyService service;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach void setUp() {
       planService = new ClusterChangePlanService(clusterService, client);
@@ -63,6 +64,13 @@ class ClusterChangesetApplyServiceTest {
       lenient().when(clusterService.getClusterEnabled())
          .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(true).build());
       lenient().when(client.getConfiguredServers()).thenReturn(Set.of("s1", "s2"));
+      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach void tearDown() {
+      tool.close();
    }
 
    // -------------------------------------------------------------------------
@@ -280,11 +288,10 @@ class ClusterChangesetApplyServiceTest {
       // stubbed here too, specifically so the audit write actually reaches Audit.getInstance()
       // .auditAdminChange(...) and this test can assert on the record's real field values, rather
       // than only proving the write was attempted the way every prior area's test settles for.
-      try(MockedStatic<Audit> audit = mockStatic(Audit.class);
-          MockedStatic<Tool> tool = mockStatic(Tool.class, CALLS_REAL_METHODS))
-      {
+      tool.when(Tool::getHost).thenReturn("test-host");
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
          audit.when(Audit::getInstance).thenReturn(auditInstance);
-         tool.when(Tool::getHost).thenReturn("test-host");
          service.apply(applyRequest("task", hash, "looks good", pause("s1")), user);
       }
 

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
@@ -29,10 +29,12 @@ import inetsoft.web.cluster.ServerClusterClient;
 import inetsoft.web.cluster.ServerClusterStatus;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Set;
@@ -64,7 +66,8 @@ class ClusterChangesetApplyServiceTest {
       lenient().when(clusterService.getClusterEnabled())
          .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(true).build());
       lenient().when(client.getConfiguredServers()).thenReturn(Set.of("s1", "s2"));
-      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
    }

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanServiceTest.java
@@ -20,12 +20,16 @@ package inetsoft.web.admin.ai.licensing;
 import inetsoft.report.internal.license.License;
 import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.report.internal.license.LicenseType;
+import inetsoft.util.Tool;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -44,10 +48,20 @@ import static org.mockito.Mockito.*;
 class LicenseChangePlanServiceTest {
    @Mock private LicenseManager licenseManager;
    private LicenseChangePlanService service;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach
    void setUp() {
       service = new LicenseChangePlanService(licenseManager);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach
+   void tearDown() {
+      tool.close();
    }
 
    private static License license(String key, LicenseType type, LocalDateTime expires) {

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
@@ -67,6 +67,7 @@ class LicenseChangesetApplyServiceTest {
    private final Set<License> installed = new LinkedHashSet<>();
    private LicenseChangePlanService planService;
    private LicenseChangesetApplyService service;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach
    void setUp() throws Exception {
@@ -77,6 +78,9 @@ class LicenseChangesetApplyServiceTest {
       lenient().when(licenseManager.getInstalledLicenses())
          .thenAnswer(inv -> new LinkedHashSet<>(installed));
       lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
+      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
 
       lenient().doAnswer(inv -> {
          String key = inv.getArgument(0);
@@ -89,6 +93,11 @@ class LicenseChangesetApplyServiceTest {
          installed.removeIf(l -> Objects.equals(l.key(), key));
          return null;
       }).when(licenseKeySettingsService).removeServerKey(anyString());
+   }
+
+   @AfterEach
+   void tearDown() {
+      tool.close();
    }
 
    private static License license(String key, LicenseType type, LocalDateTime expires) {
@@ -390,11 +399,10 @@ class LicenseChangesetApplyServiceTest {
       LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
       Audit auditInstance = mock(Audit.class);
 
-      try(MockedStatic<Audit> audit = mockStatic(Audit.class);
-          MockedStatic<Tool> tool = mockStatic(Tool.class, CALLS_REAL_METHODS))
-      {
+      tool.when(Tool::getHost).thenReturn("test-host");
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
          audit.when(Audit::getInstance).thenReturn(auditInstance);
-         tool.when(Tool::getHost).thenReturn("test-host");
          service.apply(req, user);
       }
 

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -78,7 +79,8 @@ class LicenseChangesetApplyServiceTest {
       lenient().when(licenseManager.getInstalledLicenses())
          .thenAnswer(inv -> new LinkedHashSet<>(installed));
       lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
-      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
 

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
@@ -20,13 +20,17 @@ package inetsoft.web.admin.ai.presentation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.util.Tool;
 import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.general.model.WebMapSettingsModel;
 import inetsoft.web.admin.presentation.model.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.security.Principal;
 import java.util.Arrays;
@@ -36,6 +40,8 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * 01-spec.md section 0/2 (16-entry catalog, dead-field exclusion), section 4 (risk/scope split),
@@ -50,6 +56,7 @@ class PresentationChangePlanServiceTest {
    @Mock
    private PresentationSettingsAccess access;
    private PresentationChangePlanService service;
+   private MockedStatic<Tool> tool;
 
    private static final Principal PRINCIPAL = () -> "admin";
    private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -57,6 +64,15 @@ class PresentationChangePlanServiceTest {
    @BeforeEach
    void setUp() {
       service = new PresentationChangePlanService(access);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach
+   void tearDown() {
+      tool.close();
    }
 
    // ---------------------------------------------------------------- request builders

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
@@ -20,6 +20,7 @@ package inetsoft.web.admin.ai.presentation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.uql.XPrincipal;
+import inetsoft.util.Tool;
 import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
 import inetsoft.web.admin.presentation.model.LookAndFeelSettingsModel;
@@ -28,6 +29,7 @@ import inetsoft.web.admin.presentation.model.PresentationFormatsSettingsModel;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
@@ -59,6 +61,7 @@ class PresentationChangesetApplyServiceTest {
    private final Map<String, Object> state = new HashMap<>();
    private PresentationChangePlanService planService;
    private PresentationChangesetApplyService service;
+   private MockedStatic<Tool> tool;
 
    private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -68,6 +71,9 @@ class PresentationChangesetApplyServiceTest {
       service = new PresentationChangesetApplyService(planService, access, backupService);
 
       lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
+      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
 
       lenient().when(access.read(any(), any(), anyBoolean())).thenAnswer(inv -> {
          PresentationSubModel subModel = inv.getArgument(0);
@@ -82,6 +88,11 @@ class PresentationChangesetApplyServiceTest {
          state.put(stateKey(subModel, global), model);
          return null;
       }).when(access).write(any(), any(), any(), anyBoolean());
+   }
+
+   @AfterEach
+   void tearDown() {
+      tool.close();
    }
 
    private static String stateKey(PresentationSubModel subModel, boolean global) {

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
@@ -28,9 +28,11 @@ import inetsoft.web.admin.presentation.model.PresentationDashboardSettingsModel;
 import inetsoft.web.admin.presentation.model.PresentationFormatsSettingsModel;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.util.HashMap;
 import java.util.List;
@@ -71,7 +73,8 @@ class PresentationChangesetApplyServiceTest {
       service = new PresentationChangesetApplyService(planService, access, backupService);
 
       lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
-      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
 

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
@@ -22,14 +22,17 @@ import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.util.Identity;
+import inetsoft.util.Tool;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
 import inetsoft.web.admin.security.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Optional;
@@ -53,11 +56,20 @@ class ProviderChangePlanServiceTest {
    @Mock private SecurityEngine securityEngine;
    @Mock private XPrincipal user;
    private ProviderChangePlanService service;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach void setUp() {
       service = new ProviderChangePlanService(authenticationProviderService,
                                               authorizationProviderService, securityEngine);
       lenient().when(user.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach void tearDown() {
+      tool.close();
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
@@ -21,6 +21,7 @@ import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.MessageException;
+import inetsoft.util.Tool;
 import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.*;
@@ -64,6 +66,7 @@ class ProviderChangesetApplyServiceTest {
 
    private ProviderChangePlanService planService;
    private ProviderChangesetApplyService service;
+   private MockedStatic<Tool> tool;
 
    @BeforeEach void setUp() throws Exception {
       planService = new ProviderChangePlanService(authenticationProviderService,
@@ -73,8 +76,15 @@ class ProviderChangesetApplyServiceTest {
 
       lenient().when(user.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
       lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
+      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
       wireAuthenticationFake();
       wireAuthorizationFake();
+   }
+
+   @AfterEach void tearDown() {
+      tool.close();
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
@@ -29,10 +29,12 @@ import inetsoft.web.admin.ai.ResolvedPlan;
 import inetsoft.web.admin.security.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -76,7 +78,8 @@ class ProviderChangesetApplyServiceTest {
 
       lenient().when(user.getRoles()).thenReturn(new IdentityID[] { CALLER_ROLE });
       lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
-      tool = mockStatic(Tool.class, CALLS_REAL_METHODS);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
       wireAuthenticationFake();


### PR DESCRIPTION
## Summary

The Properties area's admin-chat `preview`/`apply` flow now pins the reviewed `task` narrative
into the permanent audit record, instead of trusting whatever `task` text the `apply` request
itself carries — closing a gap left open by the `#76445`/`#76454`/`#76472` planHash fix family
(Redmine #76493).

- `preview` now issues a stateless, signed `taskToken` (`Tool.encryptPassword` over
  `planHash + task`) alongside the existing `planHash`.
- `apply` requires and verifies `taskToken`; the server extracts the **previewed** `task` from
  inside it and uses that — not the apply request's own `task` field — for every audit record the
  changeset writes, including rollback.
- Does **not** reintroduce the earlier `#76445` regression: a caller paraphrasing (or completely
  rewriting) `task` between preview and apply still never causes `apply` to fail — only
  `changes`/`planHash` gates a conflict.
- A 409 conflict response's `plan` never carries a usable `taskToken` — that scrub lives in the
  shared `PlanHashMismatchException`/`TaskTokenMismatchException` constructors, so it protects all
  10 admin-chat areas by construction, not per-controller.

Because `ResolvedPlan` is a record shared by all 10 of StyleBI's admin-chat areas (5 here, 5 in the
sibling `stylebi-enterprise` repo), adding `taskToken` to it forced every area's `resolve()` call
site to be updated to keep the tree compiling — even though only **Properties** gets the full
verify-and-pin *behavior* in this PR. The other 4 areas here (Cluster, Licensing, Presentation,
Providers) now issue a real, usable `taskToken`, but their own `apply()` still writes the
apply-time `task` — deliberately deferred to follow-on tickets, matching this defect family's own
`#76445` → `#76454` → `#76472` precedent.

Design doc: `docs/superpowers/specs/2026-09-07-planhash-task-audit-pinning-design.md` and
`docs/superpowers/plans/2026-09-07-planhash-task-audit-pinning.md` in the `stylebi-wiz` repo.

## Merge ordering — please read before merging

This PR is one of three, across three repos, with a real dependency order:

1. **This PR (community/`stylebi`)** — merge first.
2. **`stylebi-enterprise`**, branch `feature/76493-task-audit-token` — the mechanical
   `ResolvedPlan.taskToken` thread-through for the 5 enterprise areas. It depends on this PR: its
   CI cannot build in isolation until this merges and the `community` submodule pointer in
   `stylebi-enterprise`'s `stylebi-wiz-main-rebase` branch is bumped to include it.
3. **`stylebi-wiz`**, branch `feature/76493-planhash-task-audit-pinning-spec` — the `plugin/admin`
   MCP tool update (`preview_changes`/`apply_changes` now carry/require `taskToken`). Independent
   of the two Java repos' CI, but deploying it against a StyleBI backend that predates this PR
   makes Properties `apply` unusable until the backend catches up (the plugin's own error message
   now says so explicitly).

## Test plan

- [x] `./mvnw test -pl core` — 8875 tests, 0 failures, 0 errors, 69 skipped (pre-existing/unrelated), independently re-run by the reviewing lead (not just the implementer) at each fix round.
- [x] Task-level review (spec compliance + code quality) for each of the 4 commits' original tasks — all Approved, no Critical/Important.
- [x] Whole-branch final review — 3 rounds (Important: 409 taskToken leak scoped to one controller instead of the shared exception classes; a factually-backwards `hash()` javadoc rewrite) — both closed; final verdict Ready to merge, only cosmetic Minors remain (noted inline in the diff's own comments where relevant).

🤖 Generated with a subagent-driven-development workflow (Claude Code)