### PR TITLE
feat(tabular): Datagov (Socrata) catalog SPI (TabularCatalogProvider)

### DIFF
--- a/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovCatalog.java
+++ b/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovCatalog.java
@@ -235,8 +235,8 @@ final class DatagovCatalog {
 
       if(!SOCRATA_4X4.matcher(datasetId).matches()) {
          throw new Exception("Datagov was asked to describe dataset id '" + datasetId + "', " +
-            "which is not a Socrata 4x4 id (exactly 4 lowercase letters/digits, a hyphen, 4 " +
-            "more lowercase letters/digits) -- refusing to embed it into a request URL.");
+            "which is not a Socrata 4x4 id (exactly 4 letters/digits, a hyphen, 4 more " +
+            "letters/digits) -- refusing to embed it into a request URL.");
       }
    }
 
@@ -309,8 +309,14 @@ final class DatagovCatalog {
          return ((JsonNumber) v).longValue();
       }
 
+      // Tolerates a numeric value Socrata sent as a quoted JSON string. JsonValue#toString() on a
+      // JsonString includes the surrounding quotes, so Long.parseLong needs the unquoted text --
+      // without this branch a quoted number always fell through to null, silently.
+      String text = v.getValueType() == JsonValue.ValueType.STRING ? ((JsonString) v).getString()
+         : v.toString();
+
       try {
-         return Long.parseLong(v.toString());
+         return Long.parseLong(text);
       }
       catch(NumberFormatException e) {
          return null;
@@ -363,9 +369,17 @@ final class DatagovCatalog {
       Map.entry("meta_data", XSchema.STRING));
 
    /**
-    * Exactly 4 lowercase letters/digits, a hyphen, 4 more -- Socrata's own 4x4 id shape.
+    * Exactly 4 letters/digits, a hyphen, 4 more -- Socrata's own 4x4 id shape. Case-insensitive
+    * deliberately: every id observed live during this connector's development was lowercase, but
+    * {@link #listDatasets} applies no case filter of its own (only {@code resource.type ==
+    * "dataset"}), so a case-sensitive pattern here could reject an id {@code listDatasets} itself
+    * just vouched for one call earlier -- a self-inconsistent round trip for the connector's own
+    * output. Case carries no meaning for this check anyway: the id is embedded into the request
+    * path unencoded either way, and an uppercase letter is exactly as safe there as a lowercase
+    * one -- only the shape (length/hyphen placement/character class) is the security boundary.
     */
-   private static final Pattern SOCRATA_4X4 = Pattern.compile("[a-z0-9]{4}-[a-z0-9]{4}");
+   private static final Pattern SOCRATA_4X4 =
+      Pattern.compile("[a-z0-9]{4}-[a-z0-9]{4}", Pattern.CASE_INSENSITIVE);
 
    /**
     * Confirmed live: {@code limit=10000} against a real, large Socrata site returned every

--- a/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovCatalog.java
+++ b/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovCatalog.java
@@ -1,0 +1,384 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.datagov;
+
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.json.*;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Assembles {@link DatagovRuntime}'s {@link TabularCatalogProvider} answers out of two Socrata
+ * endpoints: the centrally-hosted Discovery API ({@link #listDatasets}) and one site's own classic
+ * Views API metadata ({@link #describeDataset}). Mirrors {@code ElasticCatalog}/{@code
+ * MongoCatalog}'s role: package-private, static methods, no state of its own.
+ *
+ * <p>See {@code DatagovRuntime#requireSiteDomain}/{@code getDiscoveryMetadata}/
+ * {@code getSiteMetadata} for why the Discovery API call carries no credentials while the classic
+ * API call reuses {@code runQuery}'s existing Basic-Auth-if-configured behavior — they target two
+ * different hosts with two different auth expectations.
+ */
+final class DatagovCatalog {
+   private DatagovCatalog() {
+   }
+
+   /**
+    * @param ds the data source whose {@code URL} host names the Socrata site to enumerate.
+    * @return one dataset per Socrata "dataset"-typed asset the site's Discovery API reports,
+    *         across every page. {@code relationships()} is always empty — the Discovery API is a
+    *         search index over independently published assets, not a data dictionary.
+    * @throws Exception if the Discovery API could not be read, answered with an unexpected shape,
+    *                   or did not finish paging within {@link #MAX_DISCOVERY_REQUESTS} requests.
+    */
+   static TabularCatalog listDatasets(DatagovDataSource ds) throws Exception {
+      String domain = DatagovRuntime.requireSiteDomain(ds);
+      List<TabularDatasetRef> datasets = new ArrayList<>();
+      int offset = 0;
+      int resultSetSize = Integer.MAX_VALUE;
+      int requests = 0;
+
+      while(offset < resultSetSize) {
+         if(++requests > MAX_DISCOVERY_REQUESTS) {
+            throw new Exception("Socrata Discovery API for domain '" + domain + "' did not " +
+               "finish enumerating after " + MAX_DISCOVERY_REQUESTS + " requests (" +
+               datasets.size() + " datasets seen so far); refusing to keep paging.");
+         }
+
+         String url = "https://api.us.socrata.com/api/catalog/v1?domains=" +
+            URLEncoder.encode(domain, StandardCharsets.UTF_8) + "&only=datasets&limit=" +
+            DISCOVERY_PAGE_SIZE + "&offset=" + offset;
+         String context = "Socrata Discovery API for domain '" + domain + "'";
+         JsonObject page = parseObject(DatagovRuntime.getDiscoveryMetadata(url), context);
+
+         Integer size = getInt(page, "resultSetSize");
+
+         if(size == null) {
+            throw new Exception(context + " answered with no numeric resultSetSize.");
+         }
+
+         resultSetSize = size;
+         JsonArray results = page.getJsonArray("results");
+
+         if(results == null) {
+            throw new Exception(context + " answered with no results array.");
+         }
+
+         for(JsonValue v : results) {
+            if(v.getValueType() != JsonValue.ValueType.OBJECT) {
+               throw new Exception(context + " returned a result that is not a JSON object.");
+            }
+
+            JsonObject resource = v.asJsonObject().getJsonObject("resource");
+            String id = resource == null ? null : getString(resource, "id");
+
+            if(id == null || id.isBlank()) {
+               throw new Exception(context + " returned a result with no resource.id.");
+            }
+
+            // Belt-and-suspenders: `only=datasets` is a real, server-side filter, but this is
+            // cheap insurance against a response that includes a non-dataset asset (a chart, map,
+            // filtered view, story...) despite the filter -- those are not describable via
+            // rows.json, and emitting one here would only surface as a confusing describeDataset
+            // failure later.
+            String type = getString(resource, "type");
+
+            if(!"dataset".equals(type)) {
+               LOG.debug("Skipping Socrata catalog entry {} ({}): type is '{}', not 'dataset'",
+                         id, getString(resource, "name"), type);
+               continue;
+            }
+
+            datasets.add(new TabularDatasetRef(id));
+         }
+
+         offset += DISCOVERY_PAGE_SIZE;
+      }
+
+      return new TabularCatalog(datasets, List.of());
+   }
+
+   /**
+    * @param datasetId a Socrata 4x4 id, as {@link #listDatasets} returned it.
+    * @throws Exception if the id is not a legal Socrata 4x4 id, the dataset is unknown, or it
+    *                   declares no columns.
+    */
+   static TabularDatasetSchema describeDataset(DatagovDataSource ds, String datasetId)
+      throws Exception
+   {
+      validateDatasetId(datasetId);
+      // Guards the same precondition listDatasets guards via requireSiteDomain -- an
+      // in-progress/incompletely-configured data source (URL never set) must fail with a
+      // message naming what's missing, not a bare NullPointerException out of ds.getURL().trim()
+      // below. The returned domain itself is unused here; only the validation side effect matters.
+      DatagovRuntime.requireSiteDomain(ds);
+
+      URI base = URI.create(ds.getURL().trim());
+      // An ABSOLUTE-PATH reference replaces base's whole path when resolved, keeping only
+      // scheme+authority -- this reaches the site's classic API root regardless of whether the
+      // operator's URL points at the site root or at one specific resource's full path (see A10).
+      URI target = base.resolve("/api/views/" + datasetId + "/rows.json?max_rows=0");
+      String context = "Socrata dataset '" + datasetId + "'";
+
+      String json = DatagovRuntime.getSiteMetadata(ds, target.toString());
+      JsonObject root = parseObject(json, context);
+      JsonObject meta = root.getJsonObject("meta");
+      JsonObject view = meta == null ? null : meta.getJsonObject("view");
+
+      if(view == null) {
+         throw new Exception(context + " answered with no meta.view block.");
+      }
+
+      JsonArray rawColumns = view.getJsonArray("columns");
+
+      if(rawColumns == null || rawColumns.isEmpty()) {
+         throw new Exception(context + " declares no columns.");
+      }
+
+      List<TabularColumn> columns = new ArrayList<>();
+      List<String> unrecognizedTypes = new ArrayList<>();
+      Long rowIdentifierColumnId = getLong(view, "rowIdentifierColumnId");
+      String keyColumnName = null;
+
+      for(JsonValue v : rawColumns) {
+         if(v.getValueType() != JsonValue.ValueType.OBJECT) {
+            throw new Exception(context + " declares a column that is not a JSON object.");
+         }
+
+         JsonObject col = v.asJsonObject();
+         String name = getString(col, "name");
+
+         if(name == null || name.isBlank()) {
+            throw new Exception(context + " declares a column with no name.");
+         }
+
+         String dataTypeName = getString(col, "dataTypeName");
+         String xtype = TYPES.get(dataTypeName);
+
+         if(xtype == null) {
+            xtype = XSchema.STRING;
+            unrecognizedTypes.add(name + " (" + dataTypeName + ")");
+            LOG.warn("Unrecognized Socrata dataTypeName '{}' on column '{}' of dataset '{}'; " +
+                     "reporting it as {}.", dataTypeName, name, datasetId, XSchema.STRING);
+         }
+
+         String description = getString(col, "description");
+
+         if(description != null) {
+            description = description.strip();
+
+            if(description.isEmpty()) {
+               description = null;
+            }
+         }
+
+         columns.add(new TabularColumn(name, xtype, description, null, null));
+
+         Long colId = getLong(col, "id");
+
+         if(rowIdentifierColumnId != null && rowIdentifierColumnId.equals(colId)) {
+            keyColumnName = name;
+         }
+      }
+
+      Map<String, String> params = new LinkedHashMap<>();
+      // Fully filled, with no empty value -- once the dataset id is known the exact suffix that
+      // reproduces this dataset's rows is completely determined. The classic /api/views/{id}/
+      // rows.json path is used deliberately, not the modern /resource/{id}.json path: DatagovTable's
+      // constructor requires meta.view.columns + a data array-of-arrays, exactly and only what the
+      // classic endpoint returns.
+      params.put("suffix", "/api/views/" + datasetId + "/rows.json");
+
+      return new TabularDatasetSchema(datasetId, columns,
+         keyColumnName == null ? List.of() : List.of(keyColumnName), params, false,
+         datasetDescription(datasetId, view, unrecognizedTypes));
+   }
+
+   /**
+    * Rejects a {@code datasetId} that could not possibly be a real Socrata 4x4 id before it ever
+    * reaches {@link DatagovRuntime#getSiteMetadata} and is embedded into a live request URL.
+    * {@code TabularCatalogService.describeTable} passes a caller-supplied target straight through
+    * with no prior {@link #listDatasets} check, so this is the only place that can refuse a shape
+    * built to escape the URL path segment.
+    *
+    * <p>Every 4x4 id observed live while this connector was written
+    * ({@code erm2-nwe9}, {@code 8wbx-tsch}, {@code w7w3-xahh}, {@code k397-673e}) matches this
+    * pattern; Socrata's own docs and every third-party client describe the id as exactly this
+    * shape (4 lowercase alphanumerics, a hyphen, 4 more).
+    */
+   private static void validateDatasetId(String datasetId) throws Exception {
+      if(datasetId == null || datasetId.isBlank()) {
+         throw new Exception("Datagov was asked to describe a blank dataset id.");
+      }
+
+      if(!SOCRATA_4X4.matcher(datasetId).matches()) {
+         throw new Exception("Datagov was asked to describe dataset id '" + datasetId + "', " +
+            "which is not a Socrata 4x4 id (exactly 4 lowercase letters/digits, a hyphen, 4 " +
+            "more lowercase letters/digits) -- refusing to embed it into a request URL.");
+      }
+   }
+
+   /**
+    * The dataset-level description: the site's own {@code view.description}, verbatim, when there
+    * is one, plus this connector's own structural note (row grain, how the columns were read, and
+    * which columns fell back to a string because their Socrata type was not recognized).
+    */
+   private static String datasetDescription(String datasetId, JsonObject view,
+                                            List<String> unrecognizedTypes)
+   {
+      StringBuilder text = new StringBuilder();
+      String declared = getString(view, "description");
+
+      if(declared != null && !declared.isBlank()) {
+         text.append(declared.strip()).append("\n\n");
+      }
+
+      text.append("Socrata dataset '").append(datasetId)
+         .append("'. One row per record, columns read from the dataset's own declared metadata " +
+                 "(GET /api/views/").append(datasetId).append("/rows.json?max_rows=0) -- not a " +
+                 "sample, so the column list is complete for the columns Socrata declares.");
+
+      if(!unrecognizedTypes.isEmpty()) {
+         text.append("\n\nThis connector does not recognize the Socrata dataTypeName declared " +
+               "for ").append(unrecognizedTypes.size()).append(" column(s), so each is reported " +
+               "as a string rather than its declared type: ")
+            .append(String.join(", ", unrecognizedTypes)).append(".");
+      }
+
+      return text.toString();
+   }
+
+   private static JsonObject parseObject(String json, String context) throws Exception {
+      JsonValue value;
+
+      try(JsonReader reader = Json.createReader(new StringReader(json))) {
+         value = reader.readValue();
+      }
+      catch(JsonException e) {
+         throw new Exception(context + " answered with invalid JSON.", e);
+      }
+
+      if(value.getValueType() != JsonValue.ValueType.OBJECT) {
+         throw new Exception(context + " answered with " + value.getValueType() +
+                             " instead of a JSON object.");
+      }
+
+      return value.asJsonObject();
+   }
+
+   private static String getString(JsonObject obj, String key) {
+      if(obj == null || !obj.containsKey(key) || obj.isNull(key)) {
+         return null;
+      }
+
+      JsonValue v = obj.get(key);
+      return v.getValueType() == JsonValue.ValueType.STRING ? ((JsonString) v).getString()
+         : v.toString();
+   }
+
+   private static Long getLong(JsonObject obj, String key) {
+      if(obj == null || !obj.containsKey(key) || obj.isNull(key)) {
+         return null;
+      }
+
+      JsonValue v = obj.get(key);
+
+      if(v.getValueType() == JsonValue.ValueType.NUMBER) {
+         return ((JsonNumber) v).longValue();
+      }
+
+      try {
+         return Long.parseLong(v.toString());
+      }
+      catch(NumberFormatException e) {
+         return null;
+      }
+   }
+
+   private static Integer getInt(JsonObject obj, String key) {
+      Long l = getLong(obj, key);
+      return l == null ? null : l.intValue();
+   }
+
+   /**
+    * Socrata {@code dataTypeName} to {@link XSchema} constant, for the fields that become columns.
+    * A {@code Map<String,String>} rather than an exhaustive {@code switch}, deliberately: this is a
+    * string from an HTTP JSON response, not a Java enum the driver controls at compile time, so an
+    * unrecognized value degrades to {@link XSchema#STRING} with a WARN log and a dataset-description
+    * sentence naming it (see {@link #describeDataset}), rather than failing the whole call.
+    *
+    * <p>{@code number}/{@code money}/{@code percent} map to {@code DECIMAL}, not {@code DOUBLE}:
+    * {@code DatagovTable}'s own per-value parse path (its {@code NUMBER} case) produces a
+    * {@code BigDecimal} for these -- {@code getClassName}'s {@code Double.class} for the same names
+    * is only the fallback type used when zero rows are returned, never what a populated column
+    * actually yields. {@code calendar_date}/{@code fixed_timestamp}/{@code floating_timestamp} map
+    * to {@code TIME_INSTANT} (a full timestamp), not a bare {@code DATE}.
+    */
+   private static final Map<String, String> TYPES = Map.ofEntries(
+      Map.entry("text", XSchema.STRING),
+      Map.entry("number", XSchema.DECIMAL),
+      Map.entry("money", XSchema.DECIMAL),
+      Map.entry("percent", XSchema.DECIMAL),
+      Map.entry("checkbox", XSchema.BOOLEAN),
+      Map.entry("calendar_date", XSchema.TIME_INSTANT),
+      Map.entry("fixed_timestamp", XSchema.TIME_INSTANT),
+      Map.entry("floating_timestamp", XSchema.TIME_INSTANT),
+      Map.entry("point", XSchema.STRING),
+      Map.entry("location", XSchema.STRING),
+      Map.entry("phone", XSchema.STRING),
+      Map.entry("url", XSchema.STRING),
+      Map.entry("email", XSchema.STRING),
+      Map.entry("document", XSchema.STRING),
+      Map.entry("photo", XSchema.STRING),
+      Map.entry("multipolygon", XSchema.STRING),
+      Map.entry("line", XSchema.STRING),
+      Map.entry("multiline", XSchema.STRING),
+      Map.entry("multipoint", XSchema.STRING),
+      Map.entry("polygon", XSchema.STRING),
+      Map.entry("flag", XSchema.STRING),
+      Map.entry("stars", XSchema.STRING),
+      Map.entry("drop_down_list", XSchema.STRING),
+      Map.entry("meta_data", XSchema.STRING));
+
+   /**
+    * Exactly 4 lowercase letters/digits, a hyphen, 4 more -- Socrata's own 4x4 id shape.
+    */
+   private static final Pattern SOCRATA_4X4 = Pattern.compile("[a-z0-9]{4}-[a-z0-9]{4}");
+
+   /**
+    * Confirmed live: {@code limit=10000} against a real, large Socrata site returned every
+    * dataset in one page, HTTP 200.
+    */
+   private static final int DISCOVERY_PAGE_SIZE = 10000;
+
+   /**
+    * A sanity ceiling (up to 500,000 datasets before refusing), not a real-world limit. Hitting it
+    * throws rather than truncating, per {@link TabularCatalogProvider}'s own "no limit and no
+    * paging" contract -- a loud refusal, never a silent partial catalog.
+    */
+   private static final int MAX_DISCOVERY_REQUESTS = 50;
+
+   private static final Logger LOG = LoggerFactory.getLogger(DatagovCatalog.class.getName());
+}

--- a/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovRuntime.java
+++ b/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovRuntime.java
@@ -35,7 +35,19 @@ import java.util.Base64;
  * Runtime implementation for the data.gov data source.
  */
 @SuppressWarnings("unused")
-public class DatagovRuntime extends TabularRuntime {
+public class DatagovRuntime extends TabularRuntime implements TabularCatalogProvider {
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      return DatagovCatalog.listDatasets((DatagovDataSource) dataSource);
+   }
+
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      return DatagovCatalog.describeDataset((DatagovDataSource) dataSource, datasetId);
+   }
+
    @Override
    public XTableNode runQuery(TabularQuery query0, VariableTable params) {
       DatagovQuery query = (DatagovQuery) query0;
@@ -116,6 +128,123 @@ public class DatagovRuntime extends TabularRuntime {
       }
 
       return uri.toString();
+   }
+
+   /**
+    * The Socrata site domain the catalog SPI needs to reach this data source's site -- the
+    * Discovery API ({@code listDatasets}) to enumerate it, the classic Views API
+    * ({@code describeDataset}) to describe one dataset of it -- derived from the existing
+    * {@code URL} property rather than a new one.
+    *
+    * <p>{@code createURL} already treats {@code URL} as a real base {@code URI} (a full address
+    * with a scheme and host, not a bare hostname), whether the operator pointed it at the site's
+    * root or at one specific resource's full path -- either shape shares the same host, so
+    * extracting it works regardless of which convention an already-configured data source used.
+    * This adds a new capability (catalog enumeration/description) without changing {@code URL}'s
+    * existing meaning, so {@code runQuery}/{@code testDataSource} and every already-configured
+    * data source are unaffected.
+    */
+   static String requireSiteDomain(DatagovDataSource ds) throws Exception {
+      String url = ds.getURL();
+
+      if(url == null || url.isBlank()) {
+         throw new Exception("Datagov data source has no URL configured; the Socrata site's " +
+            "domain is needed to reach it.");
+      }
+
+      String host;
+
+      try {
+         host = new URI(url.trim()).getHost();
+      }
+      catch(URISyntaxException e) {
+         throw new Exception("Datagov data source URL '" + url + "' is not a valid URI; cannot " +
+            "determine the Socrata site domain.", e);
+      }
+
+      if(host == null || host.isBlank()) {
+         throw new Exception("Datagov data source URL '" + url + "' has no host component " +
+            "(configure it as a full https://<site>/... address); cannot determine the Socrata " +
+            "site domain.");
+      }
+
+      return host;
+   }
+
+   /**
+    * Reads Socrata's centrally-hosted Discovery API -- a fixed host, unrelated to any one site,
+    * and (confirmed live) anonymous-readable. Deliberately sends NO credentials:
+    * {@code ds.getUser()}/{@code getPassword()} authenticate against the SITE the operator
+    * configured ({@code ds.getURL()}'s host), and {@code api.us.socrata.com} is a different host
+    * entirely -- forwarding site credentials to it would be sending them somewhere the operator
+    * never pointed them at, for a call that does not need them.
+    */
+   static String getDiscoveryMetadata(String url) throws Exception {
+      HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+      conn.setRequestMethod("GET");
+      conn.setRequestProperty("Accept", "application/json");
+      return readMetadataResponse(conn, url);
+   }
+
+   /**
+    * Reads one of the configured site's own classic-API endpoints (used only for
+    * {@code describeDataset}'s {@code rows.json?max_rows=0} call). A SEPARATE method from
+    * {@link #getConnection} rather than a reuse of it: {@code getConnection} is shaped around
+    * {@code runQuery}'s POST-with-no-body semantics ({@code conn.setDoOutput(true)}
+    * unconditionally) and this call must stay GET-only per {@link TabularCatalogProvider}'s "must
+    * not mutate... beyond what a normal connection already does" contract -- a metadata read has no
+    * business ever becoming a write. Applies the SAME Basic-Auth-if-configured behavior
+    * {@link #getConnection} already applies, because this call targets the SAME host
+    * {@code runQuery} targets -- reproducing the existing user/password-vs-App-Token mismatch
+    * faithfully rather than fixing it (a residual gap, not this change's problem to solve).
+    *
+    * @param url the full, already-resolved request URL.
+    */
+   static String getSiteMetadata(DatagovDataSource ds, String url) throws Exception {
+      HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+      conn.setRequestMethod("GET");
+      conn.setRequestProperty("Accept", "application/json");
+      String user = ds.getUser();
+      String password = ds.getPassword();
+
+      if(user != null && password != null) {
+         String credential = Base64.getEncoder().encodeToString(
+            (user + ":" + password).getBytes(StandardCharsets.UTF_8));
+         conn.setRequestProperty("Authorization", "Basic " + credential);
+      }
+
+      return readMetadataResponse(conn, url);
+   }
+
+   /**
+    * A non-2xx response is turned into an exception carrying the status and the server's own
+    * error body, rather than the bare {@code IOException} {@code getInputStream} throws on its
+    * own -- this is what makes {@code listDatasets}/{@code describeDataset} throw rather than
+    * degrade to an empty/fabricated result on a request failure: the failure propagates as an
+    * exception through the whole call chain with no try/catch needed at the catalog layer.
+    */
+   private static String readMetadataResponse(HttpURLConnection conn, String urlString)
+      throws Exception
+   {
+      int status = conn.getResponseCode();
+
+      if(status < 200 || status >= 300) {
+         String body;
+
+         try(InputStream error = conn.getErrorStream()) {
+            body = error == null ? "" : IOUtils.toString(error, StandardCharsets.UTF_8);
+         }
+         catch(Exception ignore) {
+            body = "";
+         }
+
+         throw new Exception("Datagov site answered HTTP " + status + " for " + urlString +
+                             (body.isEmpty() ? "" : ": " + body));
+      }
+
+      try(InputStream input = conn.getInputStream()) {
+         return IOUtils.toString(input, StandardCharsets.UTF_8);
+      }
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(DatagovRuntime.class.getName());

--- a/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovRuntime.java
+++ b/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovRuntime.java
@@ -181,6 +181,8 @@ public class DatagovRuntime extends TabularRuntime implements TabularCatalogProv
     */
    static String getDiscoveryMetadata(String url) throws Exception {
       HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+      conn.setConnectTimeout(CATALOG_HTTP_TIMEOUT);
+      conn.setReadTimeout(CATALOG_HTTP_TIMEOUT);
       conn.setRequestMethod("GET");
       conn.setRequestProperty("Accept", "application/json");
       return readMetadataResponse(conn, url);
@@ -202,6 +204,8 @@ public class DatagovRuntime extends TabularRuntime implements TabularCatalogProv
     */
    static String getSiteMetadata(DatagovDataSource ds, String url) throws Exception {
       HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+      conn.setConnectTimeout(CATALOG_HTTP_TIMEOUT);
+      conn.setReadTimeout(CATALOG_HTTP_TIMEOUT);
       conn.setRequestMethod("GET");
       conn.setRequestProperty("Accept", "application/json");
       String user = ds.getUser();
@@ -246,6 +250,18 @@ public class DatagovRuntime extends TabularRuntime implements TabularCatalogProv
          return IOUtils.toString(input, StandardCharsets.UTF_8);
       }
    }
+
+   /**
+    * Connect/read timeout (ms) for the catalog SPI's two HTTP calls ({@link #getDiscoveryMetadata}/
+    * {@link #getSiteMetadata}) only -- deliberately not applied to {@link #getConnection}/
+    * {@link #testDataSource}'s pre-existing, unrelated {@code runQuery} path. Those two methods are
+    * a new, synchronous call path (invoked from an interactive "annotate this data source" flow),
+    * so an unreachable or slow Socrata site must fail loudly within a bounded time rather than hang
+    * the calling request indefinitely -- exactly the failure mode this session's own live
+    * verification hit once already (a JVM hang against a flaky sandbox proxy connection with no
+    * timeout set anywhere in this class).
+    */
+   private static final int CATALOG_HTTP_TIMEOUT = 30_000;
 
    private static final Logger LOG = LoggerFactory.getLogger(DatagovRuntime.class.getName());
 }

--- a/connectors/inetsoft-datagov/src/test/java/inetsoft/uql/datagov/DatagovCatalogTest.java
+++ b/connectors/inetsoft-datagov/src/test/java/inetsoft/uql/datagov/DatagovCatalogTest.java
@@ -435,7 +435,7 @@ class DatagovCatalogTest {
 
    @ParameterizedTest
    @ValueSource(strings = {
-      "a/b-cdef", "erm2-nwe9/../secret", "erm2 nwe9", "ERM2-NWE9", "erm2-nwe", "erm2-nwe99"
+      "a/b-cdef", "erm2-nwe9/../secret", "erm2 nwe9", "erm2-nwe", "erm2-nwe99"
    })
    void describeDataset_malformedId_rejectedBeforeAnyHttpRequest(String id) {
       // Stubbed to blow up loudly (an Error, not an Exception the code under test could catch) if
@@ -448,6 +448,26 @@ class DatagovCatalogTest {
          () -> DatagovCatalog.describeDataset(ds(), id), "id='" + id + "'");
       assertTrue(thrown.getMessage().contains("not a Socrata 4x4 id"),
          "id='" + id + "': " + thrown.getMessage());
+   }
+
+   // ----- describeDataset: case-insensitive id (review R1, Moderate 1) -----
+
+   @ParameterizedTest
+   @ValueSource(strings = {"ERM2-NWE9", "Erm2-Nwe9"})
+   void describeDataset_uppercaseId_acceptedCaseInsensitively(String id) throws Exception {
+      // listDatasets applies no case filter of its own (only resource.type == "dataset"), so an
+      // uppercase 4x4 id it hands back must not be rejected one call later by describeDataset --
+      // otherwise the connector's own output would be self-inconsistent. The id is embedded into
+      // the request URL exactly as given (not lowercased), which is what the argument captor below
+      // confirms.
+      ArgumentCaptor<String> requested = ArgumentCaptor.forClass(String.class);
+      ensureStatic().when(() -> DatagovRuntime.getSiteMetadata(any(), requested.capture()))
+         .thenReturn(rowsJson(null, null, column(1, "sid", "meta_data")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), id);
+
+      assertEquals(id, schema.datasetId());
+      assertTrue(requested.getValue().contains(id), requested.getValue());
    }
 
    @ParameterizedTest
@@ -514,6 +534,23 @@ class DatagovCatalogTest {
       TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
 
       assertEquals(List.of("sid"), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_quotedNumericRowIdentifierColumnId_stillResolvesKeyColumn()
+      throws Exception
+   {
+      // A Socrata response that sends rowIdentifierColumnId/column id as a quoted JSON string
+      // rather than a bare number -- exercises getLong's JsonString fallback branch (review R1,
+      // Minor 2), not just its NUMBER fast path every other test in this class hits via rowsJson/
+      // column's unquoted-literal helpers.
+      stubSiteMetadata("{\"meta\":{\"view\":{\"rowIdentifierColumnId\":\"2\",\"columns\":[" +
+         "{\"id\":\"1\",\"name\":\"sid\",\"dataTypeName\":\"meta_data\"}," +
+         "{\"id\":\"2\",\"name\":\"Unique Key\",\"dataTypeName\":\"text\"}]}}}");
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(List.of("Unique Key"), schema.keyColumns());
    }
 
    // ----- describeDataset: descriptions passed through verbatim -----

--- a/connectors/inetsoft-datagov/src/test/java/inetsoft/uql/datagov/DatagovCatalogTest.java
+++ b/connectors/inetsoft-datagov/src/test/java/inetsoft/uql/datagov/DatagovCatalogTest.java
@@ -1,0 +1,622 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.datagov;
+
+import com.sun.net.httpserver.HttpServer;
+import inetsoft.test.*;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.XTableNode;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.credential.*;
+import inetsoft.web.wiz.service.TabularQueryContractSupport;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link DatagovCatalog}, driven off {@link DatagovRuntime}'s two extracted static fetch
+ * methods ({@link DatagovRuntime#getDiscoveryMetadata}/{@link DatagovRuntime#getSiteMetadata})
+ * mocked via {@code MockedStatic} -- the same pattern {@code MongoCatalogTest}/
+ * {@code ElasticCatalogTests} use, for the same reason: there is no live Socrata site to exercise
+ * in this environment. Fixtures below reproduce the real, live JSON shapes confirmed while this
+ * connector was designed (Discovery API pages, {@code meta.view} blocks), not hand-invented ones.
+ *
+ * <p>Wire-level correctness of {@code getDiscoveryMetadata}/{@code getSiteMetadata} themselves
+ * (GET-only, correct auth-header behavior) is covered separately by
+ * {@code DatagovMetadataFetchTests}, which cannot be caught here since mocking replaces the method
+ * entirely.
+ *
+ * <p>The Spring context wiring below exists only so {@code new DatagovDataSource()} can construct
+ * (its constructor eagerly creates a credential via {@code CredentialService.getInstance()}); no
+ * test here calls {@code ds.getUser()}/{@code getPassword()} for real, since every fetch call is
+ * mocked away.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, DatagovCatalogTest.TestConfig.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+class DatagovCatalogTest {
+   @AfterAll
+   static void resetContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+   }
+
+   private MockedStatic<DatagovRuntime> runtimeStatic;
+
+   @AfterEach
+   void closeStaticMock() {
+      if(runtimeStatic != null) {
+         runtimeStatic.close();
+      }
+   }
+
+   private MockedStatic<DatagovRuntime> ensureStatic() {
+      if(runtimeStatic == null) {
+         runtimeStatic = mockStatic(DatagovRuntime.class, org.mockito.Mockito.CALLS_REAL_METHODS);
+      }
+
+      return runtimeStatic;
+   }
+
+   private static DatagovDataSource ds() {
+      return ds("https://data.cityofnewyork.us/");
+   }
+
+   private static DatagovDataSource ds(String url) {
+      DatagovDataSource ds = new DatagovDataSource();
+      ds.setURL(url);
+      return ds;
+   }
+
+   private void stubDiscovery(java.util.function.Function<String, String> byUrl) {
+      ensureStatic().when(() -> DatagovRuntime.getDiscoveryMetadata(anyString()))
+         .thenAnswer(inv -> byUrl.apply(inv.getArgument(0)));
+   }
+
+   private void stubDiscoveryThrows(Exception ex) {
+      ensureStatic().when(() -> DatagovRuntime.getDiscoveryMetadata(anyString())).thenThrow(ex);
+   }
+
+   private void stubSiteMetadata(String json) {
+      ensureStatic().when(() -> DatagovRuntime.getSiteMetadata(any(), anyString()))
+         .thenReturn(json);
+   }
+
+   private void stubSiteMetadataThrows(Exception ex) {
+      ensureStatic().when(() -> DatagovRuntime.getSiteMetadata(any(), anyString())).thenThrow(ex);
+   }
+
+   private static String discoveryPage(int resultSetSize, String... datasetEntries) {
+      return "{\"resultSetSize\":" + resultSetSize + ",\"results\":[" +
+         String.join(",", datasetEntries) + "]}";
+   }
+
+   private static String datasetEntry(String id) {
+      return datasetEntry(id, "dataset");
+   }
+
+   private static String datasetEntry(String id, String type) {
+      return "{\"resource\":{\"id\":\"" + id + "\",\"type\":\"" + type + "\",\"name\":\"n\"}}";
+   }
+
+   private static String rowsJson(String description, Long rowIdentifierColumnId,
+                                  String... columns)
+   {
+      StringBuilder sb = new StringBuilder("{\"meta\":{\"view\":{");
+
+      if(description != null) {
+         sb.append("\"description\":\"").append(description).append("\",");
+      }
+
+      if(rowIdentifierColumnId != null) {
+         sb.append("\"rowIdentifierColumnId\":").append(rowIdentifierColumnId).append(",");
+      }
+
+      sb.append("\"columns\":[").append(String.join(",", columns)).append("]}}}");
+      return sb.toString();
+   }
+
+   private static String column(int id, String name, String dataTypeName) {
+      return column(id, name, dataTypeName, null);
+   }
+
+   private static String column(int id, String name, String dataTypeName, String description) {
+      return "{\"id\":" + id + ",\"name\":\"" + name + "\",\"dataTypeName\":\"" + dataTypeName +
+         "\"" + (description != null ? ",\"description\":\"" + description + "\"" : "") + "}";
+   }
+
+   // ----- listDatasets -----
+
+   @Test
+   void listDatasets_returnsOneRefPerDataset() throws Exception {
+      stubDiscovery(url -> discoveryPage(2, datasetEntry("erm2-nwe9"), datasetEntry("8wbx-tsch")));
+
+      TabularCatalog catalog = DatagovCatalog.listDatasets(ds());
+
+      assertEquals(Set.of("erm2-nwe9", "8wbx-tsch"),
+         Set.copyOf(catalog.datasets().stream().map(TabularDatasetRef::id).toList()));
+      assertEquals(List.of(), catalog.relationships(),
+         "the Discovery API is a search index over independently published assets, not a data " +
+         "dictionary");
+   }
+
+   @Test
+   void listDatasets_excludesNonDatasetAssetTypes() throws Exception {
+      stubDiscovery(url -> discoveryPage(2,
+         datasetEntry("erm2-nwe9", "dataset"), datasetEntry("abcd-wxyz", "chart")));
+
+      TabularCatalog catalog = DatagovCatalog.listDatasets(ds());
+
+      assertEquals(List.of("erm2-nwe9"),
+         catalog.datasets().stream().map(TabularDatasetRef::id).toList());
+   }
+
+   @Test
+   void listDatasets_requestsOnlyDatasetsThroughTheServerFilter() throws Exception {
+      ArgumentCaptor<String> urls = ArgumentCaptor.forClass(String.class);
+      ensureStatic().when(() -> DatagovRuntime.getDiscoveryMetadata(urls.capture()))
+         .thenReturn(discoveryPage(1, datasetEntry("erm2-nwe9")));
+
+      DatagovCatalog.listDatasets(ds());
+
+      assertTrue(urls.getValue().contains("only=datasets"), urls.getValue());
+   }
+
+   @Test
+   void listDatasets_fetchesAllPages() throws Exception {
+      // resultSetSize (10001) exceeds one page (10000), so a second request at offset=10000 is
+      // required to finish enumerating -- this replaces a retired "only one page is fetched"
+      // expectation, which under-read TabularCatalogProvider's own "no limit and no paging"
+      // contract.
+      stubDiscovery(url -> url.contains("offset=0")
+         ? discoveryPage(10001, datasetEntry("erm2-nwe9"), datasetEntry("8wbx-tsch"))
+         : discoveryPage(10001, datasetEntry("w7w3-xahh")));
+
+      TabularCatalog catalog = DatagovCatalog.listDatasets(ds());
+
+      assertEquals(Set.of("erm2-nwe9", "8wbx-tsch", "w7w3-xahh"),
+         Set.copyOf(catalog.datasets().stream().map(TabularDatasetRef::id).toList()));
+      runtimeStatic.verify(() -> DatagovRuntime.getDiscoveryMetadata(contains("offset=0")));
+      runtimeStatic.verify(() -> DatagovRuntime.getDiscoveryMetadata(contains("offset=10000")));
+   }
+
+   @Test
+   void listDatasets_exceedsMaxRequests_throws() throws Exception {
+      // resultSetSize never shrinks the remaining gap relative to offset, so pagination would
+      // never terminate on its own -- this must throw rather than truncate silently.
+      int[] calls = {0};
+      stubDiscovery(url -> {
+         calls[0]++;
+         return discoveryPage(Integer.MAX_VALUE, datasetEntry("erm2-nwe9"));
+      });
+
+      Exception thrown = assertThrows(Exception.class, () -> DatagovCatalog.listDatasets(ds()));
+
+      assertTrue(thrown.getMessage().contains("50 requests"), thrown.getMessage());
+      assertEquals(50, calls[0], "must stop AT the safety ceiling, not silently keep going");
+   }
+
+   @Test
+   void listDatasets_fetchFailure_propagates() {
+      stubDiscoveryThrows(new Exception("connection refused"));
+
+      Exception thrown = assertThrows(Exception.class, () -> DatagovCatalog.listDatasets(ds()));
+      assertTrue(thrown.getMessage().contains("connection refused"), thrown.getMessage());
+   }
+
+   @Test
+   void listDatasets_noResultSetSize_throws() {
+      stubDiscovery(url -> "{\"results\":[]}");
+
+      Exception thrown = assertThrows(Exception.class, () -> DatagovCatalog.listDatasets(ds()));
+      assertTrue(thrown.getMessage().contains("resultSetSize"), thrown.getMessage());
+   }
+
+   @Test
+   void listDatasets_noResultsArray_throws() {
+      stubDiscovery(url -> "{\"resultSetSize\":0}");
+
+      Exception thrown = assertThrows(Exception.class, () -> DatagovCatalog.listDatasets(ds()));
+      assertTrue(thrown.getMessage().contains("results array"), thrown.getMessage());
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {
+      "https://data.cityofnewyork.us/",
+      "https://data.cityofnewyork.us/api/views/erm2-nwe9/rows.json",
+      "https://data.cityofnewyork.us:443/some/path"
+   })
+   void listDatasets_derivesDomainFromExistingUrlProperty(String url) throws Exception {
+      ArgumentCaptor<String> requested = ArgumentCaptor.forClass(String.class);
+      ensureStatic().when(() -> DatagovRuntime.getDiscoveryMetadata(requested.capture()))
+         .thenReturn(discoveryPage(1, datasetEntry("erm2-nwe9")));
+
+      DatagovCatalog.listDatasets(ds(url));
+
+      assertTrue(requested.getValue().contains("domains=data.cityofnewyork.us"),
+         "url='" + url + "': " + requested.getValue());
+   }
+
+   // ----- describeDataset: contract-level -----
+
+   @Test
+   void describeDataset_echoesDatasetIdAndMarksColumnsComplete() throws Exception {
+      stubSiteMetadata(rowsJson(null, null, column(1, "sid", "meta_data")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals("erm2-nwe9", schema.datasetId());
+      assertFalse(schema.columnsMayBeIncomplete(),
+         "rows.json?max_rows=0 is declared metadata, not a bounded scan");
+   }
+
+   @Test
+   void describeDataset_noColumns_throws() {
+      stubSiteMetadata(rowsJson(null, null));
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> DatagovCatalog.describeDataset(ds(), "erm2-nwe9"));
+      assertTrue(thrown.getMessage().contains("no columns"), thrown.getMessage());
+   }
+
+   @Test
+   void describeDataset_unknownDataset_throwsNamingTheId() {
+      stubSiteMetadataThrows(new Exception("Datagov site answered HTTP 404 for " +
+         "https://data.cityofnewyork.us/api/views/aaaa-bbbb/rows.json?max_rows=0"));
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> DatagovCatalog.describeDataset(ds(), "aaaa-bbbb"));
+      assertTrue(thrown.getMessage().contains("aaaa-bbbb"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("404"), thrown.getMessage());
+   }
+
+   @Test
+   void describeDataset_columnOrderFollowsMetaViewColumnsArrayOrder() throws Exception {
+      stubSiteMetadata(rowsJson(null, null,
+         column(3, "Third", "text"), column(1, "First", "text"), column(2, "Second", "text")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(List.of("Third", "First", "Second"),
+         schema.columns().stream().map(TabularColumn::name).toList(),
+         "column order must follow the raw JSON array order, not the 'id'/'position' field");
+   }
+
+   @Test
+   void describeDataset_paramsKeyMatchesDatagovQuerysOwnBeanProperty() throws Exception {
+      // Derived, not written out: TabularUtil derives a property name from the getter, so a getter
+      // rename must break this assertion rather than leave a literal here green.
+      stubSiteMetadata(rowsJson(null, null, column(1, "sid", "meta_data")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      Set<String> datagovQueryProperties = TabularUtil.getPropertyMap(DatagovQuery.class).keySet();
+      assertTrue(datagovQueryProperties.containsAll(schema.params().keySet()),
+         schema.params().keySet() + " must all be properties of DatagovQuery, which has " +
+         datagovQueryProperties);
+      assertTrue(schema.params().containsKey("suffix"));
+      // Fully filled -- no empty value.
+      schema.params().forEach((k, v) -> assertFalse(v == null || v.isBlank(),
+         "params['" + k + "'] must not be empty"));
+      assertEquals("/api/views/erm2-nwe9/rows.json", schema.params().get("suffix"));
+   }
+
+   /**
+    * A8's strong round-trip: whatever {@code describeDataset} puts in {@code params} really does
+    * reproduce this dataset's rows via a real (locally-served, not mocked) {@code runQuery} --
+    * modeled on {@code ElasticCatalogTests.paramsRoundTripThroughTheBindingPathAndReturnEveryRow}.
+    * A wrong implementation this catches that the params-shape-only test above cannot: renaming
+    * {@code DatagovQuery.suffix}, or folding an extra query parameter into the emitted suffix --
+    * both would leave every other {@code DatagovCatalogTest} case green while this one fails,
+    * because this is the only test that ever hands the map back to a real {@code DatagovQuery}/
+    * {@code DatagovRuntime.runQuery}.
+    *
+    * <p>Reuses {@code DatagovRuntimeTest}'s own {@code rows.json} fixture for BOTH roles at once:
+    * the mocked {@code meta.view} response {@code describeDataset} reads its declared columns
+    * from, AND the literal HTTP body a local, in-process server (no live network, no Docker --
+    * same {@code com.sun.net.httpserver.HttpServer} approach as {@code DatagovMetadataFetchTests})
+    * answers with when {@code runQuery} requests the exact suffix {@code describeDataset}
+    * declared. One real payload, not two hand-authored ones that could silently drift apart.
+    */
+   @Test
+   void describeDataset_paramsRoundTripThroughApplyQueryContractAndRunQueryReturnsRows()
+      throws Exception
+   {
+      String fixture;
+
+      try(InputStream in = getClass().getResourceAsStream("rows.json")) {
+         fixture = new String(IOUtils.toByteArray(in), StandardCharsets.UTF_8);
+      }
+
+      stubSiteMetadata(fixture);
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+      List<String> declaredColumns = schema.columns().stream().map(TabularColumn::name).toList();
+
+      HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+
+      try {
+         // Exactly the suffix path describeDataset declared -- a suffix pointing anywhere else
+         // (a renamed property, an appended query parameter) 404s here instead of passing.
+         server.createContext("/api/views/erm2-nwe9/rows.json", exchange -> {
+            byte[] body = fixture.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+
+            try(OutputStream out = exchange.getResponseBody()) {
+               out.write(body);
+            }
+         });
+         server.start();
+
+         DatagovDataSource liveDs =
+            ds("http://localhost:" + server.getAddress().getPort() + "/");
+         DatagovQuery query = new DatagovQuery();
+         query.setDataSource(liveDs);
+
+         TabularQueryContractSupport.applyQueryContract(
+            query, TabularUtil.getPropertyMap(query.getClass()),
+            new TabularSchemaExtractor().extract(query, DatagovDataSource.TYPE),
+            new LinkedHashMap<>(schema.params()), "datagov-test");
+
+         assertEquals(schema.params().get("suffix"), query.getSuffix(),
+            "applyQueryContract must write the exact suffix describeDataset declared");
+
+         XTableNode table = new DatagovRuntime().runQuery(query, new VariableTable());
+         assertNotNull(table, "the query built from describeDataset's own params must run");
+
+         List<String> actualColumns = new ArrayList<>();
+
+         for(int i = 0; i < table.getColCount(); i++) {
+            actualColumns.add(table.getName(i));
+         }
+
+         assertEquals(declaredColumns, actualColumns,
+            "the columns describeDataset declared must match what runQuery's DatagovTable, fed " +
+            "the params describeDataset returned, actually parses");
+
+         int rows = 0;
+
+         while(table.next()) {
+            rows++;
+         }
+
+         assertEquals(1094, rows,
+            "the fixture holds 1094 rows and the binding must return them all");
+      }
+      finally {
+         server.stop(0);
+      }
+   }
+
+   // ----- describeDataset: malformed id (A7) -----
+
+   @ParameterizedTest
+   @ValueSource(strings = {
+      "a/b-cdef", "erm2-nwe9/../secret", "erm2 nwe9", "ERM2-NWE9", "erm2-nwe", "erm2-nwe99"
+   })
+   void describeDataset_malformedId_rejectedBeforeAnyHttpRequest(String id) {
+      // Stubbed to blow up loudly (an Error, not an Exception the code under test could catch) if
+      // validation fails to short-circuit before a network call -- proves the rejection happens
+      // BEFORE any request, not merely that some exception was eventually thrown.
+      ensureStatic().when(() -> DatagovRuntime.getSiteMetadata(any(), anyString()))
+         .thenThrow(new AssertionError("must not reach the network for a malformed id: " + id));
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> DatagovCatalog.describeDataset(ds(), id), "id='" + id + "'");
+      assertTrue(thrown.getMessage().contains("not a Socrata 4x4 id"),
+         "id='" + id + "': " + thrown.getMessage());
+   }
+
+   @ParameterizedTest
+   @NullAndEmptySource
+   void describeDataset_blankId_rejectedBeforeAnyHttpRequest(String id) {
+      ensureStatic().when(() -> DatagovRuntime.getSiteMetadata(any(), anyString()))
+         .thenThrow(new AssertionError("must not reach the network for a blank id"));
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> DatagovCatalog.describeDataset(ds(), id));
+      assertTrue(thrown.getMessage().contains("blank"), thrown.getMessage());
+   }
+
+   // ----- describeDataset: blank/null data source URL (review R1, Important 2) -----
+
+   @ParameterizedTest
+   @NullAndEmptySource
+   void describeDataset_blankUrl_throwsNamedError(String url) {
+      // Same precondition listDatasets already guards via requireSiteDomain -- an in-progress
+      // data source (URL never configured) must fail with a message naming the data source and
+      // what's missing, not a bare NullPointerException out of ds.getURL().trim(). Stubbed to
+      // blow up loudly if validation fails to short-circuit before a network call, exactly as
+      // describeDataset_malformedId_rejectedBeforeAnyHttpRequest does for a bad id.
+      ensureStatic().when(() -> DatagovRuntime.getSiteMetadata(any(), anyString()))
+         .thenThrow(new AssertionError("must not reach the network with no URL configured"));
+      DatagovDataSource blankUrlDs = new DatagovDataSource();
+      blankUrlDs.setURL(url);
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> DatagovCatalog.describeDataset(blankUrlDs, "erm2-nwe9"));
+      assertTrue(thrown.getMessage().contains("no URL configured"), thrown.getMessage());
+      assertFalse(thrown instanceof NullPointerException, thrown.getClass().getName());
+   }
+
+   // ----- describeDataset: row-identifier resolution -----
+
+   @Test
+   void describeDataset_rowIdentifierNamesABusinessColumn_reportedAsKeyColumn() throws Exception {
+      stubSiteMetadata(rowsJson(null, 2L,
+         column(1, "sid", "meta_data"), column(2, "Unique Key", "text")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(List.of("Unique Key"), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_noRowIdentifier_keyColumnsEmpty() throws Exception {
+      stubSiteMetadata(rowsJson(null, null,
+         column(1, "sid", "meta_data"), column(2, "Unique Key", "text")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(List.of(), schema.keyColumns());
+   }
+
+   @Test
+   void describeDataset_rowIdentifierNamesTheSystemColumn_stillFaithfullyReported()
+      throws Exception
+   {
+      stubSiteMetadata(rowsJson(null, 1L,
+         column(1, "sid", "meta_data"), column(2, "Unique Key", "text")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(List.of("sid"), schema.keyColumns());
+   }
+
+   // ----- describeDataset: descriptions passed through verbatim -----
+
+   @Test
+   void describeDataset_descriptionsAreTrimmedAndCarriedVerbatim() throws Exception {
+      stubSiteMetadata(rowsJson("NYC 311 service requests.\\n", null,
+         column(1, "Unique Key", "text",
+                "Unique identifier of a Service Request (SR) in the open data set\\n")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertTrue(schema.description().startsWith("NYC 311 service requests."),
+         schema.description());
+      assertEquals("Unique identifier of a Service Request (SR) in the open data set",
+         schema.columns().get(0).description());
+   }
+
+   @Test
+   void describeDataset_blankDescriptions_reportedAsNullNotEmptyString() throws Exception {
+      stubSiteMetadata(rowsJson(null, null, column(1, "sid", "meta_data")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertNull(schema.columns().get(0).description());
+   }
+
+   // ----- describeDataset: dataTypeName -> XSchema mapping (A4) -----
+
+   @ParameterizedTest(name = "{0} -> {1}")
+   @MethodSource("dataTypeMappings")
+   void describeDataset_mapsDataTypeNameToXSchema(String dataTypeName, String expectedXSchema)
+      throws Exception
+   {
+      stubSiteMetadata(rowsJson(null, null, column(1, "col", dataTypeName)));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(expectedXSchema, schema.columns().get(0).type(),
+         "dataTypeName '" + dataTypeName + "'");
+   }
+
+   static Stream<Arguments> dataTypeMappings() {
+      return Stream.of(
+         Arguments.of("text", XSchema.STRING),
+         Arguments.of("number", XSchema.DECIMAL),
+         Arguments.of("money", XSchema.DECIMAL),
+         Arguments.of("percent", XSchema.DECIMAL),
+         Arguments.of("checkbox", XSchema.BOOLEAN),
+         Arguments.of("calendar_date", XSchema.TIME_INSTANT),
+         Arguments.of("fixed_timestamp", XSchema.TIME_INSTANT),
+         Arguments.of("floating_timestamp", XSchema.TIME_INSTANT),
+         Arguments.of("point", XSchema.STRING),
+         Arguments.of("location", XSchema.STRING),
+         Arguments.of("phone", XSchema.STRING),
+         Arguments.of("url", XSchema.STRING),
+         Arguments.of("email", XSchema.STRING),
+         Arguments.of("document", XSchema.STRING),
+         Arguments.of("photo", XSchema.STRING),
+         Arguments.of("multipolygon", XSchema.STRING),
+         Arguments.of("line", XSchema.STRING),
+         Arguments.of("multiline", XSchema.STRING),
+         Arguments.of("multipoint", XSchema.STRING),
+         Arguments.of("polygon", XSchema.STRING),
+         Arguments.of("flag", XSchema.STRING),
+         Arguments.of("stars", XSchema.STRING),
+         Arguments.of("drop_down_list", XSchema.STRING),
+         Arguments.of("meta_data", XSchema.STRING));
+   }
+
+   @Test
+   void describeDataset_unrecognizedDataTypeName_reportedAsStringAndFlaggedInDescription()
+      throws Exception
+   {
+      stubSiteMetadata(rowsJson(null, null, column(1, "futureField", "some_brand_new_type")));
+
+      TabularDatasetSchema schema = DatagovCatalog.describeDataset(ds(), "erm2-nwe9");
+
+      assertEquals(XSchema.STRING, schema.columns().get(0).type());
+      assertTrue(schema.description().contains("futureField") &&
+                 schema.description().contains("some_brand_new_type"),
+         schema.description());
+   }
+
+   @Configuration
+   static class TestConfig {
+      @Bean
+      public CredentialService credentialService() {
+         CredentialService credentialService = mock(CredentialService.class);
+         when(credentialService.createCredential(CredentialType.PASSWORD))
+            .thenReturn(mock(LocalPasswordCredential.class));
+         when(credentialService.createCredential(CredentialType.PASSWORD, false))
+            .thenReturn(mock(LocalPasswordCredential.class));
+         return credentialService;
+      }
+
+      // TabularSchemaExtractor (the round-trip test's applyQueryContract path) reaches Config for
+      // a display-label resource bundle via LayoutCreator.createLayout -- a mock returns null for
+      // it, which is the branch that leaves the label alone. Same reasoning as
+      // ElasticCatalogTests.loadData's identical stub.
+      @Bean
+      public inetsoft.uql.util.Config config() {
+         return mock(inetsoft.uql.util.Config.class);
+      }
+   }
+}

--- a/connectors/inetsoft-datagov/src/test/java/inetsoft/uql/datagov/DatagovMetadataFetchTests.java
+++ b/connectors/inetsoft-datagov/src/test/java/inetsoft/uql/datagov/DatagovMetadataFetchTests.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.datagov;
+
+import com.sun.net.httpserver.HttpServer;
+import inetsoft.test.*;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.util.credential.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Wire-level coverage for {@link DatagovRuntime#getDiscoveryMetadata}/
+ * {@link DatagovRuntime#getSiteMetadata}, against a real local loopback HTTP server rather than a
+ * mock -- mocking those two methods (as {@code DatagovCatalogTest} does to isolate
+ * {@link DatagovCatalog}'s own logic) cannot catch a bug IN them, such as an accidental
+ * {@code setDoOutput(true)} or a missing/wrong {@code Authorization} header, because mocking
+ * replaces the method entirely. Mirrors the reasoning behind
+ * {@code ElasticCatalogTests.metadataEndpointsAreReadWithGet}, using
+ * {@code com.sun.net.httpserver.HttpServer} instead of testcontainers since there is no equivalent
+ * "spin up a real Socrata site" option available in this environment.
+ *
+ * <p>{@code getDiscoveryMetadata} targets Socrata's centrally-hosted Discovery API
+ * ({@code api.us.socrata.com}), a different host than whatever a data source's own {@code user}/
+ * {@code password} authenticate against, so it must never send credentials -- configured or not.
+ * {@code getSiteMetadata} targets the SAME host {@code runQuery} does, so it applies the same
+ * Basic-Auth-if-configured behavior {@code DatagovRuntime.getConnection} already applies.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, DatagovMetadataFetchTests.TestConfig.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+class DatagovMetadataFetchTests {
+   private HttpServer server;
+   private String baseUrl;
+   private volatile String capturedMethod;
+   private volatile String capturedAuthHeader;
+   private volatile boolean capturedHadBody;
+
+   @BeforeEach
+   void startServer() throws IOException {
+      server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+      server.createContext("/", exchange -> {
+         capturedMethod = exchange.getRequestMethod();
+         capturedAuthHeader = exchange.getRequestHeaders().getFirst("Authorization");
+         capturedHadBody = exchange.getRequestBody().read() != -1;
+
+         byte[] response = "{}".getBytes(StandardCharsets.UTF_8);
+         exchange.getResponseHeaders().add("Content-Type", "application/json");
+         exchange.sendResponseHeaders(200, response.length);
+
+         try(OutputStream out = exchange.getResponseBody()) {
+            out.write(response);
+         }
+      });
+      server.start();
+      baseUrl = "http://localhost:" + server.getAddress().getPort();
+   }
+
+   @AfterEach
+   void stopServer() {
+      server.stop(0);
+   }
+
+   @AfterAll
+   static void resetContext() {
+      ConfigurationContext.getContext().setApplicationContext(null);
+   }
+
+   @Test
+   void discoveryApiNeverSendsCredentials_evenWhenConfigured() throws Exception {
+      DatagovDataSource ds = new DatagovDataSource();
+      ds.setUser("someuser");
+      ds.setPassword("somepass");
+
+      // getDiscoveryMetadata takes no data source at all -- it cannot send ds's credentials even
+      // if it wanted to. This test exists to pin that shape as deliberate, not to prove a
+      // parameter is unused.
+      DatagovRuntime.getDiscoveryMetadata(baseUrl + "/api/catalog/v1?domains=data.example.us");
+
+      assertEquals("GET", capturedMethod);
+      assertNull(capturedAuthHeader, "the Discovery API is a different host than the site the " +
+         "operator's credentials authenticate against, so it must never receive them");
+      assertFalse(capturedHadBody, "a metadata read must never write a request body");
+   }
+
+   @Test
+   void discoveryApiNeverSendsCredentials_whenNoneConfigured() throws Exception {
+      DatagovRuntime.getDiscoveryMetadata(baseUrl + "/api/catalog/v1?domains=data.example.us");
+
+      assertEquals("GET", capturedMethod);
+      assertNull(capturedAuthHeader);
+      assertFalse(capturedHadBody);
+   }
+
+   @Test
+   void siteMetadataSendsBasicAuthWhenConfigured() throws Exception {
+      DatagovDataSource ds = new DatagovDataSource();
+      ds.setUser("someuser");
+      ds.setPassword("somepass");
+
+      DatagovRuntime.getSiteMetadata(ds, baseUrl + "/api/views/erm2-nwe9/rows.json?max_rows=0");
+
+      assertEquals("GET", capturedMethod);
+      assertFalse(capturedHadBody, "a metadata read must never write a request body");
+      String expected = "Basic " + Base64.getEncoder()
+         .encodeToString("someuser:somepass".getBytes(StandardCharsets.UTF_8));
+      assertEquals(expected, capturedAuthHeader);
+   }
+
+   @Test
+   void siteMetadataSendsNoAuthWhenNotConfigured() throws Exception {
+      DatagovDataSource ds = new DatagovDataSource();
+
+      DatagovRuntime.getSiteMetadata(ds, baseUrl + "/api/views/erm2-nwe9/rows.json?max_rows=0");
+
+      assertEquals("GET", capturedMethod);
+      assertNull(capturedAuthHeader);
+      assertFalse(capturedHadBody);
+   }
+
+   @Configuration
+   static class TestConfig {
+      @Bean
+      public CredentialService credentialService() {
+         CredentialService credentialService = mock(CredentialService.class);
+         // A real LocalPasswordCredential, not a Mockito mock: this suite needs setUser/
+         // setPassword/getUser/getPassword to actually hold state so the Basic-Auth assertions
+         // above are checking real credential values, not a mock's default nulls. A fresh
+         // instance per call keeps each DatagovDataSource's credential independent.
+         when(credentialService.createCredential(CredentialType.PASSWORD))
+            .thenAnswer(invocation -> new LocalPasswordCredential());
+         when(credentialService.createCredential(CredentialType.PASSWORD, false))
+            .thenAnswer(invocation -> new LocalPasswordCredential());
+         when(credentialService.createCredential(CredentialType.PASSWORD, true))
+            .thenAnswer(invocation -> new LocalPasswordCredential());
+         return credentialService;
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- `DatagovRuntime` now implements `TabularCatalogProvider`. The connector's own runtime protocol turns out to be Socrata's classic Views API ("SODA"), not CKAN, despite the connector's name — confirmed by reading `DatagovTable`'s actual JSON parsing (`meta.view.columns`) and by live HTTP calls against real public Socrata sites, before any design was written.
- `listDatasets` enumerates via Socrata's centrally-hosted Discovery API (`api.us.socrata.com/api/catalog/v1?domains=<site>`), fully paginated (capped at a safety ceiling that throws rather than silently truncating), filtered to dataset-typed results. The site domain is derived from the data source's existing `URL` property (its host component) — no new property, zero compatibility impact on already-configured data sources.
- `describeDataset` reads the classic `GET /api/views/{id}/rows.json?max_rows=0` endpoint: fully declarative metadata, no sampling, so `columnsMayBeIncomplete` is `false`. The row identifier column is resolved from Socrata's own `rowIdentifierColumnId`, never a hardcoded name.
- A Socrata 4x4 dataset id is validated before it ever reaches a request URL — `TabularCatalogService.describeTable` passes a caller-supplied target straight through with no guarantee it came from `listDatasets`.
- Kept as an independent `TabularQuery`/`TabularDataSource` (like Elasticsearch), not folded into the `EndpointJsonQuery`/ENDPOINT_CATALOG family — Socrata's catalog surface is a handful of fixed system operations, not a large curated set of business endpoints.

## Verification
Verified against real public Socrata domains (`data.cityofnewyork.us`, `data.cityofchicago.org`, `data.sfgov.org`) in addition to the mocked/loopback-server unit suite: the Discovery API, declarative column metadata (56/31/28 columns across three real datasets), the real HTTP 404 shape for an unknown id, and the exact wire shape `runQuery` depends on (positional `data` arrays aligned to `meta.view.columns`) — all confirmed live via direct HTTP.

Two review rounds:
- Round 1 found a missing `params` round-trip test (production behavior was correct, but nothing exercised `applyQueryContract` → `runQuery` end to end) and a raw `NullPointerException` in `describeDataset` on a blank/null `URL` (inconsistent with `listDatasets`'s own guard).
- Round 2 mutation-tested both fixes — actually reverted each fix, confirmed the corresponding test goes red, then restored — rather than trusting the fix's own description. Converged with no blockers or importants outstanding; one cosmetic nit recorded (a test's own javadoc slightly overclaims which mutation it alone catches — the suite as a whole still catches it via a different, pre-existing test).

66 tests pass, `BUILD SUCCESS` (`./mvnw -pl connectors/inetsoft-datagov -am test`), independently re-run and confirmed clean at three separate points in the process, not just trusted from a single log.

## Test plan
- [x] `DatagovCatalogTest` — unit tests against extracted static fetch methods (`MockedStatic`, same pattern as `MongoCatalogTest`/`ElasticCatalogTests`): pagination (single- and multi-page, plus a safety-ceiling throw), dataset-type filtering, per-`dataTypeName` → `XSchema` mapping, unrecognized-type degradation, malformed/blank dataset-id rejection before any network call, blank/null `URL` rejection before any network call, `params` derivation via `TabularUtil.getPropertyMap`, and a full `applyQueryContract` → `runQuery` round trip against a local loopback server.
- [x] `DatagovMetadataFetchTests` — local loopback `HttpServer` tests confirming both new fetch methods are GET-only with no request body, and that Discovery-API calls never send credentials while site calls send Basic Auth only when configured (matching `runQuery`'s existing behavior).
- [x] `DatagovRuntimeTest` (pre-existing) — unmodified, still passes, confirming no regression to existing `runQuery`/`testDataSource` behavior.
- [x] Live verification against three real public Socrata domains (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)