### PR TITLE
fix(wiz/binding): resolve aggregate-bound chart fields by column value, not full name (#76495 follow-up)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -330,7 +330,13 @@ public class ChartBindingService {
       }
 
       if(ref instanceof ChartAggregateRefModel aggregate) {
-         return aggregate.getFullName();
+         // NOT getFullName(): that is a formula display string ("Sum(DISCOUNT)") on the production
+         // read path (BAggregateRefModel#init) and null on the set_chart_shelf/set_single_shelf
+         // write path (FieldRefFactory#toChartRef never sets it) -- either way it never matches a
+         // raw column name, so resolves() always failed and every aggregate-bound field was
+         // discarded on every forced repoint, even a same-shaped-sibling-table one. getColumnValue()
+         // carries the raw column on both paths, mirroring the dimension branch above.
+         return aggregate.getColumnValue() == null ? aggregate.getName() : aggregate.getColumnValue();
       }
 
       return null;

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -555,6 +555,49 @@ class ChartBindingServiceTest {
    }
 
    /**
+    * The same selective discard, on an aggregate-bound measure rather than a dimension --
+    * {@code columnNameOf}'s aggregate branch reads {@code getColumnValue()}, not
+    * {@code getFullName()} (a formula display string like "Sum(Sales)" on the production read
+    * path, and null on the set_chart_shelf/set_single_shelf write path -- either way never a raw
+    * column name), so a measure on x/y or a single-value shelf must survive a same-shaped-sibling
+    * repoint exactly like a dimension does. Regression test for the gap CI's own automated review
+    * caught after this fix's first merge: every prior test here exercised only dimensions/geo/
+    * aesthetic fields, so an aggregate always failing to resolve (and therefore always being
+    * discarded, even when its column still existed) shipped unnoticed.
+    */
+   @Test
+   void setSourceKeepsAnAggregateFieldWhoseColumnStillResolvesButClearsOneThatDoesNot()
+      throws Exception
+   {
+      ChartBindingModel existing =
+         chartWithTablesAndColumns("ORDERS1", "ORDER_DETAILS1", "Sales");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartAggregateRefModel kept = new ChartAggregateRefModel();
+      kept.setColumnValue("Sales");
+      kept.setFormula("Sum");
+      ChartAggregateRefModel cleared = new ChartAggregateRefModel();
+      cleared.setColumnValue("Cost");
+      cleared.setFormula("Sum");
+      existing.setYFields(List.of(kept, cleared));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      List<inetsoft.web.binding.model.graph.ChartRefModel> yFields =
+         captor.getValue().getModel().getYFields();
+      assertEquals(1, yFields.size(),
+                   "the aggregate bound to 'Sales' must be kept since that column still resolves " +
+                   "in the new source; the one bound to 'Cost' must be cleared");
+      assertEquals("Sales", ((ChartAggregateRefModel) yFields.get(0)).getColumnValue());
+   }
+
+   /**
     * Forcing a repoint to the chart's own current table is the no-op exemption
     * {@code ChartBindingService.discardBoundFields} shares with {@code requireNoBoundFields}
     * (both guarded by {@code BindingSources.alreadyPointedAt}) -- every field-carrying location


### PR DESCRIPTION
## Summary

Follow-up to #76495's fix (PR #5064, merged as `e25c1478c`). CI's automated review on that PR (after it merged) caught a high-severity regression in the new selective-discard logic:

`ChartBindingService.discardBoundFields`'s `columnNameOf()` read a `ChartAggregateRefModel`'s column via `getFullName()` -- a formula display string (e.g. `"Sum(Sales)"`) on the production read path (`BAggregateRefModel#init`), and `null` on the `set_chart_shelf`/`set_single_shelf` write path (`FieldRefFactory#toChartRef` never sets it). Either way it never matched a raw column name, so `resolves()` always failed for an aggregate -- meaning **every aggregate-bound field on a list shelf (a measure on x/y, the most common chart shape) or a single-value shelf (a candlestick's open/high/low/close) was discarded on every forced repoint**, even to a same-shaped sibling table whose column still exists. This undermined the central "selective, not blanket" goal of #76495's own fix for its most common case.

## Fix

`columnNameOf`'s aggregate branch now reads `getColumnValue()` (falling back to `getName()` if null), mirroring the `ChartDimensionRefModel` branch immediately above it. Verified `getColumnValue()` carries the raw column name on both the production path (`BAggregateRefModel#init` copies it directly from the underlying `VSAggregateRef`) and the write path (`FieldRefFactory#toChartRef` sets it from the caller's field).

## Testing

- Added `setSourceKeepsAnAggregateFieldWhoseColumnStillResolvesButClearsOneThatDoesNot`, mirroring the existing dimension-side selective-discard test.
- Confirmed it fails against the unfixed code (temporarily reverted the one-line fix, re-ran: 0 fields survive instead of 1) and passes against the fix.
- Full suite: `ChartBindingServiceTest`, 51/51 pass.

## References

- #76495 (original bug)
- #76302 (sibling fix this mirrors)
- PR #5064 (the PR this is a same-day follow-up to)