### PR TITLE
Bug #76511, fix crosstab sort on date levels created by Expand Hierarchy

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
@@ -1831,6 +1831,18 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
    }
 
    /**
+    * Clear the tracked runtime date level. A dimension created for a new date level by a
+    * drill operation is cloned from the dimension of the previous level, so it inherits
+    * the previous level in oldRuntimeDateLevel. If it is not cleared, the next update()
+    * sees the level as changed and flags runtimeDateLevelChange(), which makes the drill
+    * look like a dynamic date level change to the callers of that method.
+    */
+   public void resetOldRuntimeDateLevel() {
+      oldRuntimeDateLevel = null;
+      runtimeDValueChange = false;
+   }
+
+   /**
     * Set runtime id.
     */
    public void setRuntimeID(int rid) {

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableDrillService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableDrillService.java
@@ -857,7 +857,14 @@ public abstract class BaseTableDrillService <T extends BaseTableEvent> extends B
     * Get next ref fro drill down.
     */
    private VSDimensionRef getDrillDownRef(VSDimensionRef ref, XCube cube) {
-      return VSUtil.getNextLevelRef(ref, cube, true);
+      VSDimensionRef nref = VSUtil.getNextLevelRef(ref, cube, true);
+
+      // see the comment in CrosstabDrillHandler.drillDownChild()
+      if(nref != null && !VSUtil.isDynamicValue(ref.getDateLevelValue())) {
+         nref.resetOldRuntimeDateLevel();
+      }
+
+      return nref;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandler.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandler.java
@@ -294,6 +294,10 @@ public class CrosstabDrillHandler
             dimRef.setDateLevelValue(ref.getDateLevelValue());
             dimRef.setDateLevel(level);
          }
+         else if(dimRef != null && !VSUtil.isDynamicValue(dimRef.getDateLevelValue())) {
+            // see the comment in drillDownChild()
+            dimRef.resetOldRuntimeDateLevel();
+         }
       }
 
       if(index < 0) {
@@ -528,6 +532,15 @@ public class CrosstabDrillHandler
          if(nref != null && VSUtil.isVariableValue(ref.getDateLevelValue())) {
             int level = nref.getDateLevel();
             nref.setDateLevel(level);
+         }
+         else if(nref != null && !VSUtil.isDynamicValue(ref.getDateLevelValue())) {
+            // the child is cloned from the parent level, so it carries the parent's
+            // tracked runtime date level. clear it, otherwise the next update() reports
+            // runtimeDateLevelChange() and removeUselessChildRefs() drops the hierarchy
+            // from the CrosstabTree on every execution, which in turn lets
+            // CrosstabTree.updateChildRef() copy the parent level's options (including
+            // the sort order) over this dimension. (crosstab sort on a drilled level)
+            nref.resetOldRuntimeDateLevel();
          }
 
          childRef = nref;

--- a/core/src/test/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillDateLevelTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillDateLevelTest.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.viewsheet.handler.crosstab;
+
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.internal.CrosstabTree;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for "sorting a MonthOfYear/DayOfMonth cell after Expand Hierarchy does
+ * nothing".
+ *
+ * Expand Hierarchy creates each new date level by cloning the dimension of the previous
+ * level and lowering its date level. The clone also inherits the previous level in the
+ * transient VSDimensionRef#oldRuntimeDateLevel field, so the first
+ * VSDimensionRef#update() after the drill saw the level as "changed" and latched
+ * runtimeDateLevelChange() = true (the flag is only cleared by setDateLevel()).
+ *
+ * CrossBaseVSAssemblyInfo#removeUselessChildRefs() then stripped those levels out of the
+ * CrosstabTree on every execution, and the rebuild in CrosstabTree#updateHierarchy() ran
+ * the "collapsed ref" branch of updateChildRef(), which copies the previous level's
+ * options -- including the sort order -- over the dimension. The order set by
+ * BaseTableSortColumnService therefore never survived to the query. Both flags are
+ * transient, which is why the sort worked again after the viewsheet was saved and
+ * reopened.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CrosstabDrillDateLevelTest {
+   /**
+    * Drilling must not be mistaken for a dynamic date level change on any of the levels
+    * it creates.
+    */
+   @Test
+   void expandHierarchyDoesNotFlagRuntimeDateLevelChange() {
+      List<DataRef> refs = expandHierarchy().refs();
+
+      // Year, QuarterOfYear, MonthOfYear, DayOfMonth
+      assertTrue(refs.size() > 2, "expected the date hierarchy to expand, got " + names(refs));
+
+      for(DataRef ref : refs) {
+         VSDimensionRef dim = (VSDimensionRef) ref;
+         // run the runtime update twice: update0() sets the flag on the design ref, and
+         // the runtime clone only picks it up on the following pass.
+         dim.update(null, columns());
+         dim.update(null, columns());
+
+         assertFalse(dim.runtimeDateLevelChange(),
+                     dim.getFullName() + " must not report a runtime date level change");
+      }
+   }
+
+   /**
+    * With the level no longer flagged, the hierarchy stays in the CrosstabTree across
+    * executions, so re-registering it does not copy the parent level's sort order over a
+    * drilled level.
+    */
+   @Test
+   void drilledLevelKeepsItsOwnSortOrder() {
+      Hierarchy hierarchy = expandHierarchy();
+      List<DataRef> refs = hierarchy.refs();
+      CrosstabTree tree = hierarchy.tree();
+
+      for(DataRef ref : refs) {
+         ((VSDimensionRef) ref).update(null, columns());
+         ((VSDimensionRef) ref).update(null, columns());
+      }
+
+      // mirror CrossBaseVSAssemblyInfo.removeUselessChildRefs(): a level that reports a
+      // runtime date level change is dropped from the hierarchy on every execution
+      for(DataRef ref : refs) {
+         VSDimensionRef dim = (VSDimensionRef) ref;
+
+         if(dim.runtimeDateLevelChange()) {
+            tree.removeChildRef(dim.getFullName());
+         }
+      }
+
+      // give the levels alternating sort orders, then let the parent -> child links be
+      // re-registered the way CrosstabTree.updateHierarchy() does on every execution
+      for(int i = 0; i < refs.size(); i++) {
+         ((VSDimensionRef) refs.get(i))
+            .setOrder(i % 2 == 0 ? XConstants.SORT_ASC : XConstants.SORT_DESC);
+      }
+
+      for(int i = 0; i < refs.size() - 1; i++) {
+         VSDimensionRef parent = (VSDimensionRef) refs.get(i);
+         VSDimensionRef child = (VSDimensionRef) refs.get(i + 1);
+         int order = child.getOrder();
+
+         tree.updateChildRef(parent.getFullName(), child);
+
+         assertEquals(order, child.getOrder(),
+                      child.getFullName() + " sort order must not be overwritten by " +
+                         parent.getFullName());
+      }
+   }
+
+   private Hierarchy expandHierarchy() {
+      ColumnSelection columns = columns();
+      VSDimensionRef year = new VSDimensionRef();
+      year.setGroupColumnValue(DATE_COLUMN);
+      year.setDateLevelValue(XConstants.YEAR_DATE_GROUP + "");
+
+      // the runtime refs are regenerated from the design ref on every execution; it takes
+      // two passes before the clone carries the design ref's tracked runtime date level,
+      // which is what a drill then inherits.
+      year.update(null, columns);
+      List<DataRef> updated = year.update(null, columns);
+      assertEquals(1, updated.size());
+      VSDimensionRef rtYear = (VSDimensionRef) updated.get(0);
+
+      List<DataRef> refs = new ArrayList<>();
+      refs.add(rtYear);
+      Set<String> childFields = new HashSet<>();
+      childFields.add(rtYear.getFullName());
+
+      CrosstabTree tree = new CrosstabTree();
+      new CrosstabDrillHandler(null, null, null)
+         .drillDownChild(tree, null, null, refs, childFields, rtYear, true, false,
+                         (cube, dim) -> true, false);
+
+      return new Hierarchy(refs, tree);
+   }
+
+   private ColumnSelection columns() {
+      ColumnSelection columns = new ColumnSelection();
+      ColumnRef col = new ColumnRef(new AttributeRef(null, DATE_COLUMN));
+      col.setDataType(XSchema.DATE);
+      columns.addAttribute(col);
+
+      return columns;
+   }
+
+   private static String names(List<DataRef> refs) {
+      StringBuilder sb = new StringBuilder();
+
+      for(DataRef ref : refs) {
+         sb.append(sb.length() == 0 ? "" : ", ").append(((VSDimensionRef) ref).getFullName());
+      }
+
+      return sb.toString();
+   }
+
+   private record Hierarchy(List<DataRef> refs, CrosstabTree tree) {}
+
+   private static final String DATE_COLUMN = "Date";
+}


### PR DESCRIPTION
## Problem

In a crosstab bound to a date column, after **Expand Hierarchy** the sort icon on a
`MonthOfYear` or `DayOfMonth` row-header cell does nothing — the row order never changes.
`Year` and `QuarterOfYear` sort normally. Saving and reopening the viewsheet makes the
sort work again.

## Root cause

`VSUtil.getNextLevelRef()` builds each expanded level by cloning the dimension of the
previous level and lowering its date level. The clone also inherits the previous level in
the transient `VSDimensionRef.oldRuntimeDateLevel` field, so the first
`VSDimensionRef.update()` after the drill sees the level as changed and latches
`runtimeDateLevelChange() == true` (the flag is only cleared by `setDateLevel()`).

From then on, on every execution:

1. `CrossBaseVSAssemblyInfo.removeUselessChildRefs()` sees the flag and strips those levels
   out of `CrosstabTree.childRefs`. `removeParentRef()` removes the key equal to the ref's
   *own* full name, so `Year(...)` survives but `QuarterOfYear(...)`, `MonthOfYear(...)`
   and the root key are dropped.
2. `CrosstabTree.updateHierarchy()` re-registers the links through `updateChildRef()`,
   which now takes the `collapsedRefs.containsKey(refName) && !childRefs.containsKey(parent)`
   branch and calls `childRef.copyOptions(...)`. `collapsedRefs` is keyed by the *base*
   column name, so all four levels share one slot and each level gets the previous level's
   options — including `order`.

Walking the row headers, `Year` keeps its key (no copy), `QuarterOfYear` copies from
itself (harmless), and `MonthOfYear`/`DayOfMonth` get their sort order overwritten — which
is exactly the reported set of broken levels. The order that
`BaseTableSortColumnService.setOrder()` writes to the design ref is applied correctly and
then clobbered before the query runs.

Both `oldRuntimeDateLevel` and `runtimeDValueChange` are transient and not persisted, so
after a save/reopen the flag is never set and the sort works.

## Fix

Clear the tracked runtime date level on the dimension a crosstab drill creates, so a drill
is not mistaken for a dynamic date level change:

- `VSDimensionRef.resetOldRuntimeDateLevel()` — new.
- Called in `CrosstabDrillHandler.drillDownChild()` (Expand Hierarchy / Expand Field),
  `CrosstabDrillHandler.drillUpAction()` (collapse), and
  `BaseTableDrillService.getDrillDownRef()` (per-cell `[+]` drill).

Dynamic date levels are deliberately left alone: the variable case already clears the flag
via `setDateLevel()`, and `DrillFilterVSAssembly.validDrillFilterCondition()` depends on
the flag for dynamic levels. The guards therefore use `!VSUtil.isDynamicValue(...)` so
script-valued levels are excluded too. The chart drill paths are untouched.

## Testing

New `CrosstabDrillDateLevelTest` (2 cases): a drilled level must not report
`runtimeDateLevelChange()`, and with the level unflagged the hierarchy survives in the
`CrosstabTree` so re-registering it does not copy the parent level's sort order over the
child.

With the fix reverted both fail, reproducing the bug:

```
expandHierarchyDoesNotFlagRuntimeDateLevelChange:84
  QuarterOfYear(Date) must not report a runtime date level change ==> expected: <false> but was: <true>
drilledLevelKeepsItsOwnSortOrder:129
  MonthOfYear(Date) sort order must not be overwritten by QuarterOfYear(Date) ==> expected: <1> but was: <2>
```

With the fix: `tests="2" errors="0" failures="0"`.

Also verified manually in the app against Data Source/Examples/Orders/Order Model:
Expand Hierarchy, then sort on MonthOfYear and DayOfMonth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
