### PR TITLE
feat(wiz): set_variable_values accepts multi-select variable values (bug 76502 WBS-029)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -100,7 +100,10 @@ import java.util.Map;
  *       produces via the Composer's own "Add Grouping" dialog; or {@code type} (standalone
  *       grouping, matched by data type; defaults to {@code "string"})</li>
  *   <li>{@code set_column_description} — {@code table}, {@code column}, {@code description}</li>
- *   <li>{@code set_variable_values} — {@code variableValues} (map of variable name → value)</li>
+ *   <li>{@code set_variable_values} — {@code variableValues} (map of variable name → value,
+ *       where value is a {@code String} for a single value or a {@code List<String>} of 2+
+ *       entries to assign multiple values at once to a {@code list}/{@code checkboxes}
+ *       display-style variable)</li>
  *   <li>{@code set_mirror_auto_update} — {@code table}, {@code visible} (true=auto-update on, false=off)</li>
  *   <li>{@code convert_to_embedded} — {@code table}</li>
  *   <li>{@code set_assembly_position} — {@code table}, {@code x}, {@code y}</li>
@@ -233,8 +236,12 @@ public record EditRequest(
    List<WorksheetMutationSupport.GroupMapping> groupMappings,
    /** Whether to group unmapped values as "Others" for add_named_group. */
    Boolean groupOthers,
-   /** Variable name → value mappings for set_variable_values. */
-   Map<String, String> variableValues,
+   /**
+    * Variable name → value mappings for set_variable_values. Each value is either a
+    * {@code String} (single value) or a {@code List<String>} (2+ entries assign multiple
+    * values at once; a 1-element list is treated identically to a plain String).
+    */
+   Map<String, Object> variableValues,
    /** X pixel coordinate for set_assembly_position. */
    Integer x,
    /** Y pixel coordinate for set_assembly_position. */
@@ -422,7 +429,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
@@ -460,7 +467,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
@@ -497,7 +504,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
@@ -533,7 +540,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
@@ -568,7 +575,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
@@ -602,7 +609,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
@@ -635,7 +642,7 @@ public record EditRequest(
       List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
       Integer index, String alias, String description, Integer maxRows, Boolean distinct,
       List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
-      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
       String defaultValue, String mode, Boolean insert, List<String> subtables,
       String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
       List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -2440,7 +2440,7 @@ public class WorksheetAgentController {
          inetsoft.uql.VariableTable vtable = new inetsoft.uql.VariableTable();
 
          if(req.variableValues() != null) {
-            for(Map.Entry<String, String> entry : req.variableValues().entrySet()) {
+            for(Map.Entry<String, Object> entry : req.variableValues().entrySet()) {
                String vname = entry.getKey();
                Assembly assembly = ws.getAssembly(vname);
 
@@ -2458,46 +2458,53 @@ public class WorksheetAgentController {
                }
 
                AssetVariable declared = va.getVariable();
-               String rawValue = entry.getValue();
-               String declaredType = declared.getTypeNode() != null
-                  ? declared.getTypeNode().getType() : null;
-               // L2-Group8: VariableInputDialogService.initVariableInfos converts every
-               // submitted string through this same CoreTool.getData(type, val, true) call
-               // before it ever reaches the VariableTable -- the agent path previously put
-               // the raw string in unconditionally, so a declared-integer variable stored
-               // "abc" verbatim instead of matching the native path's own conversion.
-               Object value = rawValue == null ? null
-                  : CoreTool.getData(declaredType, rawValue, true);
+               Object rawValue = entry.getValue();
 
-               // L2-Group8: a bounded-picker variable (combobox/list/radio/checkboxes) can
-               // only ever be given one of its declared values through the native "Enter
-               // Parameters" prompt -- the widget itself cannot render anything else. A
-               // free-text variable (displayStyle NONE) has no such restriction natively
-               // either, so it is deliberately left unchecked here to avoid making this tool
-               // *more* restrictive than the UI it is compared against. Variables whose
-               // choices come from a live query source (no stored 'values' array) are also
-               // left unchecked -- there is nothing to validate against without re-running
-               // that query.
-               if(value != null && declared.getDisplayStyle() != UserVariable.NONE
-                  && declared.getValues() != null && declared.getValues().length > 0)
-               {
-                  boolean found = false;
-
-                  for(Object candidate : declared.getValues()) {
-                     if(java.util.Objects.equals(candidate, value)) {
-                        found = true;
-                        break;
-                     }
-                  }
-
-                  if(!found) {
+               // WBS-029: rawValue is either a plain String (single value, unchanged path) or
+               // a List (bug 76502) -- a 1-element list is treated identically to a plain
+               // String regardless of display style (unambiguous single-value intent), while a
+               // 2+ element list is a genuine multi-value assignment gated behind a
+               // list/checkboxes display style and validated per element (fixing the previous
+               // whole-joined-string-as-one-candidate bug).
+               if(rawValue instanceof List<?> list) {
+                  if(list.isEmpty()) {
                      throw new PairingException(
-                        "'" + rawValue + "' is not one of the declared choices for " +
-                        "variable '" + vname + "'.");
+                        "variableValues['" + vname + "'] is an empty list. Omit '" + vname +
+                        "' to leave it unset, or supply at least one value.");
                   }
+
+                  if(list.size() == 1) {
+                     vtable.put(vname, convertAndValidateSingleValue(
+                        vname, declared, requireStringElement(vname, 0, list.get(0))));
+                     continue;
+                  }
+
+                  int style = declared.getDisplayStyle();
+
+                  if(style != UserVariable.LIST && style != UserVariable.CHECKBOXES) {
+                     String styleName = WorksheetMutationSupport.displayStyleName(style);
+                     throw new PairingException(
+                        "variableValues['" + vname + "'] supplied " + list.size() + " values, " +
+                        "but variable '" + vname + "' has display style '" +
+                        (styleName != null ? styleName : style) + "'. Only a 'list' or " +
+                        "'checkboxes' picker can take more than one value in a single " +
+                        "set_variable_values call.");
+                  }
+
+                  Object[] values = new Object[list.size()];
+
+                  for(int i = 0; i < list.size(); i++) {
+                     values[i] = convertAndValidateSingleValue(
+                        vname, declared, requireStringElement(vname, i, list.get(i)));
+                  }
+
+                  vtable.setAsIs(vname, true);
+                  vtable.put(vname, values);
+                  continue;
                }
 
-               vtable.put(vname, value);
+               String stringValue = requireStringElement(vname, -1, rawValue);
+               vtable.put(vname, convertAndValidateSingleValue(vname, declared, stringValue));
             }
          }
 
@@ -2505,6 +2512,79 @@ public class WorksheetAgentController {
          box.reset();
          return null;
       });
+   }
+
+   /**
+    * Requires that a {@code variableValues} entry (or one element of one, when {@code index}
+    * is 0 or greater) is a plain {@code String}, rejecting any other JSON type (e.g. a number
+    * or boolean) with a message naming the field path and the element's actual runtime type.
+    * The top-level scalar entry ({@code index == -1}) permits {@code null} (clears the variable,
+    * matching this endpoint's pre-existing behavior); a {@code null} list element does not,
+    * since a list conveys 2+ (or exactly 1) explicit values with no "leave unset" case.
+    */
+   private static String requireStringElement(String vname, int index, Object raw)
+      throws PairingException
+   {
+      if(raw == null) {
+         if(index < 0) {
+            return null;
+         }
+
+         throw new PairingException(
+            "variableValues['" + vname + "'][" + index + "] is null. Every value must be a " +
+            "string.");
+      }
+
+      if(raw instanceof String s) {
+         return s;
+      }
+
+      String path = index < 0 ? "variableValues['" + vname + "']"
+         : "variableValues['" + vname + "'][" + index + "]";
+      throw new PairingException(
+         path + " must be a string, but got " + raw.getClass().getSimpleName() + ".");
+   }
+
+   /**
+    * Converts and validates one submitted value for {@code vname} exactly as the pre-WBS-029
+    * scalar path always did: {@link CoreTool#getData} conversion matching
+    * {@code VariableInputDialogService.initVariableInfos}, then (when the variable declares a
+    * non-{@code NONE} display style and a non-empty {@code values} list) a check that the
+    * converted value is one of the declared choices. Used for the plain-string case, the
+    * 1-element-list case, and once per element of a 2+-element list.
+    */
+   private static Object convertAndValidateSingleValue(
+      String vname, AssetVariable declared, String rawValue)
+      throws PairingException
+   {
+      if(rawValue == null) {
+         return null;
+      }
+
+      String declaredType = declared.getTypeNode() != null
+         ? declared.getTypeNode().getType() : null;
+      Object value = CoreTool.getData(declaredType, rawValue, true);
+
+      if(value != null && declared.getDisplayStyle() != UserVariable.NONE
+         && declared.getValues() != null && declared.getValues().length > 0)
+      {
+         boolean found = false;
+
+         for(Object candidate : declared.getValues()) {
+            if(java.util.Objects.equals(candidate, value)) {
+               found = true;
+               break;
+            }
+         }
+
+         if(!found) {
+            throw new PairingException(
+               "'" + rawValue + "' is not one of the declared choices for " +
+               "variable '" + vname + "'.");
+         }
+      }
+
+      return value;
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -2273,6 +2273,23 @@ public final class WorksheetMutationSupport {
    }
 
    /**
+    * Inverse of {@link #parseVariableDisplayStyle}. {@code DATE_COMBOBOX} is read-only: it has
+    * no forward case there because it is reachable only via StyleBI's native, non-agent Composer
+    * variable dialog, not {@code add_variable}/{@code edit_variable}.
+    */
+   static String displayStyleName(int style) {
+      return switch(style) {
+         case UserVariable.NONE -> "none";
+         case UserVariable.COMBOBOX -> "combobox";
+         case UserVariable.LIST -> "list";
+         case UserVariable.RADIO_BUTTONS -> "radio";
+         case UserVariable.CHECKBOXES -> "checkboxes";
+         case UserVariable.DATE_COMBOBOX -> "date_combobox";
+         default -> null;
+      };
+   }
+
+   /**
     * Describes one hand-authored "Join With" lookup level for a GENERIC/CUSTOM REST-JSON
     * datasource's {@code add_table} binding (see {@code TabularEndpointBindingSupport
     * #applyCustomLookupChain}), as opposed to {@code lookup} (a named connector's pre-built

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -463,7 +463,7 @@ public class WorksheetReadService {
          return null;
       }
 
-      String displayStyle = displayStyleName(var.getDisplayStyle());
+      String displayStyle = WorksheetMutationSupport.displayStyleName(var.getDisplayStyle());
 
       if(var.getChoices() != null) {
          // getChoices()/getValues() are named from the write side's perspective
@@ -494,23 +494,6 @@ public class WorksheetReadService {
       }
 
       return result;
-   }
-
-   /**
-    * Inverse of {@code WorksheetMutationSupport#parseVariableDisplayStyle}. {@code DATE_COMBOBOX}
-    * is read-only: it has no forward case there because it is reachable only via StyleBI's
-    * native, non-agent Composer variable dialog, not {@code add_variable}/{@code edit_variable}.
-    */
-   private static String displayStyleName(int style) {
-      return switch(style) {
-         case UserVariable.NONE -> "none";
-         case UserVariable.COMBOBOX -> "combobox";
-         case UserVariable.LIST -> "list";
-         case UserVariable.RADIO_BUTTONS -> "radio";
-         case UserVariable.CHECKBOXES -> "checkboxes";
-         case UserVariable.DATE_COMBOBOX -> "date_combobox";
-         default -> null;
-      };
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
@@ -22,6 +22,8 @@ import inetsoft.web.WebConfig;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -71,5 +73,38 @@ class EditRequestParametersDeserializationTest {
 
       assertEquals("Repository Issue Events", req.endpoint());
       assertNull(req.parameters());
+   }
+
+   /**
+    * WBS-029 (bug 76502): {@code variableValues} is now {@code Map<String, Object>} so a JSON
+    * array can bind to a genuine multi-value assignment. Confirms the real app
+    * {@code ObjectMapper}'s default binding for an untyped {@code Object} map value -- a plain
+    * JSON string stays a {@code String} (single-value callers unaffected), and a JSON array of
+    * strings becomes a {@code List<String>} (specifically an {@code ArrayList}), not some other
+    * unexpected runtime shape -- before {@code WorksheetAgentController.setVariableValues} is
+    * considered complete (see design's flagged, not-live-verified risk).
+    */
+   @Test
+   void deserializesVariableValuesStringAndArrayShapes() throws Exception {
+      EditRequest req = mapper.readValue("""
+         {
+           "op": "set_variable_values",
+           "variableValues": {
+             "Region": "East",
+             "Reasons": ["Item defective", "No longer needed"]
+           }
+         }
+         """, EditRequest.class);
+
+      assertNotNull(req.variableValues());
+      assertEquals("East", req.variableValues().get("Region"));
+
+      Object reasons = req.variableValues().get("Reasons");
+      assertInstanceOf(List.class, reasons);
+      assertEquals(List.of("Item defective", "No longer needed"), reasons);
+
+      for(Object element : (List<?>) reasons) {
+         assertInstanceOf(String.class, element);
+      }
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -1931,7 +1931,7 @@ class WorksheetAgentControllerTest {
    // ---------------------------------------------------------------------------
 
    /** Builds a {@code set_variable_values} EditRequest that routes to setVariableValues(). */
-   private static EditRequest setVariableValuesRequest(Map<String, String> variableValues) {
+   private static EditRequest setVariableValuesRequest(Map<String, Object> variableValues) {
       return new EditRequest(
          "set_variable_values", null, null, null, null, null, null, null, null, null,
          null, null, null, false,
@@ -2087,6 +2087,292 @@ class WorksheetAgentControllerTest {
       ArgumentCaptor<VariableTable> captor = ArgumentCaptor.forClass(VariableTable.class);
       verify(box).refreshVariableTable(captor.capture());
       assertEquals("AnythingGoes", captor.getValue().get("FreeVar"));
+   }
+
+   @Test
+   void setVariableValuesSingleStringValueOnMultiSelectVariableStillWorks() throws Exception {
+      // WBS-029 regression guard: a plain string on a checkboxes/list variable must keep
+      // behaving exactly as before -- a multi-select variable still accepts exactly one value
+      // via a plain string, unconditionally on display style.
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Reasons", XSchema.STRING,
+         new Object[] {"Item defective", "No longer needed"}, UserVariable.CHECKBOXES);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV5"), any())).thenReturn(session("TOK-SVV5"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-SVV5",
+         setVariableValuesRequest(Map.of("Reasons", "Item defective")), agent);
+
+      ArgumentCaptor<VariableTable> captor = ArgumentCaptor.forClass(VariableTable.class);
+      verify(box).refreshVariableTable(captor.capture());
+      assertEquals("Item defective", captor.getValue().get("Reasons"));
+   }
+
+   @Test
+   void setVariableValuesArrayOfTwoValuesOnCheckboxesVariableSucceeds() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Reasons", XSchema.STRING,
+         new Object[] {"Item defective", "No longer needed", "Other"}, UserVariable.CHECKBOXES);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV6"), any())).thenReturn(session("TOK-SVV6"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-SVV6", setVariableValuesRequest(
+         Map.of("Reasons", List.of("Item defective", "No longer needed"))), agent);
+
+      ArgumentCaptor<VariableTable> captor = ArgumentCaptor.forClass(VariableTable.class);
+      verify(box).refreshVariableTable(captor.capture());
+      Object value = captor.getValue().get("Reasons");
+      assertInstanceOf(Object[].class, value, "a genuine multi-value assignment must be an array");
+      assertArrayEquals(new Object[] {"Item defective", "No longer needed"}, (Object[]) value);
+      assertTrue(captor.getValue().isAsIs("Reasons"),
+         "asIs must be set so a downstream ONE_OF condition doesn't re-split each element");
+   }
+
+   @Test
+   void setVariableValuesArrayOfTwoValuesOnListVariableSucceeds() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Region", XSchema.STRING,
+         new Object[] {"East", "West", "North"}, UserVariable.LIST);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV7"), any())).thenReturn(session("TOK-SVV7"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-SVV7",
+         setVariableValuesRequest(Map.of("Region", List.of("East", "West"))), agent);
+
+      ArgumentCaptor<VariableTable> captor = ArgumentCaptor.forClass(VariableTable.class);
+      verify(box).refreshVariableTable(captor.capture());
+      Object value = captor.getValue().get("Region");
+      assertInstanceOf(Object[].class, value);
+      assertArrayEquals(new Object[] {"East", "West"}, (Object[]) value);
+   }
+
+   @Test
+   void setVariableValuesArrayWithOneInvalidTokenIsRejectedNamingThatToken() throws Exception {
+      // The literal "each token checked individually, not the whole joined string as one
+      // candidate" fix -- the second element is bad, and must be named specifically, not the
+      // first element or the whole array.
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Reasons", XSchema.STRING,
+         new Object[] {"Item defective", "No longer needed"}, UserVariable.CHECKBOXES);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV8"), any())).thenReturn(session("TOK-SVV8"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> ctrl.edit("TOK-SVV8",
+         setVariableValuesRequest(Map.of(
+            "Reasons", List.of("Item defective", "Not a real reason"))), agent));
+      assertTrue(ex.getMessage().contains("Not a real reason"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("Item defective"), ex.getMessage());
+   }
+
+   @Test
+   void setVariableValuesArrayOnComboboxVariableIsRejected() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Region", XSchema.STRING,
+         new Object[] {"East", "West"}, UserVariable.COMBOBOX);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV9"), any())).thenReturn(session("TOK-SVV9"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> ctrl.edit("TOK-SVV9",
+         setVariableValuesRequest(Map.of("Region", List.of("East", "West"))), agent));
+      assertTrue(ex.getMessage().contains("Region"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("combobox"), ex.getMessage());
+   }
+
+   @Test
+   void setVariableValuesSingleElementArrayTreatedAsScalarRegardlessOfStyle() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Region", XSchema.STRING,
+         new Object[] {"East", "West"}, UserVariable.COMBOBOX);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(rws.getAssetQuerySandbox()).thenReturn(box);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV10"), any())).thenReturn(session("TOK-SVV10"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-SVV10",
+         setVariableValuesRequest(Map.of("Region", List.of("East"))), agent);
+
+      ArgumentCaptor<VariableTable> captor = ArgumentCaptor.forClass(VariableTable.class);
+      verify(box).refreshVariableTable(captor.capture());
+      assertEquals("East", captor.getValue().get("Region"),
+         "a 1-element array must be unwrapped to a scalar, not rejected as multi-value-on-combobox");
+   }
+
+   @Test
+   void setVariableValuesEmptyArrayIsRejected() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      variableAssemblyForValues(ws, "Region", XSchema.STRING);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV11"), any())).thenReturn(session("TOK-SVV11"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> ctrl.edit("TOK-SVV11",
+         setVariableValuesRequest(Map.of("Region", List.of())), agent));
+      assertTrue(ex.getMessage().contains("Region"), ex.getMessage());
+   }
+
+   @Test
+   void setVariableValuesArrayWithNonStringElementIsRejected() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      boundedChoiceVariable(ws, "Reasons", XSchema.STRING,
+         new Object[] {"Item defective", "No longer needed"}, UserVariable.CHECKBOXES);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV12"), any())).thenReturn(session("TOK-SVV12"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      List<Object> reasons = new ArrayList<>();
+      reasons.add("Item defective");
+      reasons.add(42);
+
+      PairingException ex = assertThrows(PairingException.class, () -> ctrl.edit("TOK-SVV12",
+         setVariableValuesRequest(Map.of("Reasons", reasons)), agent));
+      assertTrue(ex.getMessage().contains("Integer"), ex.getMessage());
+   }
+
+   @Test
+   void setVariableValuesUnknownVariableStillRejectedWithArrayValue() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-SVV13"), any())).thenReturn(session("TOK-SVV13"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> ctrl.edit("TOK-SVV13",
+         setVariableValuesRequest(Map.of(
+            "TotallyNonexistentVar", List.of("a", "b"))), agent));
+      assertTrue(ex.getMessage().contains("TotallyNonexistentVar"), ex.getMessage());
    }
 
    private static DefaultVariableAssembly variableAssemblyForValues(


### PR DESCRIPTION
## Summary
- `set_variable_values` could never assign more than one value to a variable whose picker (`add_variable`'s `choices.displayStyle`) is `list`/`checkboxes` — `EditRequest.variableValues` was `Map<String, String>`, so a JSON array 400'd at deserialization.
- `EditRequest.variableValues` is now `Map<String, Object>`: a plain string keeps today's single-value behavior byte-for-byte, a 1-element list is treated identically to a plain string regardless of display style, and a 2+ element list is a genuine multi-value assignment — gated behind a `list`/`checkboxes` display style, validated per element (fixing the previous "whole joined string checked as one candidate" bug), converted to a real `Object[]` with `vtable.setAsIs(true)` so a downstream `ONE_OF` condition doesn't re-split an element on embedded commas. Mirrors `VariableInputDialogService.initVariableInfos`, the native "Enter Parameters" dialog's own submit path.
- Relocates WBS-030's `displayStyleName` inverse-mapping helper from `WorksheetReadService` to `WorksheetMutationSupport` as a shared package-visible static, since this fix's reject message needs the same mapping (was flagged as a soft coordination dependency in the design; WBS-030/#5063 is already merged, so this lands directly on the shared version rather than a temporary duplicate).
- New capability, built per an approved-with-one-required-fix design: `docs/teams/2026-09-08-bugs-76502-wbs-gaps/bug-wbs029/01-design.md` and `02-design-review.md` in `inetsoft-technology/stylebi-wiz`.

Companion plugin PR (client schema + precheck): inetsoft-technology/stylebi-wiz#2295

## Test plan
- [x] `WorksheetAgentControllerTest` (152 tests, 0 failures) — added: single string on multi-select still works, array of 2 on checkboxes/list succeeds, one invalid token named specifically, array on combobox rejected naming the style, 1-element array treated as scalar regardless of style, empty array rejected, non-string element rejected, unknown variable still rejected with an array value.
- [x] `EditRequestParametersDeserializationTest` (3 tests) — new test confirms the real app `ObjectMapper` binds a JSON string to `String` and a JSON array of strings to `List<String>` for the now-`Map<String, Object>` `variableValues` field.
- [x] `WorksheetReadServiceTest` (46 tests, 0 failures) — confirms the relocated `displayStyleName` helper didn't regress WBS-030's read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)