### PR TITLE
fix(wiz): add community-native schedule-task admin-plugin support

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/AdminScheduleController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/AdminScheduleController.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.ScheduleTaskList;
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ApplyResult;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * REST controller for the schedule-task admin-plugin area (spec §10). Same {@code
+ * requireSiteAdmin}/{@code AdminAiCallerGuard} shape as {@code AdminAiController}/{@code
+ * AdminChangesetController} -- copied, not shared, matching the existing precedent for that
+ * duplication (neither of those two share it with each other).
+ */
+@RestController
+public class AdminScheduleController {
+   @Autowired
+   public AdminScheduleController(AdminScheduleGateway scheduleGateway,
+                                  ScheduleChangePlanService planService,
+                                  ScheduleChangesetApplyService applyService)
+   {
+      this.scheduleGateway = scheduleGateway;
+      this.planService = planService;
+      this.applyService = applyService;
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/schedule/tasks",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/schedule/tasks")
+   public ScheduleTaskList listTasks(Principal user) throws Exception {
+      requireSiteAdmin(user);
+      // No organizationid filter exposed in this cut (spec §11: list_schedule_tasks takes no
+      // arguments) -- getScheduleTasks is already permission-scoped by repository.getScheduleTasks
+      // regardless of this parameter.
+      return scheduleGateway.getScheduleTasks(null, user);
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/schedule/tasks",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/schedule/tasks/{taskId}")
+   public ScheduleTaskView getTask(@PathVariable("taskId") String taskId, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return new ScheduleTaskView(taskId,
+         scheduleGateway.getScheduleTask(taskId, null, user),
+         scheduleGateway.getTaskConditionsLenient(taskId, null, user),
+         scheduleGateway.getTaskActionsLenient(taskId, null, user));
+   }
+
+   /**
+    * Resolves a schedule-task change plan without mutating anything. See {@code
+    * AdminAiController#preview} for the shape this mirrors.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/schedule/tasks",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/schedule/preview")
+   public ResolvedPlan preview(@RequestBody ScheduleChangePlanRequest req, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      return planService.resolve(req, user);
+   }
+
+   /**
+    * Applies a reviewed schedule-task change plan, all-or-nothing. Same status contract as {@code
+    * AdminAiController#apply}: {@code applied}/{@code rolled-back}/{@code rollback-failed}, never a
+    * non-200 meaning "partially applied".
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/schedule/tasks",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/schedule/apply")
+   public ApplyResult apply(@RequestBody ScheduleApplyRequest req, Principal user) throws Exception {
+      requireSiteAdmin(user);
+      return applyService.apply(req, user);
+   }
+
+   /** Same rationale and shape as {@code AdminAiController#requireSiteAdmin} -- see there. */
+   private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
+      }
+   }
+
+   @ExceptionHandler(IllegalArgumentException.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleIllegalArgument(IllegalArgumentException ex) {
+      return Map.of("status", "failed", "error", String.valueOf(ex.getMessage()));
+   }
+
+   @ExceptionHandler(inetsoft.web.security.auth.MissingResourceException.class)
+   @ResponseStatus(HttpStatus.NOT_FOUND)
+   @ResponseBody
+   public Map<String, String> handleMissingResource(inetsoft.web.security.auth.MissingResourceException ex) {
+      return Map.of("status", "not-found", "error", String.valueOf(ex.getMessage()));
+   }
+
+   @ExceptionHandler(AdminChangesetApplyService.PlanHashMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handlePlanHashMismatch(
+      AdminChangesetApplyService.PlanHashMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
+   private final AdminScheduleGateway scheduleGateway;
+   private final ScheduleChangePlanService planService;
+   private final ScheduleChangesetApplyService applyService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/AdminScheduleGateway.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/AdminScheduleGateway.java
@@ -1,0 +1,944 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.report.io.csv.CSVConfig;
+import inetsoft.sree.*;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.schedule.*;
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.util.Identity;
+import inetsoft.uql.viewsheet.FileFormatInfo;
+import inetsoft.util.Tool;
+import inetsoft.util.dep.AbstractSheetAsset;
+import inetsoft.util.dep.XAsset;
+import inetsoft.util.dep.XAssetUtil;
+import inetsoft.web.admin.schedule.*;
+import inetsoft.web.admin.schedule.model.AddParameterDialogModel;
+import inetsoft.web.api.schedule.*;
+// Single-type imports: these simple names exist in BOTH inetsoft.web.api.schedule (the wildcard
+// above) and inetsoft.sree.schedule (this file's own internal-type package, always referenced
+// fully-qualified below as inetsoft.sree.schedule.X) -- a single-type import always wins over an
+// on-demand import, so every bare use of one of these names below unambiguously means the API
+// DTO, matching this file's own convention (bare = API DTO, inetsoft.sree.schedule.X = internal).
+import inetsoft.web.api.schedule.BatchAction;
+import inetsoft.web.api.schedule.CompletionCondition;
+import inetsoft.web.api.schedule.IndividualAssetBackupAction;
+import inetsoft.web.api.schedule.ScheduleAction;
+import inetsoft.web.api.schedule.ScheduleAlert;
+import inetsoft.web.api.schedule.ScheduleCondition;
+import inetsoft.web.api.schedule.ScheduleTask;
+import inetsoft.web.api.schedule.ServerPathInfo;
+import inetsoft.web.api.schedule.TimeCondition;
+import inetsoft.web.api.schedule.ViewsheetAction;
+import inetsoft.web.composer.model.condition.ConditionValueModel;
+import inetsoft.web.composer.model.vs.DynamicValueModel;
+import inetsoft.web.security.auth.MissingResourceException;
+import inetsoft.web.security.auth.ResourceExistsException;
+import inetsoft.web.security.auth.UnauthorizedAccessException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * {@code AdminScheduleGateway} implements, directly against community-only types, exactly the
+ * schedule-task operations admin-chat's schedule-task area (see {@link AdminScheduleController})
+ * needs: list/get a task, its conditions and actions, create and delete a task, and the two
+ * inverse-permission preflights {@link ScheduleChangePlanService} uses.
+ *
+ * <p>This is a deliberate, new, community-native replacement for the enterprise Public API's
+ * {@code inetsoft.enterprise.web.api.schedule.ScheduleApiService}, NOT a relocation of it --
+ * {@code ScheduleApiService} and its REST controller stay in the enterprise module because they
+ * carry genuine enterprise-only dependencies this gateway does not need: the {@code @SwitchOrg}/
+ * {@code @Audited} AOP (which re-initializes per-org state via {@code
+ * SecurityApiService.switchOrganization} when a site admin targets an organization other than
+ * their own current one), and status as the licensed Public REST API surface for schedule
+ * automation (run/stop, data cycles, batch actions -- none of which this gateway implements).
+ * Admin-chat never passes a non-default {@code organizationid} (see {@link
+ * AdminScheduleController#listTasks}'s own comment), so the multi-tenant org-switching machinery
+ * has nothing to do here in the first place.
+ *
+ * <p>Every method below is modeled line-by-line on the corresponding {@code ScheduleApiService}
+ * method (list/get/create/delete plus the permission and org-boundary checks and the condition/
+ * action converters), with the {@code @SwitchOrg}/{@code @Audited}/{@code @OrganizationID}/{@code
+ * @AuditObjectName} annotations and the {@code OrganizationAccess.check} calls they gated removed
+ * (both are enterprise-only and a no-op for a caller that never passes a non-null organization id),
+ * and with condition/action support restricted to nothing beyond what {@code ScheduleApiService}
+ * itself supports (still every type it recognizes, since an existing task predating this area may
+ * carry any of them, even though {@link ScheduleChangePlanService} refuses to let admin-chat
+ * *create* anything but a time condition and a viewsheet action).
+ */
+@Service
+public class AdminScheduleGateway {
+   @Autowired
+   public AdminScheduleGateway(AnalyticRepository repository, ScheduleManager scheduleManager,
+                               ScheduleService scheduleService,
+                               ScheduleConditionService scheduleConditionService,
+                               ScheduleTaskService scheduleTaskService)
+   {
+      this.repository = repository;
+      this.scheduleManager = scheduleManager;
+      this.scheduleService = scheduleService;
+      this.scheduleConditionService = scheduleConditionService;
+      this.scheduleTaskService = scheduleTaskService;
+   }
+
+   /**
+    * Gets the list of scheduled tasks. Mirrors {@code ScheduleApiService#getScheduleTasks}.
+    */
+   public ScheduleTaskList getScheduleTasks(String organizationid, Principal user) throws Exception {
+      checkPermission(user);
+      ScheduleTaskList list = new ScheduleTaskList();
+      Arrays.stream(repository.getScheduleTasks(user))
+         .map(scheduleManager::getScheduleTask)
+         .filter(Objects::nonNull)
+         .filter(s -> organizationid == null || s.getOwner().getOrgID().equals(organizationid))
+         .map(this::convertTask)
+         .forEach(list.getTasks()::add);
+      return list;
+   }
+
+   /**
+    * Adds a schedule task. Mirrors {@code ScheduleApiService#addScheduleTask}.
+    */
+   public void addScheduleTask(ScheduleTaskMetaData taskMetaData, boolean enabled,
+                               boolean deleteIfNotScheduledToRun, long startDate, long endDate,
+                               String description, String locale, ScheduleTask.ExecuteAsID executeAsID,
+                               List<ScheduleCondition> conditions, List<ScheduleAction> actions,
+                               String organizationid, String linkUri, Principal user)
+      throws Exception
+   {
+      checkPermission(user);
+      String taskId = taskMetaData.getTaskId();
+      inetsoft.sree.schedule.ScheduleTask task = repository.getScheduleTask(taskId);
+
+      if(task != null) {
+         throw new ResourceExistsException(taskId);
+      }
+
+      IdentityID owner = IdentityID.getIdentityIDFromKey(taskMetaData.getTaskOwnerId());
+
+      if(owner == null) {
+         throw new MissingResourceException(taskMetaData.getTaskOwnerId());
+      }
+
+      String name = taskMetaData.getTaskName();
+      checkOwnerPermission(user, owner, executeAsID);
+      task = convertTask(new ScheduleTask(name, owner, enabled, deleteIfNotScheduledToRun, startDate, endDate, description, locale, executeAsID));
+
+      conditions.stream()
+         .map(this::convertCondition)
+         .filter(Objects::nonNull)
+         .forEach(task::addCondition);
+
+      inetsoft.sree.schedule.ScheduleTask finalTask = task;
+
+      for(ScheduleAction action : actions) {
+         checkActionOrgBoundary(action, user);
+      }
+
+      actions.stream()
+         .map(this::convertAction)
+         .filter(Objects::nonNull)
+         .forEach(action -> finalTask.addAction(action, linkUri));
+
+      // Enforce schedule option permissions -- same sanitization applied by the UI.
+      // A new task has no prior state, so pass an empty task as the "original".
+      inetsoft.sree.schedule.ScheduleTask emptyTask = new inetsoft.sree.schedule.ScheduleTask();
+      scheduleTaskService.sanitizeConditions(task, emptyTask, user);
+
+      for(int i = 0; i < task.getActionCount(); i++) {
+         scheduleTaskService.sanitizeAction(task.getAction(i), null, user);
+      }
+
+      scheduleManager.setScheduleTask(task.getTaskId(), task, user);
+   }
+
+   /**
+    * Gets a schedule task. Mirrors {@code ScheduleApiService#getScheduleTask}.
+    */
+   public ScheduleTask getScheduleTask(String taskId, String organizationid, Principal user)
+      throws Exception
+   {
+      return convertTask(getTask(taskId, user));
+   }
+
+   /**
+    * Removes a schedule task. Mirrors {@code ScheduleApiService#removeScheduleTask}, including its
+    * cross-org guard for a non-site-admin caller.
+    */
+   public void removeScheduleTask(String taskId, String organizationid, Principal user) throws Exception {
+      checkPermission(user);
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         IdentityID taskOwner = ScheduleManager.getOwner(taskId);
+
+         if(taskOwner != null && taskOwner.getOrgID() != null &&
+            !taskOwner.getOrgID().equals(OrganizationManager.getInstance().getCurrentOrgID(user)))
+         {
+            throw new UnauthorizedAccessException();
+         }
+      }
+
+      checkPermission(user, taskId, ResourceAction.DELETE);
+      repository.removeScheduleTask(user, taskId);
+   }
+
+   /**
+    * Gets the list of conditions defined for a task. Mirrors {@code
+    * ScheduleApiService#getTaskConditions}.
+    */
+   public ScheduleConditionList getTaskConditions(String taskId, String organizationid, Principal user)
+      throws Exception
+   {
+      inetsoft.sree.schedule.ScheduleTask task = getTask(taskId, user);
+      ScheduleConditionList list = new ScheduleConditionList();
+      task.getConditionStream()
+         .map(this::convertCondition)
+         .forEach(list.getConditions()::add);
+      return list;
+   }
+
+   /**
+    * Like {@link #getTaskConditions}, but never throws for a condition with no community API DTO
+    * -- substitutes an {@link UnsupportedScheduleItem} placeholder instead of propagating. Mirrors
+    * {@code ScheduleApiService#getTaskConditionsLenient}.
+    */
+   public List<Object> getTaskConditionsLenient(String taskId, String organizationid, Principal user)
+      throws Exception
+   {
+      inetsoft.sree.schedule.ScheduleTask task = getTask(taskId, user);
+      List<Object> list = new ArrayList<>();
+
+      task.getConditionStream().forEach(c -> {
+         try {
+            list.add(convertCondition(c));
+         }
+         catch(IllegalArgumentException e) {
+            list.add(new UnsupportedScheduleItem(c.getClass().getName()));
+         }
+      });
+
+      return list;
+   }
+
+   /**
+    * Gets the list of actions defined for a task. Mirrors {@code ScheduleApiService#getTaskActions}.
+    */
+   public ScheduleActionList getTaskActions(String taskId, String organizationid, Principal user)
+      throws Exception
+   {
+      inetsoft.sree.schedule.ScheduleTask task = getTask(taskId, user);
+      ScheduleActionList builder = new ScheduleActionList();
+      task.getActionStream()
+         .map(this::convertAction)
+         .forEach(builder.getActions()::add);
+      return builder;
+   }
+
+   /**
+    * Like {@link #getTaskActions}, but never throws for an action with no community API DTO --
+    * substitutes an {@link UnsupportedScheduleItem} placeholder instead of propagating. Mirrors
+    * {@code ScheduleApiService#getTaskActionsLenient}.
+    */
+   public List<Object> getTaskActionsLenient(String taskId, String organizationid, Principal user)
+      throws Exception
+   {
+      inetsoft.sree.schedule.ScheduleTask task = getTask(taskId, user);
+      List<Object> list = new ArrayList<>();
+
+      task.getActionStream().forEach(a -> {
+         try {
+            list.add(convertAction(a));
+         }
+         catch(IllegalArgumentException e) {
+            list.add(new UnsupportedScheduleItem(a.getClass().getName()));
+         }
+      });
+
+      return list;
+   }
+
+   /**
+    * Reports whether {@code user} holds {@code DELETE} on {@code taskId}, without requiring the
+    * task to actually exist and without throwing on a "no" answer. Mirrors {@code
+    * ScheduleApiService#hasDeletePermission} -- delegates to the same {@code
+    * repository.checkPermission} call {@link #removeScheduleTask} itself uses, so this can never
+    * drift from the real gate.
+    */
+   public boolean hasDeletePermission(String taskId, Principal user) throws Exception {
+      return repository.checkPermission(user, ResourceType.SCHEDULE_TASK, taskId, ResourceAction.DELETE);
+   }
+
+   /**
+    * Reports whether {@code user} holds the rights over {@code owner} (and {@code executeAsID}, if
+    * set) that {@link #addScheduleTask} would itself require, without throwing on a "no" answer.
+    * Mirrors {@code ScheduleApiService#hasOwnerAdminPermission}.
+    */
+   public boolean hasOwnerAdminPermission(IdentityID owner, ScheduleTask.ExecuteAsID executeAsID,
+                                          Principal user)
+      throws Exception
+   {
+      try {
+         checkOwnerPermission(user, owner, executeAsID);
+         return true;
+      }
+      catch(UnauthorizedAccessException e) {
+         return false;
+      }
+   }
+
+   private void checkPermission(Principal user) throws Exception {
+      if(!repository.checkPermission(user, ResourceType.SCHEDULER, "*", ResourceAction.ACCESS)) {
+         throw new UnauthorizedAccessException();
+      }
+   }
+
+   private void checkPermission(Principal user, String task, ResourceAction action) throws Exception
+   {
+      if(!repository.checkPermission(user, ResourceType.SCHEDULE_TASK, task, action)) {
+         throw new UnauthorizedAccessException();
+      }
+   }
+
+   /**
+    * Verifies that the caller has admin rights over the identity a task is being owned by and/or
+    * executed as, so that a task cannot be created to run under another identity's privileges
+    * without authorization. A caller is always allowed to own and/or execute as their own identity.
+    * Mirrors {@code ScheduleApiService}'s private {@code checkOwnerPermission(Principal,
+    * IdentityID, ScheduleTask.ExecuteAsID)}.
+    */
+   private void checkOwnerPermission(Principal user, IdentityID owner,
+                                     ScheduleTask.ExecuteAsID executeAsID)
+      throws Exception
+   {
+      IdentityID callerID = IdentityID.getIdentityIDFromKey(user.getName());
+
+      if(!Tool.equals(callerID, owner) &&
+         !repository.checkPermission(user, ResourceType.SECURITY_USER, owner,
+                                     ResourceAction.ADMIN))
+      {
+         throw new UnauthorizedAccessException();
+      }
+
+      if(executeAsID != null) {
+         boolean isSelf = executeAsID.getType() == ScheduleTask.ExecuteAsID.Type.USER &&
+            Tool.equals(callerID, executeAsID.getIdentityID());
+
+         if(!isSelf) {
+            ResourceType type = executeAsID.getType() == ScheduleTask.ExecuteAsID.Type.USER ?
+               ResourceType.SECURITY_USER : ResourceType.SECURITY_GROUP;
+
+            if(!repository.checkPermission(user, type, executeAsID.getIdentityID(),
+                                           ResourceAction.ADMIN))
+            {
+               throw new UnauthorizedAccessException();
+            }
+         }
+      }
+   }
+
+   /**
+    * Rejects a client-supplied action whose asset id(s) embed an organization other than the
+    * caller's, so an org admin cannot reference another organization's asset by id when creating a
+    * schedule task action. Mirrors {@code ScheduleApiService#checkActionOrgBoundary}.
+    */
+   private void checkActionOrgBoundary(ScheduleAction action, Principal user) throws Exception {
+      if(action instanceof ViewsheetAction viewsheetAction) {
+         checkAssetOrgBoundary(viewsheetAction.getViewsheet(), user);
+      }
+      else if(action instanceof BatchAction batchAction) {
+         checkAssetOrgBoundary(batchAction.getQueryEntry(), user);
+      }
+      else if(action instanceof IndividualAssetBackupAction backupAction &&
+              backupAction.getAssetIdentifiers() != null)
+      {
+         for(String identifier : backupAction.getAssetIdentifiers()) {
+            // Only sheet-type assets (worksheet/viewsheet) expose a reliable per-org identity --
+            // see ScheduleApiService#checkActionOrgBoundary's own comment for why the org must be
+            // read from the raw identifier rather than XAsset.parseIdentifier()'s AssetEntry.
+            if(XAssetUtil.createXAsset(identifier) instanceof AbstractSheetAsset) {
+               int idx = identifier.indexOf('^');
+
+               if(idx >= 0) {
+                  checkAssetOrgBoundary(identifier.substring(idx + 1), user);
+               }
+            }
+         }
+      }
+   }
+
+   private void checkAssetOrgBoundary(String assetId, Principal user) throws Exception {
+      if(assetId == null || !(user instanceof XPrincipal principal) ||
+         OrganizationManager.getInstance().isSiteAdmin(user))
+      {
+         return;
+      }
+
+      AssetEntry entry = AssetEntry.createAssetEntry(assetId);
+
+      if(entry != null && entry.getOrgID() != null &&
+         !Tool.equals(entry.getOrgID(), principal.getCurrentOrgId()))
+      {
+         throw new UnauthorizedAccessException();
+      }
+   }
+
+   private inetsoft.sree.schedule.ScheduleTask convertTask(ScheduleTask task) {
+      ScheduleTask.ExecuteAsID executeAsID = task.getExecuteAsID();
+
+      inetsoft.sree.schedule.ScheduleTask output = new inetsoft.sree.schedule.ScheduleTask();
+      output.setName(task.getName());
+      output.setOwner(task.getOwner());
+      output.setDescription(task.getDescription());
+      output.setLocale(task.getLocale());
+
+      if(task.getEndDate() >= 0) {
+         output.setEndDate(new Date(task.getEndDate()));
+      }
+
+      if(task.getStartDate() >= 0) {
+         output.setStartDate(new Date(task.getStartDate()));
+      }
+
+      output.setEnabled(task.isEnabled());
+      output.setDeleteIfNoMoreRun(task.isDeleteIfNotScheduledToRun());
+
+      if(executeAsID != null) {
+         Identity id = SUtil.getIdentity(executeAsID.getIdentityID(), executeAsID.getType().ordinal());
+         output.setIdentity(id);
+      }
+
+      return output;
+   }
+
+   private ScheduleTask convertTask(inetsoft.sree.schedule.ScheduleTask task) {
+      ScheduleTask result = new ScheduleTask(task);
+      result.setDescription(task.getDescription());
+      result.setLocale(task.getLocale());
+      result.setDeleteIfNotScheduledToRun(task.isDeleteIfNoMoreRun());
+      result.setStatus(getStatus(task));
+
+      if(task.getStartDate() != null) {
+         result.setStartDate(task.getStartDate().getTime());
+      }
+
+      if(task.getEndDate() != null) {
+         result.setEndDate(task.getEndDate().getTime());
+      }
+
+      if(task.getIdentity() != null) {
+         ScheduleTask.ExecuteAsID.Type type =
+            ScheduleTask.ExecuteAsID.Type.values()[task.getIdentity().getType()];
+         result.setExecuteAsID(new ScheduleTask.ExecuteAsID(type, task.getIdentity().getIdentityID()));
+      }
+      else {
+         ScheduleTask.ExecuteAsID executeAsID =
+            new ScheduleTask.ExecuteAsID(ScheduleTask.ExecuteAsID.Type.USER, task.getOwner());
+         result.setExecuteAsID(executeAsID);
+      }
+
+      return result;
+   }
+
+   private inetsoft.sree.schedule.ScheduleCondition convertCondition(ScheduleCondition condition) {
+      if(condition instanceof TimeCondition) {
+         return convertCondition((TimeCondition) condition);
+      }
+      else if(condition instanceof CompletionCondition) {
+         return convertCondition((CompletionCondition) condition);
+      }
+      else {
+         throw new IllegalArgumentException("Unsupported condition type: " + condition);
+      }
+   }
+
+   private inetsoft.sree.schedule.TimeCondition convertCondition(TimeCondition condition) {
+      inetsoft.sree.schedule.TimeCondition output = new inetsoft.sree.schedule.TimeCondition();
+      final TimeCondition.Type type = condition.getType();
+      output.setType(type.value());
+
+      if(condition.getTimeRange() != null) {
+         TimeRange range = TimeRange.getTimeRanges().stream()
+            .filter(r -> r.getName().equals(condition.getTimeRange()))
+            .findFirst()
+            .orElse(null);
+         output.setTimeRange(range);
+      }
+
+      if(condition.getTimeZone() != null) {
+         output.setTimeZone(TimeZone.getTimeZone(condition.getTimeZone()));
+      }
+
+      output.setHour(condition.getHour());
+      output.setMinute(condition.getMinute());
+      output.setSecond(condition.getSecond());
+
+      switch(type) {
+      case AT:
+         final OffsetDateTime date = condition.getDate();
+         Objects.requireNonNull(date, "ISO 8601 Date is required for \"AT\" type");
+         output.setDate(Date.from(date.toInstant()));
+         break;
+      case EVERY_DAY:
+         output.setInterval(condition.getInterval());
+         output.setWeekdayOnly(condition.isWeekdayOnly());
+         break;
+      case EVERY_WEEK:
+      case DAY_OF_WEEK:
+         output.setInterval(condition.getInterval());
+         output.setDaysOfWeek(condition.getDaysOfWeek());
+         break;
+      case EVERY_MONTH:
+         output.setDayOfMonth(condition.getDayOfMonth());
+         output.setWeekOfMonth(condition.getWeekOfMonth());
+         output.setDayOfWeek(condition.getDayOfWeek());
+         output.setMonthsOfYear(condition.getMonthsOfYear());
+         break;
+      case WEEK_OF_MONTH:
+         output.setWeekOfMonth(condition.getWeekOfMonth());
+         output.setDayOfWeek(condition.getDayOfWeek());
+         output.setMonthsOfYear(condition.getMonthsOfYear());
+         break;
+      case DAY_OF_MONTH:
+         output.setDayOfMonth(condition.getDayOfMonth());
+         output.setMonthsOfYear(condition.getMonthsOfYear());
+         break;
+      case EVERY_HOUR:
+         output.setHourEnd(condition.getHourEnd());
+         output.setMinuteEnd(condition.getMinuteEnd());
+         output.setSecondEnd(condition.getSecondEnd());
+         output.setHourlyInterval(condition.getHourlyInterval());
+      default:
+         output.setDayOfMonth(condition.getDayOfMonth());
+         output.setDayOfWeek(condition.getDayOfWeek());
+         output.setWeekOfMonth(condition.getWeekOfMonth());
+         output.setInterval(condition.getInterval());
+         output.setDaysOfWeek(condition.getDaysOfWeek());
+         output.setMonthsOfYear(condition.getMonthsOfYear());
+         output.setWeekdayOnly(condition.isWeekdayOnly());
+         break;
+      }
+
+      return output;
+   }
+
+   private inetsoft.sree.schedule.CompletionCondition convertCondition(CompletionCondition condition) {
+      inetsoft.sree.schedule.CompletionCondition output =
+         new inetsoft.sree.schedule.CompletionCondition();
+      output.setTaskName(ScheduleManager.getTaskId(condition.getOwner(), condition.getTaskName(), null));
+      return output;
+   }
+
+   private ScheduleCondition convertCondition(inetsoft.sree.schedule.ScheduleCondition condition) {
+      if(condition instanceof inetsoft.sree.schedule.TimeCondition) {
+         return new TimeCondition((inetsoft.sree.schedule.TimeCondition) condition);
+      }
+      else if(condition instanceof inetsoft.sree.schedule.CompletionCondition) {
+         return new CompletionCondition((inetsoft.sree.schedule.CompletionCondition) condition);
+      }
+      else {
+         throw new IllegalArgumentException("Unsupported condition type: " + condition);
+      }
+   }
+
+   private inetsoft.sree.schedule.ScheduleAction convertAction(ScheduleAction action) {
+      if(action instanceof ViewsheetAction) {
+         return convertAction((ViewsheetAction) action);
+      }
+      else if(action instanceof BatchAction) {
+         return convertAction((BatchAction) action);
+      }
+      else if(action instanceof IndividualAssetBackupAction) {
+         return convertAction((IndividualAssetBackupAction) action);
+      }
+      else {
+         throw new IllegalArgumentException("Unsupported action type: " + action);
+      }
+   }
+
+   private inetsoft.sree.schedule.ViewsheetAction convertAction(ViewsheetAction action) {
+      inetsoft.sree.schedule.ViewsheetAction output = new inetsoft.sree.schedule.ViewsheetAction();
+      output.setViewsheet(action.getViewsheet());
+      output.setBookmarks(new String[]{action.getBookmarkName()});
+      output.setBookmarkUsers(new IdentityID[]{action.getBookmarkUser()});
+      // bookmarkTypes must stay parallel to bookmarks/bookmarkUsers -- both branches always set
+      // it, defaulting to PRIVATE when the caller didn't specify one, so the internal
+      // ViewsheetAction's getBookmarkTypes() is never null (see the read-side constructor, which
+      // indexes into it unconditionally).
+      output.setBookmarkTypes(new int[]{
+         action.getBookmarkType() != null
+            ? action.getBookmarkType().code() : ViewsheetAction.BookmarkType.PRIVATE.code()
+      });
+
+      if(action.getBookmarkNames() != null) {
+         output.setBookmarks(action.getBookmarkNames().toArray(new String[0]));
+         output.setBookmarkUsers(action.getBookmarkUsers().toArray(new IdentityID[0]));
+         output.setBookmarkTypes(action.getBookmarkTypes() != null
+            ? action.getBookmarkTypes().stream()
+                 .mapToInt(ViewsheetAction.BookmarkType::code)
+                 .toArray()
+            : action.getBookmarkNames().stream()
+                 .mapToInt(n -> ViewsheetAction.BookmarkType.PRIVATE.code())
+                 .toArray());
+      }
+
+      populateSaveToServerFilePaths(action, output);
+
+      if(!action.getEmails().isEmpty()) {
+         String recipients = String.join(",", action.getEmails());
+         output.setEmails(recipients);
+      }
+
+      if(!action.getNotifies().isEmpty()) {
+         String recipients = String.join(",", action.getNotifies());
+         output.setNotifications(recipients);
+
+         if(action.isNotifyIfFailed() != null) {
+            output.setNotifyError(action.isNotifyIfFailed());
+         }
+
+         if(action.isNotifyLink() != null) {
+            output.setLink(action.isNotifyLink());
+         }
+      }
+
+      String format = action.getFormat() != null ?
+         FileFormatInfo.EXPORT_ALL_NAMES[action.getFormat().getTypeValue()] : null;
+
+      RepletRequest request = new RepletRequest();
+
+      for(Map.Entry<String, Object> e : action.getParameters().entrySet()) {
+         if(e.getValue() instanceof Map) {
+            request.setParameter(e.getKey(), convertParameter((Map) e.getValue()));
+         }
+         else {
+            request.setParameter(e.getKey(), e.getValue());
+         }
+      }
+
+      output.setViewsheetRequest(request);
+
+      output.setFrom(action.getSender());
+      output.setFileFormat(format);
+      output.setSubject(action.getSubject());
+      output.setMessage(action.getMessage());
+      output.setMessageHtml(action.isHtmlMessage());
+      setEmailProperties(action, output);
+
+      populateScheduleAlerts(action, output);
+      output.setSaveToServerMatch(action.isSaveToServerMatch());
+      output.setSaveToServerExpandSelections(action.isSaveToServerExpandSelections());
+      output.setSaveToServerOnlyDataComponents(action.isSaveToServerOnlyDataComponents());
+      output.setSaveExportAllTabbedTables(action.isSaveExportAllTabbedTables());
+
+      if(action.getSaveToServerCsvConfig() != null) {
+         CSVConfig config = new CSVConfig();
+         inetsoft.web.api.schedule.CSVConfig configModel = action.getSaveToServerCsvConfig();
+         config.setDelimiter(configModel.getDelimiter());
+         config.setQuote(configModel.getQuote());
+         config.setKeepHeader(configModel.isKeepHeader());
+         config.setTabDelimited(configModel.isTabDelimited());
+         config.setExportAssemblies(configModel.getSelectedAssemblies());
+         output.setSaveCSVConfig(config);
+      }
+
+      output.setViewsheetRequest(request);
+
+      return output;
+   }
+
+   private Object convertParameter(Map map) {
+      if(!map.containsKey("value")) {
+         return map;
+      }
+
+      if(!map.containsKey("dataType")) {
+         return map.get("value");
+      }
+
+      String value = String.valueOf(map.get("value"));
+      String type = (String) map.get("dataType");
+      String valueType = map.get("type") != null && map.get("type").equals(ConditionValueModel.EXPRESSION) ?
+         ConditionValueModel.EXPRESSION : ConditionValueModel.VALUE;
+      boolean array = map.containsKey("array") && (Boolean) map.get("array");
+      DynamicParameterValue parameterValue = new DynamicParameterValue(value, valueType, type);
+
+      if(array) {
+         return scheduleConditionService.getParamValueAsArray(type, value);
+      }
+      else if(valueType.equals(ConditionValueModel.VALUE)) {
+         parameterValue.setValue(scheduleConditionService.getParamValueAsType(type, new DynamicValueModel(value)));
+      }
+
+      return parameterValue;
+   }
+
+   private inetsoft.sree.schedule.BatchAction convertAction(BatchAction action) {
+      inetsoft.sree.schedule.BatchAction output = new inetsoft.sree.schedule.BatchAction();
+      output.setTaskId(ScheduleManager.getTaskId(action.getOwner(), action.getTaskName(), null));
+      output.setQueryParameters(action.getQueryParameters());
+      output.setQueryEntry(AssetEntry.createAssetEntry(action.getQueryEntry()));
+      output.setEmbeddedParameters(convertEmbeddedParameters(action.getEmbeddedParameters()));
+
+      return output;
+   }
+
+   private List<Map<String, Object>> convertEmbeddedParameters(List<Map<String, Object>> parameters) {
+      ArrayList<Map<String, Object>> embeddedParameters = new ArrayList<>();
+
+      for(Map<String, Object> row : parameters) {
+         HashMap<String, Object> convertedRow = new HashMap<>();
+
+         for(Map.Entry e : row.entrySet()) {
+            if(e.getValue() instanceof Map) {
+               convertedRow.put(e.getKey().toString(), convertParameter((Map) e.getValue()));
+            }
+            else {
+               convertedRow.put(e.getKey().toString(), e.getValue());
+            }
+         }
+
+         embeddedParameters.add(convertedRow);
+      }
+
+      return embeddedParameters;
+   }
+
+   private inetsoft.sree.schedule.IndividualAssetBackupAction convertAction(IndividualAssetBackupAction action) {
+      inetsoft.sree.schedule.IndividualAssetBackupAction output = new inetsoft.sree.schedule.IndividualAssetBackupAction();
+      ServerPathInfo pathInfo = action.getPathInfo();
+
+      if(pathInfo != null) {
+         inetsoft.sree.schedule.ServerPathInfo info = new inetsoft.sree.schedule.ServerPathInfo();
+         info.setPath(pathInfo.getPath());
+
+         if(pathInfo.isUseCredential()) {
+            info.setUseCredential(true);
+            info.setSecretId(pathInfo.getSecretId());
+         }
+         else {
+            info.setUsername(pathInfo.getUserName());
+            info.setPassword(pathInfo.getPassword());
+         }
+
+         output.setServerPaths(info);
+      }
+
+      List<String> identifiers = action.getAssetIdentifiers();
+
+      if(identifiers != null) {
+         List<XAsset> assets = identifiers.stream()
+            .map(identifier -> XAssetUtil.createXAsset(identifier))
+            .collect(Collectors.toList());
+         output.setAssets(assets);
+      }
+
+      output.setEncoding(action.isEncoding());
+      return output;
+   }
+
+   private void populateSaveToServerFilePaths(ViewsheetAction action, inetsoft.sree.schedule.ViewsheetAction output) {
+      for(ViewsheetAction.SaveToServerFilePath filePath : action.getSaveToServerFilePaths()) {
+         if(filePath.getPath() != null && filePath.getFormat() != null) {
+            inetsoft.sree.schedule.ServerPathInfo info;
+
+            if(filePath.isUseCredential()) {
+               info = new inetsoft.sree.schedule.ServerPathInfo(filePath.getPath(), null, null);
+               info.setUseCredential(true);
+               info.setSecretId(filePath.getSecretId());
+            }
+            else {
+               info = new inetsoft.sree.schedule.ServerPathInfo(filePath.getPath(),
+                                                                filePath.getUsername(), filePath.getPassword());
+            }
+
+            output.setFilePath(filePath.getFormat().getTypeValue(), info);
+
+            if(filePath.getFormat() == ViewsheetAction.Format.CSV && output.getSaveCSVConfig() == null) {
+               output.setSaveCSVConfig(new CSVConfig());
+            }
+         }
+      }
+   }
+
+   private void populateScheduleAlerts(ViewsheetAction action,
+                                       inetsoft.sree.schedule.ViewsheetAction output)
+   {
+      List<ScheduleAlert> alerts = action.getAlerts();
+      inetsoft.sree.schedule.ScheduleAlert[] outputAlerts =
+         new inetsoft.sree.schedule.ScheduleAlert[alerts.size()];
+
+      for(int i = 0; i < alerts.size(); i ++) {
+         ScheduleAlert alert = alerts.get(i);
+
+         if(alert.getElementId() != null && alert.getHighlightName() != null) {
+            inetsoft.sree.schedule.ScheduleAlert newAlert = new inetsoft.sree.schedule.ScheduleAlert();
+            newAlert.setElementId(alert.getElementId());
+            newAlert.setHighlightName(alert.getHighlightName());
+            outputAlerts[i] = newAlert;
+         }
+      }
+
+      output.setAlerts(outputAlerts);
+   }
+
+   private void setEmailProperties(ViewsheetAction action,
+                                   inetsoft.sree.schedule.ViewsheetAction output)
+   {
+      if(action.getCCAddresses() != null) {
+         output.setCCAddresses(action.getCCAddresses());
+      }
+
+      if(action.getBCCAddresses() != null) {
+         output.setBCCAddresses(action.getBCCAddresses());
+      }
+
+      if(action.isEmailMatch() != null) {
+         output.setMatchLayout(action.isEmailMatch());
+      }
+
+      if(action.isEmailExpandSelections() != null) {
+         output.setExpandSelections(action.isEmailExpandSelections());
+      }
+
+      if(action.isEmailOnlyDataComponents() != null) {
+         output.setOnlyDataComponents(action.isEmailOnlyDataComponents());
+      }
+
+      if(action.isExportAllTabbedTables() != null) {
+         output.setExportAllTabbedTables(action.isExportAllTabbedTables());
+      }
+
+      if(action.isEmailZip() != null) {
+         output.setCompressFile(action.isEmailZip());
+      }
+
+      if(action.getAttachmentName() != null) {
+         output.setAttachmentName(action.getAttachmentName());
+      }
+
+      if(action.isEmailLink() != null) {
+         output.setDeliverLink(action.isEmailLink());
+      }
+
+      if(action.getEmailCSVConfig() != null) {
+         CSVConfig config = new CSVConfig();
+         inetsoft.web.api.schedule.CSVConfig configModel = action.getEmailCSVConfig();
+         config.setDelimiter(configModel.getDelimiter());
+         config.setQuote(configModel.getQuote());
+         config.setKeepHeader(configModel.isKeepHeader());
+         config.setTabDelimited(configModel.isTabDelimited());
+         config.setExportAssemblies(configModel.getSelectedAssemblies());
+         output.setEmailCSVConfig(config);
+      }
+   }
+
+   private ScheduleAction convertAction(inetsoft.sree.schedule.ScheduleAction action) {
+      if(action instanceof inetsoft.sree.schedule.ViewsheetAction) {
+         return new ViewsheetAction((inetsoft.sree.schedule.ViewsheetAction) action);
+      }
+      else if(action instanceof inetsoft.sree.schedule.BatchAction) {
+         BatchAction batchAction = new BatchAction((inetsoft.sree.schedule.BatchAction) action);
+         updateBatchActionEmbeddedParameters(batchAction);
+         return batchAction;
+      }
+      else if(action instanceof inetsoft.sree.schedule.IndividualAssetBackupAction) {
+         return new IndividualAssetBackupAction((inetsoft.sree.schedule.IndividualAssetBackupAction) action);
+      }
+      else {
+         throw new IllegalArgumentException("Unsupported action type: " + action);
+      }
+   }
+
+   private void updateBatchActionEmbeddedParameters(BatchAction batchAction) {
+      List<Map<String, Object>> parameters = batchAction.getEmbeddedParameters();
+      List<Map<String, Object>> result = new ArrayList<>();
+
+      for(Map<String, Object> parameter : parameters) {
+         RepletRequest repletRequest = new RepletRequest();
+
+         for(String paramName : parameter.keySet()) {
+            repletRequest.setParameter(paramName, parameter.get(paramName));
+         }
+
+         AddParameterDialogModel[] paraModels = scheduleConditionService.getParameterModelList(repletRequest)
+            .toArray(new AddParameterDialogModel[0]);
+
+         for(AddParameterDialogModel paraModel : paraModels) {
+            Map<String, Object> paramProperties = new HashMap<>();
+            DynamicValueModel value = paraModel.value();
+
+            if(value == null) {
+               continue;
+            }
+
+            if(!Tool.isEmptyString(value.getType())) {
+               paramProperties.put("type", value.getType());
+            }
+
+            if(!Tool.isEmptyString(value.getDataType())) {
+               paramProperties.put("dataType", value.getDataType());
+            }
+
+            if(paraModel.array()) {
+               paramProperties.put("array", paraModel.array());
+            }
+
+            paramProperties.put("value", value.getValue());
+            Map<String, Object> param = new HashMap<>();
+            param.put(paraModel.name(), paramProperties);
+            result.add(param);
+         }
+      }
+
+      batchAction.setEmbeddedParameters(result);
+   }
+
+   private inetsoft.sree.schedule.ScheduleTask getTask(String taskId, Principal user) throws Exception
+   {
+      checkPermission(user);
+      inetsoft.sree.schedule.ScheduleTask task = repository.getScheduleTask(taskId);
+
+      if(task == null) {
+         throw new MissingResourceException(taskId);
+      }
+
+      checkPermission(user, taskId, ResourceAction.READ);
+      return task;
+   }
+
+   private ScheduleTaskStatus getStatus(inetsoft.sree.schedule.ScheduleTask task) {
+      TaskActivity activity = scheduleService.getActivity(task.getTaskId());
+      ScheduleTaskStatus status = new ScheduleTaskStatus(activity);
+      status.setTask(task.getTaskId());
+      return status;
+   }
+
+   private final AnalyticRepository repository;
+   private final ScheduleManager scheduleManager;
+   private final ScheduleService scheduleService;
+   private final ScheduleConditionService scheduleConditionService;
+   private final ScheduleTaskService scheduleTaskService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleApplyRequest.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Request body for {@code POST /api/wiz/v1/admin/schedule/apply}: a plan request plus the hash
+ * from {@code preview}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScheduleApplyRequest extends ScheduleChangePlanRequest {
+   public String getPlanHash() { return planHash; }
+   public void setPlanHash(String v) { this.planHash = v; }
+   public String getReviewOutcome() { return reviewOutcome; }
+   public void setReviewOutcome(String v) { this.reviewOutcome = v; }
+
+   private String planHash, reviewOutcome;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Request body for {@code POST /api/wiz/v1/admin/schedule/preview}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScheduleChangePlanRequest {
+   public String getTask() { return task; }
+   public void setTask(String v) { this.task = v; }
+   public List<ScheduleChangeRequest> getChanges() { return changes; }
+   public void setChanges(List<ScheduleChangeRequest> v) { this.changes = v; }
+
+   private String task;
+   private List<ScheduleChangeRequest> changes;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanService.java
@@ -1,0 +1,354 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.*;
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Resolves a requested list of schedule-task changes into a {@link ResolvedPlan} and hashes it --
+ * the schedule-task analog of {@code inetsoft.web.admin.ai.AdminChangePlanService}, replicated
+ * rather than shared per {@code 01-spec.md} §6 (carry-forward item 5: {@code
+ * AdminChangesetApplyService}'s constructor is concretely wired to {@code AdminChangeService}/
+ * {@code SreeEnv}, so a second area cannot reuse it without generalizing the engine on one data
+ * point -- not done here, revisit once a second structural area exists).
+ *
+ * <p>Unlike its properties analog, {@link #resolve} takes a {@link Principal}: two of this area's
+ * refusals (spec §4) are per-caller inverse-permission preflights that properties has no
+ * equivalent of, because a property write's inverse (write the before-value back) never needs a
+ * *different* permission than the write itself, while a schedule task's does (see the two checks
+ * below).
+ */
+@Component
+public class ScheduleChangePlanService {
+   @Autowired
+   public ScheduleChangePlanService(AdminScheduleGateway scheduleGateway,
+                                    ScheduleManager scheduleManager)
+   {
+      this.scheduleGateway = scheduleGateway;
+      this.scheduleManager = scheduleManager;
+   }
+
+   /**
+    * Resolves and hashes a plan. Performs no mutation of schedule-task state, but DOES perform
+    * live permission checks (the two preflights below), which is why -- unlike the properties
+    * analog -- this takes a {@link Principal}.
+    *
+    * @throws IllegalArgumentException with a field-named message on a blank task, an empty change
+    *                                 list, an unrecognized verb, an unsupported condition/action
+    *                                 type, a create whose id already exists, a delete whose id does
+    *                                 not exist, or either inverse-permission preflight failing.
+    */
+   public ResolvedPlan resolve(ScheduleChangePlanRequest req, Principal user) throws Exception {
+      if(req == null || req.getTask() == null || req.getTask().trim().isEmpty()) {
+         throw new IllegalArgumentException("task: a non-empty description is required");
+      }
+
+      if(req.getChanges() == null || req.getChanges().isEmpty()) {
+         throw new IllegalArgumentException("changes: at least one change is required");
+      }
+
+      List<PlanChange> changes = new ArrayList<>();
+      Set<String> seenTaskIds = new HashSet<>();
+      int index = 0;
+
+      for(ScheduleChangeRequest change : req.getChanges()) {
+         String label = "changes[" + index++ + "]";
+         changes.add(resolveOne(label, change, user, seenTaskIds));
+      }
+
+      // Both verbs are risk:high with snapshotScope:storage unconditionally (spec §4) -- there is
+      // no "recognized" axis for a schedule task the way an uncatalogued property has one, and no
+      // low-risk schedule verb in this area's first cut.
+      String planHash = hash(changes);
+      String task = req.getTask().trim();
+      return new ResolvedPlan(task, Collections.unmodifiableList(changes),
+                              true, true, planHash, TaskAuditToken.issue(planHash, task));
+   }
+
+   private PlanChange resolveOne(String label, ScheduleChangeRequest change, Principal user,
+                                 Set<String> seenTaskIds)
+      throws Exception
+   {
+      if(change == null) {
+         throw new IllegalArgumentException(label + ": must not be null");
+      }
+
+      String verb = normalizeVerb(label, change.getVerb());
+
+      if(ScheduleChangeRequest.VERB_CREATE.equals(verb)) {
+         return resolveCreate(label, change, user, seenTaskIds);
+      }
+
+      return resolveDelete(label, change, user, seenTaskIds);
+   }
+
+   /** Accepts "create"/"delete" verbatim; the tool layer normalizes natural aliases before this
+    * point (see {@code plugin/admin/src/tools/normalize.ts#normalizeVerb}), so anything reaching
+    * here that is not exactly one of the two canonical verbs is a genuine caller error, not an
+    * unrecognized alias -- fail loud rather than guess. */
+   private static String normalizeVerb(String label, String verb) {
+      if(ScheduleChangeRequest.VERB_CREATE.equals(verb) || ScheduleChangeRequest.VERB_DELETE.equals(verb)) {
+         return verb;
+      }
+
+      throw new IllegalArgumentException(
+         label + ".verb: must be \"" + ScheduleChangeRequest.VERB_CREATE + "\" or \"" +
+         ScheduleChangeRequest.VERB_DELETE + "\", got " + String.valueOf(verb));
+   }
+
+   private PlanChange resolveCreate(String label, ScheduleChangeRequest change, Principal user,
+                                    Set<String> seenTaskIds)
+      throws Exception
+   {
+      CreateScheduleTaskRequest spec = change.getSpec();
+
+      if(spec == null) {
+         throw new IllegalArgumentException(label + ".spec: required for verb=create");
+      }
+
+      if(spec.getName() == null || spec.getName().isBlank()) {
+         throw new IllegalArgumentException(label + ".spec.name: required");
+      }
+
+      if(spec.getOwner() == null) {
+         throw new IllegalArgumentException(label + ".spec.owner: required");
+      }
+
+      requireSupportedConditions(label, spec.getConditions());
+      requireSupportedActions(label, spec.getActions());
+
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      requireUnseen(label, taskId, seenTaskIds);
+
+      if(scheduleManager.getScheduleTask(taskId) != null) {
+         throw new IllegalArgumentException(
+            label + ": a task already exists with id \"" + taskId + "\"");
+      }
+
+      // Inverse-permission preflight (spec §4): a create's rollback is a delete, so refuse the
+      // plan now if the caller could not actually perform that delete, rather than discovering it
+      // mid-rollback.
+      if(!scheduleGateway.hasDeletePermission(taskId, user)) {
+         throw new IllegalArgumentException(
+            label + ": you do not hold DELETE on \"" + taskId + "\", which this create's rollback " +
+            "would require -- refusing to plan a change whose own undo you could not perform");
+      }
+
+      String proposed = projectSpec(spec);
+      return new PlanChange(taskId, spec.getOwner().getOrgID(), null, proposed,
+                            AdminChangeRecord.RISK_HIGH, AdminChangeRecord.SCOPE_STORAGE, true,
+                            "create schedule task");
+   }
+
+   private PlanChange resolveDelete(String label, ScheduleChangeRequest change, Principal user,
+                                    Set<String> seenTaskIds)
+      throws Exception
+   {
+      String taskId = change.getTaskId();
+
+      if(taskId == null || taskId.isBlank()) {
+         throw new IllegalArgumentException(label + ".taskId: required for verb=delete");
+      }
+
+      if(change.getSpec() != null) {
+         throw new IllegalArgumentException(
+            label + ".spec: not used for verb=delete; remove it or use verb=create");
+      }
+
+      requireUnseen(label, taskId, seenTaskIds);
+
+      inetsoft.sree.schedule.ScheduleTask existing = scheduleManager.getScheduleTask(taskId);
+
+      if(existing == null) {
+         throw new IllegalArgumentException(label + ".taskId: no task exists with id \"" + taskId + "\"");
+      }
+
+      // Inverse-permission preflight (spec §4): a delete's rollback is a re-create of the captured
+      // task, which needs ADMIN over the owner (and executeAsID, if set) -- a strictly stronger
+      // requirement than the DELETE this verb itself needs. Refuse now rather than mid-rollback.
+      inetsoft.web.api.schedule.ScheduleTask.ExecuteAsID executeAsID =
+         existing.getIdentity() == null ? null :
+         new inetsoft.web.api.schedule.ScheduleTask.ExecuteAsID(
+            inetsoft.web.api.schedule.ScheduleTask.ExecuteAsID.Type
+               .values()[existing.getIdentity().getType()],
+            existing.getIdentity().getIdentityID());
+
+      if(!scheduleGateway.hasOwnerAdminPermission(existing.getOwner(), executeAsID, user)) {
+         throw new IllegalArgumentException(
+            label + ": you do not hold ADMIN over the owner of \"" + taskId + "\", which this " +
+            "delete's rollback (re-creating the task) would require -- refusing to plan a change " +
+            "whose own undo you could not perform");
+      }
+
+      String current = ScheduleXmlProjection.project(existing);
+      return new PlanChange(taskId, existing.getOwner().getOrgID(), current, null,
+                            AdminChangeRecord.RISK_HIGH, AdminChangeRecord.SCOPE_STORAGE, true,
+                            "delete schedule task");
+   }
+
+   private static void requireUnseen(String label, String taskId, Set<String> seenTaskIds) {
+      if(!seenTaskIds.add(taskId)) {
+         throw new IllegalArgumentException(
+            label + ": duplicate entry for task id \"" + taskId + "\"; list each task at most once");
+      }
+   }
+
+   private static void requireSupportedConditions(String label, List<ScheduleCondition> conditions) {
+      if(conditions == null || conditions.isEmpty()) {
+         throw new IllegalArgumentException(label + ".spec.conditions: at least one is required");
+      }
+
+      for(int i = 0; i < conditions.size(); i++) {
+         if(!(conditions.get(i) instanceof TimeCondition)) {
+            throw new IllegalArgumentException(
+               label + ".spec.conditions[" + i + "]: only time conditions are supported in this " +
+               "area (got " + conditions.get(i).getClass().getSimpleName() + ")");
+         }
+      }
+   }
+
+   private static void requireSupportedActions(String label, List<ScheduleAction> actions) {
+      if(actions == null) {
+         return;
+      }
+
+      for(int i = 0; i < actions.size(); i++) {
+         if(!(actions.get(i) instanceof ViewsheetAction)) {
+            throw new IllegalArgumentException(
+               label + ".spec.actions[" + i + "]: only viewsheet actions are supported in this " +
+               "area (got " + actions.get(i).getClass().getSimpleName() + ")");
+         }
+      }
+   }
+
+   /**
+    * A preview-only projection of a NOT-YET-CREATED task, built directly from the request rather
+    * than by round-tripping through {@code ScheduleApiService}'s private converters (which cannot
+    * be called without side effects). Deliberately narrower than {@link ScheduleXmlProjection}: it
+    * covers the fields that identify what would be created (enough that two materially different
+    * requests hash differently, closing the same collision class {@code SpikeHashProbe} found for
+    * the read path), not full fidelity with every action/condition field {@code addScheduleTask}
+    * itself understands. This is the bounded, documented duplication carry-forward item 3
+    * anticipated -- not a second copy of any authorization logic.
+    */
+   static String projectSpec(CreateScheduleTaskRequest spec) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("name=").append(spec.getName())
+         .append(";owner=").append(spec.getOwner())
+         .append(";enabled=").append(spec.isEnabled())
+         .append(";deleteIfNotScheduledToRun=").append(spec.isDeleteIfNotScheduledToRun())
+         .append(";startDate=").append(spec.getStartDate())
+         .append(";endDate=").append(spec.getEndDate())
+         .append(";description=").append(spec.getDescription())
+         .append(";locale=").append(spec.getLocale())
+         .append(";executeAsID=").append(spec.getExecuteAsID());
+
+      for(ScheduleCondition c : spec.getConditions()) {
+         TimeCondition tc = (TimeCondition) c;
+         sb.append(";condition[type=").append(tc.getType())
+            .append(",hour=").append(tc.getHour())
+            .append(",minute=").append(tc.getMinute())
+            .append(",second=").append(tc.getSecond())
+            .append(",interval=").append(tc.getInterval())
+            .append(",daysOfWeek=").append(Arrays.toString(tc.getDaysOfWeek()))
+            .append(",dayOfMonth=").append(tc.getDayOfMonth())
+            .append(",weekOfMonth=").append(tc.getWeekOfMonth())
+            .append(",monthsOfYear=").append(Arrays.toString(tc.getMonthsOfYear()))
+            .append(",weekdayOnly=").append(tc.isWeekdayOnly())
+            .append(",date=").append(tc.getDate())
+            .append(",timeRange=").append(tc.getTimeRange())
+            .append(",timeZone=").append(tc.getTimeZone())
+            .append(']');
+      }
+
+      for(ScheduleAction a : spec.getActions()) {
+         ViewsheetAction va = (ViewsheetAction) a;
+         sb.append(";action[viewsheet=").append(va.getViewsheet())
+            .append(",bookmarkNames=").append(va.getBookmarkNames())
+            .append(",emails=").append(va.getEmails())
+            .append(",notifies=").append(va.getNotifies())
+            .append(",format=").append(va.getFormat())
+            .append(",subject=").append(va.getSubject())
+            .append(",message=").append(va.getMessage())
+            .append(']');
+      }
+
+      return sb.toString();
+   }
+
+   /**
+    * SHA-256 over the canonical plan. Same field-order/control-character contract as {@code
+    * AdminChangePlanService#hash} -- changing it invalidates every outstanding preview, which is
+    * safe (apply is refused with 409) but forces re-review.
+    *
+    * <p>Deliberately excludes {@code task}: it is a free-text, audit-only label (see {@link
+    * ScheduleChangesetApplyService}'s {@code writeAudit} calls, its only use post-resolve) with no
+    * bearing on what is actually mutated or verified, and the caller is never required to replay it
+    * byte-for-byte between preview and apply.
+    */
+   private static String hash(List<PlanChange> changes) {
+      StringBuilder canonical = new StringBuilder();
+
+      for(PlanChange change : changes) {
+         canonical.append(change.property()).append(SEP)
+            .append(canonical(change.currentValue())).append(SEP)
+            .append(canonical(change.proposedValue())).append(SEP)
+            .append(change.risk()).append(SEP)
+            .append(change.snapshotScope()).append(SEP);
+      }
+
+      try {
+         byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+         StringBuilder hex = new StringBuilder(digest.length * 2);
+
+         for(byte b : digest) {
+            hex.append(String.format("%02x", b));
+         }
+
+         return hex.toString();
+      }
+      catch(NoSuchAlgorithmException e) {
+         throw new IllegalStateException("SHA-256 is required to hash a schedule change plan", e);
+      }
+   }
+
+   private static String canonical(String value) {
+      return value == null ? NULL_MARKER : value;
+   }
+
+   private static final char SEP = (char) 0x1f;
+   private static final String NULL_MARKER = String.valueOf((char) 0x01);
+   private final AdminScheduleGateway scheduleGateway;
+   private final ScheduleManager scheduleManager;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangeRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangeRequest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import inetsoft.web.api.schedule.CreateScheduleTaskRequest;
+
+/**
+ * One requested schedule-task change: create a new task from {@code spec}, or delete the task
+ * named by {@code taskId}. Exactly one of {@code spec} (create) or {@code taskId} alone (delete)
+ * applies to a given entry -- {@link ScheduleChangePlanService#resolve} enforces which, per verb,
+ * rather than silently ignoring whichever field does not apply (see its javadoc).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScheduleChangeRequest {
+   public static final String VERB_CREATE = "create";
+   public static final String VERB_DELETE = "delete";
+
+   public String getVerb() { return verb; }
+   public void setVerb(String v) { this.verb = v; }
+
+   /**
+    * The task id for a {@code delete}. Ignored for a {@code create}, whose id is derived from
+    * {@code spec}'s owner and name (see {@code inetsoft.sree.schedule.ScheduleManager#getTaskId}).
+    */
+   public String getTaskId() { return taskId; }
+   public void setTaskId(String v) { this.taskId = v; }
+
+   /** The new task's definition, for a {@code create}. Ignored for a {@code delete}. */
+   public CreateScheduleTaskRequest getSpec() { return spec; }
+   public void setSpec(CreateScheduleTaskRequest v) { this.spec = v; }
+
+   private String verb;
+   private String taskId;
+   private CreateScheduleTaskRequest spec;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyService.java
@@ -1,0 +1,394 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.*;
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTaskMetaData;
+import inetsoft.util.Tool;
+import inetsoft.util.audit.*;
+import inetsoft.web.admin.ai.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.security.SecureRandom;
+import java.sql.Timestamp;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a whole schedule-task changeset, all-or-nothing, and audits every attempt -- the
+ * schedule-task analog of {@code inetsoft.web.admin.ai.AdminChangesetApplyService}, replicated
+ * rather than shared (spec §6, carry-forward item 5).
+ *
+ * <p>Two structural differences from the properties path, both because this area's unit is not a
+ * scalar (spec §6):
+ * <ul>
+ *   <li>The inverse of a {@code create} is a {@code delete}; the inverse of a {@code delete} is a
+ *       re-create from a snapshot captured <b>during this apply</b>, via three round trips through
+ *       {@link AdminScheduleGateway} (its DTO carries no conditions/actions on its own -- Track
+ *       C.0 finding), not from anything the caller supplied. This mirrors {@code
+ *       AdminChangesetApplyService}'s own rule that the before-value used for rollback is the one
+ *       "the server recorded during the apply", not the preview-time one.</li>
+ *   <li>Verification is existence-based ("does the task now exist / no longer exist"), not a
+ *       value-equality check against a projection the caller approved -- there is no single
+ *       expected post-create projection to compare against, unlike a property's expected written
+ *       value.</li>
+ * </ul>
+ */
+@Component
+public class ScheduleChangesetApplyService {
+   @Autowired
+   public ScheduleChangesetApplyService(ScheduleChangePlanService planService,
+                                        AdminScheduleGateway scheduleGateway,
+                                        ScheduleManager scheduleManager,
+                                        AdminBackupService backupService)
+   {
+      this.planService = planService;
+      this.scheduleGateway = scheduleGateway;
+      this.scheduleManager = scheduleManager;
+      this.backupService = backupService;
+   }
+
+   /**
+    * Resolves, gates on the plan hash, then executes.
+    *
+    * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
+    *         (maps to HTTP 409) -- the exception type is reused verbatim from the properties area
+    *         (spec §6), not redeclared.
+    * @throws Exception if the Tier-2 backup fails, in which case nothing was applied.
+    */
+   public ApplyResult apply(ScheduleApplyRequest req, Principal user) throws Exception {
+      APPLY_LOCK.lock();
+
+      try {
+         ResolvedPlan plan = planService.resolve(req, user);
+
+         if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
+            throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
+         }
+
+         if(plan.requiresAgentSignoff() &&
+            (req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()))
+         {
+            throw new IllegalArgumentException(
+               "reviewOutcome: required because this changeset contains a high-risk change");
+         }
+
+         String txId = "schedtask-" + newIdSuffix();
+         String backupRef = plan.requiresStorageBackup() ? backupService.backup(txId) : null;
+         List<ApplyOutcome> results = new ArrayList<>();
+         List<Undo> undoable = new ArrayList<>();
+         List<RollbackFailure> unknownStateFailures = new ArrayList<>();
+         boolean failed = false;
+
+         List<ScheduleChangeRequest> originals = req.getChanges();
+
+         for(int i = 0; i < plan.changes().size(); i++) {
+            PlanChange change = plan.changes().get(i);
+            ScheduleChangeRequest original = originals.get(i);
+            String taskId = change.property();
+
+            try {
+               if(ScheduleChangeRequest.VERB_CREATE.equals(original.getVerb())) {
+                  applyCreate(txId, plan.task(), taskId, original.getSpec(), backupRef,
+                             req.getReviewOutcome(), user, results, undoable);
+               }
+               else {
+                  applyDelete(txId, plan.task(), taskId, backupRef, req.getReviewOutcome(), user,
+                             results, undoable);
+               }
+            }
+            catch(PreflightCaptureFailedException e) {
+               // Thrown only from applyDelete's captureSpec call, which runs entirely before any
+               // mutating call -- unlike a throw from the mutation itself, this proves nothing
+               // was changed, so it must NOT contribute an unknown-state RollbackFailure (there is
+               // nothing to roll back). Same shape as IdentityChangesetApplyService's non-
+               // compensable-delete branch.
+               results.add(new ApplyOutcome(taskId, null, null, AdminChangeRecord.STATUS_FAILED,
+                                            messageOf(e.getCause())));
+               failed = true;
+               break;
+            }
+            catch(Exception e) {
+               // A throw carries no verifiable before/after evidence for THIS change -- unlike a
+               // reported failure, it must never be treated as rolled back. See
+               // AdminChangesetApplyService's own javadoc for the properties-area precedent this
+               // mirrors.
+               results.add(new ApplyOutcome(taskId, null, null, AdminChangeRecord.STATUS_FAILED,
+                                            messageOf(e)));
+               unknownStateFailures.add(new RollbackFailure(taskId,
+                  "state unknown: apply did not return a verifiable outcome (" + messageOf(e) + ")"));
+               failed = true;
+               break;
+            }
+
+            if(AdminChangeRecord.STATUS_FAILED.equals(lastStatus(results))) {
+               failed = true;
+               break;
+            }
+         }
+
+         if(!failed) {
+            return new ApplyResult(txId, AdminChangesetApplyService.STATUS_APPLIED, backupRef,
+                                   Collections.unmodifiableList(results), null);
+         }
+
+         List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
+         failures.addAll(rollback(txId, plan.task(), undoable, backupRef, req.getReviewOutcome(),
+                                  user));
+
+         if(failures.isEmpty()) {
+            return new ApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLED_BACK, backupRef,
+                                   Collections.unmodifiableList(results), null);
+         }
+
+         LOG.error("Schedule-task changeset {} rollback failed; tasks still changed: {}", txId,
+                  failures.stream().map(RollbackFailure::property).collect(Collectors.joining(", ")));
+         return new ApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, backupRef,
+                                Collections.unmodifiableList(results),
+                                Collections.unmodifiableList(failures));
+      }
+      finally {
+         APPLY_LOCK.unlock();
+      }
+   }
+
+   private void applyCreate(String txId, String task, String taskId,
+                            CreateScheduleTaskRequest spec, String backupRef,
+                            String reviewOutcome, Principal user, List<ApplyOutcome> results,
+                            List<Undo> undoable)
+      throws Exception
+   {
+      ScheduleTaskMetaData meta = new ScheduleTaskMetaData(spec.getName(),
+                                                            spec.getOwner().convertToKey());
+      scheduleGateway.addScheduleTask(meta, spec.isEnabled(), spec.isDeleteIfNotScheduledToRun(),
+         spec.getStartDate(), spec.getEndDate(), spec.getDescription(), spec.getLocale(),
+         spec.getExecuteAsID(), spec.getConditions(), spec.getActions(), spec.getOwner().getOrgID(),
+         null, user);
+
+      String after = ScheduleXmlProjection.project(scheduleManager.getScheduleTask(taskId));
+      boolean verified = after != null;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      results.add(new ApplyOutcome(taskId, null, after, status,
+                                   verified ? null : "task not found after create"));
+      writeAudit(txId, task, taskId, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                null, after, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(new Undo(ScheduleChangeRequest.VERB_CREATE, taskId,
+                               spec.getOwner().getOrgID(), null));
+      }
+   }
+
+   private void applyDelete(String txId, String task, String taskId, String backupRef,
+                            String reviewOutcome, Principal user, List<ApplyOutcome> results,
+                            List<Undo> undoable)
+      throws Exception
+   {
+      // Authoritative before-state, captured DURING apply -- not the preview-time snapshot -- per
+      // the same rule AdminChangesetApplyService's javadoc states for properties.
+      inetsoft.sree.schedule.ScheduleTask beforeTask = scheduleManager.getScheduleTask(taskId);
+      String before = ScheduleXmlProjection.project(beforeTask);
+      String orgId = beforeTask == null ? null : beforeTask.getOwner().getOrgID();
+      CreateScheduleTaskRequest recreateSpec;
+
+      try {
+         recreateSpec = captureSpec(taskId, orgId, user);
+      }
+      catch(Exception e) {
+         // Read-only, runs strictly before removeScheduleTask below -- a throw here proves
+         // nothing was mutated yet, distinct from a throw during/after the mutating call.
+         throw new PreflightCaptureFailedException(e);
+      }
+
+      scheduleGateway.removeScheduleTask(taskId, orgId, user);
+
+      boolean verified = scheduleManager.getScheduleTask(taskId) == null;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      results.add(new ApplyOutcome(taskId, before, null, status,
+                                   verified ? null : "task still exists after delete"));
+      writeAudit(txId, task, taskId, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                before, null, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(new Undo(ScheduleChangeRequest.VERB_DELETE, taskId, orgId, recreateSpec));
+      }
+   }
+
+   /** Undoes verified changes newest-first, attempting all of them and collecting any failures. */
+   private List<RollbackFailure> rollback(String txId, String task, List<Undo> undoable,
+                                          String backupRef, String reviewOutcome, Principal user)
+   {
+      List<RollbackFailure> failures = new ArrayList<>();
+
+      for(int i = undoable.size() - 1; i >= 0; i--) {
+         Undo undo = undoable.get(i);
+
+         try {
+            if(ScheduleChangeRequest.VERB_CREATE.equals(undo.originalVerb)) {
+               // Undo a create: delete the task it created.
+               scheduleGateway.removeScheduleTask(undo.taskId, undo.orgId, user);
+               boolean verified = scheduleManager.getScheduleTask(undo.taskId) == null;
+               writeAudit(txId, task, undo.taskId, ActionRecord.ACTION_NAME_DELETE,
+                         AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                         verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                         backupRef, reviewOutcome, user);
+
+               if(!verified) {
+                  failures.add(new RollbackFailure(undo.taskId,
+                     "rollback of create reported the task as still present after delete"));
+               }
+            }
+            else {
+               // Undo a delete: re-create the task from the snapshot captured during apply.
+               CreateScheduleTaskRequest spec = undo.recreateSpec;
+               ScheduleTaskMetaData meta =
+                  new ScheduleTaskMetaData(spec.getName(), spec.getOwner().convertToKey());
+               scheduleGateway.addScheduleTask(meta, spec.isEnabled(),
+                  spec.isDeleteIfNotScheduledToRun(), spec.getStartDate(), spec.getEndDate(),
+                  spec.getDescription(), spec.getLocale(), spec.getExecuteAsID(),
+                  spec.getConditions(), spec.getActions(), spec.getOwner().getOrgID(), null, user);
+               boolean verified = scheduleManager.getScheduleTask(undo.taskId) != null;
+               writeAudit(txId, task, undo.taskId, ActionRecord.ACTION_NAME_CREATE,
+                         AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                         verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                         backupRef, reviewOutcome, user);
+
+               if(!verified) {
+                  failures.add(new RollbackFailure(undo.taskId,
+                     "rollback of delete reported the task as still missing after re-create"));
+               }
+            }
+         }
+         catch(Exception e) {
+            failures.add(new RollbackFailure(undo.taskId, messageOf(e)));
+         }
+      }
+
+      return failures;
+   }
+
+   /** Builds a total create-request from a live task, via three round trips (Track C.0 finding:
+    * the enterprise DTO alone carries no conditions/actions) -- used only to reconstruct a deleted
+    * task on rollback, never as the record admin-chat reports back to the caller. */
+   private CreateScheduleTaskRequest captureSpec(String taskId, String orgId, Principal user)
+      throws Exception
+   {
+      ScheduleTask dto = scheduleGateway.getScheduleTask(taskId, orgId, user);
+      ScheduleConditionList conditions = scheduleGateway.getTaskConditions(taskId, orgId, user);
+      ScheduleActionList actions = scheduleGateway.getTaskActions(taskId, orgId, user);
+
+      CreateScheduleTaskRequest spec = new CreateScheduleTaskRequest();
+      spec.setName(dto.getName());
+      spec.setOwner(dto.getOwner());
+      spec.setEnabled(dto.isEnabled());
+      spec.setDeleteIfNotScheduledToRun(dto.isDeleteIfNotScheduledToRun());
+      spec.setStartDate(dto.getStartDate());
+      spec.setEndDate(dto.getEndDate());
+      spec.setDescription(dto.getDescription());
+      spec.setLocale(dto.getLocale());
+      spec.setExecuteAsID(dto.getExecuteAsID());
+      spec.setConditions(conditions.getConditions());
+      spec.setActions(actions.getActions());
+      return spec;
+   }
+
+   private void writeAudit(String txId, String task, String taskId, String actionRecordName,
+                           String adminAction, String before, String after, String status,
+                           String backupRef, String reviewOutcome, Principal user)
+   {
+      try {
+         AdminChangeRecord record = new AdminChangeRecord();
+         record.setTransactionId(txId);
+         record.setTaskDescription(task);
+         record.setProperty(taskId);
+         record.setObjectType(ActionRecord.OBJECT_TYPE_TASK);
+         record.setBeforeValue(before);
+         record.setAfterValue(after);
+         record.setAction(adminAction);
+         record.setStatus(status);
+         record.setRiskLevel(AdminChangeRecord.RISK_HIGH);
+         record.setSnapshotScope(AdminChangeRecord.SCOPE_STORAGE);
+         record.setBackupRef(backupRef);
+         record.setReviewOutcome(reviewOutcome);
+         record.setUserName(user == null ? null : user.getName());
+         record.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
+         record.setServerHostName(Tool.getHost());
+         Audit.getInstance().auditAdminChange(record, user);
+      }
+      catch(Exception auditFailure) {
+         // An audit write must never replace the real outcome -- same rule
+         // AdminChangeService.applyChange follows for properties.
+         LOG.error("Failed to write schedule-task admin change audit record for transaction {}",
+                   txId, auditFailure);
+      }
+   }
+
+   private static String lastStatus(List<ApplyOutcome> results) {
+      return results.isEmpty() ? null : results.get(results.size() - 1).status();
+   }
+
+   private static String messageOf(Throwable e) {
+      return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+   }
+
+   private static String newIdSuffix() {
+      return String.format("%016x", RANDOM.nextLong());
+   }
+
+   /** One undo descriptor built during apply, replayed in reverse by {@link #rollback}. */
+   private static final class Undo {
+      Undo(String originalVerb, String taskId, String orgId, CreateScheduleTaskRequest recreateSpec) {
+         this.originalVerb = originalVerb;
+         this.taskId = taskId;
+         this.orgId = orgId;
+         this.recreateSpec = recreateSpec;
+      }
+
+      final String originalVerb;
+      final String taskId;
+      final String orgId;
+      /** Only set when {@code originalVerb} is {@code delete} -- the snapshot to re-create from. */
+      final CreateScheduleTaskRequest recreateSpec;
+   }
+
+   /** Signals that {@link #applyDelete}'s preflight {@link #captureSpec} call failed, strictly
+    * before the mutating {@code removeScheduleTask} call -- distinct from a throw during/after
+    * the mutating call, which leaves the post-mutation state genuinely unknown. */
+   private static final class PreflightCaptureFailedException extends RuntimeException {
+      PreflightCaptureFailedException(Throwable cause) {
+         super(cause);
+      }
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(ScheduleChangesetApplyService.class);
+   private static final SecureRandom RANDOM = new SecureRandom();
+   /** Serializes the entire body of {@link #apply} -- same rationale as {@code
+    * AdminChangesetApplyService#APPLY_LOCK}: JVM-local only, does not protect a clustered
+    * deployment or a concurrent edit made through Enterprise Manager directly. */
+   private static final ReentrantLock APPLY_LOCK = new ReentrantLock();
+   private final ScheduleChangePlanService planService;
+   private final AdminScheduleGateway scheduleGateway;
+   private final ScheduleManager scheduleManager;
+   private final AdminBackupService backupService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleTaskView.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleTaskView.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.ScheduleTask;
+import inetsoft.web.api.schedule.UnsupportedScheduleItem;
+
+import java.util.List;
+
+/**
+ * A total read of one schedule task -- the task itself plus its conditions and actions, combined
+ * into one response. {@code get_schedule_task} exists specifically so a caller does not have to
+ * make the three separate calls {@link ScheduleTask} alone would require (spec §3, Track C.0
+ * finding: the enterprise DTO carries neither on its own).
+ *
+ * <p>{@code conditions}/{@code actions} are {@code List<Object>}, not {@code
+ * List<ScheduleCondition>}/{@code List<ScheduleAction>}, because each entry may instead be an
+ * {@link UnsupportedScheduleItem} placeholder (see {@code
+ * ScheduleApiService#getTaskConditionsLenient}/{@code #getTaskActionsLenient}) -- a built-in
+ * system task's condition/action has no enterprise API DTO at all, and those two hierarchies are
+ * shared with the public REST API, so they must stay closed rather than gain a placeholder
+ * subtype.
+ */
+public class ScheduleTaskView {
+   public ScheduleTaskView(String taskId, ScheduleTask task, List<Object> conditions,
+                           List<Object> actions)
+   {
+      this.taskId = taskId;
+      this.task = task;
+      this.conditions = conditions;
+      this.actions = actions;
+   }
+
+   public String getTaskId() {
+      return taskId;
+   }
+
+   public ScheduleTask getTask() {
+      return task;
+   }
+
+   public List<Object> getConditions() {
+      return conditions;
+   }
+
+   public List<Object> getActions() {
+      return actions;
+   }
+
+   private final String taskId;
+   private final ScheduleTask task;
+   private final List<Object> conditions;
+   private final List<Object> actions;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleXmlProjection.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleXmlProjection.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.sree.schedule.ScheduleTask;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.regex.Pattern;
+
+/**
+ * A total, hashable projection of a schedule task, used both as the plan-hash input (spec §5) and
+ * as the apply-time verification signal (spec §6).
+ *
+ * <p>{@link ScheduleTask#writeXML} is used rather than the enterprise API DTO because the DTO
+ * carries no conditions or actions (Track C.0 finding) -- projecting off it let two materially
+ * different tasks hash identically. {@code writeXML} is total, but not stable: {@code
+ * inetsoft.sree.schedule.ScheduleManager#setScheduleTask} stamps {@code lastModified} on every
+ * save, so a naive equality check would report every successful apply as a verification failure
+ * and roll it straight back. {@link #EXCLUDED_ATTRIBUTES} strips exactly the attributes confirmed
+ * (or, for {@code path}/{@code editable}/{@code removable}, suspected and pending a regression
+ * test -- see {@code 01-spec.md} §5) to be recomputed by the persistence layer rather than part of
+ * what an operator approved.
+ *
+ * <p>This is deliberately NOT a general-purpose XML diff: stripping is attribute-name-based, on
+ * the raw {@code writeXML} text, because the attribute names this excludes are specific to the
+ * {@code <Task>} element's own scalar fields and do not recur as attribute names anywhere in a
+ * condition or action sub-element.
+ */
+public final class ScheduleXmlProjection {
+   private ScheduleXmlProjection() {
+   }
+
+   /**
+    * @return the normalized projection, or {@code null} if {@code task} is {@code null} (the unit
+    *         does not exist).
+    */
+   public static String project(ScheduleTask task) {
+      if(task == null) {
+         return null;
+      }
+
+      StringWriter sw = new StringWriter();
+
+      try(PrintWriter pw = new PrintWriter(sw)) {
+         task.writeXML(pw);
+      }
+
+      return normalize(sw.toString());
+   }
+
+   /** Strips every {@link #EXCLUDED_ATTRIBUTES} entry from a raw {@code writeXML} string. */
+   static String normalize(String xml) {
+      String result = xml;
+
+      for(Pattern p : EXCLUSION_PATTERNS) {
+         result = p.matcher(result).replaceAll("");
+      }
+
+      return result;
+   }
+
+   /**
+    * Attributes recomputed by the persistence layer, and therefore excluded from both the plan
+    * hash and the apply-time verification -- see the class javadoc.
+    *
+    * <p>{@code lastModified}: CONFIRMED unstable, by reading {@code ScheduleManager
+    * #setScheduleTask}, which calls {@code task.setLastModified(System.currentTimeMillis())}
+    * unconditionally on every save.
+    *
+    * <p>{@code path}, {@code editable}, {@code removable}: NOT confirmed either way -- included
+    * here conservatively pending the per-attribute regression test spec §5 requires before
+    * shipping. Do not remove an entry from this list without a passing test demonstrating it is
+    * stable; do not assume a fourth attribute is safe to include in the hash without the same
+    * test.
+    */
+   static final String[] EXCLUDED_ATTRIBUTES = { "lastModified", "path", "editable", "removable" };
+
+   private static final Pattern[] EXCLUSION_PATTERNS = buildPatterns();
+
+   private static Pattern[] buildPatterns() {
+      Pattern[] patterns = new Pattern[EXCLUDED_ATTRIBUTES.length];
+
+      for(int i = 0; i < EXCLUDED_ATTRIBUTES.length; i++) {
+         patterns[i] = Pattern.compile("\\s+" + Pattern.quote(EXCLUDED_ATTRIBUTES[i]) + "=\"[^\"]*\"");
+      }
+
+      return patterns;
+   }
+}

--- a/core/src/main/java/inetsoft/web/api/identity/TaskExecuteAsIdentityID.java
+++ b/core/src/main/java/inetsoft/web/api/identity/TaskExecuteAsIdentityID.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.identity;
+
+import inetsoft.sree.security.IdentityID;
+
+/**
+ * The IdentityID of the executing identity.
+ */
+public class TaskExecuteAsIdentityID extends IdentityID {
+}

--- a/core/src/main/java/inetsoft/web/api/identity/TaskOwnerIdentityID.java
+++ b/core/src/main/java/inetsoft/web/api/identity/TaskOwnerIdentityID.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.identity;
+
+import inetsoft.sree.security.IdentityID;
+
+/**
+ * The IdentityID of the user that owns the task..
+ */
+public class TaskOwnerIdentityID extends IdentityID {
+}

--- a/core/src/main/java/inetsoft/web/api/identity/VSOwnerIdentityID.java
+++ b/core/src/main/java/inetsoft/web/api/identity/VSOwnerIdentityID.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.identity;
+
+import inetsoft.sree.security.IdentityID;
+
+/**
+ * The IdentityID of the user that owns the renamed viewsheet if _global_ is false.
+ */
+public class VSOwnerIdentityID extends IdentityID {
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/BatchAction.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/BatchAction.java
@@ -1,0 +1,204 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTaskMetaData;
+import inetsoft.sree.security.IdentityID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.*;
+
+/**
+ * BatchAction describes an action that executes another task with parameters.
+ */
+@Validated
+@Schema(description = "An action that executes another task with parameters.")
+public class BatchAction extends ScheduleAction {
+   /**
+    * Creates a new instance of {@code BatchAction}.
+    */
+   public BatchAction() {
+      setActionType(ActionType.BATCH);
+   }
+
+   /**
+    * Creates a new instance of {@code BatchAction}.
+    *
+    * @param action the action object being represented.
+    */
+   public BatchAction(inetsoft.sree.schedule.BatchAction action) {
+      setActionType(ActionType.BATCH);
+      ScheduleTaskMetaData taskMetaData = ScheduleManager.getTaskMetaData(action.getTaskId());
+      setTaskName(taskMetaData.getTaskName());
+      setOwner(IdentityID.getIdentityIDFromKey(taskMetaData.getTaskOwnerId()).name);
+
+      if(action.getQueryEntry() != null) {
+         setQueryEntry(action.getQueryEntry().toIdentifier());
+      }
+
+      setQueryParameters(action.getQueryParameters());
+      setEmbeddedParameters(action.getEmbeddedParameters());
+   }
+
+   /**
+    * Gets the name of the task to execute.
+    *
+    * @return the name of the task.
+    */
+   @NotNull
+   @Schema(description = "The name of the task to execute.", example = "Task1")
+   public String getTaskName() {
+      return taskName;
+   }
+
+   /**
+    * Sets the name of the task to execute.
+    *
+    * @param taskName the name of the task to execute.
+    */
+   public void setTaskName(String taskName) {
+      this.taskName = taskName;
+   }
+
+   /**
+    * Gets the name of the task to execute.
+    *
+    * @return the name of the task.
+    */
+   @NotNull
+   @Schema(description = "The owner of the task to execute.", example = "user0")
+   public String getOwner() {
+      return owner;
+   }
+
+   /**
+    * Sets the owner of the task to execute.
+    *
+    * @param owner the owner of the task to execute.
+    */
+   public void setOwner(String owner) {
+      this.owner = owner;
+   }
+
+   /**
+    * Gets the query used to execute the task.
+    *
+    * @return the query used to execute the task.
+    */
+   @Schema(description = "The query used to execute the task.")
+   public String getQueryEntry() {
+      return queryEntry;
+   }
+
+   /**
+    * Sets the query used to execute the task.
+    *
+    * @param queryEntry the query used to execute the task.
+    */
+   public void setQueryEntry(String queryEntry) {
+      this.queryEntry = queryEntry;
+   }
+
+   /**
+    * Gets the query parameters used in the query.
+    *
+    * @return the query parameters used in the query.
+    */
+   @Schema(description = "The query parameters used in the query..")
+   public Map<String, Object> getQueryParameters() {
+      return queryParameters;
+   }
+
+   /**
+    * Sets the query parameters used in the query.
+    *
+    * @param queryParameters the query parameters used in the query.
+    */
+   public void setQueryParameters(Map<String, Object> queryParameters) {
+      this.queryParameters = queryParameters;
+   }
+
+   /**
+    * Gets the parameters used to execute the task.
+    *
+    * @return the parameters used to execute the task.
+    */
+   @Schema(description = "The query parameters used in the query..",
+      example = "[{ \"clientId\": 1, " +
+         "\"expressionParam\": {\"value\": \"=2+4\", \"dataType\": \"integer\", \"type\": \"EXPRESSION\"}, " +
+         "\"arrayParam\": {\"value\": \"value1,value2\", \"array\": true, \"dataType\": \"string\", \"type\": \"VALUE\"} }]"
+   )
+   public List<Map<String, Object>> getEmbeddedParameters() {
+      return embeddedParameters;
+   }
+
+   /**
+    * Sets the parameters used to execute the task.
+    *
+    * @param embeddedParameters the parameters used to execute the task.
+    */
+   public void setEmbeddedParameters(List<Map<String, Object>> embeddedParameters) {
+      this.embeddedParameters = embeddedParameters;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      if(!super.equals(o)) {
+         return false;
+      }
+
+      BatchAction that = (BatchAction) o;
+      return Objects.equals(taskName, that.taskName) &&
+         Objects.equals(queryEntry, that.queryEntry) &&
+         Objects.equals(queryParameters, that.queryParameters) &&
+         Objects.equals(embeddedParameters, that.embeddedParameters);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(
+         super.hashCode(), taskName, queryEntry, queryParameters, embeddedParameters);
+   }
+
+   @Override
+   public String toString() {
+      return "BatchAction{" +
+         "taskName='" + taskName + '\'' +
+         ", queryEntry='" + queryEntry  + '\'' +
+         ", queryParameters=" + queryParameters  +
+         ", embeddedParameters=" + embeddedParameters +
+         '}';
+   }
+
+   private String taskName;
+   private String owner;
+   private String queryEntry = "null";
+   private Map<String, Object> queryParameters = new LinkedHashMap<>();
+   private List<Map<String, Object>> embeddedParameters = new ArrayList<>();
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/CSVConfig.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/CSVConfig.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * CSVConfig contains configuration properties for a csv export.
+ */
+@Schema(description = "The configuration properties for a csv export.")
+public class CSVConfig {
+
+   public CSVConfig() {
+
+   }
+
+   public CSVConfig(inetsoft.report.io.csv.CSVConfig config) {
+      this.delimiter = config.getDelimiter();
+      this.quote = config.getQuote();
+      this.keepHeader = config.isKeepHeader();
+      this.tabDelimited = config.isTabDelimited();
+      this.selectedAssemblies = config.getExportAssemblies();
+   }
+
+   /**
+    * Gets the delimiter.
+    *
+    * @return the delimiter.
+    */
+   @NotNull
+   @Schema(description = "The delimiter.", example = ",")
+   public String getDelimiter() {
+      return delimiter;
+   }
+
+   /**
+    * Sets the delimiter.
+    *
+    * @param delimiter the delimiter.
+    */
+   public void setDelimiter(String delimiter) {
+      this.delimiter = delimiter;
+   }
+
+   /**
+    * Gets the quote string.
+    *
+    * @return the quote string.
+    */
+   @Schema(description = "The quote string.")
+   public String getQuote() {
+      return quote;
+   }
+
+   /**
+    * Sets the quote string.
+    *
+    * @param quote the quote string.
+    */
+   public void setQuote(String quote) {
+      this.quote = quote;
+   }
+
+   /**
+    * Check if the header should be kept
+    */
+   @Schema(description = "The flag indicating that the header should be kept.", example = "true")
+   public boolean isKeepHeader() {
+      return keepHeader;
+   }
+
+   /**
+    * Set if the header should be kept
+    *
+    * @param keepHeader the flag.
+    */
+   public void setKeepHeader(boolean keepHeader) {
+      this.keepHeader = keepHeader;
+   }
+
+   /**
+    * Check if the file should be tab delimited
+    */
+   @Schema(description = "The flag indicating that the file should be tab delimited.", example = "false")
+   public boolean isTabDelimited() {
+      return tabDelimited;
+   }
+
+   /**
+    * Set if the file should be tab delimited
+    *
+    * @param tabDelimited the flag.
+    */
+   public void setTabDelimited(boolean tabDelimited) {
+      this.tabDelimited = tabDelimited;
+   }
+
+   @Schema(description = "Select the table to export.", example = "null")
+   public List<String> getSelectedAssemblies() {
+      return selectedAssemblies;
+   }
+
+   public void setSelectedAssemblies(List<String> selectedAssemblies) {
+      this.selectedAssemblies = selectedAssemblies;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      if(!super.equals(o)) {
+         return false;
+      }
+
+      CSVConfig that = (CSVConfig) o;
+      return Objects.equals(delimiter, that.delimiter) &&
+         Objects.equals(quote, that.quote) &&
+         Objects.equals(selectedAssemblies, that.selectedAssemblies) &&
+         keepHeader == that.keepHeader &&
+         tabDelimited == that.tabDelimited;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(
+         super.hashCode(), delimiter, quote, keepHeader, tabDelimited, selectedAssemblies);
+   }
+
+   @Override
+   public String toString() {
+      return "CSVConfig{" +
+         "delimiter='" + delimiter + '\'' +
+         ", quote='" + quote + '\'' +
+         ", keepHeader=" + keepHeader +
+         ", tabDelimited=" + tabDelimited +
+         ", selectedAssemblies=" + selectedAssemblies +
+         '}';
+   }
+
+   private String delimiter = ",";
+   private String quote = null;
+   private boolean keepHeader = true;
+   private boolean tabDelimited = false;
+   private List<String> selectedAssemblies;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/CompletionCondition.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/CompletionCondition.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTaskMetaData;
+import inetsoft.sree.security.IdentityID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * {@code ScheduleCompletionCondition} describes a condition that is satisfied when another schedule
+ * task finishes.
+ */
+@Validated
+@Schema(description = "A condition that is satisfied when another schedule task finishes.")
+public class CompletionCondition extends ScheduleCondition {
+   /**
+    * Creates a new instance of {@code CompletionCondition}.
+    */
+   public CompletionCondition() {
+      setConditionType(ConditionType.COMPLETION);
+   }
+
+   /**
+    * Creates a new instance of {@code CompletionCondition}.
+    *
+    * @param condition the schedule condition being represented.
+    */
+   public CompletionCondition(inetsoft.sree.schedule.CompletionCondition condition) {
+      ScheduleTaskMetaData taskMetaData = ScheduleManager.getTaskMetaData(condition.getTaskName());
+      setTaskName(taskMetaData.getTaskName());
+
+      if(taskMetaData.getTaskOwnerId() != null) {
+         setOwner(IdentityID.getIdentityIDFromKey(taskMetaData.getTaskOwnerId()).name);
+      }
+
+      setConditionType(ConditionType.COMPLETION);
+   }
+
+   /**
+    * Gets the name of the task on which the condition depends.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(
+      description = "The name of the task on  which the condition depends.",
+      example = "Monthly Task")
+   public String getTaskName() {
+      return taskName;
+   }
+
+   /**
+    * Sets the name of the task on which the condition depends.
+    *
+    * @param task the task name.
+    */
+   public void setTaskName(String task) {
+      this.taskName = task;
+   }
+
+   /**
+    * Gets he name of the task on which the condition depends.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(
+      description = "The owner of the task on  which the condition depends.",
+      example = "user0")
+   public String getOwner() {
+      return owner;
+   }
+
+   /**
+    * Sets the owner of the task on which the condition depends.
+    *
+    * @param owner the task owner.
+    */
+   public void setOwner(String owner) {
+      this.owner = owner;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      CompletionCondition that = (CompletionCondition) o;
+      return Objects.equals(taskName, that.taskName) && Objects.equals(owner, that.owner);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(taskName, owner);
+   }
+
+   @Override
+   public String toString() {
+      return "CompletionCondition{" +
+         "conditionType=" + getConditionType() +
+         ", taskName='" + taskName + '\'' +
+         ", owner='" + owner + '\'' +
+         '}';
+   }
+
+   private String taskName;
+   private String owner;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/CreateDataCycleRequest.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/CreateDataCycleRequest.java
@@ -1,0 +1,306 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.*;
+
+/**
+ * Cycle contains the properties of a cycle.
+ */
+@Schema(description = "The properties of a cycle.")
+public class CreateDataCycleRequest {
+   /**
+    * Gets the name of the cycle.
+    *
+    * @return the cycle name.
+    */
+   @NotNull
+   @Schema(description = "The name of the cycle.", example = "Cycle1")
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * Sets the name of the cycle.
+    *
+    * @param name the cycle name.
+    */
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   /**
+    * Gets the list of conditions for the cycle.
+    *
+    * @return the condition list.
+    */
+   @NotNull
+   @NotEmpty
+   @Schema(description = "The list of conditions for the cycle. At least one condition is required.")
+   public List<TimeCondition> getConditions() {
+      if(conditions == null) {
+         conditions = new ArrayList<>();
+      }
+
+      return conditions;
+   }
+
+   /**
+    * Sets the list of conditions for the cycle.
+    *
+    * @param conditions the condition list.
+    */
+   public void setConditions(List<TimeCondition> conditions) {
+      this.conditions = conditions;
+   }
+
+   /**
+    * Gets whether to send a notification when the cycle starts.
+    *
+    * @return whether to notify on cycle start.
+    */
+   @Schema(description = "Whether to send a notification on cycle start.", example = "false")
+   public boolean isStartNotify() {
+      return startNotify;
+   }
+
+   /**
+    * Sets whether to send a notification email when the cycle starts.
+    *
+    * @param startNotify whether to notify on cycle start.
+    */
+   public void setStartNotify(boolean startNotify) {
+      this.startNotify = startNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle starts.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getStartEmail() {
+      return startEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle starts.
+    *
+    * @param startEmail the email to notify.
+    */
+   public void setStartEmail(String startEmail) {
+      this.startEmail = startEmail;
+   }
+
+   /**
+    * Gets whether to send a notification email when the cycle ends.
+    *
+    * @return whether to notify on cycle end.
+    */
+   @Schema(description = "Whether to send a notification on cycle end.", example = "false")
+   public boolean isEndNotify() {
+      return endNotify;
+   }
+
+   /**
+    * Sets whether to send a notification when the cycle ends.
+    *
+    * @param endNotify whether to notify on cycle end.
+    */
+   public void setEndNotify(boolean endNotify) {
+      this.endNotify = endNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle ends.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getEndEmail() {
+      return endEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle ends.
+    *
+    * @param endEmail the email to notify.
+    */
+   public void setEndEmail(String endEmail) {
+      this.endEmail = endEmail;
+   }
+
+   /**
+    * Gets whether to send a notification email when the cycle fails.
+    *
+    * @return whether to notify on cycle failure.
+    */
+   @Schema(description = "Whether to send a notification on cycle failure.", example = "false")
+   public boolean isFailureNotify() {
+      return failureNotify;
+   }
+
+   /**
+    * Sets whether to send a notification when the cycle fails.
+    *
+    * @param failureNotify whether to notify on cycle failure.
+    */
+   public void setFailureNotify(boolean failureNotify) {
+      this.failureNotify = failureNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle fails.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getFailureEmail() {
+      return failureEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle fails.
+    *
+    * @param failureEmail the email to notify.
+    */
+   public void setFailureEmail(String failureEmail) {
+      this.failureEmail = failureEmail;
+   }
+
+   /**
+    * Gets whether to send a notification email when the cycle threshold is exceeded.
+    *
+    * @return whether to notify when the threshold is exceeded.
+    */
+   @Schema(description = "Whether to send a notification when the threshold is exceeded.", example = "false")
+   public boolean isExceedNotify() {
+      return exceedNotify;
+   }
+
+   /**
+    * Sets whether to send a notification when the cycle threshold is exceeded.
+    *
+    * @param exceedNotify whether to notify when the threshold is exceeded.
+    */
+   public void setExceedNotify(boolean exceedNotify) {
+      this.exceedNotify = exceedNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle threshold is exceeded.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getExceedEmail() {
+      return exceedEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle threshold is exceeded.
+    *
+    * @param exceedEmail the email to notify.
+    */
+   public void setExceedEmail(String exceedEmail) {
+      this.exceedEmail = exceedEmail;
+   }
+
+   /**
+    * Gets the cycle threshold required for the notification.
+    *
+    * @return the cycle threshold.
+    */
+   @Schema(description = "The cycle threshold in seconds.")
+   public int getThreshold() {
+      return threshold;
+   }
+
+   /**
+    * Sets the cycle threshold required for the notification.
+    *
+    * @param threshold the cycle threshold in seconds.
+    */
+   public void setThreshold(int threshold) {
+      this.threshold = threshold;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      CreateDataCycleRequest that = (CreateDataCycleRequest) o;
+      return startNotify == that.startNotify &&
+         endNotify == that.endNotify &&
+         failureNotify == that.failureNotify &&
+         exceedNotify == that.exceedNotify &&
+         threshold == that.threshold &&
+         Objects.equals(name, that.name) &&
+         Objects.equals(conditions, that.conditions) &&
+         Objects.equals(startEmail, that.startEmail) &&
+         Objects.equals(endEmail, that.endEmail) &&
+         Objects.equals(failureEmail, that.failureEmail) &&
+         Objects.equals(exceedEmail, that.exceedEmail);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, startNotify, startEmail, endNotify, endEmail,
+                          failureNotify, failureEmail, exceedNotify, exceedEmail, threshold);
+   }
+
+   @Override
+   public String toString() {
+      return "CreateScheduleTaskRequest{" +
+         "name='" + name + '\'' +
+         ", conditions=" + conditions +
+         ", startNotify=" + startNotify +
+         ", startEmail='" + startEmail + '\'' +
+         ", endNotify=" + endNotify +
+         ", endEmail='" + endEmail + '\'' +
+         ", failureNotify=" + failureNotify +
+         ", failureEmail='" + failureEmail + '\'' +
+         ", exceedNotify=" + exceedNotify +
+         ", exceedEmail='" + exceedEmail + '\'' +
+         ", threshold=" + threshold +
+         '}';
+   }
+
+   private String name;
+   private List<TimeCondition> conditions;
+   private boolean startNotify;
+   private String startEmail;
+   private boolean endNotify;
+   private String endEmail;
+   private boolean failureNotify;
+   private String failureEmail;
+   private boolean exceedNotify;
+   private String exceedEmail;
+   private int threshold;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/CreateScheduleTaskRequest.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/CreateScheduleTaskRequest.java
@@ -1,0 +1,257 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import inetsoft.web.api.identity.VSOwnerIdentityID;
+import inetsoft.sree.security.IdentityID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.*;
+
+/**
+ * {@code CreateScheduleTaskRequest} contains the parameters used to create a schedule task.
+ */
+@Validated
+@Schema(description = "The parameters used to create a schedule task.")
+public class CreateScheduleTaskRequest {
+   /**
+    * Gets the name of the task.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(description = "The name of the task.", example = "Weekly Summary")
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * Sets the name of the task.
+    *
+    * @param name the task name.
+    */
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   /**
+    * Gets the name of the user that owns the task.
+    *
+    * @return the owner.
+    */
+   @NotNull
+   @Schema(
+      description = "The owner of the task.",
+      implementation = VSOwnerIdentityID.class,
+      example = "{\"name\":\"user0\",\"orgID\":\"organization0\"}"
+   )
+   public IdentityID getOwner() {
+      return owner;
+   }
+
+   /**
+    * Sets the name of the user that owns the task.
+    *
+    * @param owner the owner.
+    */
+   public void setOwner(IdentityID owner) {
+      this.owner = owner;
+   }
+
+   /**
+    * Gets the flag indicating the if the task is enabled or disabled.
+    *
+    * @return {@code true} if enabled; {@code false} otherwise.
+    */
+   @NotNull
+   @Schema(
+      description = "A flag that indicates if the task is enabled or disabled.",
+      example = "true")
+   public boolean isEnabled() {
+      return enabled;
+   }
+
+   /**
+    * Sets the flag indicating the if the task is enabled or disabled.
+    *
+    * @param enabled {@code true} if enabled; {@code false} otherwise.
+    */
+   public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+   }
+
+   public boolean isDeleteIfNotScheduledToRun() {
+      return deleteIfNotScheduledToRun;
+   }
+
+   public void setDeleteIfNotScheduledToRun(boolean deleteIfNotScheduledToRun) {
+      this.deleteIfNotScheduledToRun = deleteIfNotScheduledToRun;
+   }
+
+   public long getStartDate() {
+      return startDate;
+   }
+
+   public void setStartDate(long startDate) {
+      this.startDate = startDate;
+   }
+
+   public long getEndDate() {
+      return endDate;
+   }
+
+   public void setEndDate(long endDate) {
+      this.endDate = endDate;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public void setDescription(String description) {
+      this.description = description;
+   }
+
+   public String getLocale() {
+      return locale;
+   }
+
+   public void setLocale(String locale) {
+      this.locale = locale;
+   }
+
+   public ScheduleTask.ExecuteAsID getExecuteAsID() {
+      return executeAsID;
+   }
+
+   public void setExecuteAsID(ScheduleTask.ExecuteAsID executeAsID) {
+      this.executeAsID = executeAsID;
+   }
+
+   /**
+    * Gets the list of conditions for the task.
+    *
+    * @return the condition list.
+    */
+   @NotNull
+   @NotEmpty
+   @Schema(description = "The list of conditions for the task. At least one condition is required.")
+   public List<ScheduleCondition> getConditions() {
+      if(conditions == null) {
+         conditions = new ArrayList<>();
+      }
+
+      return conditions;
+   }
+
+   /**
+    * Sets the list of conditions for the task.
+    *
+    * @param conditions the condition list.
+    */
+   public void setConditions(List<ScheduleCondition> conditions) {
+      this.conditions = conditions;
+   }
+
+   /**
+    * Gets the list of actions for the class.
+    *
+    * @return the action list.
+    */
+   @NotNull
+   @NotEmpty
+   @Schema(description = "The list of actions for the task. At least one action is required.")
+   public List<ScheduleAction> getActions() {
+      if(actions == null) {
+         actions = new ArrayList<>();
+      }
+
+      return actions;
+   }
+
+   /**
+    * Sets the list of actions for the class.
+    *
+    * @param actions the action list.
+    */
+   public void setActions(List<ScheduleAction> actions) {
+      this.actions = actions;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      CreateScheduleTaskRequest that = (CreateScheduleTaskRequest) o;
+      return enabled == that.enabled &&
+         Objects.equals(name, that.name) &&
+         Objects.equals(owner, that.owner) &&
+         Objects.equals(deleteIfNotScheduledToRun, that.deleteIfNotScheduledToRun) &&
+         Objects.equals(startDate, that.startDate) &&
+         Objects.equals(endDate, that.endDate) &&
+         Objects.equals(description, that.description) &&
+         Objects.equals(locale, that.locale) &&
+         Objects.equals(executeAsID, that.executeAsID) &&
+         Objects.equals(conditions, that.conditions) &&
+         Objects.equals(actions, that.actions);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, owner, enabled, deleteIfNotScheduledToRun,
+                          startDate, endDate, description, locale, executeAsID, conditions, actions);
+   }
+
+   @Override
+   public String toString() {
+      return "CreateScheduleTaskRequest{" +
+         "name='" + name + '\'' +
+         ", owner='" + owner + '\'' +
+         ", enabled=" + enabled +
+         ", deleteIfNotScheduledToRun=" + deleteIfNotScheduledToRun +
+         ", startDate=" + startDate +
+         ", endDate=" + endDate +
+         ", description=" + description +
+         ", locale=" + locale +
+         ", executeAsID=" + executeAsID +
+         ", conditions=" + conditions +
+         ", actions=" + actions +
+         '}';
+   }
+
+   private String name;
+   private IdentityID owner;
+   private boolean enabled;
+   private boolean deleteIfNotScheduledToRun;
+   private long startDate;
+   private long endDate;
+   private String description;
+   private String locale;
+   private ScheduleTask.ExecuteAsID executeAsID;
+   private List<ScheduleCondition> conditions;
+   private List<ScheduleAction> actions;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/DataCycle.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/DataCycle.java
@@ -1,0 +1,303 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.schedule;
+
+import inetsoft.sree.internal.DataCycleManager;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Cycle contains the properties of a cycle.
+ */
+@Schema(description = "The properties of a cycle.")
+public class DataCycle {
+   /**
+    * Creates a new instance of {@code DataCycle}.
+    */
+   public DataCycle() {
+   }
+
+   /**
+    * Creates a new instance of {@code DataCycle}.
+    *
+    * @param cycleName    the cycle name.
+    * @param orgID   the cycle orgID
+    */
+   public DataCycle(String cycleName) {
+      this.name = cycleName;
+   }
+
+   /**
+    * Creates a new instance of {@code DataCycle}.
+    *
+    * @param cycleInfo the cycleInfo object being represented.
+    */
+   public DataCycle(DataCycleManager.CycleInfo cycleInfo) {
+      this(cycleInfo.getName());
+   }
+
+   /**
+    * Gets the name of the cycle.
+    *
+    * @return the cycle name.
+    */
+   @NotNull
+   @Schema(description = "The name of the cycle.", example = "Cycle1")
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * Sets the name of the cycle.
+    *
+    * @param name the cycle name.
+    */
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   /**
+    * Gets whether to send a notification when the cycle starts.
+    *
+    * @return whether to notify on cycle start.
+    */
+   @Schema(description = "Whether to send a notification on cycle start.", example = "false")
+   public boolean isStartNotify() {
+      return startNotify;
+   }
+
+   /**
+    * Sets whether to send a notification email when the cycle starts.
+    *
+    * @param startNotify whether to notify on cycle start.
+    */
+   public void setStartNotify(boolean startNotify) {
+      this.startNotify = startNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle starts.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getStartEmail() {
+      return startEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle starts.
+    *
+    * @param startEmail the email to notify.
+    */
+   public void setStartEmail(String startEmail) {
+      this.startEmail = startEmail;
+   }
+
+   /**
+    * Gets whether to send a notification email when the cycle ends.
+    *
+    * @return whether to notify on cycle end.
+    */
+   @Schema(description = "Whether to send a notification on cycle end.", example = "false")
+   public boolean isEndNotify() {
+      return endNotify;
+   }
+
+   /**
+    * Sets whether to send a notification when the cycle ends.
+    *
+    * @param endNotify whether to notify on cycle end.
+    */
+   public void setEndNotify(boolean endNotify) {
+      this.endNotify = endNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle ends.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getEndEmail() {
+      return endEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle ends.
+    *
+    * @param endEmail the email to notify.
+    */
+   public void setEndEmail(String endEmail) {
+      this.endEmail = endEmail;
+   }
+
+   /**
+    * Gets whether to send a notification email when the cycle fails.
+    *
+    * @return whether to notify on cycle failure.
+    */
+   @Schema(description = "Whether to send a notification on cycle failure.", example = "false")
+   public boolean isFailureNotify() {
+      return failureNotify;
+   }
+
+   /**
+    * Sets whether to send a notification when the cycle fails.
+    *
+    * @param failureNotify whether to notify on cycle failure.
+    */
+   public void setFailureNotify(boolean failureNotify) {
+      this.failureNotify = failureNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle fails.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getFailureEmail() {
+      return failureEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle fails.
+    *
+    * @param failureEmail the email to notify.
+    */
+   public void setFailureEmail(String failureEmail) {
+      this.failureEmail = failureEmail;
+   }
+
+   /**
+    * Gets whether to send a notification email when the cycle threshold is exceeded.
+    *
+    * @return whether to notify when the threshold is exceeded.
+    */
+   @Schema(description = "Whether to send a notification when the threshold is exceeded.", example = "false")
+   public boolean isExceedNotify() {
+      return exceedNotify;
+   }
+
+   /**
+    * Sets whether to send a notification when the cycle threshold is exceeded.
+    *
+    * @param exceedNotify whether to notify when the threshold is exceeded.
+    */
+   public void setExceedNotify(boolean exceedNotify) {
+      this.exceedNotify = exceedNotify;
+   }
+
+   /**
+    * Gets the email to notify when the cycle threshold is exceeded.
+    *
+    * @return the email to notify.
+    */
+   @Schema(description = "The email to notify.")
+   public String getExceedEmail() {
+      return exceedEmail;
+   }
+
+   /**
+    * Sets the email to notify when the cycle threshold is exceeded.
+    *
+    * @param exceedEmail the email to notify.
+    */
+   public void setExceedEmail(String exceedEmail) {
+      this.exceedEmail = exceedEmail;
+   }
+
+   /**
+    * Gets the cycle threshold required for the notification.
+    *
+    * @return the cycle threshold.
+    */
+   @Schema(description = "The cycle threshold in seconds.")
+   public int getThreshold() {
+      return threshold;
+   }
+
+   /**
+    * Sets the cycle threshold required for the notification.
+    *
+    * @param threshold the cycle threshold in seconds.
+    */
+   public void setThreshold(int threshold) {
+      this.threshold = threshold;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      DataCycle that = (DataCycle) o;
+      return startNotify == that.startNotify &&
+         endNotify == that.endNotify &&
+         failureNotify == that.failureNotify &&
+         exceedNotify == that.exceedNotify &&
+         threshold == that.threshold &&
+         Objects.equals(name, that.name) &&
+         Objects.equals(startEmail, that.startEmail) &&
+         Objects.equals(endEmail, that.endEmail) &&
+         Objects.equals(failureEmail, that.failureEmail) &&
+         Objects.equals(exceedEmail, that.exceedEmail);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, startNotify, startEmail, endNotify, endEmail,
+                          failureNotify, failureEmail, exceedNotify, exceedEmail, threshold);
+   }
+
+   @Override
+   public String toString() {
+      return "DataCycle{" +
+         "name='" + name + '\'' +
+         ", startNotify=" + startNotify +
+         ", startEmail='" + startEmail + '\'' +
+         ", endNotify=" + endNotify +
+         ", endEmail='" + endEmail + '\'' +
+         ", failureNotify=" + failureNotify +
+         ", failureEmail='" + failureEmail + '\'' +
+         ", exceedNotify=" + exceedNotify +
+         ", exceedEmail='" + exceedEmail + '\'' +
+         ", threshold=" + threshold +
+         '}';
+   }
+
+   private String name;
+   private boolean startNotify;
+   private String startEmail;
+   private boolean endNotify;
+   private String endEmail;
+   private boolean failureNotify;
+   private String failureEmail;
+   private boolean exceedNotify;
+   private String exceedEmail;
+   private int threshold;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/DataCycleList.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/DataCycleList.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.*;
+
+public class DataCycleList {
+   /**
+    * Gets the list of data cycles.
+    *
+    * @return the cycle list.
+    */
+   @NotNull
+   @Schema(description = "The data cycles.")
+   public List<DataCycle> getCycles() {
+      if(cycles == null) {
+         cycles = new ArrayList<>();
+      }
+
+      return cycles;
+   }
+
+   /**
+    * Sets the list of cycles.
+    *
+    * @param cycles the cycle list.
+    */
+   public void setCycles(List<DataCycle> cycles) {
+      this.cycles = cycles;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      DataCycleList that = (DataCycleList) o;
+      return Objects.equals(cycles, that.cycles);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(cycles);
+   }
+
+   @Override
+   public String toString() {
+      return "DataCycleList{" +
+         "cycles=" + cycles +
+         '}';
+   }
+
+   private List<DataCycle> cycles;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/IndividualAssetBackupAction.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/IndividualAssetBackupAction.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.schedule;
+
+
+import inetsoft.util.dep.XAsset;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Validated
+@Schema(description = "An action that backs up a specified asset file to specified location.")
+public class IndividualAssetBackupAction extends ScheduleAction {
+
+   /**
+    * Creates a new instance of {@code IndividualAssetBackupAction}.
+    */
+   public IndividualAssetBackupAction() {
+      setActionType(ActionType.BACKUP);
+   }
+
+   public IndividualAssetBackupAction(inetsoft.sree.schedule.IndividualAssetBackupAction action) {
+      this();
+
+      if(action == null) {
+         return;
+      }
+
+      List<XAsset> xAssets = action.getAssets();
+
+      if(xAssets != null) {
+         assetIdentifiers = xAssets.stream()
+            .filter(asset -> asset != null)
+            .map(asset -> asset.toIdentifier())
+            .collect(Collectors.toList());
+      }
+
+      if(action.getServerPath() != null) {
+         pathInfo = new ServerPathInfo(action.getServerPath());
+      }
+
+      encoding = action.isEncoding();
+   }
+
+   @NotNull
+   @Schema(description = "The identifiers list of the assets which need to be backuped by this action.",
+      example = "inetsoft.util.dep.ViewsheetAsset^1^128^__NULL__^Examples/Census^host-org\n" +
+      "inetsoft.util.dep.WorksheetAsset^1^2^__NULL__^Examples/Analysis^host-org\n" +
+      "inetsoft.util.dep.XDataSourceAsset^Examples/Orders\n" +
+      "inetsoft.util.dep.XLogicalModelAsset^Examples/Orders^Order Model\n" +
+      "inetsoft.util.dep.ScheduleTaskAsset^admin~;~host-org:Task1^IdentityID{name='admin', orgID='host-org'}\n")
+   public List<String> getAssetIdentifiers() {
+      return assetIdentifiers;
+   }
+
+   public void setAssetIdentifiers(List<String> assetIdentifiers) {
+      this.assetIdentifiers = assetIdentifiers;
+   }
+
+   @Schema(description = "The server path to store the backup files.")
+   public ServerPathInfo getPathInfo() {
+      return pathInfo;
+   }
+
+   public void setPathInfo(ServerPathInfo pathInfo) {
+      this.pathInfo = pathInfo;
+   }
+
+   public boolean isEncoding() {
+      return encoding;
+   }
+
+   @Schema(description = "If to byte encode the backup file content.")
+   public void setEncoding(boolean encoding) {
+      this.encoding = encoding;
+   }
+
+   private List<String> assetIdentifiers = new ArrayList<>();
+   private ServerPathInfo pathInfo;
+   private boolean encoding = true;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/RunScheduleTaskRequest.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/RunScheduleTaskRequest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * RunScheduleTaskRequest contains the parameters used to run a schedule task.
+ */
+@Validated
+@Schema(description = "The parameters used to run a schedule task.")
+public class RunScheduleTaskRequest {
+   /**
+    * Gets the name of the task to run.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(description = "The name of the task.", example = "admin~;~host-org:Monthly Summary")
+   public String getTask() {
+      return task;
+   }
+
+   /**
+    * Sets the name of the task to run.
+    *
+    * @param task the task name.
+    */
+   public void setTask(String task) {
+      this.task = task;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      RunScheduleTaskRequest that = (RunScheduleTaskRequest) o;
+      return Objects.equals(task, that.task);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(task);
+   }
+
+   @Override
+   public String toString() {
+      return "RunScheduleTaskRequest{" +
+         "task='" + task + '\'' +
+         '}';
+   }
+
+   private String task;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleAction.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleAction.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import com.fasterxml.jackson.annotation.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * {@code ScheduleAction} defines the actions to be performed when a schedule task runs.
+ */
+@JsonTypeInfo(
+   use = JsonTypeInfo.Id.NAME,
+   include = JsonTypeInfo.As.EXISTING_PROPERTY,
+   property = "actionType",
+   visible = true
+)
+@JsonSubTypes({
+   @JsonSubTypes.Type(value = ViewsheetAction.class, name = "viewsheet"),
+   @JsonSubTypes.Type(value = BatchAction.class, name = "batch")
+})
+@Validated
+@Schema(description = "An action to be performed when a schedule task runs.")
+public abstract class ScheduleAction {
+   /**
+    * Gets the type of action.
+    *
+    * @return the action type.
+    */
+   @NotNull
+   @Schema(description = "The type of action.")
+   public ActionType getActionType() {
+      return actionType;
+   }
+
+   /**
+    * Sets the type of action.
+    *
+    * @param actionType the action type.
+    */
+   public void setActionType(ActionType actionType) {
+      this.actionType = actionType;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleAction that = (ScheduleAction) o;
+      return actionType == that.actionType;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(actionType);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleAction{" +
+         "actionType=" + actionType +
+         '}';
+   }
+
+   private ActionType actionType;
+
+   /**
+    * Enumeration of the types of schedule actions.
+    */
+   public enum ActionType {
+      /**
+       * An action that opens a viewsheet and performs one or more sub-actions on it.
+       */
+      VIEWSHEET("viewsheet"),
+
+      /**
+       * An action that executes another task with parameters.
+       */
+      BATCH("batch"),
+
+      BACKUP("backup");
+
+      private final String value;
+
+      ActionType(String value) {
+         this.value = value;
+      }
+
+      @Override
+      @JsonValue
+      public String toString() {
+         return value;
+      }
+
+      @SuppressWarnings("unused")
+      @JsonCreator
+      public static ActionType fromValue(String value) {
+         for(ActionType type : values()) {
+            if(value.equals(type.value)) {
+               return type;
+            }
+         }
+
+         return null;
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleActionList.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleActionList.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.*;
+
+/**
+ * ScheduleActionList is a list of schedule actions.
+ */
+@Validated
+@Schema(description = "A list of schedule actions")
+public class ScheduleActionList {
+   /**
+    * Gets the list of actions.
+    *
+    * @return the action list.
+    */
+   @NotNull
+   @Schema(description = "The actions.")
+   public List<ScheduleAction> getActions() {
+      if(actions == null) {
+         actions = new ArrayList<>();
+      }
+
+      return actions;
+   }
+
+   /**
+    * Sets the list of actions.
+    *
+    * @param actions the action list.
+    */
+   public void setActions(List<ScheduleAction> actions) {
+      this.actions = actions;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleActionList that = (ScheduleActionList) o;
+      return Objects.equals(actions, that.actions);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(actions);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleActionList{" +
+         "actions=" + actions +
+         '}';
+   }
+
+   private List<ScheduleAction> actions;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleAlert.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleAlert.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * ScheduleAlert describes the name and associated assembly id for an alert that triggers when a highlight's conditions are met.
+ */
+@Validated
+@Schema(description = "Describes the name and associated assembly id for a highlight alert.")
+public class ScheduleAlert {
+   /**
+    * Creates a new instance of {@code ScheduleAlert}.
+    */
+   public ScheduleAlert() {
+   }
+
+   /**
+    * Creates a new instance of {@code ScheduleAlert}.
+    *
+    * @param elementId the save to server file format.
+    * @param highlightName   the save to server file path.
+    */
+   public ScheduleAlert(String elementId, String highlightName) {
+      this.elementId = elementId;
+      this.highlightName = highlightName;
+   }
+
+   /**
+    * Gets the element id of the assembly that the highlight is applied to.
+    *
+    * @return the element id of the assembly that the highlight is applied to.
+    */
+   @NotNull
+   @Schema(description = "The element id of the assembly that the highlight is applied to.", example = "Table1")
+   public String getElementId() {
+      return elementId;
+   }
+
+   /**
+    * Sets the element id of the assembly that the highlight is applied to.
+    *
+    * @param elementId the element id of the assembly that the highlight is applied to.
+    */
+   public void setElementId(String elementId) {
+      this.elementId = elementId;
+   }
+
+   /**
+    * Gets the name of the highlight used for the alert.
+    *
+    * @return the name of the highlight used for the alert.
+    */
+   @NotNull
+   @Schema(
+      description = "The name of the highlight used for the alert.",
+      example = "Restock Alert")
+   public String getHighlightName() {
+      return highlightName;
+   }
+
+   /**
+    * Sets the name of the highlight used for the alert.
+    *
+    * @param highlightName the name of the highlight used for the alert.
+    */
+   public void setHighlightName(String highlightName) {
+      this.highlightName = highlightName;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleAlert that = (ScheduleAlert) o;
+      return Objects.equals(elementId, that.elementId) && Objects.equals(highlightName, that.highlightName);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(elementId, highlightName);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleAlert{" +
+         "elementId='" + elementId + '\'' +
+         ", highlightName='" + highlightName + '\'' +
+         '}';
+   }
+
+   private String elementId;
+   private String highlightName;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleCondition.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleCondition.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import com.fasterxml.jackson.annotation.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * ScheduleCondition defines the conditions at which a schedule task runs.
+ */
+@JsonTypeInfo(
+   use = JsonTypeInfo.Id.NAME,
+   include = JsonTypeInfo.As.EXISTING_PROPERTY,
+   property = "conditionType",
+   visible = true
+)
+@JsonSubTypes({
+   @JsonSubTypes.Type(value = TimeCondition.class, name = "time"),
+   @JsonSubTypes.Type(value = CompletionCondition.class, name = "completion")
+})
+@Validated
+@Schema(description = "A condition that determines when a schedule task runs.")
+public abstract class ScheduleCondition {
+   /**
+    * Gets the type of condition.
+    *
+    * @return the condition type.
+    */
+   @NotNull
+   @Schema(description = "The type of condition.")
+   public ConditionType getConditionType() {
+      return conditionType;
+   }
+
+   /**
+    * Sets the type of condition.
+    *
+    * @param conditionType the condition type.
+    */
+   public void setConditionType(ConditionType conditionType) {
+      this.conditionType = conditionType;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleCondition that = (ScheduleCondition) o;
+      return conditionType == that.conditionType;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(conditionType);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleCondition{" +
+         "conditionType=" + conditionType +
+         '}';
+   }
+
+   private ConditionType conditionType;
+
+   /**
+    * Enumeration of the type of schedule conditions.
+    */
+   public enum ConditionType {
+      /**
+       * A condition that is satisfied when another schedule task finishes.
+       */
+      COMPLETION("completion"),
+
+      /**
+       * A condition that is satisfied by some time-based criteria.
+       */
+      TIME("time");
+
+      private final String value;
+
+      ConditionType(String value) {
+         this.value = value;
+      }
+
+      @Override
+      @JsonValue
+      public String toString() {
+         return value;
+      }
+
+      @SuppressWarnings("unused")
+      @JsonCreator
+      public static ConditionType fromValue(String value) {
+         for(ConditionType type : values()) {
+            if(Objects.equals(type.value, value)) {
+               return type;
+            }
+         }
+
+         return null;
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleConditionList.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleConditionList.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.*;
+
+/**
+ * ScheduleConditionList contains a list of schedule conditions.
+ */
+@Validated
+@Schema(description = "A list of schedule conditions.")
+public class ScheduleConditionList {
+   /**
+    * Gets the list of conditions.
+    *
+    * @return the condition list.
+    */
+   @NotNull
+   @Schema(description = "The conditions.")
+   public List<ScheduleCondition> getConditions() {
+      if(conditions == null) {
+         conditions = new ArrayList<>();
+      }
+
+      return conditions;
+   }
+
+   /**
+    * Sets the list of conditions.
+    *
+    * @param conditions the condition list.
+    */
+   public void setConditions(List<ScheduleCondition> conditions) {
+      this.conditions = conditions;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleConditionList that = (ScheduleConditionList) o;
+      return Objects.equals(conditions, that.conditions);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(conditions);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleConditionList{" +
+         "conditions=" + conditions +
+         '}';
+   }
+
+   private List<ScheduleCondition> conditions;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleOptions.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleOptions.java
@@ -1,0 +1,197 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import inetsoft.util.Tool;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+@Validated
+@Schema(description = "Options that determines when a schedule task runs.")
+public class ScheduleOptions {
+   /**
+    * Gets the enabled of task.
+    *
+    * @return the enabled of task.
+    */
+   @Schema(description = "The enable of schedule.")
+   public boolean isEnabled() {
+      return enabled;
+   }
+
+   /**
+    * Sets the enabled of task.
+    *
+    * @param enabled the enabled or not.
+    */
+   public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+   }
+
+   /**
+    * Gets the deleteIfNotScheduledToRun of task.
+    *
+    * @return the deleteIfNotScheduledToRun of task.
+    */
+   @Schema(description = "The deleteIfNotScheduledToRun of schedule.")
+   public boolean isDeleteIfNotScheduledToRun() {
+      return deleteIfNotScheduledToRun;
+   }
+
+   /**
+    * Sets the deleteIfNotScheduledToRun of task.
+    *
+    * @param deleteIfNotScheduledToRun the deleteIfNotScheduledToRun or not.
+    */
+   public void setDeleteIfNotScheduledToRun(boolean deleteIfNotScheduledToRun) {
+      this.deleteIfNotScheduledToRun = deleteIfNotScheduledToRun;
+   }
+
+   /**
+    * Gets the description of task.
+    *
+    * @return the description of task.
+    */
+   @Schema(description = "The deleteIfNotScheduledToRun of schedule.")
+   public String getDescription() {
+      return description;
+   }
+
+   /**
+    * Sets the description of task.
+    *
+    * @param description the description or not.
+    */
+   public void setDescription(String description) {
+      this.description = description;
+   }
+
+   /**
+    * Gets the locale of task.
+    *
+    * @return the locale of task.
+    */
+   @Schema(description = "The locale of schedule.")
+   public String getLocale() {
+      return locale;
+   }
+
+   /**
+    * Sets the locale of task.
+    *
+    * @param locale the description or not.
+    */
+   public void setLocale(String locale) {
+      this.locale = locale;
+   }
+
+   /**
+    * Gets the locale of task.
+    *
+    * @return the locale of task.
+    */
+   @Schema(description = "The startDate of schedule.")
+   public long getStartDate() {
+      return startDate;
+   }
+
+   /**
+    * Sets the locale of task.
+    *
+    * @param startDate the description or not.
+    */
+   public void setStartDate(long startDate) {
+      this.startDate = startDate;
+   }
+
+   /**
+    * Gets the locale of task.
+    *
+    * @return the locale of task.
+    */
+   @Schema(description = "The startDate of schedule.")
+   public long getEndDate() {
+      return endDate;
+   }
+
+   /**
+    * Sets the locale of task.
+    *
+    * @param endDate the description or not.
+    */
+   public void setEndDate(long endDate) {
+      this.endDate = endDate;
+   }
+
+   /**
+    * Gets the executeAsID of task.
+    *
+    * @return the executeAsID of task.
+    */
+   @Schema(description = "The executeAsID of schedule.")
+   public ScheduleTask.ExecuteAsID getExecuteAsID() {
+      return executeAsID;
+   }
+
+   /**
+    * Sets the locale of task.
+    *
+    * @param executeAsID the description or not.
+    */
+   public void setExecuteAsID(ScheduleTask.ExecuteAsID executeAsID) {
+      this.executeAsID = executeAsID;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleOptions that = (ScheduleOptions) o;
+      return enabled == that.enabled && deleteIfNotScheduledToRun == that.deleteIfNotScheduledToRun
+         && Tool.equals(description, that.description);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(enabled);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleOptions{" +
+         "enabled=" + enabled + " deleteIfNotScheduledToRun=" + deleteIfNotScheduledToRun +
+         " description=" + description +
+         '}';
+   }
+
+   private boolean enabled;
+   private boolean deleteIfNotScheduledToRun;
+   private String description;
+   private String locale;
+   private ScheduleTask.ExecuteAsID executeAsID;
+   private long startDate;
+   private long endDate;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleTask.java
@@ -1,0 +1,455 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import inetsoft.web.api.identity.TaskExecuteAsIdentityID;
+import inetsoft.web.api.identity.TaskOwnerIdentityID;
+import inetsoft.sree.security.IdentityID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * ScheduleTask contains the properties of a scheduled task.
+ */
+@Schema(description = "The properties of a scheduled task.")
+public class ScheduleTask {
+   /**
+    * Creates a new instance of {@code ScheduleTask}.
+    */
+   public ScheduleTask() {
+   }
+
+   public ScheduleTask(String name, IdentityID owner, boolean enabled, boolean deleteIfNotScheduledToRun, long startDate, long endDate, String description, String locale, ExecuteAsID executeAsID) {
+      this.name = name;
+      this.owner = owner;
+      this.description = description;
+      this.locale = locale;
+      this.startDate = startDate;
+      this.endDate = endDate;
+      this.enabled = enabled;
+      this.deleteIfNotScheduledToRun = deleteIfNotScheduledToRun;
+      this.executeAsID = executeAsID;
+   }
+
+   /**
+    * Creates a new instance of {@code ScheduleTask}.
+    *
+    * @param taskName    the task name.
+    * @param owner   the task owner.
+    * @param enabled {@code true} if enabled; {@code false} if disabled.
+    */
+   public ScheduleTask(String taskName, IdentityID owner, boolean enabled) {
+      this.name = taskName;
+      this.owner = owner;
+      this.enabled = enabled;
+   }
+
+   /**
+    * Creates a new instance of {@code ScheduleTask}.
+    *
+    * @param task the task object being represented.
+    */
+   public ScheduleTask(inetsoft.sree.schedule.ScheduleTask task) {
+      this(task.getName(), task.getOwner(), task.isEnabled());
+   }
+
+   /**
+    * Gets the name of the task.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(description = "The name of the task.", example = "Weekly Task")
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * Sets the name of the task.
+    *
+    * @param name the task name.
+    */
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   /**
+    * Gets the name of the user that owns the task.
+    *
+    * @return the task owner.
+    */
+   @NotNull
+   @Schema(
+      description = "The name of the user that owns the task.",
+      implementation = TaskOwnerIdentityID.class,
+      example = "{\"name\":\"user0\",\"orgID\":\"organization0\"}"
+   )
+   public IdentityID getOwner() {
+      return owner;
+   }
+
+   /**
+    * Sets the name of the user that owns the task.
+    *
+    * @param owner the task owner.
+    */
+   public void setOwner(IdentityID owner) {
+      this.owner = owner;
+   }
+
+   /**
+    * Gets the description of the task.
+    *
+    * @return the task description.
+    *
+    * @since 2023
+    */
+   @Schema(description = "The description of the task.")
+   public String getDescription() {
+      return description;
+   }
+
+   /**
+    * Sets the description of the task.
+    *
+    * @param description the task description.
+    *
+    * @since 2023
+    */
+   public void setDescription(String description) {
+      this.description = description;
+   }
+
+   /**
+    * Gets the locale of the task.
+    *
+    * @return the task locale.
+    *
+    * @since 2023
+    */
+   @Schema(description = "The locale of the task.")
+   public String getLocale() {
+      return locale;
+   }
+
+   /**
+    * Sets the locale of the task.
+    *
+    * @param locale the task locale.
+    *
+    * @since 2023
+    */
+   public void setLocale(String locale) {
+      this.locale = locale;
+   }
+
+   /**
+    * Gets the start date of the task in milliseconds.
+    *
+    * @return the task start date.
+    *
+    * @since 2023
+    */
+   @Schema(description = "The start date of the task in milliseconds.")
+   public long getStartDate() {
+      return startDate;
+   }
+
+   /**
+    * Sets the start date of the task in milliseconds.
+    *
+    * @param startDate the task start date in milliseconds.
+    *
+    * @since 2023
+    */
+   public void setStartDate(long startDate) {
+      this.startDate = startDate;
+   }
+
+   /**
+    * Gets the end date of the task in milliseconds.
+    *
+    * @return the task end date.
+    *
+    * @since 2023
+    */
+   @Schema(description = "The end date of the task in milliseconds.")
+   public long getEndDate() {
+      return endDate;
+   }
+
+   /**
+    * Sets the end date of the task in milliseconds.
+    *
+    * @param endDate the task end date in milliseconds.
+    *
+    * @since 2023
+    */
+   public void setEndDate(long endDate) {
+      this.endDate = endDate;
+   }
+
+   /**
+    * Gets a flag indicating if the task is enabled or disabled.
+    *
+    * @return {@code true} if enabled; {@code false} if disabled.
+    */
+   @NotNull
+   @Schema(description = "A flag indicating if the task is enabled or disabled.", example = "true")
+   public boolean isEnabled() {
+      return enabled;
+   }
+
+   /**
+    * Sets a flag indicating if the task is enabled or disabled.
+    *
+    * @param enabled {@code true} if enabled; {@code false} if disabled.
+    */
+   public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+   }
+
+   /**
+    * Gets the flag indicating if the task should be deleted if it is not scheduled to run again.
+    *
+    * @return the flag indicating if the task should be deleted.
+    *
+    * @since 2023
+    */
+   @Schema(description = "The flag indicating if the task should be deleted if it is not scheduled to run again.")
+   public boolean isDeleteIfNotScheduledToRun() {
+      return deleteIfNotScheduledToRun;
+   }
+
+   /**
+    * Sets the flag indicating if the task should be deleted if it is not scheduled to run again.
+    *
+    * @param deleteIfNotScheduledToRun the flag indicating if the task should be deleted.
+    *
+    * @since 2023
+    */
+   public void setDeleteIfNotScheduledToRun(boolean deleteIfNotScheduledToRun) {
+      this.deleteIfNotScheduledToRun = deleteIfNotScheduledToRun;
+   }
+
+   /**
+    * Gets the identity used to execute the task.
+    *
+    * @return the identity used to execute the task.
+    *
+    * @since 2023
+    */
+   @Schema(description = "The identity used to execute the task.")
+   public ExecuteAsID getExecuteAsID() {
+      return executeAsID;
+   }
+
+   /**
+    * Sets the identity used to execute the task.
+    *
+    * @param executeAsID the identity used to execute the task.
+    *
+    * @since 2023
+    */
+   public void setExecuteAsID(ExecuteAsID executeAsID) {
+      this.executeAsID = executeAsID;
+   }
+
+   /**
+    * Gets the current status of the task.
+    *
+    * @return the task status.
+    */
+   @Schema(description = "The current status of the task.")
+   public ScheduleTaskStatus getStatus() {
+      return status;
+   }
+
+   /**
+    * Sets the current status of the task.
+    *
+    * @param status the task status.
+    */
+   public void setStatus(ScheduleTaskStatus status) {
+      this.status = status;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleTask that = (ScheduleTask) o;
+      return enabled == that.enabled &&
+         deleteIfNotScheduledToRun == that.deleteIfNotScheduledToRun &&
+         startDate == that.startDate &&
+         endDate == that.endDate &&
+         Objects.equals(name, that.name) &&
+         Objects.equals(owner, that.owner) &&
+         Objects.equals(description, that.description) &&
+         Objects.equals(locale, that.locale) &&
+         Objects.equals(executeAsID, that.executeAsID) &&
+         Objects.equals(status, that.status);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, owner, description, locale, startDate, endDate,
+                          enabled, deleteIfNotScheduledToRun, executeAsID, status);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleTask{" +
+         "name='" + name + '\'' +
+         ", owner='" + owner + '\'' +
+         ", description='" + description + '\'' +
+         ", locale='" + locale + '\'' +
+         ", startDate=" + startDate +
+         ", endDate=" + endDate +
+         ", enabled=" + enabled +
+         ", deleteIfNotScheduledToRun=" + deleteIfNotScheduledToRun +
+         ", executeAsID=" + executeAsID +
+         ", status=" + status +
+         '}';
+   }
+
+   /**
+    * ExecuteAsID describes identity type and name for the identity used to execute the task.
+    */
+   @Validated
+   @Schema(description = "Describes identity type and name for the identity used to execute the task.")
+   public static class ExecuteAsID {
+      /**
+       * Creates a new instance of {@code ExecuteAsID}.
+       */
+      public ExecuteAsID() {
+      }
+
+      /**
+       * Creates a new instance of {@code ExecuteAsID}.
+       *
+       * @param type   the type of the executing identity.
+       * @param identityID   the name of the executing identity.
+       */
+      public ExecuteAsID(Type type, IdentityID identityID) {
+         this.type = type;
+         this.identityID = identityID;
+      }
+
+      /**
+       * Gets the type of the executing identity.
+       *
+       * @return the type of the executing identity.
+       */
+      @NotNull
+      @Schema(description = "The type of the executing identity.", example = "USER")
+      public Type getType() {
+         return type;
+      }
+
+      /**
+       * Sets the type of the executing identity.
+       *
+       * @param type the type of the executing identity.
+       */
+      public void setType(Type type) {
+         this.type = type;
+      }
+
+      /**
+       * Gets the name of the executing identity.
+       *
+       * @return the name of the executing identity.
+       */
+      @NotNull
+      @Schema(
+         description = "The name of the executing identity.",
+         implementation = TaskExecuteAsIdentityID.class,
+         example = "{\"name\":\"user0\",\"orgID\":\"organization0\"}"
+      )
+      public IdentityID getIdentityID() {
+         return identityID;
+      }
+
+      /**
+       * Sets the name of the executing identity.
+       *
+       * @param identityID the name of the executing identity.
+       */
+      public void setIdentityID(IdentityID identityID) {
+         this.identityID = identityID;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if(this == o) {
+            return true;
+         }
+
+         if(o == null || getClass() != o.getClass()) {
+            return false;
+         }
+
+         ExecuteAsID that = (ExecuteAsID) o;
+         return Objects.equals(type, that.type) && Objects.equals(identityID, that.identityID);
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(type, identityID);
+      }
+
+      @Override
+      public String toString() {
+         return "ExecuteAsID{" +
+            "type='" + type + '\'' +
+            ", name='" + identityID + '\'' +
+            '}';
+      }
+
+      private Type type;
+      private IdentityID identityID;
+
+      /**
+       * Enumeration of the types of identity types available for executing the task
+       */
+      public enum Type {
+         USER, GROUP
+      }
+   }
+
+   private String name;
+   private IdentityID owner;
+   private String description;
+   private String locale;
+   private long startDate = -1;
+   private long endDate = -1;
+   private boolean enabled;
+   private boolean deleteIfNotScheduledToRun;
+   private ExecuteAsID executeAsID;
+   private ScheduleTaskStatus status;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleTaskList.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleTaskList.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.*;
+
+/**
+ * ScheduleTaskList contains a list of schedule tasks.
+ */
+@Validated
+@Schema(description = "A list of scheduled tasks.")
+public class ScheduleTaskList {
+   /**
+    * Gets the list of tasks.
+    *
+    * @return the task list.
+    */
+   @NotNull
+   @Schema(description = "The scheduled tasks.")
+   public List<ScheduleTask> getTasks() {
+      if(tasks == null) {
+         tasks = new ArrayList<>();
+      }
+
+      return tasks;
+   }
+
+   /**
+    * Sets the list of tasks.
+    *
+    * @param tasks the task list.
+    */
+   public void setTasks(List<ScheduleTask> tasks) {
+      this.tasks = tasks;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleTaskList that = (ScheduleTaskList) o;
+      return Objects.equals(tasks, that.tasks);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(tasks);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleTaskList{" +
+         "tasks=" + tasks +
+         '}';
+   }
+
+   private List<ScheduleTask> tasks;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ScheduleTaskStatus.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ScheduleTaskStatus.java
@@ -1,0 +1,292 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import inetsoft.sree.schedule.TaskActivity;
+import inetsoft.web.json.OffsetDateTimeDeserializer;
+import inetsoft.web.json.OffsetDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.*;
+import java.util.Objects;
+
+/**
+ * ScheduleTaskStatus describes the current status of a schedule task.
+ */
+@Validated
+@Schema(description = "The current status of a scheduled task.")
+public class ScheduleTaskStatus {
+   /**
+    * Creates a new instance of {@code ScheduleTaskStatus}.
+    */
+   public ScheduleTaskStatus() {
+   }
+
+   /**
+    * Creates a new instance of {@code ScheduleTaskStatus}.
+    *
+    * @param activity the activity that contains the current status.
+    */
+   public ScheduleTaskStatus(TaskActivity activity) {
+      if(activity != null) {
+         setTask(activity.getTaskName());
+         setLastRunStatus(activity.getLastRunStatus());
+         setNextRunStatus(activity.getNextRunStatus());
+         setLastRunStart(getTimestamp(activity.getLastRunStart()));
+         setLastRunEnd(getTimestamp(activity.getLastRunEnd()));
+         setNextRunStart(getTimestamp(activity.getNextRunStart()));
+         setMessage(activity.getMessage());
+         setError(activity.getError());
+      }
+   }
+
+   /**
+    * Gets the name of the schedule task.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(description = "The name of the task.", example = "user0~;~organization0:Weekly Summary")
+   public String getTask() {
+      return task;
+   }
+
+   /**
+    * Sets the name of the schedule task.
+    *
+    * @param task the task name.
+    */
+   public void setTask(String task) {
+      this.task = task;
+   }
+
+   /**
+    * Gets the status of the last run of the task.
+    *
+    * @return the status.
+    */
+   @Schema(description = "The status of the last run of the task.", example = "Finished")
+   public String getLastRunStatus() {
+      return lastRunStatus;
+   }
+
+   /**
+    * Sets the status of the last run of the task.
+    *
+    * @param lastRunStatus the status.
+    */
+   public void setLastRunStatus(String lastRunStatus) {
+      this.lastRunStatus = lastRunStatus;
+   }
+
+   /**
+    * Gets the status of the next run of the task.
+    *
+    * @return the status.
+    */
+   @Schema(description = "The status of the next run of the task.", example = "Pending")
+   public String getNextRunStatus() {
+      return nextRunStatus;
+   }
+
+   /**
+    * Sets the status of the next run of the task.
+    *
+    * @param nextRunStatus the status.
+    */
+   public void setNextRunStatus(String nextRunStatus) {
+      this.nextRunStatus = nextRunStatus;
+   }
+
+   /**
+    * Gets the date and time at which the last run started.
+    *
+    * @return the start time.
+    */
+   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+   @JsonSerialize(using = OffsetDateTimeSerializer.class)
+   @JsonDeserialize(using = OffsetDateTimeDeserializer.class)
+   @Schema(
+      description = "The date and time that the last run of the task started.",
+      format = "date-time",
+      example = "2020-03-31T01:00:00Z")
+   public OffsetDateTime getLastRunStart() {
+      return lastRunStart;
+   }
+
+   /**
+    * Sets the date and time at which the last run started.
+    *
+    * @param lastRunStart the start time.
+    */
+   public void setLastRunStart(OffsetDateTime lastRunStart) {
+      this.lastRunStart = lastRunStart;
+   }
+
+   /**
+    * Gets the date and time at which the last run ended.
+    *
+    * @return the end time.
+    */
+   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+   @JsonSerialize(using = OffsetDateTimeSerializer.class)
+   @JsonDeserialize(using = OffsetDateTimeDeserializer.class)
+   @Schema(
+      description = "The date and time that the last run of the task ended.",
+      format = "date-time",
+      example = "2020-03-31T01:00:00Z")
+   public OffsetDateTime getLastRunEnd() {
+      return lastRunEnd;
+   }
+
+   /**
+    * Sets the date and time at which the last run ended.
+    *
+    * @param lastRunEnd the end time.
+    */
+   public void setLastRunEnd(OffsetDateTime lastRunEnd) {
+      this.lastRunEnd = lastRunEnd;
+   }
+
+   /**
+    * Gets the date and time at which the next run is scheduled.
+    *
+    * @return the start time.
+    */
+   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+   @JsonSerialize(using = OffsetDateTimeSerializer.class)
+   @JsonDeserialize(using = OffsetDateTimeDeserializer.class)
+   @Schema(
+      description = "The date and time for the next run of the task.",
+      format = "date-time",
+      example = "2020-04-06T01:00:00Z")
+   public OffsetDateTime getNextRunStart() {
+      return nextRunStart;
+   }
+
+   /**
+    * Sets the date and time at which the next run is scheduled.
+    *
+    * @param nextRunStart the start time.
+    */
+   public void setNextRunStart(OffsetDateTime nextRunStart) {
+      this.nextRunStart = nextRunStart;
+   }
+
+   /**
+    * Gets the error message from the last run, if any.
+    *
+    * @return the error message.
+    */
+   @Schema(description = "The error message from the last run, if any.", example = "Task Completed")
+   public String getMessage() {
+      return message;
+   }
+
+   /**
+    * Sets the error message from the last run, if any.
+    *
+    * @param message the error message.
+    */
+   public void setMessage(String message) {
+      this.message = message;
+   }
+
+   /**
+    * Gets the error that occurred during the last run, if any.
+    *
+    * @return the error stack trace.
+    */
+   @Schema(description = "The stack trace from the error that occurred during the last run, if any.")
+   public String getError() {
+      return error;
+   }
+
+   /**
+    * Sets the error that occurred during the last run, if any.
+    *
+    * @param error the error stack trace.
+    */
+   public void setError(String error) {
+      this.error = error;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      ScheduleTaskStatus that = (ScheduleTaskStatus) o;
+      return Objects.equals(task, that.task) &&
+         Objects.equals(lastRunStatus, that.lastRunStatus) &&
+         Objects.equals(nextRunStatus, that.nextRunStatus) &&
+         Objects.equals(lastRunStart, that.lastRunStart) &&
+         Objects.equals(lastRunEnd, that.lastRunEnd) &&
+         Objects.equals(nextRunStart, that.nextRunStart) &&
+         Objects.equals(message, that.message) &&
+         Objects.equals(error, that.error);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(
+         task, lastRunStatus, nextRunStatus, lastRunStart, lastRunEnd, nextRunStart, message,
+         error);
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduleTaskStatus{" +
+         "task='" + task + '\'' +
+         ", lastRunStatus='" + lastRunStatus + '\'' +
+         ", nextRunStatus='" + nextRunStatus + '\'' +
+         ", lastRunStart=" + lastRunStart +
+         ", lastRunEnd=" + lastRunEnd +
+         ", nextRunStart=" + nextRunStart +
+         ", message='" + message + '\'' +
+         ", error='" + error + '\'' +
+         '}';
+   }
+
+   private static OffsetDateTime getTimestamp(long ts) {
+      if(ts == 0L) {
+         return null;
+      }
+
+      return OffsetDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.of("UTC"));
+   }
+
+   private String task;
+   private String lastRunStatus;
+   private String nextRunStatus;
+   private OffsetDateTime lastRunStart;
+   private OffsetDateTime lastRunEnd;
+   private OffsetDateTime nextRunStart;
+   private String message;
+   private String error;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ServerPathInfo.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ServerPathInfo.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "The server path info for backup action.")
+public class ServerPathInfo {
+   public ServerPathInfo() {
+      super();
+   }
+
+   public ServerPathInfo(inetsoft.sree.schedule.ServerPathInfo info) {
+      super();
+
+      if(info != null) {
+         this.path = info.getPath();
+         this.useCredential = info.isUseCredential();
+
+         if(info.isUseCredential()) {
+            this.secretId = info.getSecretId();
+         }
+         else {
+            this.userName = info.getUsername();
+            this.password = info.getPassword();
+         }
+      }
+   }
+
+   public String getPath() {
+      return path;
+   }
+
+   public void setPath(String path) {
+      this.path = path;
+   }
+
+   @Schema(description = "Whether to use a vault secret ID for the credentials.")
+   public boolean isUseCredential() {
+      return useCredential;
+   }
+
+   public void setUseCredential(boolean useCredential) {
+      this.useCredential = useCredential;
+   }
+
+   @Schema(description = "The vault secret ID for the credentials.")
+   public String getSecretId() {
+      return secretId;
+   }
+
+   public void setSecretId(String secretId) {
+      this.secretId = secretId;
+   }
+
+   public String getUserName() {
+      return userName;
+   }
+
+   public void setUserName(String userName) {
+      this.userName = userName;
+   }
+
+   public String getPassword() {
+      return password;
+   }
+
+   public void setPassword(String password) {
+      this.password = password;
+   }
+
+   private String path;
+   private String userName;
+   private String password;
+   private boolean useCredential;
+   private String secretId;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/StopScheduleTaskRequest.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/StopScheduleTaskRequest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Objects;
+
+/**
+ * StopScheduleTaskRequest contains the parameters used to stop a schedule task.
+ */
+@Validated
+@Schema(description = "The parameters used to stop a schedule task.")
+public class StopScheduleTaskRequest {
+   /**
+    * Gets the name of the task to stop.
+    *
+    * @return the task name.
+    */
+   @NotNull
+   @Schema(description = "The name of the task.", example = "admin~;~host-org:Monthly Summary")
+   public String getTask() {
+      return task;
+   }
+
+   /**
+    * Sets the name of the task to stop.
+    *
+    * @param task the task name.
+    */
+   public void setTask(String task) {
+      this.task = task;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      StopScheduleTaskRequest that = (StopScheduleTaskRequest) o;
+      return Objects.equals(task, that.task);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(task);
+   }
+
+   @Override
+   public String toString() {
+      return "StopScheduleTaskRequest{" +
+         "task='" + task + '\'' +
+         '}';
+   }
+
+   private String task;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/TimeCondition.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/TimeCondition.java
@@ -1,0 +1,693 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import inetsoft.web.json.OffsetDateTimeDeserializer;
+import inetsoft.web.json.OffsetDateTimeSerializer;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * {@code ScheduleTimeCondition} describes a condition that is satisfied by some time-based
+ * criteria.
+ */
+@Validated
+@Schema(description = "A condition that is satisfied by some time-based criteria.")
+public class TimeCondition extends ScheduleCondition {
+   /**
+    * Creates a new instance of {@code TimeCondition}.
+    */
+   public TimeCondition() {
+      setConditionType(ConditionType.TIME);
+   }
+
+   /**
+    * Creates a new instance of {@code TimeCondition}.
+    *
+    * @param condition the condition object being represented.
+    */
+   public TimeCondition(inetsoft.sree.schedule.TimeCondition condition) {
+      if(condition.getDate() != null) {
+         setDate(OffsetDateTime.ofInstant(condition.getDate().toInstant(), ZoneId.of("UTC")));
+      }
+
+      setConditionType(ConditionType.TIME);
+      setType(Type.fromValue(condition.getType()));
+      setDayOfMonth(condition.getDayOfMonth());
+      setDayOfWeek(condition.getDayOfWeek());
+      setWeekOfMonth(condition.getWeekOfMonth());
+      setHour(condition.getHour());
+      setMinute(condition.getMinute());
+      setSecond(condition.getSecond());
+      setInterval(condition.getInterval());
+      setHourEnd(condition.getHourEnd());
+      setMinuteEnd(condition.getMinuteEnd());
+      setSecondEnd(condition.getSecondEnd());
+      setHourlyInterval(condition.getHourlyInterval());
+      setDaysOfWeek(condition.getDaysOfWeek());
+      setMonthsOfYear(condition.getMonthsOfYear());
+      setWeekdayOnly(condition.isWeekdayOnly());
+      setTimeRange(condition.getTimeRange() == null ? null :
+         condition.getTimeRange().getName());
+      setTimeZone(condition.getTimeZone().getID());
+   }
+
+   /**
+    * Gets the date and time at which the condition is satisfied.
+    *
+    * @return the date.
+    */
+   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+   @JsonSerialize(using = OffsetDateTimeSerializer.class)
+   @JsonDeserialize(using = OffsetDateTimeDeserializer.class)
+   @Schema(description = "The date and time at which the condition is satisfied.", format = "date-time")
+   public OffsetDateTime getDate() {
+      return date;
+   }
+
+   /**
+    * Sets the date and time at which the condition is satisfied.
+    *
+    * @param date the date.
+    */
+   public void setDate(OffsetDateTime date) {
+      this.date = date;
+   }
+
+   /**
+    * Gets the day of the month (1-31) on which the condition is satisfied.
+    *
+    * @return the day of the month.
+    */
+   @NotNull
+   @Min(0L)
+   @Max(31L)
+   @Schema(
+      description = "The day of the month on which the condition is satisfied. This must be be between 1 and 31, inclusive.",
+      example = "0")
+   public int getDayOfMonth() {
+      return dayOfMonth;
+   }
+
+   /**
+    * Sets the day of the month (1-31) on which the condition is satisfied.
+    *
+    * @param dayOfMonth the day of the month.
+    */
+   public void setDayOfMonth(int dayOfMonth) {
+      this.dayOfMonth = dayOfMonth;
+   }
+
+   /**
+    * Gets the day of the week (1-7) on which the condition is satisfied.
+    *
+    * @return the day of the week.
+    */
+   @NotNull
+   @Min(0L)
+   @Max(7L)
+   @Schema(
+      description = "The day of the week on which the condition is satisfied. This must be between 1 (Sunday) and 7 (Saturday), inclusive.",
+      example = "6")
+   public int getDayOfWeek() {
+      return dayOfWeek;
+   }
+
+   /**
+    * Sets the day of the week (1-7) on which the condition is satisfied.
+    *
+    * @param dayOfWeek the day of the week.
+    */
+   public void setDayOfWeek(int dayOfWeek) {
+      this.dayOfWeek = dayOfWeek;
+   }
+
+   /**
+    * Gets the days of the week (1-7) on which the condition is satisfied.
+    *
+    * @return the days of the week.
+    */
+   @NotNull
+   @Min(1L)
+   @Max(7L)
+   @Schema(
+      description = "The days of the week on which the condition is satisfied. The values must be a between 1 (Sunday) and 7 (Saturday), inclusive.",
+      example = "[]")
+   public int[] getDaysOfWeek() {
+      return daysOfWeek;
+   }
+
+   /**
+    * Sets the days of the week (1-7) on which the condition is satisfied.
+    *
+    * @param daysOfWeek the days of the week.
+    */
+   public void setDaysOfWeek(int[] daysOfWeek) {
+      this.daysOfWeek = daysOfWeek;
+   }
+
+   /**
+    * Gets the week of the month (1-5) in which the condition is satisfied.
+    *
+    * @return the week of the month.
+    */
+   @NotNull
+   @Min(0L)
+   @Max(5L)
+   @Schema(
+      description = "The week of the month in which the condition is satisfied. This must be between 1 and 5, inclusive",
+      example = "0")
+   public int getWeekOfMonth() {
+      return weekOfMonth;
+   }
+
+   /**
+    * Sets the week of the month (1-5) in which the condition is satisfied.
+    *
+    * @param weekOfMonth the week of the month.
+    */
+   public void setWeekOfMonth(int weekOfMonth) {
+      this.weekOfMonth = weekOfMonth;
+   }
+
+   /**
+    * Gets the months of the year (0-11) in which the condition is satisfied.
+    *
+    * @return the months of the year.
+    */
+   @NotNull
+   @Min(0L)
+   @Max(11L)
+   @Schema(
+      description = "The months of the year on which the condition is satisified. The values must be between 0 (January) and 11 (December), inclusive.",
+      example = "[]")
+   public int[] getMonthsOfYear() {
+      return monthsOfYear;
+   }
+
+   /**
+    * Sets the months of the year (0-11) in which the condition is satisfied.
+    *
+    * @param monthsOfYear the months of the year.
+    */
+   public void setMonthsOfYear(int[] monthsOfYear) {
+      this.monthsOfYear = monthsOfYear;
+   }
+
+   /**
+    * Gets the hour of the day (0-23) at which the condition is satisfied.
+    *
+    * @return the hour of the day.
+    */
+   @NotNull
+   @Min(-1L)
+   @Max(23L)
+   @Schema(
+      description = "The hour of the day at which the condition is satisfied. This must be between 0 and 23, inclusive. May be -1 if not used.",
+      example = "0")
+   public int getHour() {
+      return hour;
+   }
+
+   /**
+    * Sets the hour of the day (0-23) at which the condition is satisfied.
+    *
+    * @param hour the hour of the day.
+    */
+   public void setHour(int hour) {
+      this.hour = hour;
+   }
+
+   /**
+    * Gets the minute of the hour (0-59) at which the condition is satisfied.
+    *
+    * @return the minute.
+    */
+   @NotNull
+   @Min(-1L)
+   @Max(59L)
+   @Schema(
+      description = "The minute of the hour at which the condition is satisfied. This must be between 0 and 59, inclusive. May be -1 if not used.",
+      example = "30")
+   public int getMinute() {
+      return minute;
+   }
+
+   /**
+    * Sets the minute of the hour (0-59) at which the condition is satisfied.
+    *
+    * @param minute the minute.
+    */
+   public void setMinute(int minute) {
+      this.minute = minute;
+   }
+
+   /**
+    * Gets the second (0-59) at which the condition is satisfied.
+    *
+    * @return the second.
+    */
+   @NotNull
+   @Min(-1L)
+   @Max(59L)
+   @Schema(
+      description = "The second at which the condition is satisfied. This must be between 0 and 59, inclusive. May be -1 if not used.",
+      example = "0")
+   public int getSecond() {
+      return second;
+   }
+
+   /**
+    * Sets the second (0-59) at which the condition is satisfied.
+    *
+    * @param second the second.
+    */
+   public void setSecond(int second) {
+      this.second = second;
+   }
+
+   /**
+    * Gets the hour of the day (0-23) at which the hourly interval period ends.
+    *
+    * @return the hour of the day.
+    */
+   @Min(-1L)
+   @Max(23L)
+   @Schema(
+      description = "The hour of the day at which the hourly interval period ends. This must be between 0 and 23, inclusive. May be -1 if not used.",
+      example = "0",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public int getHourEnd() {
+      return hourEnd;
+   }
+
+   /**
+    * Sets the hour of the day (0-23) at which the hourly interval period ends.
+    *
+    * @param hour the hour of the day.
+    */
+   public void setHourEnd(int hour) {
+      this.hourEnd = hour;
+   }
+
+   /**
+    * Gets the minute of the hour (0-59) at which the hourly interval period ends.
+    *
+    * @return the minute.
+    */
+   @Min(-1L)
+   @Max(59L)
+   @Schema(
+      description = "The minute of the hour at which the hourly interval period ends. This must be between 0 and 59, inclusive. May be -1 if not used.",
+      example = "30",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public int getMinuteEnd() {
+      return minuteEnd;
+   }
+
+   /**
+    * Sets the minute of the hour (0-59) at which the hourly interval period ends.
+    *
+    * @param minute the minute.
+    */
+   public void setMinuteEnd(int minute) {
+      this.minuteEnd = minute;
+   }
+
+   /**
+    * Gets the second (0-59) at which the hourly interval period ends.
+    *
+    * @return the second.
+    */
+   @Min(-1L)
+   @Max(59L)
+   @Schema(
+      description = "The second at which the hourly interval period ends. This must be between 0 and 59, inclusive. May be -1 if not used.",
+      example = "0",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public int getSecondEnd() {
+      return secondEnd;
+   }
+
+   /**
+    * Sets the second (0-59) at which the hourly interval period ends.
+    *
+    * @param second the second.
+    */
+   public void setSecondEnd(int second) {
+      this.secondEnd = second;
+   }
+
+   /**
+    * Gets the hourly interval within the period by which the condition is satisfied.
+    *
+    * @return the range interval.
+    *
+    * @since 2019
+    */
+   @Min(0L)
+   @Schema(
+      description = "The hourly interval within the time period by which the condition is satisfied.",
+      example = "0",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public float getHourlyInterval() {
+      return hourlyInterval;
+   }
+
+   /**
+    * Sets the hourly interval within the time period by which the condition is satisfied.
+    *
+    * @param interval the range interval.
+    *
+    * @since 2019
+    */
+   public void setHourlyInterval(float interval) {
+      this.hourlyInterval = interval;
+   }
+
+   /**
+    * Gets the time range in which the condition is satisfied.
+    *
+    * @return the name of the time range.
+    */
+   @Schema(description = "The name of a configured time range in which the condition is satisfied.")
+   public String getTimeRange() {
+      return timeRange;
+   }
+
+   /**
+    * Sets the time range in which the condition is satisfied.
+    *
+    * @param timeRange the name of the time range.
+    */
+   public void setTimeRange(String timeRange) {
+      this.timeRange = timeRange;
+   }
+
+   /**
+    * Gets the type of time condition to apply. The value of this property determines which fields
+    * are valid.
+    *
+    * @return the time condition type.
+    */
+   @NotNull
+   @Schema(
+      description = "The type of time condition to apply. The value of this field determines which fields are valid.",
+      example = "DAY_OF_WEEK")
+   public Type getType() {
+      return type;
+   }
+
+   /**
+    * Sets the type of time condition to apply. The value of this property determines which fields
+    * are valid.
+    *
+    * @param type the time condition type.
+    */
+   public void setType(Type type) {
+      this.type = type;
+   }
+
+   /**
+    * Gets the interval by which the range is repeated.
+    *
+    * @return the range interval.
+    *
+    * @since 2019
+    */
+   @Min(0L)
+   @Schema(
+      description = "The interval by which the condition is satisfied.",
+      example = "0",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public int getInterval() {
+      return interval;
+   }
+
+   /**
+    * Sets the interval by which the range is repeated.
+    *
+    * @param interval the range interval.
+    *
+    * @since 2019
+    */
+   public void setInterval(int interval) {
+      this.interval = interval;
+   }
+
+   /**
+    * Gets whether the condition is restricted to weekdays.
+    *
+    * @return <i>true</i> if the condition is restricted to weekdays.
+    *
+    * @since 2019
+    */
+   @NotNull
+   @Schema(
+      description = "A flag that indicates if the condition should only be satisified on weekdays.",
+      example = "false",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public boolean isWeekdayOnly() {
+      return weekdayOnly;
+   }
+
+   /**
+    * Sets whether the condition is restricted to weekdays.
+    *
+    * @param weekdayOnly <i>true</i> if the condition is restricted to weekdays.
+    *
+    * @since 2019
+    */
+   public void setWeekdayOnly(boolean weekdayOnly) {
+      this.weekdayOnly = weekdayOnly;
+   }
+
+   /**
+    * Gets the string ID of the condition's time zone.
+    *
+    * @return the time zone's string ID.
+    *
+    * @since 2023
+    */
+   @Schema(
+      description = "The time zone's string ID. Will use condition's current time zone if null.",
+      example = "America/New_York",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public String getTimeZone() {
+      return timeZone;
+   }
+
+   /**
+    * Sets the condition time zone using the string ID.
+    *
+    * @param timeZone the time zone's string ID.
+    *
+    * @since 2023
+    */
+   public void setTimeZone(String timeZone) {
+      this.timeZone = timeZone;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass() || !super.equals(o)) {
+         return false;
+      }
+
+      TimeCondition that = (TimeCondition) o;
+      return ((date == null && that.date == null) ||
+            (date != null && date.equals(that.date))) &&
+         ((timeRange == null && that.timeRange == null) ||
+            (timeRange != null && timeRange.equals(that.timeRange))) &&
+         ((timeZone == null && that.timeZone == null) ||
+            (timeZone != null && timeZone.equals(that.timeZone))) &&
+         dayOfMonth == that.dayOfMonth &&
+         dayOfWeek == that.dayOfWeek &&
+         weekOfMonth == that.weekOfMonth &&
+         hour == that.hour &&
+         minute == that.minute &&
+         second == that.second &&
+         hourEnd == that.hourEnd &&
+         minuteEnd == that.minuteEnd &&
+         secondEnd == that.secondEnd &&
+         interval == that.interval &&
+         hourlyInterval == that.hourlyInterval &&
+         type == that.type &&
+         weekdayOnly == that.weekdayOnly;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(
+         getConditionType(),
+         date,
+         dayOfMonth,
+         dayOfWeek,
+         Arrays.hashCode(daysOfWeek),
+         Arrays.hashCode(monthsOfYear),
+         weekOfMonth,
+         hour,
+         minute,
+         second,
+         hourEnd,
+         minuteEnd,
+         secondEnd,
+         timeRange,
+         interval,
+         hourlyInterval,
+         type,
+         weekdayOnly,
+         timeZone
+      );
+   }
+
+   @Override
+   public String toString() {
+      return "TimeCondition{" +
+         "conditionType=" + getConditionType() +
+         ", date=" + date +
+         ", dayOfMonth=" + dayOfMonth +
+         ", dayOfWeek=" + dayOfWeek +
+         ", daysOfWeek=" + Arrays.toString(daysOfWeek) +
+         ", monthsOfYear=" + Arrays.toString(monthsOfYear) +
+         ", weekOfMonth=" + weekOfMonth +
+         ", hour=" + hour +
+         ", minute=" + minute +
+         ", second=" + second +
+         ", hourEnd=" + hourEnd +
+         ", minuteEnd=" + minuteEnd +
+         ", secondEnd=" + secondEnd +
+         ", timeRange='" + timeRange + "'" +
+         ", interval=" + interval +
+         ", hourlyInterval=" + hourlyInterval +
+         ", type=" + type +
+         ", weekdayOnly=" + weekdayOnly +
+         ", timeZone=" + timeZone +
+         '}';
+   }
+
+   private OffsetDateTime date;
+   private int dayOfMonth;
+   private int dayOfWeek;
+   private int[] daysOfWeek = new int[0];
+   private int[] monthsOfYear = new int[0];
+   private int weekOfMonth;
+   private int hour;
+   private int minute;
+   private int second;
+   private int hourEnd;
+   private int minuteEnd;
+   private int secondEnd;
+   private float hourlyInterval;
+   private String timeRange;
+   private int interval;
+   private Type type;
+   private boolean weekdayOnly;
+   private String timeZone;
+
+   /**
+    * Enumeration of the types of time conditions.
+    */
+   public enum Type {
+      /**
+       * Time condition that is satisfied at one date and time.
+       */
+      AT(inetsoft.sree.schedule.TimeCondition.AT),
+
+      /**
+       * @deprecated Use {@link Type#EVERY_MONTH} with the appropriate values
+       *
+       * Time condition that is satisfied on a particular day of the month.
+       */
+      @Deprecated
+      DAY_OF_MONTH(inetsoft.sree.schedule.TimeCondition.EVERY_MONTH),
+
+      /**
+       * Time condition that is satisfied on a particular day of the week.
+       */
+      DAY_OF_WEEK(inetsoft.sree.schedule.TimeCondition.EVERY_WEEK),
+
+      /**
+       * Time condition that is satisfied every day at a particular time.
+       */
+      EVERY_DAY(inetsoft.sree.schedule.TimeCondition.EVERY_DAY),
+
+      /**
+       * Time condition that is satisfied every week at a particular time.
+       */
+      EVERY_WEEK(inetsoft.sree.schedule.TimeCondition.EVERY_WEEK),
+
+      /**
+       * Time condition that is satisfied every month at a particular time.
+       */
+      EVERY_MONTH(inetsoft.sree.schedule.TimeCondition.EVERY_MONTH),
+
+      /**
+       * @deprecated Use {@link Type#EVERY_MONTH} with the appropriate values
+       *
+       * Time condition that is satisfied during a particular week of every month.
+       */
+      @Deprecated
+      WEEK_OF_MONTH(inetsoft.sree.schedule.TimeCondition.EVERY_MONTH),
+
+      /**
+       * Time condition that is satisfied every interval within a particular time period of certain days of the week.
+       */
+      EVERY_HOUR(inetsoft.sree.schedule.TimeCondition.EVERY_HOUR);
+
+      private int value;
+
+      Type(int value) {
+         this.value = value;
+      }
+
+      public int value() {
+         return value;
+      }
+
+      public static Type fromValue(int value) {
+
+         for(Type type : values()) {
+            if(value == type.value) {
+               if(EVERY_MONTH.value == value) {
+                  return EVERY_MONTH;
+               }
+
+               return type;
+            }
+         }
+
+         return null;
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/UnsupportedScheduleItem.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/UnsupportedScheduleItem.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Placeholder for a schedule condition or action with no enterprise API DTO (e.g. a built-in
+ * system task's {@code TaskBalancerCondition}/{@code NeverRunCondition}/{@code
+ * AssetFileBackupAction}) -- returned by {@link ScheduleApiService#getTaskConditionsLenient}/
+ * {@link ScheduleApiService#getTaskActionsLenient} instead of propagating the conversion
+ * failure. Deliberately not a {@link ScheduleCondition}/{@link ScheduleAction} subtype: those
+ * hierarchies are shared with the public REST API and cluster client services, and must stay
+ * closed.
+ */
+@Schema(description = "A condition or action with no representation in this API -- present so " +
+   "the task can still be read in full, but cannot itself be edited through this API.")
+public class UnsupportedScheduleItem {
+   public UnsupportedScheduleItem(String internalType) {
+      this.internalType = internalType;
+   }
+
+   @Schema(description = "Always true; marks this entry as a placeholder.")
+   public boolean isUnsupported() {
+      return true;
+   }
+
+   @Schema(description = "The internal (non-API) class name of the condition or action.")
+   public String getInternalType() {
+      return internalType;
+   }
+
+   private final String internalType;
+}

--- a/core/src/main/java/inetsoft/web/api/schedule/ViewsheetAction.java
+++ b/core/src/main/java/inetsoft/web/api/schedule/ViewsheetAction.java
@@ -1,0 +1,1357 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.api.schedule;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import inetsoft.sree.RepletRequest;
+import inetsoft.sree.schedule.ServerPathInfo;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.viewsheet.FileFormatInfo;
+import inetsoft.uql.viewsheet.VSBookmarkInfo;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * ViewsheetAction describes an action that opens a viewsheet and performs one or more sub-actions
+ * on it.
+ */
+@Validated
+@Schema(description = "An action that opens a viewsheet and performs one or more sub-actions on it.")
+public class ViewsheetAction extends ScheduleAction {
+   /**
+    * Creates a new instance of {@code ViewsheetAction}.
+    */
+   public ViewsheetAction() {
+      setActionType(ActionType.VIEWSHEET);
+   }
+
+   /**
+    * Creates a new instance of {@code ViewsheetAction}.
+    *
+    * @param action the action object being represented.
+    */
+   public ViewsheetAction(inetsoft.sree.schedule.ViewsheetAction action) {
+      setActionType(ActionType.VIEWSHEET);
+      setViewsheet(action.getViewsheet());
+
+      setBookmarkName(action.getBookmarks()[0]);
+      setBookmarkNames(Arrays.asList(action.getBookmarks()));
+      setBookmarkUsers(Arrays.asList(action.getBookmarkUsers()));
+
+      // defensive: bookmarkTypes should always be populated parallel to bookmarks/bookmarkUsers
+      // by the write side (see convertAction(ViewsheetAction)), but guard against a null/empty
+      // array from a task persisted before that fix, or created some other way.
+      if(action.getBookmarkTypes() != null && action.getBookmarkTypes().length > 0) {
+         setBookmarkType(BookmarkType.fromCode(action.getBookmarkTypes()[0]));
+         setBookmarkTypes(Arrays.stream(action.getBookmarkTypes())
+                             .mapToObj(BookmarkType::fromCode)
+                             .collect(Collectors.toList()));
+      }
+
+      populateSaveToServerFormats(action);
+
+      if(action.getEmails() != null && !action.getEmails().isEmpty()) {
+         getEmails().addAll(Arrays.asList(action.getEmails().split(",")));
+      }
+
+      if(action.getNotifications() != null && !action.getNotifications().isEmpty()) {
+         getNotifies().addAll(Arrays.asList(action.getNotifications().split(",")));
+         setNotifyIfFailed(action.isNotifyError());
+         setNotifyLink(action.isLink());
+      }
+      if(action.getFileFormat() != null && !action.getFileFormat().isEmpty()) {
+         setFormat(Format.valueOf(action.getFileFormat().toUpperCase()));
+      }
+
+      if(action.getFileFormat() != null && !action.getFileFormat().isEmpty()) {
+         setFormat(Format.valueOf(action.getFileFormat().toUpperCase()));
+      }
+
+      if(action.getRepletRequest() != null) {
+         RepletRequest request = action.getViewsheetRequest();
+
+         for(Enumeration<?> e = request.getParameterNames(); e.hasMoreElements();) {
+            String name = (String) e.nextElement();
+            getParameters().put(name, request.getParameter(name));
+         }
+      }
+
+      setSender(action.getFrom());
+      setSubject(action.getSubject());
+      setMessage(action.getMessage());
+      setHtmlMessage(action.isMessageHtml());
+      setCCAddresses(action.getCCAddresses());
+      setBCCAddresses(action.getBCCAddresses());
+      setEmailMatch(action.isMatchLayout());
+      setEmailExpandSelections(action.isExpandSelections());
+      setEmailOnlyDataComponents(action.isOnlyDataComponents());
+      setExportAllTabbedTables(action.isExportAllTabbedTables());
+      setEmailZip(action.isCompressFile());
+      setAttachmentName(action.getAttachmentName());
+      setEmailLink(action.isDeliverLink());
+      populateAlerts(action);
+
+      if(action.getEmailCSVConfig() != null) {
+         setEmailCSVConfig(new CSVConfig(action.getEmailCSVConfig()));
+      }
+
+      populateSaveToServerFormats(action);
+      setSaveToServerMatch(action.isSaveToServerMatch());
+      setSaveToServerExpandSelections(action.isSaveToServerExpandSelections());
+      setSaveToServerOnlyDataComponents(action.isSaveToServerOnlyDataComponents());
+      setSaveExportAllTabbedTables(action.isSaveExportAllTabbedTables());
+
+      if(action.getSaveCSVConfig() != null) {
+         setSaveToServerCsvConfig(new CSVConfig(action.getSaveCSVConfig()));
+      }
+
+      if(action.getViewsheetRequest() != null) {
+         RepletRequest request = action.getViewsheetRequest();
+
+         for(Enumeration<?> e = request.getParameterNames(); e.hasMoreElements();) {
+            String name = (String) e.nextElement();
+            getParameters().put(name, request.getParameter(name));
+         }
+      }
+   }
+
+   private void populateSaveToServerFormats(inetsoft.sree.schedule.ViewsheetAction action) {
+      final int[] saveFormats = action.getSaveFormats();
+
+      if(saveFormats.length > 0) {
+         saveToServerFilePaths = new ArrayList<>(saveFormats.length);
+      }
+
+      for(int saveFormat : saveFormats) {
+         final String format = FileFormatInfo.EXPORT_ALL_NAMES[saveFormat];
+
+         if(format != null) {
+            final ServerPathInfo info = action.getFilePathInfo(saveFormat);
+            saveToServerFilePaths.add(new SaveToServerFilePath(Format.valueOf(format.toUpperCase()), info));
+         }
+      }
+   }
+
+   private void populateAlerts(inetsoft.sree.schedule.ViewsheetAction action) {
+      inetsoft.sree.schedule.ScheduleAlert[] alerts = action.getAlerts();
+
+      if(alerts != null) {
+         this.alerts = new ArrayList<>(alerts.length);
+
+         for(inetsoft.sree.schedule.ScheduleAlert alert : alerts) {
+            this.alerts.add(new ScheduleAlert(alert.getElementId(), alert.getHighlightName()));
+         }
+      }
+   }
+
+   /**
+    * Gets the asset identifier of the viewsheet.
+    *
+    * @return the asset identifier.
+    */
+   @NotNull
+   @Schema(
+      description = "The asset identifier of the viewsheet.",
+      example = "1^128^__NULL__^Examples/Sales Summary^host-org")
+   public String getViewsheet() {
+      return viewsheet;
+   }
+
+   /**
+    * Sets the asset identifier of the viewsheet.
+    *
+    * @param viewsheet the asset identifier.
+    */
+   public void setViewsheet(String viewsheet) {
+      this.viewsheet = viewsheet;
+   }
+
+   /**
+    * Gets the name of the bookmark, if any, to open the viewsheet to.
+    *
+    * @return the bookmark name.
+    */
+   @Schema(description = "The name of the bookmark to open the viewsheet to.", example = "(Home)")
+   public String getBookmarkName() {
+      return bookmarkName;
+   }
+
+   /**
+    * Sets the name of the bookmark, if any, to open the viewsheet to.
+    *
+    * @param bookmarkName the bookmark name.
+    */
+   public void setBookmarkName(String bookmarkName) {
+      this.bookmarkName = bookmarkName;
+   }
+
+   /**
+    * Gets the names of the bookmarks, if any, to open the viewsheet to.
+    *
+    * @return the bookmark name.
+    */
+   @Schema(description = "The names of the bookmarks to open the viewsheet to.", example = "[ \"(Home)\" ]")
+   public List<String> getBookmarkNames() {
+      return bookmarkNames;
+   }
+
+   /**
+    * Sets the names of the bookmarks, if any, to open the viewsheet to.
+    *
+    * @param bookmarkNames the bookmark names.
+    */
+   public void setBookmarkNames(List<String> bookmarkNames) {
+      this.bookmarkNames = bookmarkNames;
+   }
+
+   /**
+    * Gets the name of the user that owns the bookmark.
+    *
+    * @return the owner.
+    */
+   @Schema(
+      description = "The name of the user that owns the bookmark. Required if `bookmarkName` is set.",
+      example = "admin")
+   public IdentityID getBookmarkUser() {
+      return bookmarkUser;
+   }
+
+   /**
+    * Sets the name of the user that owns the bookmark.
+    *
+    * @param bookmarkUser the owner.
+    */
+   public void setBookmarkUser(IdentityID bookmarkUser) {
+      this.bookmarkUser = bookmarkUser;
+   }
+
+   /**
+    * Gets the names of the users that own the bookmarks.
+    *
+    * @return the owners.
+    */
+   @Schema(
+      description = "The names of the users that own the bookmarks. Required if `bookmarkNames` is set.",
+      example = "[ admin ]")
+   public List<IdentityID> getBookmarkUsers() {
+      return bookmarkUsers;
+   }
+
+   /**
+    * Sets the names of the users that own the bookmarks.
+    *
+    * @param bookmarkUsers the owners.
+    */
+   public void setBookmarkUsers(List<IdentityID> bookmarkUsers) {
+      this.bookmarkUsers = bookmarkUsers;
+   }
+
+   /**
+    * Gets the type of bookmark.
+    *
+    * @return the bookmark type.
+    */
+   @Schema(
+      description = "The type of bookmark. Required if `bookmarkName` is set.",
+      example = "all_share")
+   public BookmarkType getBookmarkType() {
+      return bookmarkType;
+   }
+
+   /**
+    * Sets the type of bookmark.
+    *
+    * @param bookmarkType the bookmark type.
+    */
+   public void setBookmarkType(BookmarkType bookmarkType) {
+      this.bookmarkType = bookmarkType;
+   }
+
+   /**
+    * Gets the types of the bookmarks.
+    *
+    * @return the bookmark types.
+    */
+   @Schema(
+      description = "The types of the bookmarks. Required if `bookmarkNames` is set.",
+      example = "[ \"all_share\" ]")
+   public List<BookmarkType> getBookmarkTypes() {
+      return bookmarkTypes;
+   }
+
+   /**
+    * Sets the types of the bookmarks.
+    *
+    * @param bookmarkTypes the bookmark type.
+    */
+   public void setBookmarkTypes(List<BookmarkType> bookmarkTypes) {
+      this.bookmarkTypes = bookmarkTypes;
+   }
+
+   /**
+    * Gets the email address to which the viewsheet should be sent.
+    *
+    * @return the email list.
+    */
+   @Schema(
+      description = "The email addresses to which the viewsheet should be sent.",
+      example = "[ \"sales@example.com\", \"marketing@example.com\" ]")
+   public List<String> getEmails() {
+      if(emails == null) {
+         emails = new ArrayList<>();
+      }
+
+      return emails;
+   }
+
+   /**
+    * Sets the email address to which the report should be sent.
+    *
+    * @param emails the email list.
+    */
+   public void setEmails(List<String> emails) {
+      if(emails == null) {
+         emails = new ArrayList<>();
+      }
+
+      this.emails = emails;
+   }
+
+   /**
+    * Gets the email address from which the delivery and/or notification emails are sent.
+    *
+    * @return the sender.
+    */
+   @Schema(
+      description = "The email address from which the delivery and notification emails are sent. Required if `emails` or `notifies` are not empty.",
+      example = "report@example.com")
+   public String getSender() {
+      return sender;
+   }
+
+   /**
+    * Sets the email address from which the delivery and/or notification emails are sent.
+    *
+    * @param sender the sender.
+    */
+   public void setSender(String sender) {
+      this.sender = sender;
+   }
+
+   /**
+    * Gets the email addresses to which a notification should be sent that the action has been
+    * performed.
+    *
+    * @return the notify email list.
+    */
+   @Schema(
+      description = "The email addresses to which a notification should be when the action has been performed.",
+      example = "[ \"sales@example.com\", \"marketing@example.com\" ]")
+   public List<String> getNotifies() {
+      if(notifies == null) {
+         notifies = new ArrayList<>();
+      }
+
+      return notifies;
+   }
+
+   /**
+    * Sets the email addresses to which a notification should be sent that the action has been
+    * performed.
+    *
+    * @param notifies the notify email list.
+    */
+   public void setNotifies(List<String> notifies) {
+      this.notifies = notifies;
+   }
+
+   /**
+    * Sets a flag that indicates that a notification email should only be sent if the task fails.
+    *
+    * @return the flag that indicates that a notification email should be sent on fail.
+    */
+   @Schema(
+      description = "A flag that indicates that a notification email should only be sent if the task fails.",
+      example = "true",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public Boolean isNotifyIfFailed() {
+      return notifyIfFailed;
+   }
+
+   /**
+    * Gets a flag that indicates that a notification email should only be sent if the task fails.
+    *
+    * @param notifyIfFailed the flag that indicates that a notification email should be sent on fail.
+    */
+   public void setNotifyIfFailed(Boolean notifyIfFailed) {
+      this.notifyIfFailed = notifyIfFailed;
+   }
+
+   /**
+    * Sets a flag that indicates that a notification email should include a link.
+    *
+    * @return the flag that indicates that a notification email should be sent on fail.
+    */
+   @Schema(
+      description = "A flag that indicates that a notification email should include a link.",
+      example = "true",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public Boolean isNotifyLink() {
+      return notifyLink;
+   }
+
+   /**
+    * Gets a flag that indicates that a notification email should include a link.
+    *
+    * @param notifyLink the flag that indicates that a notification email should be sent on fail.
+    */
+   public void setNotifyLink(Boolean notifyLink) {
+      this.notifyLink = notifyLink;
+   }
+
+   /**
+    * Gets the format in which the viewsheet should be sent in the delivery emails.
+    *
+    * @return the viewsheet file format.
+    */
+   @Schema(
+      description = "The format in which the viewsheet should be sent in the delivery emails. Required if `emails` is not empty.",
+      example = "PDF")
+   public Format getFormat() {
+      return format;
+   }
+
+   /**
+    * Sets the format in which the viewsheet should be sent in the delivery emails.
+    *
+    * @param format the viewsheet file format.
+    */
+   public void setFormat(Format format) {
+      this.format = format;
+   }
+
+   /**
+    * Gets the subject of the delivery and/or notification emails.
+    *
+    * @return the subject line.
+    */
+   @Schema(
+      description = "The subject line of the delivery email. Required if `emails` is not empty.",
+      example = "Weekly Summary")
+   public String getSubject() {
+      return subject;
+   }
+
+   /**
+    * Sets the subject of the delivery and/or notification emails.
+    *
+    * @param subject the subject line.
+    */
+   public void setSubject(String subject) {
+      this.subject = subject;
+   }
+
+   /**
+    * Gets the message body of the delivery and/or notification emails.
+    *
+    * @return the message body.
+    */
+   @Schema(
+      description = "The body of the delivery message. Required if `emails` is not empty.",
+      example = "<p>See the attached report for the monthly sales summary.</p>")
+   public String getMessage() {
+      return message;
+   }
+
+   /**
+    * Sets the message body of the delivery and/or notification emails.
+    *
+    * @param message the message body.
+    */
+   public void setMessage(String message) {
+      this.message = message;
+   }
+
+   /**
+    * Gets a flag indicating if the message body is formatted as HTML.
+    *
+    * @return {@code true} if HTML; {@code false} otherwise.
+    */
+   @Schema(
+      description = "A flag indicating if the message body is formatted as HTML.",
+      example = "true")
+   public boolean isHtmlMessage() {
+      return htmlMessage;
+   }
+
+   /**
+    * Sets a flag indicating if the message body is formatted as HTML.
+    *
+    * @param htmlMessage {@code true} if HTML; {@code false} otherwise.
+    */
+   public void setHtmlMessage(boolean htmlMessage) {
+      this.htmlMessage = htmlMessage;
+   }
+
+   /**
+    * Get CC addresses.
+    */
+   @Schema(description = "The CC email addresses.")
+   public String getCCAddresses() {
+      return ccAddresses;
+   }
+
+   /**
+    * Set CC addresses.
+    *
+    * @param ccAddresses CC mails list.
+    */
+   public void setCCAddresses(String ccAddresses) {
+      this.ccAddresses = ccAddresses;
+   }
+
+   /**
+    * Get BCC addresses.
+    */
+   @Schema(description = "The CC email addresses.")
+   public String getBCCAddresses() {
+      return bccAddresses;
+   }
+
+   /**
+    * Set BCC addresses.
+    *
+    * @param bccAddresses BCC mails list
+    */
+   public void setBCCAddresses(String bccAddresses) {
+      this.bccAddresses = bccAddresses;
+   }
+
+   /**
+    * Gets a flag indicating if the email exports match the original layout.
+    * If this is false, the export will expand its components.
+    *
+    * @return {@code true} if match layout; {@code false} if it expands the components.
+    */
+   @Schema(
+      description = "A flag indicating if the email exports match the original layout.",
+      example = "true")
+   public Boolean isEmailMatch() {
+      return emailMatch;
+   }
+
+   /**
+    * Sets a flag indicating if the email exports match the original layout.
+    * If this is false, the export will expand its components.
+    *
+    * @param emailMatch {@code true} if match layout; {@code false} if it expands the components.
+    */
+   public void setEmailMatch(Boolean emailMatch) {
+      this.emailMatch = emailMatch;
+   }
+
+   /**
+    * Sets a flag indicating if the email exports expand their selections.
+    * emailMatch must be false for this to apply
+    *
+    * @return {@code true} if it expands selection components; {@code false} otherwise.
+    */
+   @Schema(
+      description = "A flag indicating if the email exports expand their selection lists/trees.",
+      example = "false")
+   public Boolean isEmailExpandSelections() {
+      return emailExpandSelections;
+   }
+
+   /**
+    * Sets a flag indicating if the email exports expand their selections.
+    * emailMatch must be false for this to apply
+    *
+    * @param emailExpandSelections {@code true} if it expands selection components; {@code false} otherwise.
+    */
+   public void setEmailExpandSelections(Boolean emailExpandSelections) {
+      this.emailExpandSelections = emailExpandSelections;
+   }
+
+   /**
+    * Gets a flag indicating if the email exports only expand the data components.
+    * emailMatch must be false for this to apply
+    *
+    * @return {@code true} if expand data components only; {@code false} otherwise.
+    */
+   @Schema(
+      description = "A flag indicating if the email exports only expand the data components.",
+      example = "false")
+   public Boolean isEmailOnlyDataComponents() {
+      return emailOnlyDataComponents;
+   }
+
+   /**
+    * Sets a flag indicating if the email exports only expand the data components.
+    * emailMatch must be false for this to apply
+    *
+    * @param emailOnlyDataComponents {@code true} if expand data components only; {@code false} otherwise.
+    */
+   public void setEmailOnlyDataComponents(Boolean emailOnlyDataComponents) {
+      this.emailOnlyDataComponents = emailOnlyDataComponents;
+   }
+
+   /**
+    *  Gets a flag indicating if export all tab tables.
+    * @return
+    */
+   @Schema(
+      description = "A flag indicating if export all tab tables.",
+      example = "false")
+   public Boolean isExportAllTabbedTables() {
+      return exportAllTabbedTables;
+   }
+
+   /**
+    * Sets a flag indicating if export all tab tables.
+    * @param exportAllTabbedTables
+    */
+   public void setExportAllTabbedTables(Boolean exportAllTabbedTables) {
+      this.exportAllTabbedTables = exportAllTabbedTables;
+   }
+
+   /**
+    * Check if the exported file needs to be zipped up.
+    *
+    * @return the flag that indicates that a file should be zipped.
+    */
+   @Schema(
+      description = "A flag indicating that a file should be zipped.",
+      example = "false")
+   public Boolean isEmailZip() {
+      return emailZip;
+   }
+
+   /**
+    * Set the flag indicating if the exported file needs to be zipped up.
+    *
+    * @param emailZip the flag indicating if the exported file needs to be zipped up.
+    */
+   public void setEmailZip(Boolean emailZip) {
+      this.emailZip = emailZip;
+   }
+
+   /**
+    * Gets the csv configuration properties used for csv exports to email exports.
+    *
+    * @return the csv configuration properties used for csv exports to  email exports.
+    */
+   @Schema(
+      description = "The csv configuration properties used for csv exports to email exports.")
+   public CSVConfig getEmailCSVConfig() {
+      return emailCSVConfig;
+   }
+
+   /**
+    * Sets the csv configuration properties used for csv exports to the email exports.
+    *
+    * @param emailCSVConfig the csv configuration properties used for csv exports to the email exports.
+    */
+   public void setEmailCSVConfig(CSVConfig emailCSVConfig) {
+      this.emailCSVConfig = emailCSVConfig;
+   }
+
+   /**
+    * Get the email attachment's name.
+    *
+    * @return the flag that indicates that a file should be zipped.
+    */
+   @Schema(
+      description = "The email attachment's name.",
+      example = "false")
+   public String getAttachmentName() {
+      return attachmentName;
+   }
+
+   /**
+    * Set the email attachment's name.
+    *
+    * @param attachmentName the email attachment's name.
+    */
+   public void setAttachmentName(String attachmentName) {
+      this.attachmentName = attachmentName;
+   }
+
+   /**
+    * Sets a flag that indicates that the export email should include a link.
+    *
+    * @return the flag that indicates that a notification email should be sent on fail.
+    */
+   @Schema(
+      description = "A flag that indicates that the export email should include a link.",
+      example = "true",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public Boolean isEmailLink() {
+      return emailLink;
+   }
+
+   /**
+    * Gets a flag that indicates that the export email should include a link.
+    *
+    * @param emailLink the flag that indicates that the export email should be sent on fail.
+    */
+   public void setEmailLink(Boolean emailLink) {
+      this.emailLink = emailLink;
+   }
+
+   /**
+    * Gets the parameters to use when opening the viewsheet.
+    *
+    * @return the parameter map.
+    */
+   @Schema(
+      description = "The parameters to use when opening the report.",
+      example = "{ \"simpleParam\": 1, " +
+         "\"detailedParam\": {\"value\": 5, \"dataType\": \"double\"}, " +
+         "\"expressionParam\": {\"value\": \"=2+4\", \"type\": \"expression\", \"dataType\": \"string\"}, " +
+         "\"arrayParam\": {\"value\": \"value1,value2\", \"array\": true, \"dataType\": \"string\"} }",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public Map<String, Object> getParameters() {
+      if(parameters == null) {
+         parameters = new HashMap<>();
+      }
+
+      return parameters;
+   }
+
+   /**
+    * Sets the parameters to use when opening the viewsheet.
+    *
+    * @param parameters the parameter map.
+    */
+   public void setParameters(Map<String, Object> parameters) {
+      this.parameters = parameters;
+   }
+
+   /**
+    * Gets the highlight alerts.
+    *
+    * @return the highlight alerts.
+    *
+    * @since 2022
+    */
+   @Schema(
+      description = "The highlight alerts.",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public List<ScheduleAlert> getAlerts() {
+      if(alerts == null) {
+         alerts = new ArrayList<>();
+      }
+
+      return alerts;
+   }
+
+   /**
+    * Sets the highlight alerts.
+    *
+    * @param alerts the highlight alerts.
+    *
+    * @since 2022
+    */
+   public void setAlerts(List<ScheduleAlert> alerts) {
+      this.alerts = alerts;
+   }
+
+   /**
+    * Gets the save to server file paths.
+    *
+    * @return the save to server file paths.
+    *
+    * @since 2023
+    */
+   @Schema(
+      description = "The list of files that the report should be exported to.",
+      extensions = @Extension(properties = @ExtensionProperty(name = "x-since", value = "1.0")))
+   public List<SaveToServerFilePath> getSaveToServerFilePaths() {
+      if(saveToServerFilePaths == null) {
+         saveToServerFilePaths = new ArrayList<>();
+      }
+
+      return saveToServerFilePaths;
+   }
+
+   /**
+    * Sets the save to server file paths.
+    *
+    * @param saveToServerFilePaths the save to server file paths.
+    *
+    * @since 2023
+    */
+   public void setSaveToServerFilePaths(List<SaveToServerFilePath> saveToServerFilePaths) {
+      this.saveToServerFilePaths = saveToServerFilePaths;
+   }
+
+   /**
+    * Gets a flag indicating if the server saved exports match the original layout.
+    * If this is false, the export will expand its components.
+    *
+    * @return {@code true} if match layout; {@code false} if it expands the components.
+    */
+   @Schema(
+      description = "A flag indicating if the server saved exports match the original layout.",
+      example = "true")
+   public boolean isSaveToServerMatch() {
+      return saveToServerMatch;
+   }
+
+   /**
+    * Sets a flag indicating if the server saved exports match the original layout.
+    * If this is false, the export will expand its components.
+    *
+    * @param saveToServerMatch {@code true} if match layout; {@code false} if it expands the components.
+    */
+   public void setSaveToServerMatch(boolean saveToServerMatch) {
+      this.saveToServerMatch = saveToServerMatch;
+   }
+
+   /**
+    * Sets a flag indicating if the server saved exports expand their selections.
+    * saveToServerMatch must be false for this to apply
+    *
+    * @return {@code true} if it expands selection components; {@code false} otherwise.
+    */
+   @Schema(
+      description = "A flag indicating if the server saved exports expand their selection lists/trees.",
+      example = "false")
+   public boolean isSaveToServerExpandSelections() {
+      return saveToServerExpandSelections;
+   }
+
+   /**
+    * Sets a flag indicating if the server saved exports expand their selections.
+    * saveToServerMatch must be false for this to apply
+    *
+    * @param saveToServerExpandSelections {@code true} if it expands selection components; {@code false} otherwise.
+    */
+   public void setSaveToServerExpandSelections(boolean saveToServerExpandSelections) {
+      this.saveToServerExpandSelections = saveToServerExpandSelections;
+   }
+
+   /**
+    * Gets a flag indicating if the exports only expand the data components.
+    * saveToServerMatch must be false for this to apply
+    *
+    * @return {@code true} if expand data components only; {@code false} otherwise.
+    */
+   @Schema(
+      description = "A flag indicating if the exports only expand the data components.",
+      example = "false")
+   public boolean isSaveToServerOnlyDataComponents() {
+      return saveToServerOnlyDataComponents;
+   }
+
+   /**
+    * Sets a flag indicating if the exports only expand the data components.
+    * saveToServerMatch must be false for this to apply
+    *
+    * @param saveToServerOnlyDataComponents {@code true} if expand data components only; {@code false} otherwise.
+    */
+   public void setSaveToServerOnlyDataComponents(boolean saveToServerOnlyDataComponents) {
+      this.saveToServerOnlyDataComponents = saveToServerOnlyDataComponents;
+   }
+
+   /**
+    * Gets a flag indicating if export all tab table when save to server.
+    *
+    * @return {@code true} if export all tab table when save to server; {@code false} otherwise.
+    */
+   @Schema(
+      description = "A flag indicating if export all tab table when save to server.",
+      example = "false")
+   public boolean isSaveExportAllTabbedTables() {
+      return saveExportAllTabbedTables;
+   }
+
+   /**
+    * Sets a flag indicating if export all tab table when save to server.
+    *
+    * @param saveExportAllTabbedTables {@code true} if export all tab table when save to server; {@code false} otherwise.
+    */
+   public void setSaveExportAllTabbedTables(boolean saveExportAllTabbedTables) {
+      this.saveExportAllTabbedTables = saveExportAllTabbedTables;
+   }
+
+   /**
+    * Gets the csv configuration properties used for csv exports to the server.
+    *
+    * @return the csv configuration properties used for csv exports to the server.
+    */
+   @Schema(
+      description = "The csv configuration properties used for csv exports to the server.")
+   public CSVConfig getSaveToServerCsvConfig() {
+      return saveToServerCsvConfig;
+   }
+
+   /**
+    * Sets the csv configuration properties used for csv exports to the server.
+    *
+    * @param saveToServerCsvConfig the csv configuration properties used for csv exports to the server.
+    */
+   public void setSaveToServerCsvConfig(CSVConfig saveToServerCsvConfig) {
+      this.saveToServerCsvConfig = saveToServerCsvConfig;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if(this == o) {
+         return true;
+      }
+
+      if(o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      if(!super.equals(o)) {
+         return false;
+      }
+
+      ViewsheetAction that = (ViewsheetAction) o;
+      return htmlMessage == that.htmlMessage &&
+         Objects.equals(viewsheet, that.viewsheet) &&
+         Objects.equals(bookmarkName, that.bookmarkName) &&
+         Objects.equals(bookmarkNames, that.bookmarkNames) &&
+         Objects.equals(bookmarkTypes, that.bookmarkTypes) &&
+         Objects.equals(bookmarkUser, that.bookmarkUser) &&
+         bookmarkType == that.bookmarkType &&
+         Objects.equals(emails, that.emails) &&
+         Objects.equals(sender, that.sender) &&
+         Objects.equals(notifies, that.notifies) &&
+         Objects.equals(notifyIfFailed, that.notifyIfFailed) &&
+         Objects.equals(notifyLink, that.notifyLink) &&
+         format == that.format &&
+         Objects.equals(subject, that.subject) &&
+         Objects.equals(message, that.message) &&
+         Objects.equals(ccAddresses, that.ccAddresses) &&
+         Objects.equals(bccAddresses, that.bccAddresses) &&
+         Objects.equals(emailMatch, that.emailMatch) &&
+         Objects.equals(emailExpandSelections, that.emailExpandSelections) &&
+         Objects.equals(emailOnlyDataComponents, that.emailOnlyDataComponents) &&
+         Objects.equals(emailZip, that.emailZip) &&
+         Objects.equals(attachmentName, that.attachmentName) &&
+         Objects.equals(emailLink, that.emailLink) &&
+         Objects.equals(alerts, that.alerts) &&
+         Objects.equals(saveToServerFilePaths, that.saveToServerFilePaths) &&
+         saveToServerMatch == that.saveToServerMatch &&
+         saveToServerExpandSelections == that.saveToServerExpandSelections &&
+         saveToServerOnlyDataComponents == that.saveToServerOnlyDataComponents &&
+         Objects.equals(saveToServerCsvConfig, that.saveToServerCsvConfig) &&
+         Objects.equals(parameters, that.parameters);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(
+         super.hashCode(), viewsheet, bookmarkName, bookmarkNames, bookmarkUser, bookmarkType,
+         bookmarkTypes, saveToServerFilePaths, emails, sender,
+         notifies, notifyIfFailed, notifyLink, format, subject, message, htmlMessage,
+         ccAddresses, bccAddresses, emailMatch, emailExpandSelections, emailOnlyDataComponents,
+         emailZip, attachmentName, emailLink, saveToServerFilePaths, saveToServerMatch,
+         saveToServerExpandSelections, saveToServerOnlyDataComponents, saveToServerCsvConfig, parameters, alerts);
+   }
+
+   @Override
+   public String toString() {
+      return "ViewsheetAction{" +
+         "viewsheet='" + viewsheet + '\'' +
+         ", bookmarkName='" + bookmarkName + '\'' +
+         ", bookmarkNames=" + bookmarkNames +
+         ", bookmarkUser='" + bookmarkUser + '\'' +
+         ", bookmarkUsers='" + (bookmarkUsers == null ? null : bookmarkUsers.toString()) + '\'' +
+         ", bookmarkType=" + bookmarkType +
+         ", bookmarkTypes=" + bookmarkTypes +
+         ", saveToServerFilePaths=" + saveToServerFilePaths +
+         ", emails=" + emails +
+         ", sender='" + sender + '\'' +
+         ", notifies=" + notifies +
+         ", notifyIfFailed=" + notifyIfFailed +
+         ", notifyLink=" + notifyLink +
+         ", format=" + format +
+         ", subject='" + subject + '\'' +
+         ", message='" + message + '\'' +
+         ", htmlMessage=" + htmlMessage +
+         ", ccAddresses='" + ccAddresses + '\'' +
+         ", bccAddresses='" + bccAddresses + '\'' +
+         ", emailMatch=" + emailMatch +
+         ", emailExpandSelections=" + emailExpandSelections +
+         ", emailOnlyDataComponents=" + emailOnlyDataComponents +
+         ", emailZip=" + emailZip +
+         ", attachmentName='" + attachmentName + '\'' +
+         ", emailLink=" + emailLink +
+         ", alerts=" + alerts +
+         ", saveToServerFilePaths=" + saveToServerFilePaths +
+         ", saveToServerMatch=" + saveToServerMatch +
+         ", saveToServerExpandSelections=" + saveToServerExpandSelections +
+         ", saveToServerOnlyDataComponents=" + saveToServerOnlyDataComponents +
+         ", saveToServerCsvConfig=" + saveToServerCsvConfig +
+         ", parameters=" + parameters +
+         '}';
+   }
+
+   /**
+    * SaveToServerFilePath describes the format and file path this action will save to the server.
+    */
+   @Validated
+   @Schema(description = "Describes the format and file path for a report export.")
+   public static class SaveToServerFilePath {
+      /**
+       * Creates a new instance of {@code SaveToServerFilePath}.
+       */
+      public SaveToServerFilePath() {
+      }
+
+      /**
+       * Creates a new instance of {@code SaveToServerFilePath}.
+       *
+       * @param format the save to server file format.
+       * @param path   the save to server file path.
+       */
+      public SaveToServerFilePath(Format format, String path) {
+         this.format = format;
+         this.path = path;
+      }
+
+      /**
+       * Creates a new instance of {@code SaveToServerFilePath}.
+       *
+       * @param format the save to server file format.
+       * @param info   the save to server file path info.
+       */
+      public SaveToServerFilePath(Format format, ServerPathInfo info) {
+         this.format = format;
+         this.path = info.getPath();
+         this.useCredential = info.isUseCredential();
+
+         if(info.isUseCredential()) {
+            this.secretId = info.getSecretId();
+         }
+         else {
+            this.username = info.getUsername();
+            this.password = info.getPassword();
+         }
+      }
+
+      /**
+       * Gets the format of the file that will be saved to the server.
+       *
+       * @return the format of the file that will be saved to the server.
+       */
+      @NotNull
+      @Schema(description = "The format in which the file will be saved.", example = "PDF")
+      public Format getFormat() {
+         return format;
+      }
+
+      /**
+       * Sets the format of the file that will be saved to the server.
+       *
+       * @param format the format of the file that will be saved to the server.
+       */
+      public void setFormat(Format format) {
+         this.format = format;
+      }
+
+      /**
+       * Gets the path of the file that will be saved to the server.
+       *
+       * @return the path of the file that will be saved to the server.
+       */
+      @NotNull
+      @Schema(
+         description = "The path at which the file will be saved.",
+         example = "/tmp/weekly-summary.pdf")
+      public String getPath() {
+         return path;
+      }
+
+      /**
+       * Sets the path of the file that will be saved to the server.
+       *
+       * @param path the path of the file that will be saved to the server.
+       */
+      public void setPath(String path) {
+         this.path = path;
+      }
+
+      /**
+       * Gets the username used to access the ftp server if applicable.
+       *
+       * @return the username used to access the ftp server.
+       */
+      @Schema(
+         description = "The username used to access the ftp server.")
+      public String getUsername() {
+         return username;
+      }
+
+      /**
+       * Sets the username used to access the ftp server.
+       *
+       * @param username the username used to access the ftp server.
+       */
+      public void setUsername(String username) {
+         this.username = username;
+      }
+
+      /**
+       * Gets the password used to access the ftp server if applicable.
+       *
+       * @return the password used to access the ftp server.
+       */
+      @Schema(
+         description = "The password used to access the ftp server.")
+      public String getPassword() {
+         return password;
+      }
+
+      /**
+       * Sets the password used to access the ftp server.
+       *
+       * @param password the password used to access the ftp server.
+       */
+      public void setPassword(String password) {
+         this.password = password;
+      }
+
+      @Schema(description = "Whether to use a vault secret ID for FTP credentials.")
+      public boolean isUseCredential() {
+         return useCredential;
+      }
+
+      public void setUseCredential(boolean useCredential) {
+         this.useCredential = useCredential;
+      }
+
+      @Schema(description = "The vault secret ID for FTP credentials.")
+      public String getSecretId() {
+         return secretId;
+      }
+
+      public void setSecretId(String secretId) {
+         this.secretId = secretId;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if(this == o) {
+            return true;
+         }
+
+         if(o == null || getClass() != o.getClass()) {
+            return false;
+         }
+
+         SaveToServerFilePath that = (SaveToServerFilePath) o;
+         return useCredential == that.useCredential &&
+            Objects.equals(format, that.format) && Objects.equals(path, that.path) &&
+            Objects.equals(username, that.username) && Objects.equals(password, that.password) &&
+            Objects.equals(secretId, that.secretId);
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(format, path, username, password, useCredential, secretId);
+      }
+
+      @Override
+      public String toString() {
+         StringBuilder authString = new StringBuilder();
+
+         if(useCredential) {
+            authString.append(", useCredential=true");
+
+            if(secretId != null) {
+               authString.append(", secretId='" + secretId + '\'');
+            }
+         }
+         else {
+            if(username != null) {
+               authString.append(", username='" + username + '\'');
+            }
+
+            if(password != null) {
+               authString.append(", password='" + password + '\'');
+            }
+         }
+
+         return "SaveToServerFilePath{" +
+            "format='" + format + '\'' +
+            ", path='" + path + '\'' +
+            authString +
+            '}';
+      }
+
+      private Format format;
+      private String path;
+      private String username;
+      private String password;
+      private boolean useCredential;
+      private String secretId;
+   }
+
+   private String viewsheet;
+   private String bookmarkName; //@bc redundant field is kept for the sake of backwards compatibility
+   private List<String> bookmarkNames;
+   private IdentityID bookmarkUser; //@bc redundant field is kept for the sake of backwards compatibility
+   private List<IdentityID> bookmarkUsers;
+   private BookmarkType bookmarkType; //@bc redundant field is kept for the sake of backwards compatibility
+   private List<BookmarkType> bookmarkTypes;
+   private List<SaveToServerFilePath> saveToServerFilePaths;
+   private List<String> emails;
+   private String sender;
+   private List<String> notifies;
+   private Boolean notifyIfFailed;
+   private Boolean notifyLink;
+   private Format format;
+   private String subject;
+   private String message;
+   private boolean htmlMessage;
+   private String ccAddresses;
+   private String bccAddresses;
+   private Boolean emailMatch;
+   private Boolean emailExpandSelections;
+   private Boolean emailOnlyDataComponents;
+   private Boolean exportAllTabbedTables;
+   private Boolean emailZip;
+   private CSVConfig emailCSVConfig;
+   private String attachmentName;
+   private Boolean emailLink;
+   private Map<String, Object> parameters;
+   private List<ScheduleAlert> alerts;
+   private boolean saveToServerMatch = true;
+   private boolean saveToServerExpandSelections = false;
+   private boolean saveToServerOnlyDataComponents = false;
+   private boolean saveExportAllTabbedTables = false;
+   private CSVConfig saveToServerCsvConfig;
+
+   /**
+    * Enumeration of the types of bookmarks.
+    */
+   public enum BookmarkType {
+      /**
+       * A bookmark that is private to the owner.
+       */
+      PRIVATE("private", VSBookmarkInfo.PRIVATE),
+
+      /**
+       * A bookmark shared with all users.
+       */
+      ALL_SHARE("all_share", VSBookmarkInfo.ALLSHARE),
+
+      /**
+       * A bookmark shared with members of the same group as the owner.
+       */
+      GROUP_SHARE("group_share", VSBookmarkInfo.GROUPSHARE);
+
+      private final String value;
+      private final int code;
+
+      BookmarkType(String value, int code) {
+         this.value = value;
+         this.code = code;
+      }
+
+      public int code() {
+         return code;
+      }
+
+      @JsonValue
+      @Override
+      public String toString() {
+         return value;
+      }
+
+      @SuppressWarnings("unused")
+      @JsonCreator
+      public static BookmarkType fromValue(String value) {
+         for(BookmarkType type : values()) {
+            if(Objects.equals(type.value, value)) {
+               return type;
+            }
+         }
+
+         return null;
+      }
+
+      public static BookmarkType fromCode(int code) {
+         for(BookmarkType type : values()) {
+            if(type.code == code) {
+               return type;
+            }
+         }
+
+         return null;
+      }
+   }
+
+   /**
+    * Enumeration of the types of viewsheet file formats.
+    */
+   public enum Format {
+      /**
+       * An MS Excel file.
+       */
+      EXCEL(0),
+
+      /**
+       * A MS Powerpoint file.
+       */
+      POWERPOINT(1),
+
+      /**
+       * A PDF file.
+       */
+      PDF(2),
+
+      /**
+       * A PNG file.
+       */
+      PNG(4),
+
+      /**
+       * An HTML file without pagination, embedded in the body of an email message.
+       */
+      HTML(5),
+
+      /**
+       * A delimited text file.
+       */
+      CSV(6);
+
+      private int value;
+
+      Format(int value) {
+         this.value = value;
+      }
+
+      public int getTypeValue() {
+         return value;
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/AdminScheduleControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/AdminScheduleControllerTest.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.ScheduleTask;
+import inetsoft.web.api.schedule.ScheduleTaskList;
+import inetsoft.web.api.schedule.UnsupportedScheduleItem;
+import inetsoft.sree.security.OrganizationManager;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ApplyResult;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/** Same gate shape as {@code AdminChangesetControllerTest} -- the bearer-token backstop and
+ * site-admin check are copied verbatim, so these tests mirror that file's coverage of them. */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminScheduleControllerTest {
+   @Mock private AdminScheduleGateway scheduleGateway;
+   @Mock private ScheduleChangePlanService planService;
+   @Mock private ScheduleChangesetApplyService applyService;
+   @Mock private Principal principal;
+   @Mock private OrganizationManager orgManager;
+   private AdminScheduleController controller;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+
+   @BeforeEach void setup() {
+      controller = new AdminScheduleController(scheduleGateway, planService, applyService);
+
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.isSiteAdmin(principal)).thenReturn(true);
+
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer test-jwt");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+   }
+
+   @AfterEach void tearDown() {
+      orgManagerStatic.close();
+      RequestContextHolder.resetRequestAttributes();
+   }
+
+   @Test void listTasksThrowsForbiddenWithoutBearerToken() {
+      RequestContextHolder.setRequestAttributes(
+         new ServletRequestAttributes(new MockHttpServletRequest()));
+
+      ResponseStatusException ex =
+         assertThrows(ResponseStatusException.class, () -> controller.listTasks(principal));
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(scheduleGateway);
+   }
+
+   @Test void listTasksThrowsForbiddenForNonSiteAdmin() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      ResponseStatusException ex =
+         assertThrows(ResponseStatusException.class, () -> controller.listTasks(principal));
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(scheduleGateway);
+   }
+
+   @Test void listTasksDelegatesToScheduleGateway() throws Exception {
+      ScheduleTaskList list = new ScheduleTaskList();
+      when(scheduleGateway.getScheduleTasks(isNull(), eq(principal))).thenReturn(list);
+
+      ScheduleTaskList result = controller.listTasks(principal);
+
+      assertSame(list, result);
+   }
+
+   // Bug #76351 (ST-001): a built-in system task (e.g. "__balance tasks__") has no API DTO for its
+   // condition/action, which used to make getTaskConditions/getTaskActions throw and this endpoint
+   // 500. getTask must use the lenient variants instead, so it always returns 200 -- this test does
+   // not itself exercise the placeholder substitution (that's a gateway-level concern), only that
+   // the controller wires to the lenient methods and returns their result untouched.
+   @Test void getTaskDelegatesToLenientConditionsAndActions() throws Exception {
+      String taskId = "__balance tasks__";
+      ScheduleTask task = new ScheduleTask();
+      List<Object> conditions = List.of(new UnsupportedScheduleItem("inetsoft.sree.schedule.TaskBalancerCondition"));
+      List<Object> actions = Collections.emptyList();
+      when(scheduleGateway.getScheduleTask(taskId, null, principal)).thenReturn(task);
+      when(scheduleGateway.getTaskConditionsLenient(taskId, null, principal)).thenReturn(conditions);
+      when(scheduleGateway.getTaskActionsLenient(taskId, null, principal)).thenReturn(actions);
+
+      ScheduleTaskView result = controller.getTask(taskId, principal);
+
+      assertSame(task, result.getTask());
+      assertEquals(conditions, result.getConditions());
+      assertEquals(actions, result.getActions());
+      verify(scheduleGateway, never()).getTaskConditions(anyString(), any(), any());
+      verify(scheduleGateway, never()).getTaskActions(anyString(), any(), any());
+   }
+
+   @Test void previewThrowsForbiddenForNonSiteAdmin() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.preview(new ScheduleChangePlanRequest(), principal));
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(planService);
+   }
+
+   @Test void previewDelegatesToPlanService() throws Exception {
+      ScheduleChangePlanRequest req = new ScheduleChangePlanRequest();
+      ResolvedPlan plan = new ResolvedPlan("t", Collections.emptyList(), false, false, "hash", "token");
+      when(planService.resolve(req, principal)).thenReturn(plan);
+
+      ResolvedPlan result = controller.preview(req, principal);
+
+      assertSame(plan, result);
+   }
+
+   @Test void applyThrowsForbiddenForNonSiteAdmin() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.apply(new ScheduleApplyRequest(), principal));
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(applyService);
+   }
+
+   @Test void applyDelegatesToApplyService() throws Exception {
+      ScheduleApplyRequest req = new ScheduleApplyRequest();
+      ApplyResult applied = new ApplyResult("tx-1", AdminChangesetApplyService.STATUS_APPLIED,
+                                            null, Collections.emptyList(), null);
+      when(applyService.apply(req, principal)).thenReturn(applied);
+
+      ApplyResult result = controller.apply(req, principal);
+
+      assertSame(applied, result);
+   }
+
+   @Test void handleIllegalArgumentReturnsFailedStatus() {
+      var body = controller.handleIllegalArgument(new IllegalArgumentException("bad input"));
+
+      assertEquals("failed", body.get("status"));
+      assertEquals("bad input", body.get("error"));
+   }
+
+   // PlanHashMismatchException strips taskToken from the plan it carries (see its own javadoc: a
+   // 409 conflict must never hand back a token, which would let a caller retry with an unreviewed
+   // narrative) -- so the returned plan is a new instance with taskToken nulled, not the same
+   // instance as fresh, matching AdminAiControllerTest's own coverage of this exception.
+   @Test void handlePlanHashMismatchReturnsConflictWithFreshPlan() {
+      ResolvedPlan fresh = new ResolvedPlan("t", Collections.emptyList(), false, false, "new-hash", "new-token");
+      var body = controller.handlePlanHashMismatch(
+         new AdminChangesetApplyService.PlanHashMismatchException(fresh));
+
+      assertEquals("conflict", body.get("status"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) body.get("plan");
+      assertEquals(fresh.task(), returnedPlan.task());
+      assertEquals(fresh.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/AdminScheduleGatewayTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/AdminScheduleGatewayTest.java
@@ -1,0 +1,461 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+/*
+ * Direct unit coverage for AdminScheduleGateway, added per PR #5062 review: the four ported tests
+ * in this same directory (AdminScheduleControllerTest, ScheduleChangePlanServiceTest,
+ * ScheduleChangesetApplyServiceTest, ScheduleXmlProjectionTest) all mock this class out and only
+ * assert delegation, so none of them exercise its own logic -- the cross-org boundary check and
+ * the two inverse-permission preflights in particular. Mirrors the mocking/fixture pattern of
+ * enterprise's ScheduleApiServiceTest (the class this gateway is modeled line-by-line on), since
+ * both depend on the same community-native AnalyticRepository/ScheduleManager/OrganizationManager
+ * types.
+ */
+
+import inetsoft.sree.*;
+import inetsoft.sree.schedule.*;
+import inetsoft.sree.security.*;
+import inetsoft.uql.util.XSessionService;
+import inetsoft.web.admin.schedule.ScheduleConditionService;
+import inetsoft.web.admin.schedule.ScheduleService;
+import inetsoft.web.admin.schedule.ScheduleTaskService;
+import inetsoft.web.api.schedule.BatchAction;
+import inetsoft.web.api.schedule.ScheduleAction;
+import inetsoft.web.api.schedule.ScheduleActionList;
+import inetsoft.web.api.schedule.ScheduleCondition;
+import inetsoft.web.api.schedule.ScheduleConditionList;
+import inetsoft.web.api.schedule.ScheduleTask;
+import inetsoft.web.api.schedule.TimeCondition;
+import inetsoft.web.api.schedule.ViewsheetAction;
+import inetsoft.web.security.auth.MissingResourceException;
+import inetsoft.web.security.auth.ResourceExistsException;
+import inetsoft.web.security.auth.UnauthorizedAccessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AdminScheduleGatewayTest {
+   @BeforeEach
+   void setUp() throws Exception {
+      repository = mock(AnalyticRepository.class, withSettings().lenient());
+      scheduleManager = mock(ScheduleManager.class, withSettings().lenient());
+      scheduleService = mock(ScheduleService.class, withSettings().lenient());
+      scheduleConditionService = mock(ScheduleConditionService.class, withSettings().lenient());
+      scheduleTaskService = mock(ScheduleTaskService.class, withSettings().lenient());
+
+      // caller always has generic scheduler access -- most tests here are about the
+      // owner/executeAsID/org-boundary checks specifically, not this coarse-grained gate
+      when(repository.checkPermission(any(), eq(ResourceType.SCHEDULER), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(repository.getScheduleTask(anyString())).thenReturn(null);
+
+      gateway = new AdminScheduleGateway(
+         repository, scheduleManager, scheduleService, scheduleConditionService, scheduleTaskService);
+
+      callerOwner = new IdentityID("caller", "host-org");
+      otherOwner = new IdentityID("admin", "host-org");
+      user = mock(Principal.class, withSettings().lenient());
+      when(user.getName()).thenReturn(callerOwner.convertToKey());
+   }
+
+   // -------------------------------------------------------------------------
+   // checkActionOrgBoundary / checkAssetOrgBoundary -- the cross-org security check
+   // -------------------------------------------------------------------------
+
+   @Test
+   void addScheduleTask_rejectsViewsheetActionFromDifferentOrganization() throws Exception {
+      try(MockedStatic<XSessionService> sessionStatic = mockStatic(XSessionService.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         mockSession(sessionStatic);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(false);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         SRPrincipal orgUser = createPrincipal("caller", "host-org");
+
+         ViewsheetAction action = new ViewsheetAction();
+         action.setViewsheet("1^128^__NULL__^Examples/Census^other-org");
+
+         ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+         assertThrows(UnauthorizedAccessException.class, () -> gateway.addScheduleTask(
+            taskMetaData, true, false, -1, -1, null, null, null,
+            Collections.emptyList(), List.of(action), null, "", orgUser));
+
+         verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+      }
+   }
+
+   @Test
+   void addScheduleTask_allowsViewsheetActionFromSameOrganization() throws Exception {
+      try(MockedStatic<XSessionService> sessionStatic = mockStatic(XSessionService.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         mockSession(sessionStatic);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(false);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         SRPrincipal orgUser = createPrincipal("caller", "host-org");
+
+         ViewsheetAction action = new ViewsheetAction();
+         action.setViewsheet("1^128^__NULL__^Examples/Census^host-org");
+
+         ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+         gateway.addScheduleTask(
+            taskMetaData, true, false, -1, -1, null, null, null,
+            Collections.emptyList(), List.of(action), null, "", orgUser);
+
+         verify(scheduleManager).setScheduleTask(anyString(), any(), eq(orgUser));
+      }
+   }
+
+   @Test
+   void addScheduleTask_allowsSiteAdminAcrossOrganizationsForViewsheetAction() throws Exception {
+      try(MockedStatic<XSessionService> sessionStatic = mockStatic(XSessionService.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         mockSession(sessionStatic);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(true);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         SRPrincipal siteAdmin = createPrincipal("caller", "host-org");
+
+         // site admin's own org is "host-org" but the referenced viewsheet belongs to
+         // "other-org" -- the site-admin bypass must still allow this
+         ViewsheetAction action = new ViewsheetAction();
+         action.setViewsheet("1^128^__NULL__^Examples/Census^other-org");
+
+         ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+         gateway.addScheduleTask(
+            taskMetaData, true, false, -1, -1, null, null, null,
+            Collections.emptyList(), List.of(action), null, "", siteAdmin);
+
+         verify(scheduleManager).setScheduleTask(anyString(), any(), eq(siteAdmin));
+      }
+   }
+
+   @Test
+   void addScheduleTask_rejectsBatchActionFromDifferentOrganization() throws Exception {
+      try(MockedStatic<XSessionService> sessionStatic = mockStatic(XSessionService.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         mockSession(sessionStatic);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(false);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         SRPrincipal orgUser = createPrincipal("caller", "host-org");
+
+         BatchAction action = new BatchAction();
+         action.setOwner("batchOwner");
+         action.setTaskName("batchTask");
+         action.setQueryEntry("1^2^__NULL__^Products^other-org");
+
+         ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+         assertThrows(UnauthorizedAccessException.class, () -> gateway.addScheduleTask(
+            taskMetaData, true, false, -1, -1, null, null, null,
+            Collections.emptyList(), List.of(action), null, "", orgUser));
+
+         verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // hasDeletePermission / hasOwnerAdminPermission -- the two inverse-permission preflights
+   // -------------------------------------------------------------------------
+
+   @Test
+   void hasDeletePermission_true() throws Exception {
+      when(repository.checkPermission(user, ResourceType.SCHEDULE_TASK, "t1", ResourceAction.DELETE))
+         .thenReturn(true);
+
+      assertTrue(gateway.hasDeletePermission("t1", user));
+   }
+
+   @Test
+   void hasDeletePermission_false() throws Exception {
+      when(repository.checkPermission(user, ResourceType.SCHEDULE_TASK, "t1", ResourceAction.DELETE))
+         .thenReturn(false);
+
+      assertFalse(gateway.hasDeletePermission("t1", user));
+   }
+
+   @Test
+   void hasOwnerAdminPermission_true() throws Exception {
+      when(repository.checkPermission(user, ResourceType.SECURITY_USER, otherOwner, ResourceAction.ADMIN))
+         .thenReturn(true);
+
+      assertTrue(gateway.hasOwnerAdminPermission(otherOwner, null, user));
+   }
+
+   @Test
+   void hasOwnerAdminPermission_false() throws Exception {
+      when(repository.checkPermission(user, ResourceType.SECURITY_USER, otherOwner, ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      assertFalse(gateway.hasOwnerAdminPermission(otherOwner, null, user));
+   }
+
+   @Test
+   void hasOwnerAdminPermission_trueForSelfOwnedWithoutAdminGrant() throws Exception {
+      // caller always administers their own identity, regardless of any ADMIN grant
+      assertTrue(gateway.hasOwnerAdminPermission(callerOwner, null, user));
+   }
+
+   // -------------------------------------------------------------------------
+   // addScheduleTask / removeScheduleTask -- basic success and permission-denied paths
+   // -------------------------------------------------------------------------
+
+   @Test
+   void addScheduleTask_allowsSelfOwnedTask() throws Exception {
+      ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+      gateway.addScheduleTask(
+         taskMetaData, true, false, -1, -1, null, null, null,
+         Collections.emptyList(), Collections.emptyList(), null, "", user);
+
+      verify(scheduleManager).setScheduleTask(anyString(), any(), eq(user));
+   }
+
+   @Test
+   void addScheduleTask_rejectsOwnerImpersonationWithoutAdminGrant() throws Exception {
+      when(repository.checkPermission(user, ResourceType.SECURITY_USER, otherOwner, ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", otherOwner.convertToKey());
+
+      assertThrows(UnauthorizedAccessException.class, () -> gateway.addScheduleTask(
+         taskMetaData, true, false, -1, -1, null, null, null,
+         Collections.emptyList(), Collections.emptyList(), null, "", user));
+
+      verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+   }
+
+   @Test
+   void addScheduleTask_rejectsWithoutGenericSchedulerAccess() throws Exception {
+      when(repository.checkPermission(user, ResourceType.SCHEDULER, "*", ResourceAction.ACCESS))
+         .thenReturn(false);
+
+      ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+      assertThrows(UnauthorizedAccessException.class, () -> gateway.addScheduleTask(
+         taskMetaData, true, false, -1, -1, null, null, null,
+         Collections.emptyList(), Collections.emptyList(), null, "", user));
+
+      verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+   }
+
+   @Test
+   void addScheduleTask_rejectsWhenTaskAlreadyExists() throws Exception {
+      String taskId = ScheduleManager.getTaskId(callerOwner.convertToKey(), "task1");
+      when(repository.getScheduleTask(taskId)).thenReturn(new inetsoft.sree.schedule.ScheduleTask());
+
+      ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+
+      assertThrows(ResourceExistsException.class, () -> gateway.addScheduleTask(
+         taskMetaData, true, false, -1, -1, null, null, null,
+         Collections.emptyList(), Collections.emptyList(), null, "", user));
+
+      verify(scheduleManager, never()).setScheduleTask(anyString(), any(), any());
+   }
+
+   @Test
+   void removeScheduleTask_succeedsWithDeletePermission() throws Exception {
+      String taskId = "t1";
+      when(repository.checkPermission(user, ResourceType.SCHEDULE_TASK, taskId, ResourceAction.DELETE))
+         .thenReturn(true);
+
+      try(MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(true);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         gateway.removeScheduleTask(taskId, null, user);
+
+         verify(repository).removeScheduleTask(user, taskId);
+      }
+   }
+
+   @Test
+   void removeScheduleTask_rejectsWithoutDeletePermission() throws Exception {
+      String taskId = "t1";
+      when(repository.checkPermission(user, ResourceType.SCHEDULE_TASK, taskId, ResourceAction.DELETE))
+         .thenReturn(false);
+
+      try(MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(true);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         assertThrows(UnauthorizedAccessException.class,
+                      () -> gateway.removeScheduleTask(taskId, null, user));
+
+         verify(repository, never()).removeScheduleTask(any(), anyString());
+      }
+   }
+
+   @Test
+   void removeScheduleTask_rejectsCrossOrgDeleteForNonSiteAdmin() throws Exception {
+      String taskId = "t1";
+
+      try(MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class))
+      {
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         when(orgManager.isSiteAdmin((Principal) any())).thenReturn(false);
+         when(orgManager.getCurrentOrgID(user)).thenReturn("host-org");
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+
+         try(MockedStatic<ScheduleManager> scheduleManagerStatic = mockStatic(ScheduleManager.class))
+         {
+            scheduleManagerStatic.when(() -> ScheduleManager.getOwner(taskId))
+               .thenReturn(new IdentityID("someone", "other-org"));
+
+            assertThrows(UnauthorizedAccessException.class,
+                         () -> gateway.removeScheduleTask(taskId, null, user));
+
+            verify(repository, never()).removeScheduleTask(any(), anyString());
+         }
+      }
+   }
+
+   @Test
+   void getScheduleTask_rejectsMissingTask() throws Exception {
+      when(repository.getScheduleTask("nope")).thenReturn(null);
+
+      assertThrows(MissingResourceException.class,
+                   () -> gateway.getScheduleTask("nope", null, user));
+   }
+
+   // -------------------------------------------------------------------------
+   // condition/action DTO-to-internal-and-back round trip
+   // -------------------------------------------------------------------------
+
+   @Test
+   void timeConditionRoundTripsThroughAddAndGet() throws Exception {
+      TimeCondition condition = new TimeCondition();
+      condition.setType(TimeCondition.Type.EVERY_DAY);
+      condition.setHour(9);
+      condition.setMinute(30);
+      condition.setInterval(2);
+      condition.setWeekdayOnly(true);
+
+      ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+      String taskId = taskMetaData.getTaskId();
+
+      gateway.addScheduleTask(
+         taskMetaData, true, false, -1, -1, null, null, null,
+         List.of(condition), Collections.emptyList(), null, "", user);
+
+      org.mockito.ArgumentCaptor<inetsoft.sree.schedule.ScheduleTask> captor =
+         org.mockito.ArgumentCaptor.forClass(inetsoft.sree.schedule.ScheduleTask.class);
+      verify(scheduleManager).setScheduleTask(eq(taskId), captor.capture(), eq(user));
+
+      // feed the persisted internal task back through the read path
+      when(repository.getScheduleTask(taskId)).thenReturn(captor.getValue());
+      when(repository.checkPermission(user, ResourceType.SCHEDULE_TASK, taskId, ResourceAction.READ))
+         .thenReturn(true);
+
+      ScheduleConditionList result = gateway.getTaskConditions(taskId, null, user);
+
+      assertEquals(1, result.getConditions().size());
+      ScheduleCondition roundTripped = result.getConditions().get(0);
+      assertTrue(roundTripped instanceof TimeCondition);
+      TimeCondition rt = (TimeCondition) roundTripped;
+      assertEquals(TimeCondition.Type.EVERY_DAY, rt.getType());
+      assertEquals(9, rt.getHour());
+      assertEquals(30, rt.getMinute());
+      assertEquals(2, rt.getInterval());
+      assertTrue(rt.isWeekdayOnly());
+   }
+
+   @Test
+   void viewsheetActionRoundTripsThroughAddAndGet() throws Exception {
+      ViewsheetAction action = new ViewsheetAction();
+      action.setViewsheet("1^128^__NULL__^Examples/Census^host-org");
+
+      ScheduleTaskMetaData taskMetaData = new ScheduleTaskMetaData("task1", callerOwner.convertToKey());
+      String taskId = taskMetaData.getTaskId();
+
+      gateway.addScheduleTask(
+         taskMetaData, true, false, -1, -1, null, null, null,
+         Collections.emptyList(), List.of(action), null, "", user);
+
+      org.mockito.ArgumentCaptor<inetsoft.sree.schedule.ScheduleTask> captor =
+         org.mockito.ArgumentCaptor.forClass(inetsoft.sree.schedule.ScheduleTask.class);
+      verify(scheduleManager).setScheduleTask(eq(taskId), captor.capture(), eq(user));
+
+      inetsoft.sree.schedule.ViewsheetAction persisted =
+         (inetsoft.sree.schedule.ViewsheetAction) captor.getValue().getAction(0);
+      assertEquals("1^128^__NULL__^Examples/Census^host-org", persisted.getViewsheet());
+
+      // feed the persisted internal task back through the read path
+      when(repository.getScheduleTask(taskId)).thenReturn(captor.getValue());
+      when(repository.checkPermission(user, ResourceType.SCHEDULE_TASK, taskId, ResourceAction.READ))
+         .thenReturn(true);
+
+      ScheduleActionList result = gateway.getTaskActions(taskId, null, user);
+
+      assertEquals(1, result.getActions().size());
+      ScheduleAction roundTripped = result.getActions().get(0);
+      assertTrue(roundTripped instanceof ViewsheetAction);
+      assertEquals("1^128^__NULL__^Examples/Census^host-org",
+                   ((ViewsheetAction) roundTripped).getViewsheet());
+   }
+
+   private static void mockSession(MockedStatic<XSessionService> sessionStatic) {
+      // SRPrincipal's constructor calls XSessionService.getService().createSessionID(), which
+      // requires a Spring context. Mock it to avoid that dependency.
+      XSessionService mockSessionService = mock(XSessionService.class);
+      when(mockSessionService.createSessionID(anyString(), any())).thenReturn("session-id");
+      sessionStatic.when(XSessionService::getService).thenReturn(mockSessionService);
+   }
+
+   private static SRPrincipal createPrincipal(String name, String orgId) {
+      return new SRPrincipal(
+         new IdentityID(name, orgId), new IdentityID[0], new String[0], orgId, 1L);
+   }
+
+   private AnalyticRepository repository;
+   private ScheduleManager scheduleManager;
+   private ScheduleService scheduleService;
+   private ScheduleConditionService scheduleConditionService;
+   private ScheduleTaskService scheduleTaskService;
+   private AdminScheduleGateway gateway;
+   private Principal user;
+   private IdentityID callerOwner;
+   private IdentityID otherOwner;
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanServiceTest.java
@@ -1,0 +1,349 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.*;
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.util.Tool;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The plan hash is the review gate for schedule tasks the same way it is for properties (spec §5)
+ * -- these tests focus on what is NEW here: a total (writeXML) projection rather than a scalar,
+ * the two inverse-permission preflights that have no properties-area analog (spec §4), and the
+ * unsupported-type refusals (spec §1).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ScheduleChangePlanServiceTest {
+   @Mock private AdminScheduleGateway scheduleGateway;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private Principal user;
+   private ScheduleChangePlanService service;
+   private MockedStatic<Tool> tool;
+
+   @BeforeEach void setUp() {
+      service = new ScheduleChangePlanService(scheduleGateway, scheduleManager);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach void tearDown() {
+      tool.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // basic request validation
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnBlankTask() {
+      ScheduleChangePlanRequest req = request("   ", List.of(deleteChange("t1")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("task"));
+   }
+
+   @Test void resolveThrowsOnEmptyChanges() {
+      ScheduleChangePlanRequest req = request("do something", List.of());
+
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+   }
+
+   @Test void resolveThrowsOnUnrecognizedVerb() throws Exception {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb("update");
+      change.setTaskId("t1");
+      ScheduleChangePlanRequest req = request("task", List.of(change));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("verb"));
+   }
+
+   @Test void resolveThrowsOnDuplicateTaskId() throws Exception {
+      lenient().when(scheduleManager.getScheduleTask("t1")).thenReturn(sreeTask("t1", "admin"));
+      lenient().when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user)))
+         .thenReturn(true);
+      ScheduleChangePlanRequest req = request("task", List.of(deleteChange("t1"), deleteChange("t1")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("duplicate"));
+   }
+
+   // -------------------------------------------------------------------------
+   // create
+   // -------------------------------------------------------------------------
+
+   @Test void resolveCreateThrowsWhenSpecMissing() {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_CREATE);
+      ScheduleChangePlanRequest req = request("task", List.of(change));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("spec"));
+   }
+
+   @Test void resolveCreateThrowsOnUnsupportedConditionType() {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      spec.setConditions(List.of(new CompletionCondition()));
+      ScheduleChangePlanRequest req = request("task", List.of(createChange(spec)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("conditions"));
+   }
+
+   @Test void resolveCreateThrowsOnUnsupportedActionType() {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      spec.setActions(List.of(new BatchAction()));
+      ScheduleChangePlanRequest req = request("task", List.of(createChange(spec)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("actions"));
+   }
+
+   @Test void resolveCreateThrowsWhenTaskAlreadyExists() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("nightly-refresh", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(sreeTask("nightly-refresh", "admin"));
+      ScheduleChangePlanRequest req = request("task", List.of(createChange(spec)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("already exists"));
+   }
+
+   // A create's rollback is a delete -- refusing the plan up front when the caller could not
+   // perform that delete is the concrete instance of spec §4's per-verb parity requirement.
+   @Test void resolveCreateThrowsWhenCallerLacksDeletePermissionForRollback() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(false);
+      ScheduleChangePlanRequest req = request("task", List.of(createChange(spec)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("DELETE"));
+   }
+
+   @Test void resolveCreateSucceedsWithNullCurrentAndNonNullProposed() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+      ScheduleChangePlanRequest req = request("create a task", List.of(createChange(spec)));
+
+      ResolvedPlan plan = service.resolve(req, user);
+
+      assertEquals(1, plan.changes().size());
+      PlanChange change = plan.changes().get(0);
+      assertEquals(taskId, change.property());
+      assertNull(change.currentValue());
+      assertNotNull(change.proposedValue());
+      assertTrue(change.proposedValue().contains("t1"));
+      assertEquals("high", change.risk());
+      assertEquals("storage", change.snapshotScope());
+      assertTrue(plan.requiresStorageBackup());
+      assertTrue(plan.requiresAgentSignoff());
+      assertNotNull(plan.planHash());
+   }
+
+   // -------------------------------------------------------------------------
+   // delete
+   // -------------------------------------------------------------------------
+
+   @Test void resolveDeleteThrowsWhenTaskIdMissing() {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_DELETE);
+      ScheduleChangePlanRequest req = request("task", List.of(change));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("taskId"));
+   }
+
+   @Test void resolveDeleteThrowsWhenSpecPresent() {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_DELETE);
+      change.setTaskId("t1");
+      change.setSpec(createSpec("t1", "admin"));
+      ScheduleChangePlanRequest req = request("task", List.of(change));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("spec"));
+   }
+
+   @Test void resolveDeleteThrowsWhenTaskDoesNotExist() throws Exception {
+      when(scheduleManager.getScheduleTask("t1")).thenReturn(null);
+      ScheduleChangePlanRequest req = request("task", List.of(deleteChange("t1")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("no task exists"));
+   }
+
+   // A delete's rollback is a re-create -- requires ADMIN over the owner, strictly stronger than
+   // the DELETE the verb itself needs (spec §4's asymmetric-gap finding).
+   @Test void resolveDeleteThrowsWhenCallerLacksOwnerAdminPermissionForRollback() throws Exception {
+      when(scheduleManager.getScheduleTask("t1")).thenReturn(sreeTask("t1", "admin"));
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(false);
+      ScheduleChangePlanRequest req = request("task", List.of(deleteChange("t1")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("ADMIN"));
+   }
+
+   @Test void resolveDeleteSucceedsWithNonNullCurrentAndNullProposed() throws Exception {
+      when(scheduleManager.getScheduleTask("t1")).thenReturn(sreeTask("t1", "admin"));
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      ScheduleChangePlanRequest req = request("delete a task", List.of(deleteChange("t1")));
+
+      ResolvedPlan plan = service.resolve(req, user);
+
+      PlanChange change = plan.changes().get(0);
+      assertEquals("t1", change.property());
+      assertNotNull(change.currentValue());
+      assertNull(change.proposedValue());
+   }
+
+   // -------------------------------------------------------------------------
+   // hash stability -- closes the collision SpikeHashProbe found (spec §5)
+   // -------------------------------------------------------------------------
+
+   @Test void hashChangesWhenAConditionIsAdded() throws Exception {
+      CreateScheduleTaskRequest approved = createSpec("t1", "admin");
+      approved.setConditions(List.of(timeCondition(9, 0)));
+
+      CreateScheduleTaskRequest drifted = createSpec("t1", "admin");
+      drifted.setConditions(List.of(timeCondition(9, 0), timeCondition(23, 0)));
+
+      String taskId = ScheduleManager.getTaskId(approved.getOwner().convertToKey(), approved.getName());
+      lenient().when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      lenient().when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+
+      ResolvedPlan approvedPlan = service.resolve(request("t", List.of(createChange(approved))), user);
+      ResolvedPlan driftedPlan = service.resolve(request("t", List.of(createChange(drifted))), user);
+
+      assertNotEquals(approvedPlan.planHash(), driftedPlan.planHash());
+   }
+
+   @Test void hashIsStableForIdenticalRequests() throws Exception {
+      when(scheduleManager.getScheduleTask("t1")).thenReturn(sreeTask("t1", "admin"));
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+
+      ResolvedPlan first = service.resolve(request("delete", List.of(deleteChange("t1"))), user);
+      ResolvedPlan second = service.resolve(request("delete", List.of(deleteChange("t1"))), user);
+
+      assertEquals(first.planHash(), second.planHash());
+   }
+
+   @Test void issuesATaskTokenBoundToThePlanHash() throws Exception {
+      when(scheduleManager.getScheduleTask("t1")).thenReturn(sreeTask("t1", "admin"));
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+
+      ResolvedPlan plan = service.resolve(request("delete", List.of(deleteChange("t1"))), user);
+
+      assertEquals("TKN:" + plan.planHash() + "delete", plan.taskToken());
+   }
+
+   // task is a free-text, audit-only label (bug 76445) -- a caller that does not replay it
+   // byte-for-byte between preview and apply must not see a false planHash conflict.
+   @Test void hashIsUnaffectedByDifferentTaskStrings() throws Exception {
+      when(scheduleManager.getScheduleTask("t1")).thenReturn(sreeTask("t1", "admin"));
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+
+      ResolvedPlan first = service.resolve(request("delete the nightly task", List.of(deleteChange("t1"))), user);
+      ResolvedPlan second = service.resolve(request("remove nightly-refresh task", List.of(deleteChange("t1"))), user);
+
+      assertEquals(first.planHash(), second.planHash());
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private static ScheduleChangePlanRequest request(String task, List<ScheduleChangeRequest> changes) {
+      ScheduleChangePlanRequest req = new ScheduleChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+
+   private static ScheduleChangeRequest createChange(CreateScheduleTaskRequest spec) {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_CREATE);
+      change.setSpec(spec);
+      return change;
+   }
+
+   private static ScheduleChangeRequest deleteChange(String taskId) {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_DELETE);
+      change.setTaskId(taskId);
+      return change;
+   }
+
+   private static CreateScheduleTaskRequest createSpec(String name, String owner) {
+      CreateScheduleTaskRequest spec = new CreateScheduleTaskRequest();
+      spec.setName(name);
+      spec.setOwner(new IdentityID(owner, "host-org"));
+      spec.setEnabled(true);
+      spec.setConditions(List.of(timeCondition(9, 0)));
+      return spec;
+   }
+
+   private static TimeCondition timeCondition(int hour, int minute) {
+      TimeCondition condition = new TimeCondition();
+      condition.setHour(hour);
+      condition.setMinute(minute);
+      return condition;
+   }
+
+   private static inetsoft.sree.schedule.ScheduleTask sreeTask(String name, String owner) {
+      inetsoft.sree.schedule.ScheduleTask task = new inetsoft.sree.schedule.ScheduleTask();
+      task.setName(name);
+      task.setOwner(new IdentityID(owner, "host-org"));
+      task.setEnabled(true);
+      return task;
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyServiceTest.java
@@ -1,0 +1,343 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.web.api.schedule.*;
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.util.Tool;
+import inetsoft.web.admin.ai.AdminBackupService;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ApplyResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Two structural differences from the properties-area apply-loop tests this mirrors (spec §6):
+ * verification is existence-based, not a value-equality check, and the compensating action for a
+ * delete is a re-create built from a snapshot captured DURING apply -- both exercised below.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ScheduleChangesetApplyServiceTest {
+   @Mock private AdminScheduleGateway scheduleGateway;
+   @Mock private ScheduleManager scheduleManager;
+   @Mock private AdminBackupService backupService;
+   @Mock private Principal user;
+   private ScheduleChangePlanService planService;
+   private ScheduleChangesetApplyService service;
+   private MockedStatic<Tool> tool;
+
+   @BeforeEach void setUp() {
+      planService = new ScheduleChangePlanService(scheduleGateway, scheduleManager);
+      service = new ScheduleChangesetApplyService(planService, scheduleGateway, scheduleManager,
+                                                   backupService);
+      tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
+         .defaultAnswer(Answers.CALLS_REAL_METHODS));
+      tool.when(() -> Tool.encryptPassword(anyString()))
+         .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+   }
+
+   @AfterEach void tearDown() {
+      tool.close();
+   }
+
+   // -------------------------------------------------------------------------
+   // success
+   // -------------------------------------------------------------------------
+
+   @Test void appliesACreateAndReportsApplied() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      // Not present before, present after -- the existence-based verify this area uses in place
+      // of a value-equality check.
+      when(scheduleManager.getScheduleTask(taskId))
+         .thenReturn(null)              // preview-time existence check (resolve, in preview())
+         .thenReturn(null)              // re-resolve inside apply()
+         .thenReturn(sreeTask("t1", "admin")); // apply-time verify, after addScheduleTask
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertEquals("snap-ref", result.backupRef());
+      assertNull(result.rollbackFailures());
+      verify(scheduleGateway).addScheduleTask(any(), eq(true), anyBoolean(), anyLong(), anyLong(),
+         any(), any(), any(), any(), any(), any(), any(), eq(user));
+      verify(scheduleGateway, never()).removeScheduleTask(anyString(), any(), eq(user));
+   }
+
+   @Test void appliesADeleteAndReportsApplied() throws Exception {
+      inetsoft.sree.schedule.ScheduleTask existing = sreeTask("t1", "admin");
+      when(scheduleManager.getScheduleTask("t1"))
+         .thenReturn(existing)   // preview
+         .thenReturn(existing)   // re-resolve inside apply()
+         .thenReturn(existing)   // apply: capture before-state
+         .thenReturn(null);      // apply: verify gone
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      when(scheduleGateway.getScheduleTask(eq("t1"), any(), eq(user)))
+         .thenReturn(dtoTask("t1", "admin"));
+      when(scheduleGateway.getTaskConditions(eq("t1"), any(), eq(user)))
+         .thenReturn(new ScheduleConditionList());
+      when(scheduleGateway.getTaskActions(eq("t1"), any(), eq(user)))
+         .thenReturn(new ScheduleActionList());
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = applyRequest("delete a task", deleteChange("t1"));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      verify(scheduleGateway).removeScheduleTask(eq("t1"), any(), eq(user));
+   }
+
+   // -------------------------------------------------------------------------
+   // gates
+   // -------------------------------------------------------------------------
+
+   @Test void applyThrowsOnStalePlanHash() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+      req.setPlanHash("stale-hash");
+
+      assertThrows(AdminChangesetApplyService.PlanHashMismatchException.class,
+                  () -> service.apply(req, user));
+      verify(scheduleGateway, never())
+         .addScheduleTask(any(), anyBoolean(), anyBoolean(), anyLong(), anyLong(), any(), any(),
+                          any(), any(), any(), any(), any(), eq(user));
+   }
+
+   @Test void applyThrowsWhenReviewOutcomeMissing() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+      req.setReviewOutcome(null);
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.apply(req, user));
+      assertTrue(ex.getMessage().contains("reviewOutcome"));
+   }
+
+   // -------------------------------------------------------------------------
+   // failure / rollback
+   // -------------------------------------------------------------------------
+
+   // A throw carries no verifiable before/after evidence -- it must be reported as unknown state,
+   // never as rolled back.
+   @Test void throwMidApplyIsReportedAsUnknownStateAndRollbackFailed() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+      doThrow(new IllegalStateException("boom")).when(scheduleGateway)
+         .addScheduleTask(any(), anyBoolean(), anyBoolean(), anyLong(), anyLong(), any(), any(),
+                          any(), any(), any(), any(), any(), eq(user));
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertNotNull(result.rollbackFailures());
+      assertEquals(1, result.rollbackFailures().size());
+      assertEquals(taskId, result.rollbackFailures().get(0).property());
+   }
+
+   // captureSpec is read-only and runs strictly BEFORE the mutating removeScheduleTask call --
+   // a throw there proves nothing was mutated, unlike throwMidApplyIsReportedAsUnknownStateAndRollbackFailed
+   // above (whose throw comes FROM the mutating call itself). Must not be folded into the same
+   // STATUS_ROLLBACK_FAILED/unknown-state bucket as that case.
+   @Test void deletePreflightCaptureFailureIsReportedAsRolledBackNotRollbackFailed() throws Exception {
+      inetsoft.sree.schedule.ScheduleTask existing = sreeTask("t1", "admin");
+      when(scheduleManager.getScheduleTask("t1"))
+         .thenReturn(existing)   // preview
+         .thenReturn(existing)   // re-resolve inside apply()
+         .thenReturn(existing);  // apply: capture before-state
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      when(scheduleGateway.getScheduleTask(eq("t1"), any(), eq(user)))
+         .thenReturn(dtoTask("t1", "admin"));
+      when(scheduleGateway.getTaskConditions(eq("t1"), any(), eq(user)))
+         .thenThrow(new NullPointerException("boom"));
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = applyRequest("delete a task", deleteChange("t1"));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      verify(scheduleGateway, never()).removeScheduleTask(anyString(), any(), eq(user));
+   }
+
+   // N-change plan: the first change (create) succeeds, the second (delete of an unrelated task)
+   // fails verification -- rollback must undo the first, newest-first (trivially, since it's the
+   // only undoable one), by deleting what it created.
+   @Test void secondChangeFailingRollsBackTheFirst() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String createdId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      inetsoft.sree.schedule.ScheduleTask other = sreeTask("t2", "admin");
+
+      when(scheduleManager.getScheduleTask(createdId))
+         .thenReturn(null)                       // preview
+         .thenReturn(null)                       // re-resolve
+         .thenReturn(sreeTask("t1", "admin"))     // apply-time verify: created
+         .thenReturn(null);                       // rollback-time verify: deleted
+      when(scheduleManager.getScheduleTask("t2"))
+         .thenReturn(other, other, other, other); // "exists" the whole time -- delete never verifies
+
+      when(scheduleGateway.hasDeletePermission(createdId, user)).thenReturn(true);
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      // captureSpec's three round trips, so the delete's own attempt reaches (and fails) its
+      // existence verify rather than NPE-ing on an unstubbed read.
+      when(scheduleGateway.getScheduleTask(eq("t2"), any(), eq(user)))
+         .thenReturn(dtoTask("t2", "admin"));
+      when(scheduleGateway.getTaskConditions(eq("t2"), any(), eq(user)))
+         .thenReturn(new ScheduleConditionList());
+      when(scheduleGateway.getTaskActions(eq("t2"), any(), eq(user)))
+         .thenReturn(new ScheduleActionList());
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = applyRequest("two changes", createChange(spec), deleteChange("t2"));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      verify(scheduleGateway).removeScheduleTask(eq(createdId), any(), eq(user));
+   }
+
+   // Every undo is attempted regardless, and a failed undo is named, not silently dropped.
+   @Test void rollbackItselfFailingIsReportedNamingTheTaskId() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String createdId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      inetsoft.sree.schedule.ScheduleTask other = sreeTask("t2", "admin");
+
+      when(scheduleManager.getScheduleTask(createdId))
+         .thenReturn(null, null, sreeTask("t1", "admin"), sreeTask("t1", "admin"));
+      when(scheduleManager.getScheduleTask("t2")).thenReturn(other, other, other, other);
+      when(scheduleGateway.hasDeletePermission(createdId, user)).thenReturn(true);
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      when(scheduleGateway.getScheduleTask(eq("t2"), any(), eq(user)))
+         .thenReturn(dtoTask("t2", "admin"));
+      when(scheduleGateway.getTaskConditions(eq("t2"), any(), eq(user)))
+         .thenReturn(new ScheduleConditionList());
+      when(scheduleGateway.getTaskActions(eq("t2"), any(), eq(user)))
+         .thenReturn(new ScheduleActionList());
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+      // t2's own delete attempt (forward pass) succeeds mechanically but fails to verify (still
+      // "exists" per the getScheduleTask stub above) -- only createdId's ROLLBACK throws.
+      doNothing().when(scheduleGateway).removeScheduleTask(eq("t2"), any(), eq(user));
+      doThrow(new IllegalStateException("cannot delete")).when(scheduleGateway)
+         .removeScheduleTask(eq(createdId), any(), eq(user));
+
+      ScheduleApplyRequest req = applyRequest("two changes", createChange(spec), deleteChange("t2"));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertEquals(1, result.rollbackFailures().size());
+      assertEquals(createdId, result.rollbackFailures().get(0).property());
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private ScheduleApplyRequest applyRequest(String task, ScheduleChangeRequest... changes)
+      throws Exception
+   {
+      ScheduleChangePlanRequest probe = new ScheduleChangePlanRequest();
+      probe.setTask(task);
+      probe.setChanges(List.of(changes));
+      String hash = planService.resolve(probe, user).planHash();
+
+      ScheduleApplyRequest req = new ScheduleApplyRequest();
+      req.setTask(task);
+      req.setChanges(List.of(changes));
+      req.setPlanHash(hash);
+      req.setReviewOutcome("approved");
+      return req;
+   }
+
+   private static ScheduleChangeRequest createChange(CreateScheduleTaskRequest spec) {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_CREATE);
+      change.setSpec(spec);
+      return change;
+   }
+
+   private static ScheduleChangeRequest deleteChange(String taskId) {
+      ScheduleChangeRequest change = new ScheduleChangeRequest();
+      change.setVerb(ScheduleChangeRequest.VERB_DELETE);
+      change.setTaskId(taskId);
+      return change;
+   }
+
+   private static CreateScheduleTaskRequest createSpec(String name, String owner) {
+      CreateScheduleTaskRequest spec = new CreateScheduleTaskRequest();
+      spec.setName(name);
+      spec.setOwner(new IdentityID(owner, "host-org"));
+      spec.setEnabled(true);
+      TimeCondition condition = new TimeCondition();
+      condition.setHour(9);
+      condition.setMinute(0);
+      spec.setConditions(List.of(condition));
+      return spec;
+   }
+
+   private static inetsoft.sree.schedule.ScheduleTask sreeTask(String name, String owner) {
+      inetsoft.sree.schedule.ScheduleTask task = new inetsoft.sree.schedule.ScheduleTask();
+      task.setName(name);
+      task.setOwner(new IdentityID(owner, "host-org"));
+      task.setEnabled(true);
+      return task;
+   }
+
+   private static ScheduleTask dtoTask(String name, String owner) {
+      ScheduleTask task = new ScheduleTask();
+      task.setName(name);
+      task.setOwner(new IdentityID(owner, "host-org"));
+      task.setEnabled(true);
+      return task;
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleXmlProjectionTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleXmlProjectionTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.schedule;
+
+import inetsoft.sree.schedule.ScheduleTask;
+import inetsoft.sree.schedule.TimeCondition;
+import inetsoft.sree.security.IdentityID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ScheduleXmlProjectionTest {
+   @Test void nullTaskProjectsToNull() {
+      assertNull(ScheduleXmlProjection.project(null));
+   }
+
+   @Test void projectionIncludesSemanticFields() {
+      ScheduleTask task = task("nightly-refresh", "admin");
+
+      String projection = ScheduleXmlProjection.project(task);
+
+      assertTrue(projection.contains("name=\"nightly-refresh\""));
+      // owner is written as IdentityID#convertToKey(), "name~;~orgID"-shaped -- not a bare name.
+      assertTrue(projection.contains("owner=\"admin" + IdentityID.KEY_DELIMITER + "host-org\""));
+   }
+
+   // The one attribute CONFIRMED unstable across a save (ScheduleManager#setScheduleTask stamps it
+   // unconditionally) -- without this exclusion, the apply-time verify would report every
+   // successful apply as FAILED and roll it straight back.
+   @Test void lastModifiedIsAlwaysStripped() {
+      ScheduleTask task = task("t", "admin");
+      task.setLastModified(1_787_724_000_000L);
+
+      String projection = ScheduleXmlProjection.project(task);
+
+      assertFalse(projection.contains("lastModified"));
+   }
+
+   // The two projections a plan-hash collision would look like: same single condition vs. an
+   // extra one added. Closes the exact collision SpikeHashProbe found when projecting off
+   // getCondition(0) instead of a total serialization (docs/teams/2026-08-26-track-c0-spike).
+   @Test void projectionDiffersWhenAConditionIsAdded() {
+      ScheduleTask approved = task("nightly-refresh", "admin");
+      approved.addCondition(timeCondition(9, 0));
+
+      ScheduleTask drifted = task("nightly-refresh", "admin");
+      drifted.addCondition(timeCondition(9, 0));
+      drifted.addCondition(timeCondition(23, 0));
+
+      assertNotEquals(ScheduleXmlProjection.project(approved), ScheduleXmlProjection.project(drifted));
+   }
+
+   @Test void projectionIsStableForIdenticalTasks() {
+      ScheduleTask a = task("t", "admin");
+      a.addCondition(timeCondition(9, 0));
+      ScheduleTask b = task("t", "admin");
+      b.addCondition(timeCondition(9, 0));
+
+      assertEquals(ScheduleXmlProjection.project(a), ScheduleXmlProjection.project(b));
+   }
+
+   @Test void normalizeStripsEveryExcludedAttributeByName() {
+      String xml = "<Task name=\"t\" lastModified=\"5\" path=\"/\" editable=\"true\" " +
+         "removable=\"false\" enabled=\"true\">";
+
+      String normalized = ScheduleXmlProjection.normalize(xml);
+
+      for(String attr : ScheduleXmlProjection.EXCLUDED_ATTRIBUTES) {
+         assertFalse(normalized.contains(attr + "="), "expected " + attr + " to be stripped");
+      }
+
+      assertTrue(normalized.contains("name=\"t\""));
+      assertTrue(normalized.contains("enabled=\"true\""));
+   }
+
+   private static ScheduleTask task(String name, String owner) {
+      ScheduleTask task = new ScheduleTask();
+      task.setName(name);
+      task.setOwner(new IdentityID(owner, "host-org"));
+      task.setEnabled(true);
+      return task;
+   }
+
+   private static TimeCondition timeCondition(int hour, int minute) {
+      TimeCondition condition = new TimeCondition();
+      condition.setType(TimeCondition.EVERY_DAY);
+      condition.setHour(hour);
+      condition.setMinute(minute);
+      return condition;
+   }
+}


### PR DESCRIPTION
## Summary

`admin-chat`'s schedule-task tools (`list_schedule_tasks`/`get_schedule_task`/`preview_schedule_task_changes`/`apply_schedule_task_changes`) 404 on a genuine Community-edition StyleBI deployment, because `AdminScheduleController` and everything it depends on lived only in the `enterprise` module. This contradicts `plugin/admin/CLAUDE.md`'s existing documentation (and the tools' own descriptions), which already promised community support for this area, matching the real treatment Providers and Cluster already have.

This PR moves the parts of that dependency chain that have no genuine enterprise-only dependency into `community/core`, and writes one new class for the part that legitimately can't be shared.

## What moved (verbatim, package declaration only)

- **22 dependency-free schedule DTOs** from `enterprise/.../web/api/schedule/` into `community/core/src/main/java/inetsoft/web/api/schedule/` — `BatchAction`, `CSVConfig`, `CompletionCondition`, `CreateDataCycleRequest`, `CreateScheduleTaskRequest`, `DataCycle`, `DataCycleList`, `IndividualAssetBackupAction`, `RunScheduleTaskRequest`, `ScheduleAction`, `ScheduleActionList`, `ScheduleAlert`, `ScheduleCondition`, `ScheduleConditionList`, `ScheduleOptions`, `ScheduleTask`, `ScheduleTaskList`, `ScheduleTaskStatus`, `ServerPathInfo`, `StopScheduleTaskRequest`, `TimeCondition`, `UnsupportedScheduleItem`, `ViewsheetAction`. Confirmed via import audit that none of these have any real `inetsoft.enterprise.*` dependency.
- **3 identity marker types** from `enterprise/.../web/api/identity/` into `community/core/src/main/java/inetsoft/web/api/identity/` — `TaskOwnerIdentityID`, `TaskExecuteAsIdentityID`, `VSOwnerIdentityID` (each a one-line subclass of `inetsoft.sree.security.IdentityID`).
- **8 admin-plugin files** from `enterprise/.../web/admin/ai/schedule/` into `community/core/src/main/java/inetsoft/web/admin/ai/schedule/` — `AdminScheduleController`, `ScheduleChangePlanService`, `ScheduleChangesetApplyService`, `ScheduleApplyRequest`, `ScheduleChangePlanRequest`, `ScheduleChangeRequest`, `ScheduleTaskView`, `ScheduleXmlProjection` — rewired to depend on the new `AdminScheduleGateway` instead of `ScheduleApiService`.

## What's new

- **`AdminScheduleGateway`** — a community-native replacement for the operations admin-chat's schedule-task area needs from the enterprise `ScheduleApiService`, *not* a relocation of it. `ScheduleApiService`/`ScheduleApiController` (the enterprise Public REST API surface for schedule automation) stay in enterprise because they carry two genuine enterprise-only dependencies this gateway does not need: the `@SwitchOrg`/`@Audited` AOP (which re-initializes per-org state via `SecurityApiService.switchOrganization`), and their status as the licensed Public API for run/stop/data-cycles/batch actions. `AdminScheduleGateway` is modeled line-by-line on the corresponding `ScheduleApiService` methods (list/get/create/delete, the two inverse-permission preflights, and the condition/action converters), built directly against community-only types (`AnalyticRepository`, `ScheduleManager`, `SecurityEngine`, etc.).

## Net effect on the wire contract: zero

Every moved DTO shape is unchanged (only the package declaration differs), so `plugin/admin/src/tools/scheduleTools.ts`, `normalize.ts`, and every documented field name in `SPEC_DESCRIPTION`/`CHANGES_SCHEMA` need no update.

## Tests

Ported the 4 existing enterprise-side unit tests for the moved classes (`AdminScheduleControllerTest`, `ScheduleChangePlanServiceTest`, `ScheduleChangesetApplyServiceTest`, `ScheduleXmlProjectionTest`) into `community/core/src/test/java/inetsoft/web/admin/ai/schedule/`, adapted to mock `AdminScheduleGateway` instead of `ScheduleApiService` and tagged `@Tag("core")` to match this module's surefire config. All 43 tests pass.

## Verified

- `community/core` compiles clean (`mvn compile`/`test-compile`), confirmed repeatedly from a fully clean state.
- A full multi-module reactor build (`./mvnw install -DskipTests` from the enterprise repo root, which includes `community` via the default `include-community` profile) reports `BUILD SUCCESS` across all 76 modules.

## Companion PR

This is the community-side half of a two-repo fix. The enterprise-side companion PR (deletes the 33 files now duplicated here, and repoints every other enterprise/shell file that referenced a moved type at this new community package) will link back to this PR.

This PR does **not** touch the community submodule pointer recorded in the enterprise repo — that is a separate, deliberate step for the operator to take once both PRs are reviewed and merged.