### PR TITLE
fix(wiz): removeJoin refuses removal when another assembly depends on it (bug 76517 WBS-037)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -908,11 +908,26 @@ public class WorksheetEditService {
       /**
        * Removes an assembly (typically a join assembly) from the worksheet by name.
        *
-       * <p>No-ops if no assembly with {@code name} exists.</p>
-       *
        * @param name the assembly name to remove
+       * @throws PairingException if no assembly with {@code name} exists, or if another
+       *                          assembly is built on it
        */
-      public void removeJoin(String name) {
+      public void removeJoin(String name) throws PairingException {
+         Assembly a = ws.getAssembly(name);
+
+         if(a == null) {
+            throw new PairingException("Join assembly not found in worksheet: " + name);
+         }
+
+         if(AssetEventUtil.hasDependent(a, ws, Set.of(name))) {
+            throw new PairingException(
+               "\"" + name + "\" cannot be removed because other assemblies are built on it. " +
+               "Removing it would leave them referencing an assembly that no longer exists, every " +
+               "query against them failing, and nothing able to repair them. Remove the " +
+               "assemblies that depend on it first -- read_worksheet_model reports each table's " +
+               "sources field, which is what references what.");
+         }
+
          ws.removeAssembly(name);
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2610,6 +2610,29 @@ class WorksheetEditServiceMutatorsTest {
       assertNull(ws.getAssembly("J"), "join assembly 'J' should have been removed");
    }
 
+   /** A join something depends on refuses to be removed -- mirrors deleteTable's own guard. */
+   @Test
+   void removeJoinRefusesWhenSomethingIsBuiltOnIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> {
+         ed.addJoin("J", "L", "id", "R", "id", "LEFT", null, null);
+         ed.addMirror("M", "J");
+      });
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.removeJoin("J")));
+
+      assertTrue(ex.getMessage().contains("built on it"), ex.getMessage());
+      assertNotNull(ws.getAssembly("J"), "the join must still be there");
+      assertNotNull(ws.getAssembly("M"), "and so must the mirror that depends on it");
+   }
+
    // =========================================================================
    // Column-dependency guard tests (Redmine #75968)
    //


### PR DESCRIPTION
## Summary

- `WorksheetEditService.removeJoin(String)` was a bare `ws.removeAssembly(name)` with no
  existence check and no `AssetEventUtil.hasDependent` guard, unlike its sibling
  `deleteTable`, which has both.
- Removing a join that a mirror (or other assembly) was built on left the dependent
  referencing a name that no longer existed — every subsequent query against it failed,
  with no tool able to repair it. Reported as Redmine #76517 (WBS-037).
- Fix: `removeJoin` now throws `PairingException` if the assembly doesn't exist, and if
  another assembly depends on it (via the same generic `AssetEventUtil.hasDependent` check
  `deleteTable` already uses), naming the dependent relationship in the message.
- The `remove_join` dispatch case in `WorksheetAgentController` already sits in a method
  declared `throws Exception` (same switch as `delete_table`), so no additional wiring was
  needed — confirmed by building, not just reading.

## Root cause

An incomplete parity audit: `deleteTable`'s dependent guard was added in a prior L1-parity
commit that explicitly enumerated every op it touched — `removeJoin` was never mentioned.
The repo's own `docs/parity/L1-worksheet-structure/L1-parity-report.md` already named this
gap ("row 17's guard was exercised against mirror and concatenation dependents but not a
join").

## Test plan

- [x] New test `removeJoinRefusesWhenSomethingIsBuiltOnIt` (join + mirror sourced from it) —
      asserts `PairingException` naming "built on it", both the join and the mirror survive.
- [x] Existing `removeJoinRemovesAssembly` (no-dependent case) still passes unchanged.
- [x] `WorksheetEditServiceMutatorsTest,WorksheetEditServiceTest` (266 tests) — no
      regressions in the shared file.

```
./mvnw.cmd -pl core -o -Dtest=WorksheetEditServiceMutatorsTest#removeJoinRefusesWhenSomethingIsBuiltOnIt+removeJoinRemovesAssembly test -DfailIfNoTests=false
  → Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

./mvnw.cmd -pl core -o -Dtest=WorksheetEditServiceMutatorsTest,WorksheetEditServiceTest test -DfailIfNoTests=false
  → Tests run: 266, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

Note: this branch and PR are independent of `fix/wbs-036` (also touching
`WorksheetEditService.java`, in an unrelated method `editUnpivot`, PR #5070) — both are based
directly on `origin/stylebi-wiz-main-rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)