### PR TITLE
fix(wiz-worksheet): surface timeSeries flag in read_worksheet_model groups (WBS-024, #76502)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -755,7 +755,7 @@ public class WorksheetReadService {
          String field =
             base instanceof ColumnRef cr && cr.getDataRef() instanceof DateRangeRef dr
                ? dr.getDataRef().getName() : gr.getName();
-         groups.add(new WorksheetModel.AggregateModel.GroupModel(field, dateLevel));
+         groups.add(new WorksheetModel.AggregateModel.GroupModel(field, dateLevel, gr.isTimeSeries()));
       }
 
       // Aggregates (primary + secondary)

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -228,14 +228,17 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
       /**
        * A single group-by dimension.
        *
-       * @param field     source column name
-       * @param dateLevel the date grouping level applied directly to this group (e.g.
-       *                  {@code "QUARTER"}), same vocabulary as set_group_aggregate's
-       *                  {@code dateLevel} / add_date_range_column's {@code dateOption};
-       *                  {@code null} for a plain (non-date-bucketed) group
+       * @param field      source column name
+       * @param dateLevel  the date grouping level applied directly to this group (e.g.
+       *                   {@code "QUARTER"}), same vocabulary as set_group_aggregate's
+       *                   {@code dateLevel} / add_date_range_column's {@code dateOption};
+       *                   {@code null} for a plain (non-date-bucketed) group
+       * @param timeSeries whether this group is treated as a time series (fills gaps in the
+       *                   date range with empty rows), same as set_group_aggregate's
+       *                   {@code timeSeries} flag on this group
        */
       @JsonInclude(JsonInclude.Include.NON_NULL)
-      public record GroupModel(String field, String dateLevel) {}
+      public record GroupModel(String field, String dateLevel, boolean timeSeries) {}
 
       /**
        * A single aggregate measure.

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -96,6 +96,33 @@ class WorksheetReadServiceTest {
       WorksheetModel.AggregateModel.GroupModel group = m.tables().get(0).aggregates().groups().get(0);
       assertEquals("orderDate", group.field());
       assertEquals("QUARTER", group.dateLevel());
+      assertFalse(group.timeSeries());
+   }
+
+   // Bug #76502 WBS-024: set_group_aggregate's timeSeries flag is genuinely applied to the
+   // GroupRef on write (WorksheetMutationSupport#applyAggregateInfo calls gr.setTimeSeries(true))
+   // but readAggregates never called gr.isTimeSeries() and GroupModel had no slot to carry it,
+   // so a caller could never tell the flag was set (or confirm it wasn't) from the read model.
+   @Test
+   void readsTimeSeriesFlagOnDateGroupedColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ((ColumnRef) t.getColumnSelection(false).getAttribute("orderDate"))
+         .setDataType(inetsoft.uql.schema.XSchema.DATE);
+      ws.addAssembly(t);
+
+      WorksheetMutationSupport.applyAggregateInfo(t,
+         List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER", true)),
+         List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetModel m = new WorksheetReadService().read(rws);
+      WorksheetModel.AggregateModel.GroupModel group = m.tables().get(0).aggregates().groups().get(0);
+      assertEquals("orderDate", group.field());
+      assertEquals("QUARTER", group.dateLevel());
+      assertTrue(group.timeSeries());
    }
 
    /**


### PR DESCRIPTION
## Summary
- `read_worksheet_model`'s `aggregates.groups[]` never reported whether `set_group_aggregate`'s `timeSeries` flag was applied to a group, even though the write path (`WorksheetMutationSupport#applyAggregateInfo`) already sets it unconditionally on the `GroupRef`.
- Root cause: `WorksheetReadService.readAggregates` never called `GroupRef.isTimeSeries()`, and `WorksheetModel.AggregateModel.GroupModel` had no field to carry it.
- Fix: add a `timeSeries` component to `GroupModel` and populate it from `gr.isTimeSeries()` at the (single, grep-confirmed) construction site in `readAggregates`.

## Test plan
- [x] Extended `WorksheetReadServiceTest.readsDateGroupLevelOnGroupedColumn` with a `timeSeries()` assertion (false/default case)
- [x] Added `WorksheetReadServiceTest.readsTimeSeriesFlagOnDateGroupedColumn`, round-tripping through the real `WorksheetMutationSupport.applyAggregateInfo` mutator with `timeSeries: true`, asserting `group.timeSeries()` is `true`
- [x] `./mvnw test -pl core -Dtest=WorksheetReadServiceTest` -- 41/41 pass

Refs Redmine #76502, WBS-024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)