### PR TITLE
fix(admin-chat): reject AT-type schedule condition with null date at preview

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanService.java
@@ -234,6 +234,14 @@ public class ScheduleChangePlanService {
                label + ".spec.conditions[" + i + "]: only time conditions are supported in this " +
                "area (got " + conditions.get(i).getClass().getSimpleName() + ")");
          }
+
+         TimeCondition tc = (TimeCondition) conditions.get(i);
+
+         if(tc.getType() == TimeCondition.Type.AT && tc.getDate() == null) {
+            throw new IllegalArgumentException(
+               label + ".spec.conditions[" + i + "].date: an ISO 8601 date is required for " +
+               "\"AT\"-type conditions");
+         }
       }
    }
 

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanServiceTest.java
@@ -129,6 +129,35 @@ class ScheduleChangePlanServiceTest {
       assertTrue(ex.getMessage().contains("conditions"));
    }
 
+   // bug: an "AT"-type condition with a null date sailed through preview and only failed at apply
+   // time inside AdminScheduleGateway, where the generic exception handling misclassified the
+   // failure as rollback-failed even though nothing had been written -- catch it here instead.
+   @Test void resolveCreateThrowsOnAtConditionWithNullDate() {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      spec.setConditions(List.of(atCondition(null)));
+      ScheduleChangePlanRequest req = request("task", List.of(createChange(spec)));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("date"));
+      assertTrue(ex.getMessage().contains("AT"));
+   }
+
+   // positive control: an "AT" condition with a non-null date must still resolve successfully --
+   // guards against the new check above being overly strict.
+   @Test void resolveCreateSucceedsWithAtConditionAndNonNullDate() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      spec.setConditions(List.of(atCondition(java.time.OffsetDateTime.now())));
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+      ScheduleChangePlanRequest req = request("create a task", List.of(createChange(spec)));
+
+      ResolvedPlan plan = service.resolve(req, user);
+
+      assertEquals(1, plan.changes().size());
+   }
+
    @Test void resolveCreateThrowsOnUnsupportedActionType() {
       CreateScheduleTaskRequest spec = createSpec("t1", "admin");
       spec.setActions(List.of(new BatchAction()));
@@ -336,6 +365,13 @@ class ScheduleChangePlanServiceTest {
       TimeCondition condition = new TimeCondition();
       condition.setHour(hour);
       condition.setMinute(minute);
+      return condition;
+   }
+
+   private static TimeCondition atCondition(java.time.OffsetDateTime date) {
+      TimeCondition condition = new TimeCondition();
+      condition.setType(TimeCondition.Type.AT);
+      condition.setDate(date);
       return condition;
    }
 


### PR DESCRIPTION
## Summary
- On a genuine StyleBI Enterprise deployment, `preview_schedule_task_changes` accepted a `create` plan with an `AT`-type time condition whose `date` was `null`, producing a valid-looking plan/hash.
- `apply_schedule_task_changes` then failed inside `AdminScheduleGateway.convertCondition` (`"ISO 8601 Date is required for \"AT\" type"`), and the generic apply exception handling in `ScheduleChangesetApplyService` couldn't distinguish this pre-write validation failure from an ambiguous in-flight write, so it reported the whole changeset as `rollback-failed` — even though nothing was ever actually written to storage.
- Fix: `ScheduleChangePlanService.requireSupportedConditions` now also rejects a structurally-invalid `AT` condition (type `AT`, `date == null`) with a clear, field-named `IllegalArgumentException`, closing the gap at preview time — the same treatment this method already gives the "only time conditions are supported" and unsupported-action checks.
- Deliberately narrow: does not touch `ScheduleChangesetApplyService`'s generic apply/rollback classification engine, and does not touch `AdminChangesetApplyService` (properties area's analog) — both are out of scope per the task.

## Test plan
- [x] `./mvnw -pl core test-compile` (compiles clean)
- [x] `./mvnw -pl core test -Dtest=ScheduleChangePlanServiceTest` — 21/21 pass (19 existing + 2 new: `resolveCreateThrowsOnAtConditionWithNullDate`, `resolveCreateSucceedsWithAtConditionAndNonNullDate`)