### PR TITLE
fix(wiz): read_worksheet_model surfaces a variable's Values picker (bug 76502 WBS-030)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -448,8 +448,21 @@ public class WorksheetReadService {
     * non-null) and query-mode ({@code getTableName()} non-null) are mutually exclusive, and
     * neither being set means no picker at all -- reported as {@code null}, not an empty/default
     * {@code ChoicesModel}.
+    *
+    * <p>{@code displayStyle == NONE} is checked FIRST, before {@code getChoices()}/
+    * {@code getTableName()}, matching {@code VariableAssemblyDialogService} (the native Composer
+    * variable dialog's own reader, {@code :101-104}). {@code applyVariableChoices} only clears
+    * {@code choices}/{@code values}/{@code table} when a NEW {@code values}/{@code table} source
+    * is supplied in the same call -- a caller that supplies only {@code displayStyle: "none"}
+    * (turning the picker off without resupplying/clearing its source) leaves the old picker data
+    * on the object untouched, which would otherwise read back as a fully populated picker
+    * alongside a "none" style.
     */
    private WorksheetModel.ChoicesModel readVariableChoices(AssetVariable var) {
+      if(var.getDisplayStyle() == UserVariable.NONE) {
+         return null;
+      }
+
       String displayStyle = displayStyleName(var.getDisplayStyle());
 
       if(var.getChoices() != null) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -428,7 +428,7 @@ public class WorksheetReadService {
       AssetVariable var = dva.getVariable();
 
       if(var == null) {
-         return new WorksheetModel.VariableModel(dva.getName(), null, null, null);
+         return new WorksheetModel.VariableModel(dva.getName(), null, null, null, null);
       }
 
       String label = var.getAlias();
@@ -438,7 +438,66 @@ public class WorksheetReadService {
       String defaultValue = valueNode != null ? valueNode.getValue() != null
          ? valueNode.getValue().toString() : null : null;
 
-      return new WorksheetModel.VariableModel(var.getName(), label, type, defaultValue);
+      return new WorksheetModel.VariableModel(var.getName(), label, type, defaultValue,
+                                              readVariableChoices(var));
+   }
+
+   /**
+    * Reads a variable's "Values" picker, matching the branching
+    * {@code WorksheetMutationSupport.applyVariableChoices} writes: embedded ({@code getChoices()}
+    * non-null) and query-mode ({@code getTableName()} non-null) are mutually exclusive, and
+    * neither being set means no picker at all -- reported as {@code null}, not an empty/default
+    * {@code ChoicesModel}.
+    */
+   private WorksheetModel.ChoicesModel readVariableChoices(AssetVariable var) {
+      String displayStyle = displayStyleName(var.getDisplayStyle());
+
+      if(var.getChoices() != null) {
+         // getChoices()/getValues() are named from the write side's perspective
+         // (UserVariable#setChoices/#setValues): "choices" holds the display labels, "values"
+         // holds the underlying typed values -- see applyEmbeddedVariableChoices.
+         return new WorksheetModel.ChoicesModel(stringify(var.getValues()),
+                                                stringify(var.getChoices()), null, null, null,
+                                                displayStyle);
+      }
+
+      if(var.getTableName() != null) {
+         DataRef labelRef = var.getLabelAttribute();
+         DataRef valueRef = var.getValueAttribute();
+         return new WorksheetModel.ChoicesModel(null, null, var.getTableName(),
+                                                labelRef != null ? labelRef.getAttribute() : null,
+                                                valueRef != null ? valueRef.getAttribute() : null,
+                                                displayStyle);
+      }
+
+      return null;
+   }
+
+   private static List<String> stringify(Object[] values) {
+      List<String> result = new ArrayList<>(values.length);
+
+      for(Object value : values) {
+         result.add(value != null ? value.toString() : null);
+      }
+
+      return result;
+   }
+
+   /**
+    * Inverse of {@code WorksheetMutationSupport#parseVariableDisplayStyle}. {@code DATE_COMBOBOX}
+    * is read-only: it has no forward case there because it is reachable only via StyleBI's
+    * native, non-agent Composer variable dialog, not {@code add_variable}/{@code edit_variable}.
+    */
+   private static String displayStyleName(int style) {
+      return switch(style) {
+         case UserVariable.NONE -> "none";
+         case UserVariable.COMBOBOX -> "combobox";
+         case UserVariable.LIST -> "list";
+         case UserVariable.RADIO_BUTTONS -> "radio";
+         case UserVariable.CHECKBOXES -> "checkboxes";
+         case UserVariable.DATE_COMBOBOX -> "date_combobox";
+         default -> null;
+      };
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -266,9 +266,38 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param label        display label; may be {@code null}
     * @param type         XSchema data-type string; may be {@code null}
     * @param defaultValue stringified default value; may be {@code null}
+    * @param choices      the variable's "Values" picker, or {@code null} when no picker is
+    *                     configured at all (a plain free-form/text-input variable) — not an
+    *                     empty/default {@code ChoicesModel}
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
-   public record VariableModel(String name, String label, String type, String defaultValue) {}
+   public record VariableModel(String name, String label, String type, String defaultValue,
+                               ChoicesModel choices) {}
+
+   /**
+    * A variable's enumerated "Values" picker, mirroring
+    * {@code WorksheetMutationSupport.VariableChoicesSpec} field-for-field. Embedded
+    * ({@code values}/{@code labels}) and query-mode ({@code table}/{@code labelColumn}/
+    * {@code valueColumn}) sources are mutually exclusive, matching the write side.
+    *
+    * @param values       embedded picker values; {@code null} in query mode
+    * @param labels       display labels parallel to {@code values}; {@code null} in query mode
+    * @param table        worksheet table supplying picker rows (query mode); {@code null} in
+    *                     embedded mode
+    * @param labelColumn  column on {@code table} supplying each row's display label;
+    *                     {@code null} in embedded mode
+    * @param valueColumn  column on {@code table} supplying each row's underlying value;
+    *                     {@code null} in embedded mode
+    * @param displayStyle {@code "none"}, {@code "combobox"}, {@code "list"}, {@code "radio"},
+    *                     or {@code "checkboxes"} — the same vocabulary {@code add_variable}/
+    *                     {@code edit_variable} accept. {@code "date_combobox"} is also possible
+    *                     here (StyleBI's native, non-agent Composer variable dialog can set it)
+    *                     but is read-only: it is not one of the values {@code add_variable}/
+    *                     {@code edit_variable} accept.
+    */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
+   public record ChoicesModel(List<String> values, List<String> labels, String table,
+                              String labelColumn, String valueColumn, String displayStyle) {}
 
    /**
     * A named group assembly in the worksheet.

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -484,6 +484,35 @@ class WorksheetReadServiceTest {
    }
 
    /**
+    * {@code applyVariableChoices} only clears {@code choices}/{@code values}/{@code table} when a
+    * NEW {@code values}/{@code table} source is supplied in the same call -- a caller that
+    * supplies only {@code displayStyle: "none"} (turning the picker off without resupplying or
+    * explicitly clearing its source, a very natural "turn this picker off" call, reachable as-is
+    * through {@code edit_variable}) leaves the old embedded list on the {@code AssetVariable}
+    * object untouched. The read side must not report that stale, self-contradictory combination
+    * (a fully populated picker alongside a "none" style) -- it must read back as no picker at all,
+    * matching how {@code VariableAssemblyDialogService} (the native Composer dialog's own reader)
+    * treats {@code NONE} as authoritative over any leftover {@code choices}/{@code table} data.
+    */
+   @Test
+   void variableWithDisplayStyleSetToNoneAloneReportsNullChoicesNotStaleData() {
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly va = new DefaultVariableAssembly(ws, "region");
+      AssetVariable var = new AssetVariable("region");
+      va.setVariable(var);
+      ws.addAssembly(va);
+
+      WorksheetMutationSupport.applyVariableChoices(ws, var,
+         new WorksheetMutationSupport.VariableChoicesSpec(
+            List.of("east", "west"), null, null, null, null, "list"));
+
+      WorksheetMutationSupport.applyVariableChoices(ws, var,
+         new WorksheetMutationSupport.VariableChoicesSpec(null, null, null, null, null, "none"));
+
+      assertNull(variableNamed(read(ws), "region").choices());
+   }
+
+   /**
     * {@code DATE_COMBOBOX} has no forward case in {@code parseVariableDisplayStyle} -- it is
     * reachable only via StyleBI's native, non-agent Composer variable dialog, never via
     * {@code add_variable}/{@code edit_variable}. The read side must still report it (as

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -417,8 +417,103 @@ class WorksheetReadServiceTest {
       assertEquals(List.of("region"), tm.referencedVariables());
    }
 
+   // -------------------------------------------------------------------------
+   // Variable choices (WBS-030 / bug #76502): read_worksheet_model never surfaced a variable's
+   // "Values" picker -- readVariable() only read alias/type/default, never choices/values/
+   // tableName/labelAttribute/valueAttribute/displayStyle. These round-trip through the real
+   // applyVariableChoices mutator so each fixture exercises the exact object shape the write
+   // path produces, not a hand-built AssetVariable that might miss a field the mutator sets.
+   // -------------------------------------------------------------------------
+
+   @Test
+   void variableWithEmbeddedChoicesRoundTripsThroughChoicesModel() {
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly va = new DefaultVariableAssembly(ws, "region");
+      AssetVariable var = new AssetVariable("region");
+      va.setVariable(var);
+      ws.addAssembly(va);
+
+      WorksheetMutationSupport.applyVariableChoices(ws, var,
+         new WorksheetMutationSupport.VariableChoicesSpec(
+            List.of("east", "west"), List.of("East Region", "West Region"),
+            null, null, null, "list"));
+
+      WorksheetModel.ChoicesModel choices = variableNamed(read(ws), "region").choices();
+      assertNotNull(choices);
+      assertEquals(List.of("east", "west"), choices.values());
+      assertEquals(List.of("East Region", "West Region"), choices.labels());
+      assertNull(choices.table());
+      assertNull(choices.labelColumn());
+      assertNull(choices.valueColumn());
+      assertEquals("list", choices.displayStyle());
+   }
+
+   @Test
+   void variableWithQueryModeChoicesRoundTripsThroughChoicesModel() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "Regions", "code", "name");
+      ws.addAssembly(t);
+
+      DefaultVariableAssembly va = new DefaultVariableAssembly(ws, "region");
+      AssetVariable var = new AssetVariable("region");
+      va.setVariable(var);
+      ws.addAssembly(va);
+
+      WorksheetMutationSupport.applyVariableChoices(ws, var,
+         new WorksheetMutationSupport.VariableChoicesSpec(
+            null, null, "Regions", "name", "code", "combobox"));
+
+      WorksheetModel.ChoicesModel choices = variableNamed(read(ws), "region").choices();
+      assertNotNull(choices);
+      assertNull(choices.values());
+      assertNull(choices.labels());
+      assertEquals("Regions", choices.table());
+      assertEquals("name", choices.labelColumn());
+      assertEquals("code", choices.valueColumn());
+      assertEquals("combobox", choices.displayStyle());
+   }
+
+   @Test
+   void variableWithNoPickerReportsNullChoices() {
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly va = new DefaultVariableAssembly(ws, "region");
+      va.setVariable(new AssetVariable("region"));
+      ws.addAssembly(va);
+
+      assertNull(variableNamed(read(ws), "region").choices());
+   }
+
+   /**
+    * {@code DATE_COMBOBOX} has no forward case in {@code parseVariableDisplayStyle} -- it is
+    * reachable only via StyleBI's native, non-agent Composer variable dialog, never via
+    * {@code add_variable}/{@code edit_variable}. The read side must still report it (as
+    * {@code "date_combobox"}) rather than silently dropping the variable or crashing.
+    */
+   @Test
+   void variableWithDateComboboxDisplayStyleReadsBackWithoutCrashing() {
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly va = new DefaultVariableAssembly(ws, "asOf");
+      AssetVariable var = new AssetVariable("asOf");
+      var.setSortValue(false);
+      var.setDisplayStyle(UserVariable.DATE_COMBOBOX);
+      var.setChoices(new Object[]{ "Today", "Yesterday" });
+      var.setValues(new Object[]{ "TODAY", "YESTERDAY" });
+      va.setVariable(var);
+      ws.addAssembly(va);
+
+      WorksheetModel.ChoicesModel choices = variableNamed(read(ws), "asOf").choices();
+      assertNotNull(choices);
+      assertEquals(List.of("TODAY", "YESTERDAY"), choices.values());
+      assertEquals(List.of("Today", "Yesterday"), choices.labels());
+      assertEquals("date_combobox", choices.displayStyle());
+   }
+
    private static WorksheetModel.TableModel tableNamed(WorksheetModel m, String name) {
       return m.tables().stream().filter(t -> name.equals(t.name())).findFirst().orElseThrow();
+   }
+
+   private static WorksheetModel.VariableModel variableNamed(WorksheetModel m, String name) {
+      return m.variables().stream().filter(v -> name.equals(v.name())).findFirst().orElseThrow();
    }
 
    private static WorksheetModel read(Worksheet ws) {


### PR DESCRIPTION
## Summary
- `WorksheetReadService.readVariable()` never read a variable's "Values" picker
  (`choices`/`values`/`tableName`/`labelAttribute`/`valueAttribute`/`displayStyle`) off
  `AssetVariable` -- so a picker set via `add_variable`/`edit_variable` was invisible to
  `read_worksheet_model`, even though it was genuinely stored and enforced server-side.
- Adds `WorksheetModel.ChoicesModel` (mirroring `WorksheetMutationSupport.VariableChoicesSpec`
  field-for-field) and populates `VariableModel.choices()` using the same embedded-vs-query-mode-
  vs-no-picker branching `applyVariableChoices` uses on write, so the read side can never diverge
  from what the write side considers "has a picker".
- `DATE_COMBOBOX` (ordinal 5) has no forward case in `parseVariableDisplayStyle` -- it's reachable
  only via StyleBI's native, non-agent Composer variable dialog. Deliberate scope decision: surface
  it as `"date_combobox"` on read (never drop the variable or crash), but do **not** add it to the
  write vocabulary -- that would be a new capability, not a fix for this read-side gap.

## Root cause
`WorksheetReadService.readVariable()` (`core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java`)
built a flat 4-field `VariableModel(name, label, type, defaultValue)` and never called the choices-related
getters on `AssetVariable`, even though the exact same object instance is populated by
`WorksheetMutationSupport.applyVariableChoices()` on the write path (`WorksheetEditService.editVariable()`
clones-mutates-publishes the same `AssetVariable` the read path next observes).

## Test plan
- [x] `./mvnw test -pl core -Dtest=WorksheetReadServiceTest` -- 44/44 pass (40 existing + 4 new:
  embedded-choices round-trip, query-mode-choices round-trip, no-picker → null, DATE_COMBOBOX
  read-only round-trip), all round-tripped through the real `applyVariableChoices` mutator rather
  than a hand-built `AssetVariable`.
- Broader `-pl core` run shows unrelated `NoClassDefFoundError`/Spring-context-shutdown errors from
  parallel-fork JVM contamination when running the full ~3400-test suite together (pre-existing
  environment flakiness, not from this change) -- `WorksheetReadServiceTest` alone is green in
  isolation both before and after adding the new tests.

Bug 76502 WBS-030.