### PR TITLE
fix(wiz): discard stale chart fields on a forced set_chart_source repoint (#76495)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -1233,8 +1233,17 @@ public final class ChartAestheticMutator {
     * visibly rendering — the write worked, the read lied.
     *
     * <p>{@code fullName} is kept only as a fallback, for the models our own writer built.
+    *
+    * <p>Package-private rather than private since bug #76495: {@code
+    * ChartBindingService.discardBoundFields} needs the same column-name resolution this class's
+    * own read path (this method, plus {@link #read}) already does, to decide whether a bound
+    * aesthetic channel's field still resolves in a chart's new source. Reading
+    * {@code AestheticInfo.getFullName()} directly there would not work — this method exists
+    * precisely because that property is null on every channel {@code
+    * AestheticRefModelFactory.createAestheticInfo} builds (the real read path {@code
+    * discardBoundFields} runs against), and only {@code dataInfo} carries the name.
     */
-   private static String fieldNameOf(AestheticInfo info) {
+   static String fieldNameOf(AestheticInfo info) {
       if(info == null) {
          return null;
       }
@@ -1310,7 +1319,18 @@ public final class ChartAestheticMutator {
       };
    }
 
-   private static AestheticInfo read(ChartBindingModel model, String channel) {
+   /**
+    * The {@code AestheticInfo} bound to a channel, or {@code null} when nothing is.
+    *
+    * <p>Package-private rather than private since bug #76495: this is the only method that maps
+    * a channel name to its bound field, so {@code ChartBindingService.discardBoundFields} needs
+    * it (alongside {@link #fieldNameOf}) to decide, per channel, whether a forced source repoint
+    * should clear it. Widening costs nothing to this class's own five existing callers — a
+    * package-private method is still callable unqualified from within its own class exactly as
+    * before — and no class outside this package could reference it either way, since it was
+    * unreachable from outside {@code ChartAestheticMutator} while private.
+    */
+   static AestheticInfo read(ChartBindingModel model, String channel) {
       return switch(channel) {
          case "color" -> model.getColorField();
          case "shape" -> model.getShapeField();

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -34,7 +34,11 @@ import inetsoft.web.binding.controller.SwapXYBindingService;
 import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.event.ChangeChartTypeEvent;
 import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
+import inetsoft.web.binding.model.BindingModel;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.AestheticInfo;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.binding.service.VSBindingService;
@@ -132,9 +136,15 @@ public class ChartBindingService {
     * ability to set one.
     *
     * <p>Repointing a bound chart invalidates its fields, since the columns belong to the old
-    * source; the Composer handles that by <em>deleting</em> the ones the new source does not have
-    * ({@code VSAssemblyInfoHandler.validateChartColumns}). So it is refused unless {@code force},
-    * rather than done silently on one call.
+    * source. {@code changeChartRef} — the write path this method drives — never reaches {@code
+    * VSAssemblyInfoHandler.validateChartColumns} (that method's only caller is {@code
+    * validateBinding}, and every real caller of <em>that</em> is a drag-and-drop controller or
+    * {@code ChangeGeographicService}, none of them anywhere in this call chain), so nothing
+    * downstream discards a stale field for this path the way the Composer's own drag-and-drop
+    * repoint does. So a repoint is refused unless {@code force}; when it is forced,
+    * {@link #discardBoundFields} does the discarding itself, right here, selectively keeping a
+    * field whose column still resolves in the new source rather than clearing everything (bug
+    * #76495, the sibling of {@code TableBindingService}'s own bug #76302).
     */
    public void setSource(String sessionToken, Principal user, String assemblyName, String table,
                          boolean force, String linkUri) throws Exception
@@ -150,8 +160,11 @@ public class ChartBindingService {
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
          String resolved = BindingSources.resolve(model, table, assemblyName);
 
-         if(!force && !BindingSources.alreadyPointedAt(model.getSource(), resolved)) {
+         if(!force) {
             requireNoBoundFields(model, assemblyName, resolved);
+         }
+         else {
+            discardBoundFields(model, resolved);
          }
 
          model.setSource(BindingSources.assetSource(resolved));
@@ -165,7 +178,10 @@ public class ChartBindingService {
    }
 
    /**
-    * Refuses to discard bound fields.
+    * Refuses to discard bound fields. {@link #discardBoundFields} is the {@code force:true}
+    * counterpart for the identical thirteen locations — kept as a separate method, the way
+    * {@code TableBindingService.requireNoBoundFields}/{@code discardBoundFields} are, rather than
+    * merged into one, so this one stays pure refusal.
     *
     * <p>Counts <b>every</b> place a chart keeps a field, not just x/y/group: the three list
     * shelves, the ten single-field shelves, the six aesthetic channels, and a map's geo fields.
@@ -187,6 +203,10 @@ public class ChartBindingService {
    private static void requireNoBoundFields(ChartBindingModel model, String assemblyName,
                                             String table)
    {
+      if(BindingSources.alreadyPointedAt(model.getSource(), table)) {
+         return;
+      }
+
       List<String> populated = new ArrayList<>();
 
       for(String shelf : ChartBindingMutator.SHELVES) {
@@ -223,6 +243,151 @@ public class ChartBindingService {
             "' discards them. Pass force: true to do that deliberately, or bind the fields you " +
             "want after the source is set.");
       }
+   }
+
+   /**
+    * The {@code force:true} counterpart to {@link #requireNoBoundFields}: discards only the
+    * fields that no longer resolve in the new source, across the identical thirteen locations —
+    * selectively, not a blanket clear, mirroring {@code TableBindingService.discardBoundFields}
+    * (bug #76302)'s own intent. A field whose column name also exists in the new source is kept —
+    * a same-shaped repoint (e.g. a partitioned/monthly sibling table) should not discard bindings
+    * a human doing the equivalent repoint in the Composer would keep. This is also what makes a
+    * word-cloud's or candlestick's binding — which lives entirely on an aesthetic channel or the
+    * single-field shelves, per {@link #requireNoBoundFields}'s own javadoc — survive a repoint to
+    * a same-shaped sibling table rather than being wiped just because <em>something</em> changed.
+    *
+    * <p>Before this existed, {@code setSource(force: true)} to a genuinely different table left
+    * every one of these thirteen locations untouched: {@code changeChartRef}'s real write path
+    * never reaches {@code validateChartColumns} (see {@link #setSource}'s own javadoc), so nothing
+    * downstream cleared them either. {@code get_binding} then reported fields pointing at columns
+    * that no longer existed in the chart's new source (bug #76495).
+    */
+   private static void discardBoundFields(ChartBindingModel model, String table) {
+      if(BindingSources.alreadyPointedAt(model.getSource(), table)) {
+         return;
+      }
+
+      List<String> availableColumns = columnsOf(model, table);
+
+      for(String shelf : ChartBindingMutator.SHELVES) {
+         List<ChartRefModel> bound = ChartBindingMutator.readShelf(model, shelf);
+         List<ChartRefModel> stillResolves = new ArrayList<>();
+
+         for(ChartRefModel field : bound) {
+            if(resolves(columnNameOf(field), availableColumns)) {
+               stillResolves.add(field);
+            }
+         }
+
+         if(stillResolves.size() != bound.size()) {
+            switch(shelf) {
+            case "x" -> model.setXFields(stillResolves);
+            case "y" -> model.setYFields(stillResolves);
+            default -> model.setGroupFields(stillResolves);
+            }
+         }
+      }
+
+      for(String shelf : ChartBindingMutator.SINGLE_SHELVES) {
+         ChartRefModel bound = ChartBindingMutator.readSingleShelf(model, shelf);
+
+         if(bound != null && !resolves(columnNameOf(bound), availableColumns)) {
+            ChartBindingMutator.setSingleShelf(model, shelf, null);
+         }
+      }
+
+      for(String channel : ChartAestheticMutator.boundFieldChannels(model)) {
+         AestheticInfo info = ChartAestheticMutator.read(model, channel);
+         String column = ChartAestheticMutator.fieldNameOf(info);
+
+         if(!resolves(column, availableColumns)) {
+            ChartAestheticMutator.clearField(
+               model, channel, AestheticChannels.NODE_CHANNELS.contains(channel));
+         }
+      }
+
+      List<ChartRefModel> geoFields = model.getGeoFields();
+
+      if(geoFields != null && !geoFields.isEmpty()) {
+         List<ChartRefModel> stillResolves = new ArrayList<>();
+
+         for(ChartRefModel field : geoFields) {
+            if(resolves(columnNameOf(field), availableColumns)) {
+               stillResolves.add(field);
+            }
+         }
+
+         if(stillResolves.size() != geoFields.size()) {
+            model.setGeoFields(stillResolves);
+         }
+      }
+   }
+
+   /** The column a shelf/geo {@code ChartRefModel} is bound to, or {@code null} for neither kind. */
+   private static String columnNameOf(ChartRefModel ref) {
+      if(ref instanceof ChartDimensionRefModel dimension) {
+         return dimension.getColumnValue() == null ? dimension.getName() : dimension.getColumnValue();
+      }
+
+      if(ref instanceof ChartAggregateRefModel aggregate) {
+         return aggregate.getFullName();
+      }
+
+      return null;
+   }
+
+   /**
+    * Whether a bound field's column still exists in the new source — matching either its raw
+    * name or its unqualified form against either form of each available column, the same
+    * case-insensitive, qualified-or-not comparison {@link TableBindingService#discardBoundFields}
+    * makes (see that method's own {@code columnsOf} javadoc for why both sides need expanding).
+    */
+   private static boolean resolves(String column, List<String> availableColumns) {
+      if(column == null) {
+         return false;
+      }
+
+      String bare = TableBindingService.unqualified(column);
+
+      return availableColumns.stream().anyMatch(
+         c -> c.equalsIgnoreCase(column) || c.equalsIgnoreCase(bare));
+   }
+
+   /**
+    * The new source table's column names, mirroring {@code TableBindingService.columnsOf} — not
+    * calling it directly, since its parameter type is {@code BaseTableBindingModel}, a sibling of
+    * {@code ChartBindingModel} under the common {@code BindingModel} base, not a parent — a
+    * {@code ChartBindingModel} instance cannot be passed where a {@code BaseTableBindingModel} is
+    * expected. Each column contributes both its raw name and, when qualified
+    * ({@code "table.attribute"}), its unqualified form too, for the same reason the sibling
+    * method does: a joined/merged worksheet table commonly carries qualified column names, so
+    * expanding this side is needed independently of whether an old bound field's column name
+    * happens to be qualified or not.
+    */
+   private static List<String> columnsOf(ChartBindingModel model, String table) {
+      List<String> names = new ArrayList<>();
+      List<BindingModel.SourceTable> tables = model.getTables();
+
+      if(tables != null) {
+         for(BindingModel.SourceTable candidate : tables) {
+            if(table.equalsIgnoreCase(candidate.getName()) && candidate.getColumns() != null) {
+               for(BindingModel.SourceTableColumn column : candidate.getColumns()) {
+                  if(column.getName() == null) {
+                     continue;
+                  }
+
+                  names.add(column.getName());
+                  String bare = TableBindingService.unqualified(column.getName());
+
+                  if(!bare.equals(column.getName())) {
+                     names.add(bare);
+                  }
+               }
+            }
+         }
+      }
+
+      return names;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -377,7 +377,14 @@ class ChartBindingServiceTest {
       assertTrue(thrown.getMessage().contains("geo"));
    }
 
-   /** An aesthetic-only binding is discardable on the same terms as a shelf one: with force. */
+   /**
+    * An aesthetic-only binding is discardable on the same terms as a shelf one: with force. The
+    * new source ({@code ORDER_DETAILS1}, per {@link #chartWithTables}) carries no columns at all,
+    * so the bound "Product" text field cannot resolve against it — {@link #discardBoundFields}
+    * clears it, exactly as a Composer drag-and-drop repoint would via
+    * {@code validateChartColumns}. (There used to be no discard at all here — see the
+    * still-kept-field case right below for the selective half of the same fix.)
+    */
    @Test
    void setSourceProceedsWhenForcedOverAnAestheticOnlyBinding() throws Exception {
       ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
@@ -396,9 +403,71 @@ class ChartBindingServiceTest {
                                   anyString());
       ChartBindingModel posted = captor.getValue().getModel();
       assertEquals("ORDER_DETAILS1", posted.getSource().getSource());
+      assertNull(posted.getTextField(),
+                 "'Product' does not resolve against ORDER_DETAILS1's (empty) column list, so " +
+                 "the forced repoint must discard it -- changeChartRef never reaches " +
+                 "validateChartColumns, so this class's own discardBoundFields is what clears it");
+   }
+
+   /**
+    * The selective half of the same fix: a forced repoint to a source that happens to carry a
+    * column of the same name keeps the field bound to it, rather than clearing every aesthetic
+    * channel unconditionally. This is the word-cloud/candlestick-safety case -- a chart whose
+    * entire binding lives on one aesthetic channel must not lose it just because
+    * {@code discardBoundFields} ran at all.
+    */
+   @Test
+   void setSourceKeepsAnAestheticFieldWhoseColumnStillResolvesInTheNewSource() throws Exception {
+      ChartBindingModel existing =
+         chartWithTablesAndColumns("ORDERS1", "ORDER_DETAILS1", "Product");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartAestheticMutator.setField(existing, "text",
+                                     new FieldRef("Product", "dimension", null, null, null));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      assertNotNull(captor.getValue().getModel().getTextField(),
+                    "'Product' resolves against the new source, so the selective discard must " +
+                    "keep it rather than clearing every bound channel unconditionally");
+   }
+
+   /**
+    * A word cloud's entire binding lives on the text channel ({@code requireNoBoundFields}'s own
+    * javadoc names this as the reason aesthetic channels must be counted at all). Repointed to a
+    * same-shaped sibling table with force, its one binding must survive -- this is exactly the
+    * regression a blanket-clear implementation (rather than the selective,
+    * {@code ChartAestheticMutator.read}-based discard this fix uses) would reintroduce.
+    */
+   @Test
+   void setSourceKeepsAWordCloudsOnlyBindingWhenTheSiblingTableSharesItsColumn() throws Exception {
+      ChartBindingModel existing =
+         chartWithTablesAndColumns("ORDERS1", "ORDERS2", "Product");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartAestheticMutator.setField(existing, "text",
+                                     new FieldRef("Product", "dimension", null, null, null));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDERS2", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      ChartBindingModel posted = captor.getValue().getModel();
+      assertEquals("ORDERS2", posted.getSource().getSource());
       assertNotNull(posted.getTextField(),
-                    "the repoint must not clear the channel itself — validateChartColumns " +
-                    "decides what survives, this write only moves the source");
+                    "a word cloud's only binding must survive a repoint to a same-shaped " +
+                    "sibling table -- losing it here is the exact regression a blanket-clear " +
+                    "aesthetic-channel discard would reintroduce");
    }
 
    /**
@@ -419,6 +488,14 @@ class ChartBindingServiceTest {
       verify(refs).changeChartRef(eq("rt1"), any(), any(Principal.class), any(), anyString());
    }
 
+   /**
+    * The bare {@code ChartDimensionRefModel} placed on x here carries no column name at all
+    * (neither {@code columnValue} nor {@code name} is set), so it cannot resolve against
+    * ORDER_DETAILS1 (which, per {@link #chartWithTables}, carries no columns either) -- the
+    * forced repoint must discard it, which used not to happen at all: {@code setSource(force:
+    * true)} performed no discard of any kind before this fix (bug #76495), so this field would
+    * have survived, stale, pointed at a source that no longer has it.
+    */
    @Test
    void setSourceProceedsWhenForced() throws Exception {
       ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
@@ -434,7 +511,80 @@ class ChartBindingServiceTest {
          ArgumentCaptor.forClass(ChangeChartRefEvent.class);
       verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
                                   anyString());
-      assertEquals("ORDER_DETAILS1", captor.getValue().getModel().getSource().getSource());
+      ChartBindingModel posted = captor.getValue().getModel();
+      assertEquals("ORDER_DETAILS1", posted.getSource().getSource());
+      assertTrue(posted.getXFields().isEmpty(),
+                 "the pre-existing x-shelf field has no column, so it cannot resolve against the " +
+                 "new source and must be discarded by the forced repoint");
+   }
+
+   /**
+    * The selective half of the same fix on a list shelf: a field whose column still resolves in
+    * the new source is kept, while an unrelated field on the same shelf whose column the new
+    * source lacks is cleared -- matching {@code TableBindingService.discardBoundFields}'s own
+    * "same-shaped repoint keeps matching fields" behavior.
+    */
+   @Test
+   void setSourceKeepsAShelfFieldWhoseColumnStillResolvesButClearsOneThatDoesNot()
+      throws Exception
+   {
+      ChartBindingModel existing =
+         chartWithTablesAndColumns("ORDERS1", "ORDER_DETAILS1", "Product");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartDimensionRefModel kept = new ChartDimensionRefModel();
+      kept.setColumnValue("Product");
+      ChartDimensionRefModel cleared = new ChartDimensionRefModel();
+      cleared.setColumnValue("Region");
+      existing.setXFields(List.of(kept, cleared));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      List<inetsoft.web.binding.model.graph.ChartRefModel> xFields =
+         captor.getValue().getModel().getXFields();
+      assertEquals(1, xFields.size());
+      assertEquals("Product",
+                   ((ChartDimensionRefModel) xFields.get(0)).getColumnValue(),
+                   "the field whose column ('Product') still resolves must be kept");
+   }
+
+   /**
+    * Forcing a repoint to the chart's own current table is the no-op exemption
+    * {@code ChartBindingService.discardBoundFields} shares with {@code requireNoBoundFields}
+    * (both guarded by {@code BindingSources.alreadyPointedAt}) -- every field-carrying location
+    * must survive untouched, the same as the non-forced case
+    * {@link #setSourceToTheSameTableDoesNotDemandForce} already covers.
+    */
+   @Test
+   void setSourceToTheSameTableWithForceLeavesEveryFieldUntouched() throws Exception {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      existing.setXFields(List.of(new ChartDimensionRefModel()));
+      existing.setCloseField(new ChartAggregateRefModel());
+      ChartAestheticMutator.setField(existing, "text",
+                                     new FieldRef("Product", "dimension", null, null, null));
+      existing.setGeoFields(List.of(new ChartDimensionRefModel()));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDERS1", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      ChartBindingModel posted = captor.getValue().getModel();
+      assertEquals(1, posted.getXFields().size(), "a same-table repoint must discard nothing");
+      assertNotNull(posted.getCloseField());
+      assertNotNull(posted.getTextField());
+      assertEquals(1, posted.getGeoFields().size());
    }
 
    /**
@@ -477,6 +627,37 @@ class ChartBindingServiceTest {
       }
 
       model.setTables(tables);
+
+      return model;
+   }
+
+   /**
+    * Like {@link #chartWithTables}, but the second (target) table carries the given columns --
+    * for the selective-discard tests, where a repoint's new source needs an actual column list to
+    * resolve a kept field's column name against. {@link #chartWithTables} alone leaves every
+    * table's column list null, which is why a field bound to any column is unconditionally
+    * unresolvable there (every table-repoint test that expects a clear uses that helper; every one
+    * that expects a same-named field to survive uses this one instead).
+    */
+   private static ChartBindingModel chartWithTablesAndColumns(String currentTable,
+                                                               String targetTable,
+                                                               String... targetColumns)
+   {
+      ChartBindingModel model = chartWithTables(currentTable, targetTable);
+
+      for(inetsoft.web.binding.model.BindingModel.SourceTable table : model.getTables()) {
+         if(table.getName().equalsIgnoreCase(targetTable)) {
+            List<inetsoft.web.binding.model.BindingModel.SourceTableColumn> columns =
+               new ArrayList<>();
+
+            for(String column : targetColumns) {
+               columns.add(
+                  new inetsoft.web.binding.model.BindingModel.SourceTableColumn(column, null));
+            }
+
+            table.setColumns(columns);
+         }
+      }
 
       return model;
    }


### PR DESCRIPTION
## Summary

Fixes Redmine #76495, the chart-binding sibling of #76302 (`TableBindingService`, already fixed) — flagged there as a planned follow-up but never filed until now.

- `ChartBindingService.setSource(force: true)` rewrote only the chart's `SourceInfo` pointer and left every one of the 13 field-carrying locations (the 3 list shelves, the 10 single-value shelves, the 6 aesthetic channels, and `geoFields`) untouched on a genuine repoint to a different source.
- `ChangeChartRefService.changeChartRef` — the real, non-mocked write path `setSource` drives — never reaches `VSAssemblyInfoHandler.validateChartColumns`: that method's only caller is `validateBinding`, and every real caller of `validateBinding` is a drag-and-drop controller (`VS*DndService`) or `ChangeGeographicService`, none of which sits anywhere in this call chain. So nothing downstream ever discarded a stale field either. `get_binding` then reported fields pointing at columns that no longer existed in the chart's new source.

## Mechanism / fix

- Adds `ChartBindingService.discardBoundFields`, the `force:true` counterpart to `requireNoBoundFields`, mirroring `TableBindingService.discardBoundFields`'s selective-discard shape (bug #76302): a field whose column name still exists in the new source is **kept**, not blanket-cleared — a same-shaped repoint (e.g. a sibling table with the same column names) must not lose a word-cloud's or candlestick's only binding just because *something* changed.
- Widens `ChartAestheticMutator.read` and `.fieldNameOf` from `private` to package-private so `discardBoundFields` can resolve a bound aesthetic channel's column the same way the class's own `describe()`/`channelView()` read path already does.
  - Note: relying on `AestheticInfo.getFullName()` directly (as originally proposed during triage) would **not** work — the real read path (`AestheticRefModelFactory.createAestheticInfo`, used by `binding.createModel(chart)`) never populates that property, only `dataInfo`. `fieldNameOf`'s existing `dataInfo`-first, `fullName`-fallback logic is what actually matches both the production read path and the unit-test fixtures (built via `ChartAestheticMutator.setField`, which *does* set the top-level `fullName` directly). Using `getFullName()` alone would have silently regressed every aesthetic channel to a blanket-clear in production, while passing in the test suite (since the mocked `binding.createModel()` bypasses the real factory) — exactly the kind of test/production divergence this fix needed to avoid.
- Pushes the same-table exemption inside both `requireNoBoundFields` and `discardBoundFields` (matching `TableBindingService`'s internal-exemption shape) rather than leaving it as an external guard only on the refuse branch.
- Corrects `setSource`'s javadoc, which had claimed a `validateChartColumns` safety net the agent write path never actually reaches.

## Test plan

- [x] `./mvnw -pl core -Dtest=ChartBindingServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` — 50/50 pass (46 existing + 4 new).
- [x] Sanity-checked the fix is load-bearing: temporarily reverted the `discardBoundFields` wiring and re-ran — the 3 tests that assert a stale field is now cleared failed exactly as expected (`setSourceProceedsWhenForced`, `setSourceProceedsWhenForcedOverAnAestheticOnlyBinding`, and the new selective-discard shelf test), then restored the fix and confirmed green again.
- Test changes:
  - Flips `setSourceProceedsWhenForcedOverAnAestheticOnlyBinding`'s assertion (the field must now be cleared, not survive) with a corrected comment.
  - Adds an `xFields` assertion to `setSourceProceedsWhenForced`.
  - New: `setSourceKeepsAnAestheticFieldWhoseColumnStillResolvesInTheNewSource` (selective discard, positive case).
  - New: `setSourceKeepsAWordCloudsOnlyBindingWhenTheSiblingTableSharesItsColumn` (the regression a blanket-clear implementation would reintroduce).
  - New: `setSourceKeepsAShelfFieldWhoseColumnStillResolvesButClearsOneThatDoesNot` (selective discard on a list shelf).
  - New: `setSourceToTheSameTableWithForceLeavesEveryFieldUntouched` (no-op repoint-with-force, mirroring the existing non-forced no-op test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)