### PR TITLE
fix(wiz): add per-column type check to addConcatSubtable (bug 76517, WBS-033)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1549,31 +1549,8 @@ public class WorksheetEditService {
                   (otherCount == 1 ? "" : "s") + ".");
             }
 
-            for(int c = 0; c < colCount; c++) {
-               // Read the type off DataRef rather than narrowing to ColumnRef: skipping a position
-               // whose ref is some other kind would silently leave it unchecked, which is the very
-               // failure this validation exists to prevent.
-               DataRef first = firstColumns.getAttribute(c);
-               DataRef other = otherColumns.getAttribute(c);
-               String ftype = first.getDataType();
-               String otype = other.getDataType();
-
-               // isMergeable dereferences both arguments; a ref with no type at all is not
-               // something this check can speak to, so leave it to the server.
-               if(ftype == null || otype == null) {
-                  continue;
-               }
-
-               if(!AssetUtil.isMergeable(ftype, otype)) {
-                  throw new PairingException(
-                     "Columns are concatenated by position, and position " + (c + 1) +
-                     " does not line up: \"" + sources[0].getName() + "\" has \"" +
-                     first.getAttribute() + "\" (" + ftype + ") while \"" + sources[i].getName() +
-                     "\" has \"" + other.getAttribute() + "\" (" + otype + "), and those types " +
-                     "cannot be merged. Reorder the columns so matching ones share a position, " +
-                     "or change one column's type with change_column_type.");
-               }
-            }
+            checkColumnTypesLineUp(firstColumns, sources[0].getName(),
+                                    otherColumns, sources[i].getName(), colCount);
          }
 
          // Build one operator per adjacent pair.
@@ -1597,6 +1574,49 @@ public class WorksheetEditService {
          ConcatenatedTableAssembly ctbl =
             new ConcatenatedTableAssembly(ws, name, sources, operators);
          placeAssembly(ctbl);
+      }
+
+      /**
+       * Validates that column {@code c} of {@code anchorColumns} is mergeable with column
+       * {@code c} of {@code otherColumns}, for every {@code c} in {@code [0, colCount)}. Shared
+       * by {@link #addConcatenation} and {@link #addConcatSubtable}, which both concatenate by
+       * position and therefore both need the same per-column type gate -- see the comment on
+       * {@link #addConcatenation}'s own call site for why anchoring the comparison choice does
+       * not matter.
+       *
+       * @throws PairingException naming the 1-based position and both column names/types, if any
+       *                          position does not line up.
+       */
+      private static void checkColumnTypesLineUp(ColumnSelection anchorColumns, String anchorName,
+                                                  ColumnSelection otherColumns, String otherName,
+                                                  int colCount)
+         throws PairingException
+      {
+         for(int c = 0; c < colCount; c++) {
+            // Read the type off DataRef rather than narrowing to ColumnRef: skipping a position
+            // whose ref is some other kind would silently leave it unchecked, which is the very
+            // failure this validation exists to prevent.
+            DataRef anchor = anchorColumns.getAttribute(c);
+            DataRef other = otherColumns.getAttribute(c);
+            String atype = anchor.getDataType();
+            String otype = other.getDataType();
+
+            // isMergeable dereferences both arguments; a ref with no type at all is not
+            // something this check can speak to, so leave it to the server.
+            if(atype == null || otype == null) {
+               continue;
+            }
+
+            if(!AssetUtil.isMergeable(atype, otype)) {
+               throw new PairingException(
+                  "Columns are concatenated by position, and position " + (c + 1) +
+                  " does not line up: \"" + anchorName + "\" has \"" + anchor.getAttribute() +
+                  "\" (" + atype + ") while \"" + otherName + "\" has \"" + other.getAttribute() +
+                  "\" (" + otype + "), and those types cannot be merged. Reorder the columns so " +
+                  "matching ones share a position, or change one column's type with " +
+                  "change_column_type.");
+            }
+         }
       }
 
       /**
@@ -2593,8 +2613,10 @@ public class WorksheetEditService {
          }
 
          // Validate column count matches existing subtables.
-         int colCount = existing[0].getColumnSelection(true).getAttributeCount();
-         int newCount = newTable.getColumnSelection(true).getAttributeCount();
+         ColumnSelection anchorColumns = existing[0].getColumnSelection(true);
+         ColumnSelection newColumns = newTable.getColumnSelection(true);
+         int colCount = anchorColumns.getAttributeCount();
+         int newCount = newColumns.getAttributeCount();
 
          if(newCount != colCount) {
             throw new PairingException(
@@ -2602,6 +2624,13 @@ public class WorksheetEditService {
                "concatenated. Existing subtables have " + colCount +
                " columns but \"" + tableName + "\" has " + newCount + ".");
          }
+
+         // Validate column types line up by position against the existing subtables' anchor
+         // column list, mirroring addConcatenation's check -- see checkColumnTypesLineUp for why
+         // comparing against existing[0] rather than the immediately preceding subtable is
+         // equivalent.
+         checkColumnTypesLineUp(anchorColumns, existing[0].getName(), newColumns, tableName,
+                                 colCount);
 
          TableAssembly[] updated = new TableAssembly[existing.length + 1];
          System.arraycopy(existing, 0, updated, 0, existing.length);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -4550,6 +4550,64 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    /**
+    * Same rule as {@link #addConcatenationRejectsColumnsThatDoNotLineUpByType}, reached through the
+    * other entry point: {@code addConcatSubtable} only checked column COUNT, so a subtable whose
+    * column at some position was a different {@code isMergeable} class than the existing subtables'
+    * spliced straight in with no error.
+    */
+   @Test
+   void addConcatSubtableRejectsColumnsThatDoNotLineUpByType() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a =
+         table(ws, "A", col("id", XSchema.INTEGER), col("name", XSchema.STRING));
+      EmbeddedTableAssembly b =
+         table(ws, "B", col("id", XSchema.INTEGER), col("name", XSchema.STRING));
+      EmbeddedTableAssembly c =
+         table(ws, "C", col("id", XSchema.INTEGER), col("amount", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatSubtable("U", "C")));
+
+      assertTrue(ex.getMessage().contains("position 2"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("name"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("amount"), ex.getMessage());
+      assertEquals(2, ((ConcatenatedTableAssembly) ws.getAssembly("U")).getTableAssemblies().length,
+                   "the subtable list must be unchanged when the types do not line up");
+   }
+
+   /**
+    * Companion to the rejection test above: different types are not automatically a mismatch, since
+    * {@code AssetUtil.isMergeable} treats all number types as interchangeable, and likewise date and
+    * timeInstant. This is the case that would have let the original reporter's date/timeInstant
+    * repro still pass, proving the fix does not over-tighten past what {@code addConcatenation}
+    * itself allows.
+    */
+   @Test
+   void addConcatSubtableAcceptsColumnTypesThatMerge() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("n", XSchema.INTEGER), col("s", XSchema.STRING));
+      EmbeddedTableAssembly b = table(ws, "B", col("n", XSchema.INTEGER), col("s", XSchema.STRING));
+      EmbeddedTableAssembly c = table(ws, "C", col("n", XSchema.DOUBLE), col("s", XSchema.CHAR));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION"));
+
+      svc.apply("TOK", agent, ed -> ed.addConcatSubtable("U", "C"));
+
+      assertEquals(3, ((ConcatenatedTableAssembly) ws.getAssembly("U")).getTableAssemblies().length,
+                   "a mergeable column-type pairing must still be accepted");
+   }
+
+   /**
     * With three sources the mismatch is between the third and the first, which pins down that the
     * loop keeps checking past the first pair and names the offending source rather than whichever
     * one happened to come second.


### PR DESCRIPTION
## Summary
- `WorksheetEditService.addConcatSubtable` validated only column COUNT, unlike its sibling
  `addConcatenation`, which also checks that column i of each source is
  `AssetUtil.isMergeable` with column i of the first source. A subtable whose column types did
  not line up by position with the existing concatenation's subtables could be spliced in with
  no error at edit time (the mismatch would only later surface as `concatCompatible: false` on
  a subsequent `read_worksheet_model`, with nothing telling the caller to check that field).
- Added the missing per-column type-compatibility check to `addConcatSubtable`, throwing
  `PairingException` naming the 1-based position and both column names/types, mirroring
  `addConcatenation`'s existing check.
- Extracted the two methods' near-identical loop bodies into a shared private helper
  (`checkColumnTypesLineUp`) rather than duplicating the loop, since both a diagnosis and an
  independent adversarial refutation on bug 76517 flagged this as the cleaner option to avoid
  the two checks drifting apart again (which is exactly how this gap arose in the first place).

## Test plan
- [x] `./mvnw.cmd -pl core -o -Dtest=WorksheetEditServiceMutatorsTest#addConcatSubtableRejectsColumnsThatDoNotLineUpByType+addConcatSubtableAcceptsColumnTypesThatMerge+addConcatSubtableRefusesASourceAlreadyPresent+addConcatSubtableRefusesACycleWithoutMutating+addConcatSubtableRefusesSelfReferenceWithoutMutating test -DfailIfNoTests=false` → 5/5 pass
- [x] `./mvnw.cmd -pl core -o -Dtest=WorksheetEditServiceMutatorsTest,WorksheetEditServiceTest test -DfailIfNoTests=false` → 267/267 pass, no regressions

Note: based directly on `origin/stylebi-wiz-main-rebase`, not on the unmerged `fix/wbs-036`
(#5070) or `fix/wbs-037` (#5072) branches, which touch the same file in unrelated methods
(`editUnpivot`, `removeJoin`).