### PR TITLE
feat(tabular): Rest.XML catalog SPI, describeDataset-only via opaque endpoint token

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/xml/RestXMLRuntime.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/xml/RestXMLRuntime.java
@@ -20,12 +20,40 @@ package inetsoft.uql.rest.xml;
 import inetsoft.uql.rest.AbstractRestQuery;
 import inetsoft.uql.rest.AbstractRestRuntime;
 import inetsoft.uql.rest.QueryRunner;
+import inetsoft.uql.tabular.TabularCatalog;
+import inetsoft.uql.tabular.TabularCatalogProvider;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularDatasetSchema;
 
-public class RestXMLRuntime extends AbstractRestRuntime {
+public class RestXMLRuntime extends AbstractRestRuntime implements TabularCatalogProvider {
    @Override
    protected QueryRunner getQueryRunner(AbstractRestQuery q) {
       final RestXMLQuery query = (RestXMLQuery) q;
       final XMLRestDataIteratorStrategyFactory factory = new XMLRestDataIteratorStrategyFactory();
       return new RestXMLQueryRunner(query, factory);
+   }
+
+   /**
+    * Always throws: Rest.XML's dataset structure (URL suffix, XPath, columns) is declared per
+    * query, not on the data source itself, so there is no server-side resource list to enumerate.
+    */
+   @Override
+   public TabularCatalog listDatasets(TabularDataSource<?> dataSource) throws Exception {
+      throw new Exception("Rest.XML does not support catalog enumeration: its dataset " +
+         "structure (URL suffix, XPath, columns) is declared per-query, not on the data " +
+         "source itself, so there is no server-side resource list to enumerate. Describe a " +
+         "specific endpoint directly via describeDataset with an opaque endpoint token instead.");
+   }
+
+   /**
+    * {@code dataSource} is intentionally unused: the whole point of the opaque-token design is
+    * that {@code RestXMLDataSource} carries nothing (just a bare URL) the token doesn't already
+    * carry itself.
+    */
+   @Override
+   public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId)
+      throws Exception
+   {
+      return RestXmlEndpointCatalog.describeDataset(datasetId);
    }
 }

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/xml/RestXmlEndpointCatalog.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/xml/RestXmlEndpointCatalog.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.xml;
+
+import inetsoft.uql.tabular.TabularColumn;
+import inetsoft.uql.tabular.TabularDatasetSchema;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Assembles {@link RestXMLRuntime}'s {@link inetsoft.uql.tabular.TabularCatalogProvider}
+ * {@code describeDataset} answer out of a decoded opaque endpoint token. Mirrors {@code
+ * MongoCatalog}/{@code DatagovCatalog}'s role: package-private, static methods, no state of its
+ * own.
+ */
+final class RestXmlEndpointCatalog {
+   private RestXmlEndpointCatalog() {
+   }
+
+   /**
+    * @param token the opaque, self-describing endpoint token -- see
+    *              {@link RestXmlEndpointTokenCodec}.
+    * @return a schema whose {@code datasetId()} echoes {@code token} verbatim, {@code columns()}
+    *         matches the token's flat column list in order, {@code keyColumns()} is always empty
+    *         (the token format carries no key-column designation), {@code params()} carries
+    *         exactly {@code suffix}/{@code xpath}, {@code columnsMayBeIncomplete()} is always
+    *         {@code true} (every column comes from an LLM-extraction-plus-human-review pipeline,
+    *         never the source's own declared, machine-read metadata), and {@code description()}
+    *         is always {@code null} (the token format carries no dataset-level description).
+    * @throws Exception if {@code token} is structurally invalid -- see
+    *                   {@link RestXmlEndpointTokenCodec#decode}. Never makes a network call.
+    */
+   static TabularDatasetSchema describeDataset(String token) throws Exception {
+      RestXmlEndpointTokenCodec.DecodedToken decoded = RestXmlEndpointTokenCodec.decode(token);
+      List<TabularColumn> columns = new ArrayList<>();
+
+      for(RestXmlEndpointTokenCodec.Column c : decoded.columns()) {
+         // label/isDimension are always null: the token carries only name/type/description
+         // (charter A4), and this connector has no source-declared basis for the other two --
+         // guessing either would violate TabularColumn's own "never invented" contract.
+         columns.add(new TabularColumn(c.name(), c.type(), c.description(), null, null));
+      }
+
+      Map<String, String> params = new LinkedHashMap<>();
+      params.put("suffix", decoded.suffix());
+      params.put("xpath", decoded.xpath());
+
+      // datasetId is the ORIGINAL `token` argument, not a re-serialization of `decoded` -- A3
+      // requires verbatim echo, and re-encoding risks a byte-for-byte mismatch (whitespace, key
+      // order, base64 padding) even when the content is semantically identical.
+      return new TabularDatasetSchema(token, columns, List.of(), params, true);
+   }
+}

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/xml/RestXmlEndpointTokenCodec.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/xml/RestXmlEndpointTokenCodec.java
@@ -1,0 +1,232 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.xml;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.uql.schema.XSchema;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Encodes/decodes the opaque, self-describing endpoint token {@link RestXmlEndpointCatalog}
+ * assembles a {@code TabularDatasetSchema} from. Package-private, final, no instance state --
+ * same shape as {@code MongoCatalog}/{@code DatagovCatalog} (private no-arg constructor, static
+ * methods only). Pure: no {@code TabularCatalog}/{@code TabularDatasetSchema} types cross into
+ * this class, so its own tests need zero SPI-shape fixtures, only JSON/base64 ones.
+ *
+ * <p>The token is standard (non-URL-safe) base64 wrapping a JSON object:
+ * <pre>{@code
+ * {
+ *   "version": 1,
+ *   "suffix": "/api/books",
+ *   "xpath": "/bookstore/book",
+ *   "columns": [
+ *     { "name": "title", "type": "string", "description": "Book title" },
+ *     { "name": "price", "type": "double" }
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>{@code decode} rejects a structurally invalid token before any other processing, per the
+ * charter's A7-A10 requirements -- see the validation order documented on {@link #decode}.
+ */
+final class RestXmlEndpointTokenCodec {
+   private RestXmlEndpointTokenCodec() {
+   }
+
+   /**
+    * One column of the token's flat column list.
+    */
+   record Column(String name, String type, String description) {
+   }
+
+   /**
+    * The fully-decoded, validated payload of a token.
+    */
+   record DecodedToken(String suffix, String xpath, List<Column> columns) {
+   }
+
+   /**
+    * Builds a syntactically-valid token from a {@link DecodedToken} -- test-support only, not
+    * required by the SPI or any production caller. StyleBI never encodes a token; a future,
+    * out-of-scope wiz-side pipeline would. Its only job is letting a test build a token without
+    * hand-writing base64/JSON.
+    */
+   static String encode(DecodedToken token) {
+      ObjectNode root = MAPPER.createObjectNode();
+      root.put("version", CURRENT_VERSION);
+      root.put("suffix", token.suffix());
+      root.put("xpath", token.xpath());
+
+      ArrayNode columns = root.putArray("columns");
+
+      for(Column c : token.columns()) {
+         ObjectNode column = columns.addObject();
+         column.put("name", c.name());
+         column.put("type", c.type());
+
+         if(c.description() == null) {
+            column.putNull("description");
+         }
+         else {
+            column.put("description", c.description());
+         }
+      }
+
+      return Base64.getEncoder().encodeToString(root.toString().getBytes(StandardCharsets.UTF_8));
+   }
+
+   /**
+    * Decodes and validates {@code token}, rejecting a structurally invalid one before any other
+    * processing (charter: "before any other processing"). Validation order, this class's own
+    * choice:
+    *
+    * <ol>
+    *   <li>{@code token} null/blank -- rejected.</li>
+    *   <li>Not valid base64 -- rejected.</li>
+    *   <li>Base64-decoded bytes do not parse as JSON -- rejected.</li>
+    *   <li>Parsed JSON is not an object (a bare array/string/number) -- rejected.</li>
+    *   <li>{@code version} missing, not an integer, or not equal to {@link #CURRENT_VERSION} --
+    *       rejected, naming both the expected and found value.</li>
+    *   <li>{@code suffix} missing, null, or blank -- rejected (covers both A7's "missing field"
+    *       and A10's "blank/null field" with one check).</li>
+    *   <li>{@code xpath} same check.</li>
+    *   <li>{@code columns} missing, not an array, or empty -- rejected (covers both A7 and A8).</li>
+    *   <li>Each column, in order: {@code name} non-blank, {@code type} non-blank, {@code type} a
+    *       member of {@link XSchema}'s declared constants (A9) -- first bad column fails the whole
+    *       decode (fail-fast, not a batch of collected errors). {@code description} is read as
+    *       nullable text: absent or JSON {@code null} becomes {@code null}; a JSON string is
+    *       passed through verbatim, including a blank string, which stays {@code ""} rather than
+    *       collapsing to {@code null} -- this token's data is presumed curated, not sampled from a
+    *       messy live wire format the way Datagov's is. Anything else (a non-string, non-null
+    *       value) is also treated as absent (mapped to {@code null}), never coerced.</li>
+    * </ol>
+    *
+    * @throws Exception naming what is wrong, before any network access or further processing.
+    */
+   static DecodedToken decode(String token) throws Exception {
+      if(token == null || token.isBlank()) {
+         throw new Exception("Rest.XML endpoint token is missing or blank.");
+      }
+
+      byte[] bytes;
+
+      try {
+         bytes = Base64.getDecoder().decode(token);
+      }
+      catch(IllegalArgumentException e) {
+         throw new Exception("Rest.XML endpoint token is not valid base64.", e);
+      }
+
+      JsonNode root;
+
+      try {
+         root = MAPPER.readTree(bytes);
+      }
+      catch(Exception e) {
+         throw new Exception("Rest.XML endpoint token does not decode to valid JSON.", e);
+      }
+
+      if(root == null || !root.isObject()) {
+         throw new Exception("Rest.XML endpoint token must decode to a JSON object.");
+      }
+
+      JsonNode version = root.get("version");
+
+      if(version == null || !version.isInt() || version.asInt() != CURRENT_VERSION) {
+         throw new Exception("Rest.XML endpoint token must have version=" + CURRENT_VERSION +
+            "; found " + (version == null ? "no version field" : version));
+      }
+
+      String suffix = requireNonBlankText(root, "suffix");
+      String xpath = requireNonBlankText(root, "xpath");
+      JsonNode columnsNode = root.get("columns");
+
+      if(columnsNode == null || !columnsNode.isArray() || columnsNode.isEmpty()) {
+         throw new Exception("Rest.XML endpoint token must declare at least one column in " +
+            "'columns'.");
+      }
+
+      List<Column> columns = new ArrayList<>();
+
+      for(JsonNode columnNode : columnsNode) {
+         String name = requireNonBlankText(columnNode, "name");
+         String type = requireNonBlankText(columnNode, "type");
+
+         if(!XSCHEMA_TYPES.contains(type)) {
+            throw new Exception("Rest.XML endpoint token column '" + name + "' has type '" +
+               type + "', which is not a recognized XSchema type constant.");
+         }
+
+         JsonNode descriptionNode = columnNode.get("description");
+         String description = descriptionNode != null && descriptionNode.isTextual()
+            ? descriptionNode.asText() : null;
+
+         columns.add(new Column(name, type, description));
+      }
+
+      return new DecodedToken(suffix, xpath, columns);
+   }
+
+   private static String requireNonBlankText(JsonNode node, String field) throws Exception {
+      JsonNode value = node == null ? null : node.get(field);
+
+      if(value == null || value.isNull() || !value.isTextual() || value.asText().isBlank()) {
+         throw new Exception("Rest.XML endpoint token field '" + field + "' is missing or " +
+            "blank.");
+      }
+
+      return value.asText();
+   }
+
+   /**
+    * Every {@code public static final String} constant {@link XSchema} itself declares --
+    * reflected once rather than hand-copied, so this set cannot drift from {@code XSchema}'s own
+    * vocabulary.
+    */
+   private static Set<String> reflectXSchemaConstants() {
+      Set<String> types = new HashSet<>();
+
+      for(Field field : XSchema.class.getDeclaredFields()) {
+         if(field.getType() == String.class &&
+            Modifier.isPublic(field.getModifiers()) &&
+            Modifier.isStatic(field.getModifiers()) &&
+            Modifier.isFinal(field.getModifiers()))
+         {
+            try {
+               types.add((String) field.get(null));
+            }
+            catch(IllegalAccessException e) {
+               throw new ExceptionInInitializerError(e);
+            }
+         }
+      }
+
+      return Set.copyOf(types);
+   }
+
+   private static final int CURRENT_VERSION = 1;
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+   private static final Set<String> XSCHEMA_TYPES = reflectXSchemaConstants();
+}

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/xml/RestXMLRuntimeTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/xml/RestXMLRuntimeTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.xml;
+
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.TabularCatalogProvider;
+import inetsoft.uql.tabular.TabularDatasetSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers {@link RestXMLRuntime}'s two {@link TabularCatalogProvider} methods. Every call below
+ * passes a literal {@code null} for the data source argument -- deliberately, per the reconcile
+ * doc's simplification of the original "poisoned Mockito mock" plan: {@code describeDataset}
+ * (design section 2.2 / {@link RestXmlEndpointCatalog#describeDataset}) never dereferences its
+ * data source argument at all, so a real {@code NullPointerException} would surface immediately
+ * if it ever started to -- a stronger, simpler proof than a mock that throws on any accessor call.
+ */
+class RestXMLRuntimeTest {
+   // ----- A1 -----
+
+   @Test
+   void implementsTabularCatalogProvider() {
+      assertTrue(TabularCatalogProvider.class.isAssignableFrom(RestXMLRuntime.class));
+   }
+
+   // ----- A2 -----
+
+   @Test
+   void listDatasets_alwaysThrowsNamedException() {
+      Exception thrown = assertThrows(Exception.class,
+         () -> new RestXMLRuntime().listDatasets(null));
+
+      assertTrue(thrown.getMessage().contains("does not support"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("enumeration"), thrown.getMessage());
+   }
+
+   @Test
+   void listDatasets_neverReturnsEmptyCatalog() {
+      // Wrapped in assertThrows rather than inspecting a returned TabularCatalog -- a future
+      // regression that "fixes" this into `return new TabularCatalog(List.of(), List.of())` must
+      // fail this test loudly, not slip through silently.
+      assertThrows(Exception.class, () -> new RestXMLRuntime().listDatasets(null));
+   }
+
+   @Test
+   void listDatasets_throwsEvenWithNoUrlConfigured() {
+      // Passing null (no data source at all, let alone one with a URL configured) proves the
+      // throw does not depend on inspecting the data source's state -- a future regression that
+      // adds a precondition check ahead of the categorical throw would still need to handle this
+      // case, so this guards against that too.
+      assertThrows(Exception.class, () -> new RestXMLRuntime().listDatasets(null));
+   }
+
+   // ----- describeDataset: wiring (logic itself is RestXmlEndpointCatalogTest's job) -----
+
+   @Test
+   void describeDataset_delegatesToRestXmlEndpointCatalog() throws Exception {
+      String token = RestXmlEndpointTokenCodec.encode(new RestXmlEndpointTokenCodec.DecodedToken(
+         "/api/books", "/bookstore/book",
+         List.of(new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, null))));
+
+      TabularDatasetSchema schema = new RestXMLRuntime().describeDataset(null, token);
+
+      assertSame(token, schema.datasetId());
+      assertEquals(1, schema.columns().size());
+      assertEquals("title", schema.columns().get(0).name());
+      assertEquals("/api/books", schema.params().get("suffix"));
+      assertEquals("/bookstore/book", schema.params().get("xpath"));
+      assertTrue(schema.columnsMayBeIncomplete());
+   }
+
+   // ----- describeDataset never touches the data source, valid and malformed alike -----
+
+   @Test
+   void describeDataset_neverTouchesDataSource_evenWhenNull_validToken() throws Exception {
+      String token = RestXmlEndpointTokenCodec.encode(new RestXmlEndpointTokenCodec.DecodedToken(
+         "/api/books", "/bookstore/book",
+         List.of(new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, null))));
+
+      // A real dereference of the null data source would throw NullPointerException, which would
+      // mask this assertion entirely -- reaching a normal return proves dataSource is never
+      // touched on the success path.
+      assertDoesNotThrow(() -> new RestXMLRuntime().describeDataset(null, token));
+   }
+
+   @Test
+   void describeDataset_neverTouchesDataSource_evenWhenNull_malformedToken() {
+      // Same proof on the failure path: the thrown exception must be the codec's own validation
+      // exception, never a NullPointerException from touching the null data source first.
+      Exception thrown = assertThrows(Exception.class,
+         () -> new RestXMLRuntime().describeDataset(null, "not-base64-!!!"));
+
+      assertFalse(thrown instanceof NullPointerException, thrown.getClass().getName());
+      assertTrue(thrown.getMessage().contains("base64"), thrown.getMessage());
+   }
+}

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/xml/RestXmlEndpointCatalogTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/xml/RestXmlEndpointCatalogTest.java
@@ -1,0 +1,208 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.xml;
+
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.*;
+import inetsoft.uql.util.Config;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.web.wiz.service.TabularQueryContractSupport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link RestXmlEndpointCatalog}, built off tokens {@link RestXmlEndpointTokenCodec#encode}
+ * produces. No live network, no Spring context -- {@link TabularSchemaExtractor}/
+ * {@link TabularQueryContractSupport} only need a {@code Config} bean reachable through
+ * {@link ConfigurationContext} (for a display-label resource bundle lookup that a mock answers
+ * with {@code null}), never a live data source; modeled on
+ * {@code TabularQueryContractSupportRestJsonQueryReadBackTest}'s identical setup in this same
+ * module, which explicitly avoids attaching a real {@code XDataSource} for the same reason.
+ */
+class RestXmlEndpointCatalogTest {
+   @BeforeAll
+   static void installConfig() {
+      previous = ConfigurationContext.getContext();
+      Config config = mock(Config.class);
+      when(config.getResourceBundle(any())).thenReturn(null);
+
+      ApplicationContext context = mock(ApplicationContext.class);
+      when(context.getBean(Config.class)).thenReturn(config);
+      ConfigurationContext.getContext().setApplicationContext(context);
+   }
+
+   @AfterAll
+   static void clearConfig() {
+      if(previous != null) {
+         previous.setApplicationContext(null);
+      }
+   }
+
+   private static String token(String suffix, String xpath, RestXmlEndpointTokenCodec.Column... columns) {
+      return RestXmlEndpointTokenCodec.encode(
+         new RestXmlEndpointTokenCodec.DecodedToken(suffix, xpath, List.of(columns)));
+   }
+
+   // ----- A3: verbatim echo -----
+
+   @Test
+   void describeDataset_echoesSubmittedTokenVerbatim() throws Exception {
+      String token = token("/api/books", "/bookstore/book",
+         new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, null));
+
+      TabularDatasetSchema schema = RestXmlEndpointCatalog.describeDataset(token);
+
+      assertSame(token, schema.datasetId(),
+         "datasetId must be the exact submitted String instance -- no re-serialization");
+   }
+
+   // ----- A4: columns match exactly, in order -----
+
+   @Test
+   void describeDataset_columnsMatchTokenExactlyInOrder() throws Exception {
+      String token = token("/s", "/x",
+         new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, "Book title"),
+         new RestXmlEndpointTokenCodec.Column("price", XSchema.DOUBLE, null),
+         new RestXmlEndpointTokenCodec.Column("published", XSchema.DATE, "Publication date"));
+
+      TabularDatasetSchema schema = RestXmlEndpointCatalog.describeDataset(token);
+
+      assertEquals(3, schema.columns().size());
+      assertEquals(new TabularColumn("title", XSchema.STRING, "Book title", null, null),
+         schema.columns().get(0));
+      assertEquals(new TabularColumn("price", XSchema.DOUBLE, null, null, null),
+         schema.columns().get(1));
+      assertEquals(new TabularColumn("published", XSchema.DATE, "Publication date", null, null),
+         schema.columns().get(2));
+   }
+
+   // ----- A5: params contains exactly suffix and xpath -----
+
+   @Test
+   void describeDataset_paramsContainsExactlySuffixAndXpath() throws Exception {
+      String token = token("/api/books", "/bookstore/book",
+         new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, null));
+
+      TabularDatasetSchema schema = RestXmlEndpointCatalog.describeDataset(token);
+
+      assertEquals(2, schema.params().size(), schema.params().toString());
+
+      Set<String> restXmlQueryProperties = TabularUtil.getPropertyMap(RestXMLQuery.class).keySet();
+      assertTrue(restXmlQueryProperties.containsAll(schema.params().keySet()),
+         schema.params().keySet() + " must all be properties of RestXMLQuery, which has " +
+         restXmlQueryProperties);
+
+      assertEquals("/api/books", schema.params().get("suffix"));
+      assertEquals("/bookstore/book", schema.params().get("xpath"));
+   }
+
+   // ----- A6: columnsMayBeIncomplete always true -----
+
+   @Test
+   void describeDataset_columnsMayBeIncompleteAlwaysTrue() throws Exception {
+      String oneColumn = token("/s", "/x",
+         new RestXmlEndpointTokenCodec.Column("a", XSchema.STRING, null));
+      String tenColumns = token("/s", "/x",
+         new RestXmlEndpointTokenCodec.Column("a", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("b", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("c", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("d", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("e", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("f", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("g", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("h", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("i", XSchema.STRING, null),
+         new RestXmlEndpointTokenCodec.Column("j", XSchema.STRING, null));
+
+      assertTrue(RestXmlEndpointCatalog.describeDataset(oneColumn).columnsMayBeIncomplete());
+      assertTrue(RestXmlEndpointCatalog.describeDataset(tenColumns).columnsMayBeIncomplete());
+   }
+
+   // ----- keyColumns always empty -----
+
+   @Test
+   void describeDataset_keyColumnsAlwaysEmpty() throws Exception {
+      String token = token("/s", "/x",
+         new RestXmlEndpointTokenCodec.Column("a", XSchema.STRING, null));
+
+      TabularDatasetSchema schema = RestXmlEndpointCatalog.describeDataset(token);
+
+      assertEquals(List.of(), schema.keyColumns());
+   }
+
+   // ----- dataset-level description always null -----
+
+   @Test
+   void describeDataset_descriptionAlwaysNull() throws Exception {
+      String token = token("/s", "/x",
+         new RestXmlEndpointTokenCodec.Column("a", XSchema.STRING, null));
+
+      TabularDatasetSchema schema = RestXmlEndpointCatalog.describeDataset(token);
+
+      assertNull(schema.description());
+   }
+
+   // ----- malformed token propagates from the codec -----
+
+   @Test
+   void describeDataset_malformedToken_propagatesCodecException() {
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointCatalog.describeDataset("not-base64-!!!"));
+      assertTrue(thrown.getMessage().contains("base64"), thrown.getMessage());
+   }
+
+   // ----- params round-trip into a real, working RestXMLQuery -----
+
+   /**
+    * Proves the charter's central claim -- {@code params()} carries {@code suffix}/{@code xpath}
+    * so the existing {@code TabularQueryContractSupport.applyQueryContract} path can build a real,
+    * working {@code RestXMLQuery} from it unchanged -- rather than merely asserting the map's shape
+    * looks right. No network in scope (charter's non-goals rule out live verification this round),
+    * so this stops at "the params actually fill the query bean correctly."
+    */
+   @Test
+   void describeDataset_paramsRoundTripIntoARealRestXMLQuery() throws Exception {
+      String token = token("/api/books", "/bookstore/book",
+         new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, null));
+
+      TabularDatasetSchema schema = RestXmlEndpointCatalog.describeDataset(token);
+
+      RestXMLQuery query = new RestXMLQuery();
+
+      TabularQueryContractSupport.applyQueryContract(
+         query, TabularUtil.getPropertyMap(query.getClass()),
+         new TabularSchemaExtractor().extract(query, RestXMLDataSource.TYPE),
+         new LinkedHashMap<>(schema.params()), "resturl-test");
+
+      assertEquals("/api/books", query.getSuffix());
+      assertEquals("/bookstore/book", query.getXpath());
+   }
+
+   private static ConfigurationContext previous;
+}

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/xml/RestXmlEndpointTokenCodecTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/xml/RestXmlEndpointTokenCodecTest.java
@@ -1,0 +1,291 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.xml;
+
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers {@link RestXmlEndpointTokenCodec} in isolation -- no {@code TabularCatalog}/
+ * {@code TabularDatasetSchema} types, only JSON/base64 fixtures. Malformed cases are hand-written
+ * base64/JSON strings, since a malformed token by definition cannot come from
+ * {@link RestXmlEndpointTokenCodec#encode}.
+ */
+class RestXmlEndpointTokenCodecTest {
+   // ----- valid tokens -----
+
+   @Test
+   void decode_roundTripsAValidToken() throws Exception {
+      RestXmlEndpointTokenCodec.DecodedToken original = new RestXmlEndpointTokenCodec.DecodedToken(
+         "/api/books", "/bookstore/book",
+         List.of(new RestXmlEndpointTokenCodec.Column("title", XSchema.STRING, "Book title"),
+                 new RestXmlEndpointTokenCodec.Column("price", XSchema.DOUBLE, null)));
+
+      String token = RestXmlEndpointTokenCodec.encode(original);
+      RestXmlEndpointTokenCodec.DecodedToken decoded = RestXmlEndpointTokenCodec.decode(token);
+
+      assertEquals(original, decoded);
+   }
+
+   @Test
+   void decode_columnOrderPreserved() throws Exception {
+      RestXmlEndpointTokenCodec.DecodedToken original = new RestXmlEndpointTokenCodec.DecodedToken(
+         "/api/x", "/x",
+         List.of(new RestXmlEndpointTokenCodec.Column("c1", XSchema.STRING, null),
+                 new RestXmlEndpointTokenCodec.Column("c2", XSchema.LONG, null),
+                 new RestXmlEndpointTokenCodec.Column("c3", XSchema.BOOLEAN, null),
+                 new RestXmlEndpointTokenCodec.Column("c4", XSchema.DATE, null)));
+
+      RestXmlEndpointTokenCodec.DecodedToken decoded =
+         RestXmlEndpointTokenCodec.decode(RestXmlEndpointTokenCodec.encode(original));
+
+      assertEquals(List.of("c1", "c2", "c3", "c4"),
+         decoded.columns().stream().map(RestXmlEndpointTokenCodec.Column::name).toList());
+   }
+
+   // ----- malformed tokens (A7): rejected before any other processing -----
+
+   @Test
+   void decode_notBase64_rejected() {
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode("not-base64-!!!"));
+      assertTrue(thrown.getMessage().contains("base64"), thrown.getMessage());
+   }
+
+   @Test
+   void decode_validBase64NotJson_rejected() {
+      String token = base64("not json");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("JSON"), thrown.getMessage());
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {"[1,2,3]", "\"a string\"", "42"})
+   void decode_validJsonNotAnObject_rejected(String json) {
+      String token = base64(json);
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token), "json=" + json);
+      assertTrue(thrown.getMessage().contains("JSON object"),
+         "json=" + json + ": " + thrown.getMessage());
+   }
+
+   @Test
+   void decode_versionMissing_rejected() {
+      String token = base64("{\"suffix\":\"/s\",\"xpath\":\"/x\",\"columns\":[" +
+         column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("version"), thrown.getMessage());
+   }
+
+   @Test
+   void decode_versionWrongType_rejected() {
+      String token = base64("{\"version\":\"1\",\"suffix\":\"/s\",\"xpath\":\"/x\",\"columns\":[" +
+         column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("version"), thrown.getMessage());
+   }
+
+   @Test
+   void decode_versionWrongValue_rejected() {
+      String token = base64("{\"version\":2,\"suffix\":\"/s\",\"xpath\":\"/x\",\"columns\":[" +
+         column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("version"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("2"), thrown.getMessage());
+   }
+
+   @Test
+   void decode_suffixKeyAbsent_rejected() {
+      String token = base64("{\"version\":1,\"xpath\":\"/x\",\"columns\":[" +
+         column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("suffix"), thrown.getMessage());
+   }
+
+   @Test
+   void decode_xpathKeyAbsent_rejected() {
+      String token = base64("{\"version\":1,\"suffix\":\"/s\",\"columns\":[" +
+         column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("xpath"), thrown.getMessage());
+   }
+
+   @Test
+   void decode_columnsKeyAbsent_rejected() {
+      String token = base64("{\"version\":1,\"suffix\":\"/s\",\"xpath\":\"/x\"}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("column"), thrown.getMessage());
+   }
+
+   // ----- blank/null suffix or xpath (A10) -----
+
+   @ParameterizedTest
+   @ValueSource(strings = {"null", "\"\"", "\"   \""})
+   void decode_blankOrNullSuffix_rejected(String suffixLiteral) {
+      String token = base64("{\"version\":1,\"suffix\":" + suffixLiteral + ",\"xpath\":\"/x\"," +
+         "\"columns\":[" + column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token), "suffix=" + suffixLiteral);
+      assertTrue(thrown.getMessage().contains("suffix"),
+         "suffix=" + suffixLiteral + ": " + thrown.getMessage());
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = {"null", "\"\"", "\"   \""})
+   void decode_blankOrNullXpath_rejected(String xpathLiteral) {
+      String token = base64("{\"version\":1,\"suffix\":\"/s\",\"xpath\":" + xpathLiteral + "," +
+         "\"columns\":[" + column("c", "string", null) + "]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token), "xpath=" + xpathLiteral);
+      assertTrue(thrown.getMessage().contains("xpath"),
+         "xpath=" + xpathLiteral + ": " + thrown.getMessage());
+   }
+
+   // ----- empty columns array (A8) -----
+
+   @Test
+   void decode_emptyColumnsArray_rejected() {
+      String token = base64("{\"version\":1,\"suffix\":\"/s\",\"xpath\":\"/x\",\"columns\":[]}");
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("column"), thrown.getMessage());
+   }
+
+   // ----- column type validation (A9) -----
+
+   @Test
+   void decode_columnTypeNotAnXSchemaConstant_rejected() {
+      String token = base64("{\"version\":1,\"suffix\":\"/s\",\"xpath\":\"/x\",\"columns\":[" +
+         column("badcol", "not_a_real_type", null) + "]}");
+
+      // Assert on the thrown exception, never a returned value -- a wrong implementation that
+      // silently degrades to XSchema.STRING (Datagov-style) instead of throwing must fail this
+      // test, not pass it.
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("badcol"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("not_a_real_type"), thrown.getMessage());
+   }
+
+   @ParameterizedTest
+   @MethodSource("everyXSchemaConstant")
+   void decode_everyXSchemaConstantIsAccepted(String xschemaType) throws Exception {
+      RestXmlEndpointTokenCodec.DecodedToken original = new RestXmlEndpointTokenCodec.DecodedToken(
+         "/s", "/x", List.of(new RestXmlEndpointTokenCodec.Column("c", xschemaType, null)));
+
+      RestXmlEndpointTokenCodec.DecodedToken decoded =
+         RestXmlEndpointTokenCodec.decode(RestXmlEndpointTokenCodec.encode(original));
+
+      assertEquals(xschemaType, decoded.columns().get(0).type(), "type=" + xschemaType);
+   }
+
+   /**
+    * Reflects {@link XSchema}'s own fields in THIS test too (not copy-pasted from the codec) so
+    * A9's "valid vocabulary" claim stays tied to {@code XSchema} itself rather than to a copy in
+    * either file that could silently drift.
+    */
+   static Stream<String> everyXSchemaConstant() throws IllegalAccessException {
+      List<String> values = new java.util.ArrayList<>();
+
+      for(Field field : XSchema.class.getDeclaredFields()) {
+         if(field.getType() == String.class &&
+            Modifier.isPublic(field.getModifiers()) &&
+            Modifier.isStatic(field.getModifiers()) &&
+            Modifier.isFinal(field.getModifiers()))
+         {
+            values.add((String) field.get(null));
+         }
+      }
+
+      return values.stream();
+   }
+
+   // ----- column description: null vs. absent vs. blank -----
+
+   @Test
+   void decode_columnDescriptionNullVsAbsentVsBlank() throws Exception {
+      String token = base64("{\"version\":1,\"suffix\":\"/s\",\"xpath\":\"/x\",\"columns\":[" +
+         "{\"name\":\"absent\",\"type\":\"string\"}," +
+         "{\"name\":\"jsonNull\",\"type\":\"string\",\"description\":null}," +
+         "{\"name\":\"blank\",\"type\":\"string\",\"description\":\"\"}," +
+         "{\"name\":\"real\",\"type\":\"string\",\"description\":\"a real description\"}" +
+         "]}");
+
+      RestXmlEndpointTokenCodec.DecodedToken decoded = RestXmlEndpointTokenCodec.decode(token);
+
+      assertNull(decoded.columns().get(0).description(), "absent key -> null");
+      assertNull(decoded.columns().get(1).description(), "JSON null -> null");
+      assertEquals("", decoded.columns().get(2).description(),
+         "a blank string is preserved as '', not collapsed to null -- this token's data is " +
+         "presumed pre-curated, unlike Datagov's messy live wire format");
+      assertEquals("a real description", decoded.columns().get(3).description());
+   }
+
+   // ----- missing/blank token -----
+
+   @ParameterizedTest
+   @NullAndEmptySource
+   @ValueSource(strings = {"   "})
+   void decode_missingOrBlankToken_rejected(String token) {
+      Exception thrown = assertThrows(Exception.class,
+         () -> RestXmlEndpointTokenCodec.decode(token));
+      assertTrue(thrown.getMessage().contains("missing or blank"), thrown.getMessage());
+   }
+
+   // ----- helpers -----
+
+   private static String base64(String json) {
+      return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+   }
+
+   private static String column(String name, String type, String description) {
+      return "{\"name\":\"" + name + "\",\"type\":\"" + type + "\"" +
+         (description != null ? ",\"description\":\"" + description + "\"" : "") + "}";
+   }
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderImplementerCanaryTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularCatalogProviderImplementerCanaryTest.java
@@ -59,7 +59,8 @@ class TabularCatalogProviderImplementerCanaryTest {
       "inetsoft.uql.facebook.marketing.FBAdInsightsRuntime",
       "inetsoft.uql.googleanalyticsga4.AnalyticsRuntime",
       "inetsoft.uql.sforce.SForceRuntime",
-      "inetsoft.uql.sapjco2.table.SAPTableRuntime");
+      "inetsoft.uql.sapjco2.table.SAPTableRuntime",
+      "inetsoft.uql.rest.xml.RestXMLRuntime");
 
    @Test
    void knownImplementersAreNotOnClasspath_documentedLimitOfThisModule() {


### PR DESCRIPTION
## Summary

- `RestXMLRuntime` implements `TabularCatalogProvider`, but unlike every other implementer so far, only `describeDataset` does real work. `Rest.XML`'s structural properties (URL suffix, XPath, columns) live on `RestXMLQuery`, not on the bare-`URL` `RestXMLDataSource`, so there is no server-side resource list `listDatasets` could ever enumerate — it throws a named "does not support enumeration" exception instead of faking one.
- `describeDataset` treats its `datasetId` argument as an **opaque, self-describing token** (base64 + JSON: `version`/`suffix`/`xpath`/`columns`) rather than a server-addressable resource name, decoded and validated with no network access.
- This is reachable in practice because `TabularCatalogService.describeTable` never depends on `listDatasets` having succeeded (`resolveProvider` is a bare `instanceof` check), and wiz's single-target annotation path bypasses the whole-database `listDatasets`/`/datasource/tables` call entirely — verified by reading both call chains, not assumed.
- A future wiz-side pipeline (LLM extraction from uploaded/linked API documentation, out of scope here) is what would actually produce one of these tokens; this round implements and proves only the StyleBI-side contract, against hand-built tokens.
- 61 new tests (`RestXmlEndpointTokenCodecTest`, `RestXmlEndpointCatalogTest`, `RestXMLRuntimeTest`) plus one line in `TabularCatalogProviderImplementerCanaryTest`. `RestXMLQuery.java`/`RestXMLDataSource.java` untouched; `RestXMLRuntime.java` gains only the two new interface methods.
- Full design rationale: `stylebi-wiz` repo, `docs/tabular/rest-xml-catalog-spi-feasibility.md`. Full process record (charter/design/reconcile/build/verify/review/retro): `stylebi-wiz` repo, `docs/teams/2026-09-08-rest-xml-catalog-describe-only/`.

## Test plan

- [x] `./mvnw -pl connectors/inetsoft-rest -am test -Dtest=RestXmlEndpointTokenCodecTest,RestXmlEndpointCatalogTest,RestXMLRuntimeTest` — 61/61 pass
- [x] `./mvnw -pl core test -Dtest=TabularCatalogProviderImplementerCanaryTest` — 3/3 pass
- [x] `git diff` confirms `RestXMLQuery.java`/`RestXMLDataSource.java` byte-for-byte unchanged
- [x] No live/network verification this round (no real REST XML server, no real upstream token producer yet) — unit-test-only against hand-built tokens, stated explicitly in the process record