### PR TITLE
fix(wiz): surface RuntimeExceptions in WorksheetPreviewService as PairingException (bug 76517, WBS-038)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/RawDataService.java
@@ -85,10 +85,21 @@ public class RawDataService {
          throw new RuntimeException("Table " + tableName + " not found.");
       }
 
-      TableLens lens =
-         box.getTableLens(targetTable.getAbsoluteName(), AssetQuerySandbox.RUNTIME_MODE);
+      TableLens lens;
 
-      writeCsvContent(lens, outputStream);
+      try {
+         lens = box.getTableLens(targetTable.getAbsoluteName(), AssetQuerySandbox.RUNTIME_MODE);
+
+         if(lens == null) {
+            throw new RuntimeException("Table " + tableName + " produced no data.");
+         }
+
+         writeCsvContent(lens, outputStream);
+      }
+      catch(RuntimeException e) {
+         throw new RuntimeException(
+            "Failed to export worksheet table '" + tableName + "': " + e.getMessage(), e);
+      }
    }
 
    public void writeDataSourceTableCsvStream(ExportDatabaseTableToCsvRequest requestData,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPreviewService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPreviewService.java
@@ -99,29 +99,35 @@ public class WorksheetPreviewService {
          throw new PairingException("Table not found or produced no data: " + tableName);
       }
 
-      int colCount = lens.getColCount();
+      try {
+         int colCount = lens.getColCount();
 
-      // Row 0 is the header row in StyleBI's TableLens convention.
-      String[] headers = new String[colCount];
-
-      for(int col = 0; col < colCount; col++) {
-         Object h = lens.getObject(0, col);
-         headers[col] = h != null ? h.toString() : "col" + col;
-      }
-
-      List<Map<String, Object>> rows = new ArrayList<>();
-
-      for(int row = 1; rows.size() < limit && lens.moreRows(row); row++) {
-         Map<String, Object> rowMap = new LinkedHashMap<>();
+         // Row 0 is the header row in StyleBI's TableLens convention.
+         String[] headers = new String[colCount];
 
          for(int col = 0; col < colCount; col++) {
-            rowMap.put(headers[col], toJsonSafe(lens.getObject(row, col)));
+            Object h = lens.getObject(0, col);
+            headers[col] = h != null ? h.toString() : "col" + col;
          }
 
-         rows.add(rowMap);
-      }
+         List<Map<String, Object>> rows = new ArrayList<>();
 
-      return rows;
+         for(int row = 1; rows.size() < limit && lens.moreRows(row); row++) {
+            Map<String, Object> rowMap = new LinkedHashMap<>();
+
+            for(int col = 0; col < colCount; col++) {
+               rowMap.put(headers[col], toJsonSafe(lens.getObject(row, col)));
+            }
+
+            rows.add(rowMap);
+         }
+
+         return rows;
+      }
+      catch(RuntimeException e) {
+         throw new PairingException("Failed to read result columns for '"
+                                    + tableName + "': " + e.getMessage());
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPreviewService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetPreviewService.java
@@ -126,7 +126,7 @@ public class WorksheetPreviewService {
       }
       catch(RuntimeException e) {
          throw new PairingException("Failed to read result columns for '"
-                                    + tableName + "': " + e.getMessage());
+                                    + tableName + "': " + e.getMessage(), e);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPreviewServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPreviewServiceTest.java
@@ -198,6 +198,46 @@ class WorksheetPreviewServiceTest {
       assertEquals(3, rows.size());
    }
 
+   // Bug #76517 (WBS-038): a non-null TableLens whose getColCount()/header/row extraction
+   // throws a RuntimeException (e.g. an internal wrapper TableLens with an unset delegate)
+   // previously propagated straight out of preview() as a raw, unactionable exception -
+   // everything after the getTableLens() try/catch (lines 102-122 pre-fix) had no exception
+   // handling at all. This does not reproduce the reporter's exact NPE (whose root cause is
+   // unpinned - see bug-WBS-038/02-refute.md); it proves the narrower, confirmed-safe claim
+   // that ANY RuntimeException thrown while reading columns/rows now surfaces as a
+   // PairingException naming the table, not a bare crash.
+   @Test
+   void throwsPairingExceptionWhenGetColCountThrows() throws Exception {
+      TableLens l = mock(TableLens.class);
+      when(l.getColCount()).thenThrow(new NullPointerException(
+         "Cannot invoke \"inetsoft.report.TableLens.getColCount()\" because \"table\" is null"));
+
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(box.getTableLens(eq("T"), anyInt())).thenReturn(l);
+
+      PairingException ex = assertThrows(PairingException.class,
+                                          () -> service.preview(rws(box), "T", 10));
+      assertEquals("Failed to read result columns for 'T': " +
+                   "Cannot invoke \"inetsoft.report.TableLens.getColCount()\" because \"table\" is null",
+                   ex.getMessage());
+   }
+
+   @Test
+   void throwsPairingExceptionWhenRowExtractionThrows() throws Exception {
+      TableLens l = mock(TableLens.class);
+      when(l.getColCount()).thenReturn(1);
+      when(l.getObject(0, 0)).thenReturn("col");
+      when(l.moreRows(1)).thenReturn(true);
+      when(l.getObject(1, 0)).thenThrow(new RuntimeException("row read failed"));
+
+      AssetQuerySandbox box = mock(AssetQuerySandbox.class);
+      when(box.getTableLens(eq("T"), anyInt())).thenReturn(l);
+
+      PairingException ex = assertThrows(PairingException.class,
+                                          () -> service.preview(rws(box), "T", 10));
+      assertEquals("Failed to read result columns for 'T': row read failed", ex.getMessage());
+   }
+
    @Test
    void usesFallbackHeaderNameWhenObjectIsNull() throws Exception {
       TableLens l = mock(TableLens.class);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPreviewServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetPreviewServiceTest.java
@@ -209,8 +209,9 @@ class WorksheetPreviewServiceTest {
    @Test
    void throwsPairingExceptionWhenGetColCountThrows() throws Exception {
       TableLens l = mock(TableLens.class);
-      when(l.getColCount()).thenThrow(new NullPointerException(
-         "Cannot invoke \"inetsoft.report.TableLens.getColCount()\" because \"table\" is null"));
+      NullPointerException cause = new NullPointerException(
+         "Cannot invoke \"inetsoft.report.TableLens.getColCount()\" because \"table\" is null");
+      when(l.getColCount()).thenThrow(cause);
 
       AssetQuerySandbox box = mock(AssetQuerySandbox.class);
       when(box.getTableLens(eq("T"), anyInt())).thenReturn(l);
@@ -220,6 +221,7 @@ class WorksheetPreviewServiceTest {
       assertEquals("Failed to read result columns for 'T': " +
                    "Cannot invoke \"inetsoft.report.TableLens.getColCount()\" because \"table\" is null",
                    ex.getMessage());
+      assertSame(cause, ex.getCause());
    }
 
    @Test
@@ -228,7 +230,8 @@ class WorksheetPreviewServiceTest {
       when(l.getColCount()).thenReturn(1);
       when(l.getObject(0, 0)).thenReturn("col");
       when(l.moreRows(1)).thenReturn(true);
-      when(l.getObject(1, 0)).thenThrow(new RuntimeException("row read failed"));
+      RuntimeException cause = new RuntimeException("row read failed");
+      when(l.getObject(1, 0)).thenThrow(cause);
 
       AssetQuerySandbox box = mock(AssetQuerySandbox.class);
       when(box.getTableLens(eq("T"), anyInt())).thenReturn(l);
@@ -236,6 +239,7 @@ class WorksheetPreviewServiceTest {
       PairingException ex = assertThrows(PairingException.class,
                                           () -> service.preview(rws(box), "T", 10));
       assertEquals("Failed to read result columns for 'T': row read failed", ex.getMessage());
+      assertSame(cause, ex.getCause());
    }
 
    @Test


### PR DESCRIPTION
## Summary

- Bug 76517 (WBS-038): `preview_worksheet_data` on a worksheet aggregate (0 groups, two ungrouped `CountDistinct` aggregates on different columns) raised a raw, un-prefixed `NullPointerException` instead of an actionable error.
- `WorksheetPreviewService.preview()` already wraps `box.getTableLens(...)` in a try/catch that re-throws as `PairingException`, but everything after that — `lens.getColCount()`, the header loop, and the row loop — had no exception handling at all. Any `RuntimeException` thrown there (including the reported NPE) propagated straight to the caller as an implementation-detail leak.
- Fix: wrap that block in a try/catch that converts any `RuntimeException` into `PairingException("Failed to read result columns for '<table>': <message>")`. No other behavior changes.
- Applied the identical fix shape to the sibling defect in `RawDataService.writeWorksheetTableCsvStream` (same unguarded-`getTableLens()`-then-immediate-use shape, same class of bug, different endpoint), including a null-lens guard mirroring `WorksheetPreviewService`'s own null-lens handling.

## Important: this does NOT fix the underlying root cause

This PR converts an unguarded crash into a clear, actionable error. It does **not** identify or fix why `getTableLens()` returns a `TableLens` whose internal delegate is null for this two-`CountDistinct`-aggregate shape in the first place.

Debug-workflow history for this bug (diagnosis + adversarial refutation) landed a **NOT ESTABLISHED** verdict on the deep root cause:
- A live JUnit repro against an in-memory `EmbeddedTableAssembly` (Java-side, non-SQL-merge execution path) with the exact same `AggregateInfo` shape (0 groups, 2 `CountDistinct` aggregates on different columns) computed correctly with **no exception** — this narrows the likely defect location toward the SQL-merge-and-result-wrapping path (`PreAssetQuery`'s JDBC push-down, reached only for a Postgres-backed `BoundTableAssembly`), but does not confirm it. No live JDBC-backed repro could be built this session.
- The diagnosis's proposed deeper fix — wiring a multi-distinct-count merge guard into `PreAssetQuery.isAggregateInfoMergeable0()`, mirroring `MVTransformer.isCombinable()` — was **deliberately not implemented** here. The refutation raised a substantive objection: MV combinability (merging *partial per-block* results from a materialized view) and ordinary single-query JDBC push-down mergeability are different concerns that only superficially resemble each other. Applying that fix as specified would force every dialect (including Postgres, where the merged SQL is valid and correct) off the merged-SQL path unconditionally for 2+ `CountDistinct` aggregates — a behavior change to a shared method used by every JDBC-mergeable worksheet/viewsheet query, based on an unconfirmed analogy.

**Recommendation**: pursue the deep root cause as a separate follow-up, with a live Postgres-backed repro (debugger or full-stack-trace logging in `AssetQuerySandbox.getTableLens()`'s catch blocks) to pin the exact `TableLens` subclass, before touching `PreAssetQuery`'s shared merge-decision logic.

## Test plan

- [x] `WorksheetPreviewServiceTest`: added `throwsPairingExceptionWhenGetColCountThrows` and `throwsPairingExceptionWhenRowExtractionThrows`, using a mock `TableLens` that throws mid-extraction, asserting the exception now surfaces as a `PairingException` naming the table (does not reproduce the exact reported NPE — its root cause is unpinned — but proves the narrower, confirmed-safe claim).
- [x] Ran `./mvnw.cmd -pl core -o -Dtest=WorksheetPreviewServiceTest test -DfailIfNoTests=false` from the worktree root — 11/11 tests pass (9 pre-existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)