### PR TITLE
Guard VSTreeHandler.getTableTreeModel() against a missing/disposed assembly

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/handler/VSTreeHandler.java
+++ b/core/src/main/java/inetsoft/web/binding/handler/VSTreeHandler.java
@@ -232,6 +232,12 @@ public class VSTreeHandler {
       String aname = cinfo.getAbsoluteName();
       VSAssembly cass = vs0 == null ? null : (VSAssembly) vs0.getAssembly(aname);
 
+      // viewsheet may have been disposed/reset concurrently (e.g. user interacts with the
+      // binding tree before a heavy operation finishes), so cass can be null here.
+      if(cass == null) {
+         return null;
+      }
+
       SourceInfo sinfo = cinfo.getSourceInfo();
       String prefix = null;
       String source = null;

--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingTreeService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingTreeService.java
@@ -90,7 +90,7 @@ public class VSBindingTreeService {
                assetTreeModel = treeHandler.getTableTreeModel(
                   engine.getAssetRepository(), rvs, (TableDataVSAssemblyInfo) info, principal);
 
-               if(appendComponentTree) {
+               if(assetTreeModel != null && appendComponentTree) {
                   treeHandler.appendVSAssemblyTree(rvs, assetTreeModel, principal, assembly);
                }
             }

--- a/core/src/test/java/inetsoft/web/binding/handler/VSTreeHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/binding/handler/VSTreeHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.binding.handler;
+
+import inetsoft.report.composition.AssetTreeModel;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.TableDataVSAssemblyInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class VSTreeHandlerTest {
+   @Mock VSChartHandler chartHandler;
+   @Mock SecurityEngine securityEngine;
+   @Mock AssetRepository engine;
+   @Mock RuntimeViewsheet rvs;
+   @Mock Viewsheet viewsheet;
+   @Mock TableDataVSAssemblyInfo cinfo;
+   @Mock Principal principal;
+
+   private VSTreeHandler handler;
+
+   @BeforeEach
+   public void setUp() {
+      handler = new VSTreeHandler(chartHandler, securityEngine);
+   }
+
+   /**
+    * getChartTreeModel() already guards against a concurrently-disposed/reset viewsheet or a
+    * concurrently-removed assembly (see its own null checks and comment). getTableTreeModel()
+    * previously had no equivalent guard and threw an unguarded NPE at
+    * {@code cass.getViewsheet()} whenever the named assembly could not be resolved -- a defect
+    * found while investigating Bug #76488/#76485 (see docs/teams/2026-09-07-bug-76488-76485/).
+    * This does not confirm those two bugs' root cause (no reproduction was ever achieved), but
+    * the missing guard itself is real and independently worth closing.
+    */
+   @Test
+   public void getTableTreeModel_returnsNull_whenAssemblyCannotBeResolved() throws Exception {
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(cinfo.getAbsoluteName()).thenReturn("Crosstab1");
+      when(viewsheet.getAssembly("Crosstab1")).thenReturn(null);
+
+      AssetTreeModel result = handler.getTableTreeModel(engine, rvs, cinfo, principal);
+
+      assertNull(result);
+   }
+
+   @Test
+   public void getTableTreeModel_returnsNull_whenRuntimeViewsheetHasNoViewsheet() throws Exception {
+      when(rvs.getViewsheet()).thenReturn(null);
+      when(cinfo.getAbsoluteName()).thenReturn("Crosstab1");
+
+      AssetTreeModel result = handler.getTableTreeModel(engine, rvs, cinfo, principal);
+
+      assertNull(result);
+   }
+}


### PR DESCRIPTION
## Summary

Defensive hardening fix, **not a fix for a specific reported bug**.

`VSTreeHandler.getTableTreeModel()` resolved the crosstab/calc-table assembly by name and then dereferenced it unconditionally. Its sibling `getChartTreeModel()` already guards against this exact scenario (a concurrently disposed/reset viewsheet, or a concurrently missing assembly) with an explicit comment explaining why. `getTableTreeModel()` had no equivalent guard, so a missing assembly produced an uncaught `NullPointerException` — silent to the user, since the STOMP command chain that calls this (`VSBindingTreeController → VSBindingTreeControllerService → VSBindingTreeService → VSTreeHandler`) has no exception handling anywhere above it.

This closes that gap:
- Adds the missing null guard to `getTableTreeModel()`, mirroring `getChartTreeModel()`'s existing pattern.
- Fixes the one caller (`VSBindingTreeService.getBinding()`) that called into `appendVSAssemblyTree()` unconditionally afterward — that method itself unconditionally dereferences the tree model, so a bare null-return guard alone would just relocate the NPE one frame down for this specific call site. The chart branch already had this null-check; the table branch didn't.

## Background

Found while investigating Redmine Bug #76488 and Bug #76485 via `/deep-debug-workflow` (three parallel investigators, plus lead follow-up — see `docs/teams/2026-09-07-bug-76488-76485/` in the enterprise repo for the full write-up). Despite a thorough investigation, **no reproduction of either bug was achieved**, and no confirmed trigger for this specific null case was found in either bug's exact repro shape (a plain, non-embedded-viewsheet crosstab). This PR closes a real, independently-verifiable gap on its own merits — it should **not** be read as resolving either reported bug, and neither bug's Redmine status should change based on this PR alone.

## Test plan

- [x] Added `VSTreeHandlerTest` with two cases (missing assembly, disposed runtime viewsheet) — both pass with the fix.
- [x] Confirmed both new tests are load-bearing: stashed the fix (keeping the tests), re-ran — both failed with the exact NPE this PR closes (`NullPointerException ... "cass" is null ... at VSTreeHandler.java:244`), confirming the tests aren't tautological.
- [x] Traced the one call site of `getTableTreeModel()` (`VSBindingTreeService.getBinding()`) and fixed the accompanying missing null-check there too, so the fix doesn't just relocate the NPE.
- [x] `./mvnw -pl core test -Dtest=VSTreeHandlerTest` — 2/2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)