### PR TITLE
Fix unconditional NPE in PrintInfo.getSize() on never-populated size

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/PrintInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/PrintInfo.java
@@ -38,6 +38,7 @@ public class PrintInfo implements AssetObject {
     * Constructor.
     */
    public PrintInfo() {
+      this.size = new DimensionD(DEFAULT_WIDTH, DEFAULT_HEIGHT);
    }
 
    /**
@@ -74,6 +75,8 @@ public class PrintInfo implements AssetObject {
     */
    public DimensionD getSize() {
       double ratio = 1 / getUnitRatio(); //Convert inches to current unit
+      DimensionD size = this.size == null ?
+         new DimensionD(DEFAULT_WIDTH, DEFAULT_HEIGHT) : this.size;
       return new DimensionD(size.getWidth() * ratio, size.getHeight() * ratio);
    }
 
@@ -281,7 +284,10 @@ public class PrintInfo implements AssetObject {
    public Object clone() {
       try {
          PrintInfo info2 = (PrintInfo) super.clone();
-         info2.size = (DimensionD) size.clone();
+
+         if(size != null) {
+            info2.size = (DimensionD) size.clone();
+         }
 
          return info2;
       }
@@ -290,6 +296,10 @@ public class PrintInfo implements AssetObject {
          return null;
       }
    }
+
+   // Letter size in inches, matching PaperSize's "Letter [8.5x11 in]" entry.
+   private static final double DEFAULT_WIDTH = 8.5;
+   private static final double DEFAULT_HEIGHT = 11;
 
    private String paperType;
    private DimensionD size;

--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/PrintInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/PrintInfo.java
@@ -75,9 +75,9 @@ public class PrintInfo implements AssetObject {
     */
    public DimensionD getSize() {
       double ratio = 1 / getUnitRatio(); //Convert inches to current unit
-      DimensionD size = this.size == null ?
+      DimensionD effectiveSize = this.size == null ?
          new DimensionD(DEFAULT_WIDTH, DEFAULT_HEIGHT) : this.size;
-      return new DimensionD(size.getWidth() * ratio, size.getHeight() * ratio);
+      return new DimensionD(effectiveSize.getWidth() * ratio, effectiveSize.getHeight() * ratio);
    }
 
    /**

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoTest.java
@@ -53,4 +53,17 @@ class PrintInfoTest {
 
       assertDoesNotThrow(info::clone);
    }
+
+   @Test
+   @Tag("core")
+   void clone_nullSize_doesNotThrow() {
+      PrintInfo info = new PrintInfo();
+      info.setSize(null);
+
+      // clone() itself catches any exception and returns null, so a null size NPE here
+      // wouldn't surface as a thrown exception -- assert the return value instead.
+      Object clone = assertDoesNotThrow(info::clone);
+
+      assertNotNull(clone);
+   }
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.vslayout;
+
+import inetsoft.graph.internal.DimensionD;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * PrintInfo's no-arg constructor never used to initialize the private DimensionD size field,
+ * and getSize() dereferenced it with no null-check, so getSize() threw an unconditional NPE on
+ * any PrintInfo that was default-constructed (or XML-parsed without width/height attributes)
+ * and never had setSize(...) called on it. This crashed set_print_layout/manage_device_layout
+ * on every call, since ViewsheetPropertyDialogService.getViewsheetInfo() calls getSize() as the
+ * first step of its read-merge-write cycle.
+ */
+class PrintInfoTest {
+   @Test
+   @Tag("core")
+   void getSize_freshlyConstructed_returnsDefaultInsteadOfThrowing() {
+      PrintInfo info = new PrintInfo();
+
+      DimensionD size = assertDoesNotThrow(info::getSize);
+
+      assertNotNull(size);
+      assertTrue(size.getWidth() > 0);
+      assertTrue(size.getHeight() > 0);
+   }
+
+   @Test
+   @Tag("core")
+   void clone_freshlyConstructed_doesNotThrow() {
+      PrintInfo info = new PrintInfo();
+
+      assertDoesNotThrow(info::clone);
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
@@ -20,7 +20,13 @@ package inetsoft.web.composer.vs.dialog;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.OrganizationManager;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.test.*;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.ViewsheetInfo;
 import inetsoft.uql.viewsheet.vslayout.*;
@@ -34,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Tag;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -44,10 +51,13 @@ import java.security.Principal;
 import java.util.*;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -110,6 +120,54 @@ public class ViewsheetPropertyDialogServiceTest {
       assertEquals("VSLayout001", viewsheetLayout.getID());
       assertEquals("Foo001", viewsheetLayout.getName());
       assertNotNull(viewsheetLayout.getVSAssemblyLayout("Bar001"));
+   }
+
+   // Bug: a PrintLayout whose PrintInfo.size was never populated (legacy/otherwise-constructed
+   // data, not created via the setViewsheetInfo write path) crashed getViewsheetInfo() with an
+   // unconditional NPE from PrintInfo.getSize(), which set_print_layout/manage_device_layout hit
+   // on every call since it reads the current state first.
+   @Test
+   public void getViewsheetInfo_printLayoutWithNullSize_doesNotThrow() throws Exception {
+      DeviceRegistry deviceRegistry = mock(DeviceRegistry.class);
+      when(deviceRegistry.getDevices()).thenReturn(new DeviceInfo[0]);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.isSecurityEnabled()).thenReturn(true);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+
+      ViewsheetPropertyDialogService service = new ViewsheetPropertyDialogService(
+         coreLifecycleService, viewsheetService, layoutService, viewsheetSettingsService,
+         vsAssemblyInfoHandler, securityEngine, null, deviceRegistry);
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(viewsheetService.getAssetRepository()).thenReturn(assetRepository);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getViewsheetInfo()).thenReturn(new ViewsheetInfo());
+      when(viewsheet.getAssemblies()).thenReturn(new Assembly[0]);
+
+      LayoutInfo layoutInfo = new LayoutInfo();
+      layoutInfo.setViewsheetLayouts(new ArrayList<>());
+      PrintLayout printLayout = new PrintLayout();
+      PrintInfo printInfo = new PrintInfo();
+      printInfo.setSize(null); // simulate a print layout whose size was never populated
+      printLayout.setPrintInfo(printInfo);
+      layoutInfo.setPrintLayout(printLayout);
+      when(viewsheet.getLayoutInfo()).thenReturn(layoutInfo);
+
+      try(MockedStatic<LicenseManager> license = mockStatic(LicenseManager.class);
+          MockedStatic<OrganizationManager> orgManagerStatic = mockStatic(OrganizationManager.class);
+          MockedStatic<SUtil> sutil = mockStatic(SUtil.class))
+      {
+         license.when(LicenseManager::isEnterprise).thenReturn(false);
+         OrganizationManager orgManager = mock(OrganizationManager.class);
+         orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+         when(orgManager.isSiteAdmin(nullable(Principal.class))).thenReturn(false);
+         sutil.when(SUtil::isMultiTenant).thenReturn(true);
+
+         ViewsheetPropertyDialogModel model = assertDoesNotThrow(
+            () -> service.getViewsheetInfo("Viewsheet1", null));
+
+         assertNotNull(model.screensPane().getPrintLayout());
+      }
    }
 
    @Mock ViewsheetService viewsheetService;


### PR DESCRIPTION
## Summary
- `PrintInfo`'s no-arg constructor never initialized the private `DimensionD size` field, and `getSize()` dereferenced it with zero null-check, so any `PrintInfo` that was default-constructed (or XML-parsed without width/height attributes) and never had `setSize(...)` called on it threw an unconditional NPE on every `getSize()` call.
- This is reached by `ViewsheetPropertyDialogService.getViewsheetInfo()` as the first read step whenever a viewsheet has a print layout — the shared Composer "Viewsheet Properties" dialog's own code path, not wiz-specific. It also happened to be the crash behind the wiz plugin's `set_print_layout`/`manage_device_layout` MCP tools 500ing unconditionally, since those do a read-merge-write and the read throws before any patch is ever applied.
- `clone()` had the identical unguarded dereference and would NPE on the same never-populated-size state.

## Fix
- `PrintInfo()` now initializes `size` to a Letter-size default (matching `PaperSize`'s `"Letter [8.5x11 in]"` entry), so every field is valid immediately after construction — consistent with how `paperType`/`unit`/`margins` already behave.
- `getSize()` and `clone()` now fall back safely if `size` is somehow still null (e.g. legacy/persisted data that predates this fix, or XML without width/height attributes), instead of throwing.
- Audited all other `.getPrintInfo().getSize()` call sites (`VSLayoutService.getPrintPageSize()`, `VsToReportConverter`) — they all go through the now-guarded `getSize()` getter, so no additional changes were needed there.

## Test plan
- [x] Added `PrintInfoTest`: `getSize()`/`clone()` on a freshly-constructed `PrintInfo()` no longer throw and return sensible defaults.
- [x] Added `ViewsheetPropertyDialogServiceTest#getViewsheetInfo_printLayoutWithNullSize_doesNotThrow`: `getViewsheetInfo()` on a viewsheet whose print layout carries a `PrintInfo` with `size` explicitly nulled out returns successfully instead of throwing.
- [x] Ran `PrintInfoTest`, `ViewsheetPropertyDialogServiceTest`, `VSLayoutServiceTest`, and the full `inetsoft.uql.viewsheet.vslayout.**` / `inetsoft.web.composer.vs.dialog.**` / `inetsoft.web.composer.vs.controller.**` package suites (40 tests total) — all pass, no regressions.
- [ ] Live re-verification of `set_print_layout`/`manage_device_layout` via the actual wiz plugin MCP tools against a running StyleBI instance is still owed (browser/MCP pairing was unavailable in the session that produced this fix).