### PR TITLE
Fix VBM-005: colliding first save out of TEMPORARY_SCOPE skips connected-viewsheet reset

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1129,6 +1129,8 @@ public class WorksheetAgentController {
       List<String> affectedViewsheets = isSaveAs
          ? connectedViewsheetIds(connectedViewsheets(oldEntry, user)) : List.of();
 
+      boolean isDuplicatedEntry = false;
+
       if(name != null && !name.isEmpty()) {
          IdentityID uname = IdentityID.getIdentityIDFromKey(user.getName());
          int assetScope = "user".equalsIgnoreCase(body.scope())
@@ -1143,9 +1145,10 @@ public class WorksheetAgentController {
          // called the equivalent check, so a second save_worksheet({name:"X"}) silently
          // overwrote whatever "X" already held with no signal anything collided.
          try {
-            if(worksheetService.isDuplicatedEntry(worksheetService.getAssetRepository(), entry)
-               && !Boolean.TRUE.equals(body.confirmed()))
-            {
+            isDuplicatedEntry =
+               worksheetService.isDuplicatedEntry(worksheetService.getAssetRepository(), entry);
+
+            if(isDuplicatedEntry && !Boolean.TRUE.equals(body.confirmed())) {
                throw new PairingException(
                   "'" + name + "' already exists. Pass confirmed:true to overwrite it, or " +
                   "choose a different name.");
@@ -1179,10 +1182,13 @@ public class WorksheetAgentController {
       result.put("ok", true);
 
       // Only applies to a plain save-in-place: a Save-As writes under a brand-new entry no
-      // viewsheet points at yet (see the PVA-003 warning above for that case), and a first save
-      // out of TEMPORARY_SCOPE is likewise a brand-new entry nothing could have been pointing at
-      // before.
-      if(!isSaveAs && !wasTemporary) {
+      // viewsheet points at yet (see the PVA-003 warning above for that case). A first save out
+      // of TEMPORARY_SCOPE is usually a brand-new entry nothing could have been pointing at
+      // before too -- EXCEPT when its target name collides with (and, via confirmed:true,
+      // overwrites) an asset that is already a connected viewsheet's base entry (bug VBM-005):
+      // isDuplicatedEntry is exactly that collision signal, already computed above. Still skip
+      // the scan for a genuinely new name (isDuplicatedEntry stays false, cheaply).
+      if(!isSaveAs && (!wasTemporary || isDuplicatedEntry)) {
          // Bug PVA-011: the Composer UI's own Save button runs a "Dependencies Changed" cascade
          // after every in-place save (SaveWorksheetService.saveWorksheet(), lines 84-90) that
          // rewrites any already-saved dependent asset's (e.g. a viewsheet's) stored binding to

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -4276,6 +4276,67 @@ class WorksheetAgentControllerTest {
       verify(ws, never()).getRuntimeSheets(any());
    }
 
+   /**
+    * Regression for Bug VBM-005: a first save out of TEMPORARY_SCOPE whose target name COLLIDES
+    * with (and, via {@code confirmed:true}, overwrites) an asset that is already a connected
+    * viewsheet's base entry must still reset that viewsheet's runtime -- the sibling test above
+    * ({@code firstSaveOutOfTemporaryScopeDoesNotCheckForConnectedViewsheets}) only covers a
+    * genuinely new, non-colliding name, where skipping the scan is correct and intentional.
+    *
+    * <p>Before this fix, {@code save()}'s {@code if(!isSaveAs && !wasTemporary)} gate skipped the
+    * {@code connectedViewsheets(entry, user).resetRuntime()} scan unconditionally whenever
+    * {@code wasTemporary} was true, regardless of whether the target name collided with an
+    * already-connected viewsheet's base worksheet -- leaving that viewsheet silently serving stale
+    * data forever, with {@code ok:true} on every step and no warning anywhere. The fix makes the
+    * {@code wasTemporary} half of the gate collision-aware via the already-computed
+    * {@code isDuplicatedEntry} check.
+    */
+   @Test
+   void firstSaveOutOfTemporaryScopeResetsConnectedViewsheetOnCollision() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      AssetEntry tempEntry = new AssetEntry(AssetRepository.TEMPORARY_SCOPE,
+         AssetEntry.Type.WORKSHEET, "__TEMPORARY__/ws-2", null);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getEntry()).thenReturn(tempEntry);
+      when(rws.getWorksheet()).thenReturn(new Worksheet());
+      when(rws.getCurrent()).thenReturn(0);
+
+      WorksheetEditService edit = mock(WorksheetEditService.class);
+      when(edit.resolveWithSession(eq("TOK-SAVE3-COLLIDE"), eq(agent)))
+         .thenReturn(new WorksheetEditService.ResolvedSession(rws, "rt-ws-3-collide"));
+
+      // The target entry this save writes to -- already the base entry of a connected viewsheet.
+      AssetEntry targetEntry = new AssetEntry(AssetRepository.GLOBAL_SCOPE,
+         AssetEntry.Type.WORKSHEET, "Orders WS", null);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseEntry()).thenReturn(targetEntry);
+      RuntimeViewsheet connectedRvs = mock(RuntimeViewsheet.class);
+      when(connectedRvs.getViewsheet()).thenReturn(vs);
+      when(connectedRvs.getUser()).thenReturn(agent);
+
+      WorksheetService ws = mock(WorksheetService.class);
+      when(ws.getRuntimeSheets(any())).thenReturn(new RuntimeSheet[]{ connectedRvs });
+      when(ws.isDuplicatedEntry(any(), any())).thenReturn(true);
+
+      WorksheetAgentController ctrl = controller(featureOn(), mock(SheetJoinService.class),
+         mock(SheetSessionService.class), mock(WorksheetReadService.class), edit, ws);
+
+      Map<String, Object> result;
+
+      try(MockedStatic<DependencyTool> dependencyTool = mockStatic(DependencyTool.class)) {
+         dependencyTool.when(() -> DependencyTool.getDependencies(anyString())).thenReturn(List.of());
+
+         result = ctrl.save("TOK-SAVE3-COLLIDE",
+            new WorksheetAgentController.SaveRequest("Orders WS", null, true), agent);
+      }
+
+      assertEquals(Boolean.TRUE, result.get("ok"));
+      verify(connectedRvs).resetRuntime();
+   }
+
    // ---------------------------------------------------------------------------
    // save -- L2-Group10: duplicate-name/overwrite confirmation, control-char sanitization
    // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bug VBM-005 (#76482): a `create_worksheet()`-derived session is always `TEMPORARY_SCOPE` at the time of its first save. `WorksheetAgentController.save()`'s `if(!isSaveAs && !wasTemporary)` gate skipped the `connectedViewsheets(entry, user).resetRuntime()` scan unconditionally on `wasTemporary=true` — even when that save's target name collides with (and, via `confirmed:true`, overwrites) an asset that is already a connected viewsheet's base entry. The connected viewsheet then silently serves stale data forever, with `ok:true` on every step and no warning anywhere.
- Fix: reuse the already-computed `isDuplicatedEntry` check to make the `wasTemporary` half of the gate collision-aware. A genuinely new name still skips the scan (cheap, no-op); a colliding name now runs it, exactly like the existing plain-in-place-save case does.
- Scoped to `wasTemporary` only, per this bug's diagnosis/refute — `isSaveAs` (Save-As) is left untouched; its analogous gap is a documented, intentional non-reset today (paired with the `affectedViewsheets` warning) and is tracked as a separate issue.

## Test plan
- [x] Added `firstSaveOutOfTemporaryScopeResetsConnectedViewsheetOnCollision` — a `TEMPORARY_SCOPE` first save whose target name collides with an existing, connected viewsheet's base entry now triggers `resetRuntime()`.
- [x] Existing `firstSaveOutOfTemporaryScopeDoesNotCheckForConnectedViewsheets` (non-colliding case) needed no change and still passes unmodified.
- [x] `./mvnw -pl core -am test -Dtest=WorksheetAgentControllerTest` — 133 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)