### PR TITLE
Bug #76514, follow calendar order for moving-average windows on value-sorted part-date dimensions

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/MovingColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/MovingColumn.java
@@ -146,6 +146,8 @@ public class MovingColumn extends AbstractColumn {
       }
 
       Formula formula = (Formula) this.formula.clone();
+      // rows of 'data' in the order the window is walked; null means physical row order
+      int[] window = null;
 
       // dimension?
       if(innerDim != null) {
@@ -168,6 +170,14 @@ public class MovingColumn extends AbstractColumn {
                   break;
                }
             }
+
+            // getCondData picks the window's members by the dimension's navigation order, so
+            // the window must be walked in that order too. The sub data set holds only those
+            // members but keeps them in physical row order, which differs whenever the
+            // dimension's display sort differs from its navigation order (e.g. a Top-N "Sort
+            // By Value" ranking on HourOfDay); walking it by row index then averages the
+            // wrong neighbors and puts the truncated-window nulls on the wrong rows.
+            window = orderRowsByDim(data2, router);
          }
 
          data = data2;
@@ -181,24 +191,71 @@ public class MovingColumn extends AbstractColumn {
          }
       }
 
-      int rcnt = data.getRowCount();
+      int pos = row;
+
+      if(window != null) {
+         pos = -1;
+
+         for(int i = 0; i < window.length; i++) {
+            if(window[i] == row) {
+               pos = i;
+               break;
+            }
+         }
+
+         // should not happen: window is a permutation of the sub data set's rows
+         if(pos < 0) {
+            window = null;
+            pos = row;
+         }
+      }
+
+      int rcnt = window == null ? data.getRowCount() : window.length;
+
       formula.reset();
 
       // add all data from row - pre count to row + next count
-      for(int i = Math.max(0, row - preCnt);
-         i < Math.min(rcnt, row + nextCnt + 1); i++)
+      for(int i = Math.max(0, pos - preCnt);
+         i < Math.min(rcnt, pos + nextCnt + 1); i++)
       {
-         if(i == row) {
+         int r = window == null ? i : window[i];
+
+         if(r == row) {
             if(includeCurrent) {
                formula.addValue(val);
             }
          }
          else {
-            formula.addValue(data.getData(field, i));
+            formula.addValue(data.getData(field, r));
          }
       }
 
       return formula.getResult();
+   }
+
+   /**
+    * Get the rows of the data set ordered by the position of their dimension value in the
+    * router, i.e. in the order previous/next navigation walks them. Values the router does
+    * not know sort first, and rows sharing a dimension value keep their relative row order.
+    */
+   private int[] orderRowsByDim(DataSet data, Router router) {
+      int cnt = data.getRowCount();
+      Integer[] rows = new Integer[cnt];
+
+      for(int i = 0; i < cnt; i++) {
+         rows[i] = i;
+      }
+
+      Arrays.sort(rows, Comparator.comparingInt(
+         r -> router.getIndex(data.getData(innerDim, r))));
+
+      int[] arr = new int[cnt];
+
+      for(int i = 0; i < cnt; i++) {
+         arr[i] = rows[i];
+      }
+
+      return arr;
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
@@ -59,15 +59,16 @@ public class DataSetRouter extends AbstractRouter {
          }
       }
 
-      // Any display sort configured on the field — ascending, descending, specific order, or
-      // value-based (a Top-N "Sort By Value" ranking) — defines the order that previous/next
-      // navigation follows, so that the calc stays aligned with the order the values are
-      // actually plotted in. Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear,
-      // Quarter) fall back to natural calendar order only when no sort is configured, since
-      // raw row-appearance order is arbitrary there. (76039)
+      // Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear, Quarter) navigate
+      // previous/next in natural calendar order when the field has no display sort, or when
+      // its display sort is value-based (e.g. a Top-N "Sort By Value" ranking) — "previous
+      // hour" has no meaning in rank-value order. An explicit label sort (ascending,
+      // descending, or specific order) is honored instead, so that calc navigation stays
+      // aligned with the order the values are actually plotted in. (76059, 75664-1)
+      XDimensionRef partDateDim = getPartDateDimension(data, field);
       comp = data.getComparator(field);
 
-      if(comp == null && getPartDateDimension(data, field) != null) {
+      if(partDateDim != null && (comp == null || isSortByValue(partDateDim))) {
          comp = PART_DATE_ORDER;
       }
 
@@ -99,6 +100,15 @@ public class DataSetRouter extends AbstractRouter {
 
       XDimensionRef dim = (XDimensionRef) ref;
       return (dim.getDateLevel() & XConstants.PART_DATE_GROUP) != 0 ? dim : null;
+   }
+
+   /**
+    * Check if the dimension is sorted by an aggregate value (as set by a Top-N/Bottom-N
+    * "Sort By Value" ranking) rather than by its own labels.
+    */
+   private static boolean isSortByValue(XDimensionRef dim) {
+      int order = dim.getOrder();
+      return order == XConstants.SORT_VALUE_ASC || order == XConstants.SORT_VALUE_DESC;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/MovingColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/MovingColumnTest.java
@@ -24,6 +24,7 @@ import inetsoft.report.composition.graph.VSDataSet;
 import inetsoft.report.filter.*;
 import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.viewsheet.VSDataRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.graph.AbstractCalc;
@@ -36,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -368,6 +370,72 @@ public class MovingColumnTest {
       // row 1 (3): window = [1, 3] → avg = 2
       result = movingColumn.calculate(vsDataSet, 1, false, false);
       assertEquals(2.0, result);
+   }
+
+
+   /**
+    * Regression test for the "Moving Average of N misaligned when the dimension's display
+    * sort is not its calendar order" bug, reproduced by the datatest chart suite
+    * (Binding_Spec / binding7).
+    *
+    * A part-date-group dimension (HourOfDay) under a Top-N "Sort By Value" ranking is
+    * plotted in ranking order (5, 11, 1, 2) while a moving window over hours only has
+    * meaning in calendar order (1, 2, 5, 11). Two things have to hold together for the
+    * window to land on the right rows:
+    *
+    * 1. DataSetRouter must navigate in calendar order for such a dimension, so getCondData
+    *    selects the calendar neighbors as the window's members.
+    * 2. MovingColumn must then walk that window in the same order. The sub data set keeps
+    *    the physical (ranking) row order, so walking it by row index averaged the wrong
+    *    neighbors and shifted which rows came out null.
+    *
+    * Centered 3-point average, null at the truncated ends. Calendar order is
+    * 1(173), 2(166), 5(275), 11(320), so hour 2 = avg(173,166,275) and
+    * hour 5 = avg(166,275,320), while the calendar-first and calendar-last hours are null.
+    */
+   @Test
+   void testMovingAverageFollowsCalendarOrderOnValueSortedPartDateDim() {
+      final String dim = "HourOfDay(order_time)";
+      // physical/display order is the Top-N ranking order, not calendar order
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { dim, "Sum(employee_id)" },
+         { 5, 275 },
+         { 11, 320 },
+         { 1, 173 },
+         { 2, 166 }
+      });
+
+      List<Integer> rank = Arrays.asList(5, 11, 1, 2);
+      VSDimensionRef hourRef = mock(VSDimensionRef.class);
+      when(hourRef.getFullName()).thenReturn(dim);
+      when(hourRef.getDateLevel()).thenReturn(XConstants.HOUR_OF_DAY_DATE_GROUP);
+      when(hourRef.getOrder()).thenReturn(XConstants.SORT_VALUE_DESC);
+      when(hourRef.createComparator(org.mockito.ArgumentMatchers.any()))
+         .thenReturn((Comparator) (a, b) -> Integer.compare(rank.indexOf(a), rank.indexOf(b)));
+
+      vsDataSet = new VSDataSet(tb, new VSDataRef[]{ hourRef });
+
+      movingColumn = new MovingColumn("Sum(employee_id)", "Moving Average of 3: Sum(employee_id)");
+      movingColumn.setFormula(new AverageFormula());
+      movingColumn.setPreCnt(1);
+      movingColumn.setNextCnt(1);
+      movingColumn.setIncludeCurrent(true);
+      movingColumn.setShowNull(true);
+      movingColumn.setInnerDim(dim);
+
+      // row 0 = hour 5; calendar window [2, 5, 11] -> (166 + 275 + 320) / 3
+      assertEquals(253.6667,
+                   (Double) movingColumn.calculate(vsDataSet, 0, true, false), 0.0001);
+
+      // row 1 = hour 11, last in calendar order -> truncated window -> null
+      assertNull(movingColumn.calculate(vsDataSet, 1, false, false));
+
+      // row 2 = hour 1, first in calendar order -> truncated window -> null
+      assertNull(movingColumn.calculate(vsDataSet, 2, false, false));
+
+      // row 3 = hour 2; calendar window [1, 2, 5] -> (173 + 166 + 275) / 3
+      assertEquals(204.6667,
+                   (Double) movingColumn.calculate(vsDataSet, 3, false, true), 0.0001);
    }
 
 }

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -383,24 +383,28 @@ public class ValueOfColumnTest {
    }
 
    /**
-    * Regression test for Bug #76039: PREVIOUS navigation on a part-date-group dimension
-    * (e.g. HourOfDay) must follow the dimension's display sort even when that sort is
-    * value-based, as set by a Top-N/Bottom-N "Sort By Value" ranking. The calc has to agree
-    * with the order the values are plotted in and with the order scripts see them in via
-    * getData() — so the value that is first in display order has no previous value, even
-    * though a numerically-earlier one exists elsewhere in the data.
+    * Regression test for Bug #75664 (ranking follow-up): PREVIOUS navigation on a
+    * part-date-group dimension (e.g. HourOfDay) must use natural calendar order even when
+    * the dimension has an explicit value-based sort comparator — as set by a Top-N/Bottom-N
+    * "Sort By Value" ranking. Without this, DataSetRouter sorts by the ranking's value order
+    * (e.g. by Sum(contact_id) desc) instead of numeric hour order, so "previous hour"
+    * resolves to the wrong row or incorrectly returns INVALID, and every moving-average
+    * window over the dimension slides with it.
     *
-    * This deliberately reverses the follow-up fix for Bug #75664 ("bug-75664-1"), which gave
-    * natural calendar order priority over a value-based sort comparator. The two cannot both
-    * hold: for a sort-by-value part-date dimension, calendar order and display order differ.
-    * The natural-order fallback still applies when no sort is configured — see
-    * {@link #testPreviousOnPartDateGroupWithOthersLabel()}.
+    * This supersedes the inverted expectation briefly introduced for Bug #76039, which had
+    * value-based ranking order win over calendar order for these dimensions. The two cannot
+    * both hold, and "previous hour" only has meaning in calendar order. An explicit label
+    * sort (ascending, descending, specific order) is still honored — see
+    * {@link #testPreviousOnPartDateGroupFollowsLabelSortWithNullGroup()} — and so is the
+    * no-sort calendar fallback — see {@link #testPreviousOnPartDateGroupWithOthersLabel()}.
     *
-    * Row order is 5, 2, 11; the ranking comparator puts the hours in descending order
-    * (11, 5, 2), which is neither row order nor calendar order.
+    * Data is intentionally NOT in either row order or hour order (row order: 5, 2, 11), and
+    * the mock comparator sorts by an unrelated ranking value (id desc: 11, 5, 2) rather than
+    * by hour. Natural hour order is 2, 5, 11 — so "previous" of hour 5 must resolve to hour 2
+    * (id=20), not to whatever the ranking comparator would place before it.
     */
    @Test
-   void testPreviousOnPartDateGroupFollowsRankingSortOrder() {
+   void testPreviousOnPartDateGroupIgnoresRankingSortComparator() {
       valueOfColumn = new ValueOfColumn("id", "sum(id)");
       valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
       valueOfColumn.setDim("HourOfDay(order_time)");
@@ -415,24 +419,20 @@ public class ValueOfColumnTest {
       VSDimensionRef hourRef = mock(VSDimensionRef.class);
       when(hourRef.getFullName()).thenReturn("HourOfDay(order_time)");
       when(hourRef.getDateLevel()).thenReturn(XConstants.HOUR_OF_DAY_DATE_GROUP);
-      // Simulates a Top-N ranking's "Sort By Value" comparator, ordering the hours 11, 5, 2
-      // rather than in natural hour order 2, 5, 11.
+      // Simulates a Top-N ranking's "Sort By Value" comparator: orders by id desc
+      // (11, 5, 2) rather than by natural hour order (2, 5, 11).
       when(hourRef.getOrder()).thenReturn(XConstants.SORT_VALUE_DESC);
       when(hourRef.createComparator(org.mockito.ArgumentMatchers.any()))
          .thenReturn((a, b) -> Integer.compare((Integer) b, (Integer) a));
 
       vsDataSet = new VSDataSet(tb, new VSDataRef[] { hourRef });
 
-      // Row 0 = hour 5; previous in display order (11, 5, 2) is hour 11 (id=30).
+      // Row 0 = hour 5. Natural-order previous is hour 2 (id=20).
       Object result = valueOfColumn.calculate(vsDataSet, 0, false, false);
-      assertEquals(30, result);
+      assertEquals(20, result);
 
-      // Row 1 = hour 2; previous in display order is hour 5 (id=10).
+      // Row 1 = hour 2, the earliest hour → no previous → INVALID.
       result = valueOfColumn.calculate(vsDataSet, 1, false, false);
-      assertEquals(10, result);
-
-      // Row 2 = hour 11, first in display order → no previous → INVALID.
-      result = valueOfColumn.calculate(vsDataSet, 2, false, false);
       assertEquals(CalcColumn.INVALID, result);
    }
 


### PR DESCRIPTION
Fixes Bug #76514.

## Problem

A chart binding `HourOfDay(order_time)` (Top-N "Sort By Value" ranking on `Sum(contact_id)`), `Sum(employee_id)`, and a centered `Moving Average of 3: Sum(employee_id)` put the averages — and the truncated-window nulls — on the wrong hours. The underlying `Sum(employee_id)` values are correct; only the derived calc column is wrong.

Caught by the datatest chart regression suite, `Binding_Spec` / `binding7`, diffing against the accepted baseline. Reproduces in `filter_Chart3.txt` too.

| HourOfDay | Sum(employee_id) | MA(3) before | MA(3) expected |
|---|---|---|---|
| 5 | 275 | null | 253.6667 |
| 11 | 320 | 256 | null |
| 1 | 173 | 219.6667 | null |
| 2 | 166 | null | 204.6667 |

`5, 11, 1, 2` is the configured *display* order (`Sum(contact_id)` = 2043, 2015, 1229, 1215 desc), not insertion order. Calendar order is `1(173), 2(166), 5(275), 11(320)`, so the expected values are `avg(173,166,275) = 204.6667` on hour 2 and `avg(166,275,320) = 253.6667` on hour 5, with the calendar-first and calendar-last hours truncated to null. There is no off-by-one anywhere — the whole window was landing on the wrong rows.

## Cause

Two independent causes had to line up.

**1. `DataSetRouter` navigated in rank-value order.** `HourOfDay` is a part-date level, so there is no `TimeScale`, `VSDataSet.getRouter()` returns null, and navigation falls back to `DataSetRouter`. The second commit of #4658 (`95ee0cb3`, Bug #76039) made any configured comparator win unconditionally, which removed the `isSortByValue` exception the *first* commit of that same PR (`01f1dc78`, Bug #76059) had deliberately kept — reverting the follow-up fix for Bug #75664 (`e804d7b8c`). That also contradicts #4658's own description ("Part-date-group fields keep a natural calendar order as the fallback…").

**2. `MovingColumn` walked the window by row index.** `getCondData()` selects the window's *members* by the dimension's navigation order (`router.getValues()[vindex-preCnt .. vindex+nextCnt]`), but the loop then walked the resulting `SubDataSet` by row index. `DataSetIndex.createSubDataSet` builds the sub from a `BitSet`, so its rows keep physical row order. The two only agree while the router order happens to match the physical order — with the router fixed alone, hour 5 averaged **297.5**, neither the baseline nor the reported output.

## Fix

**`DataSetRouter`** — restore the `isSortByValue` exception. A part-date-group dimension falls back to natural calendar order both when it has no display sort (Bug #75664) and when its sort is value-based (Bug #75664-1); "previous hour" only has meaning in calendar order. An explicit label sort — ascending, descending, specific order — is still honored, as Bug #76059 requires, and non-part-date dimensions keep `data.getComparator(field)` verbatim, so the rest of #76039's intent is preserved.

**`MovingColumn`** — walk the window in the router's order via a new `orderRowsByDim(DataSet, Router)` helper, so the traversal matches the order the members were selected in. Scoped narrowly:

- only applied when `getCondData` actually produced a sub data set, so there is no `O(n log n)`-per-row cost over a full dataset
- the no-`innerDim` path and the crosstab `calculate(CrosstabDataContext, PairN)` path are untouched
- when the two orders agree the traversal is byte-for-byte the previous behavior, so the existing `MovingColumnTest` cases are unaffected

`#76039` and `#75664-1` cannot both hold for a sort-by-value part-date dimension — calendar order and display order differ by definition. This PR takes the calendar-order side and says so in the test docstring, so it does not get flipped back a third time.

## Tests

- `ValueOfColumnTest.testPreviousOnPartDateGroupFollowsRankingSortOrder` reverted to `testPreviousOnPartDateGroupIgnoresRankingSortComparator`, asserting natural-hour-order previous again. Its `getOrder()` stub is load-bearing once more (the prior review flagged it as dead).
- New `MovingColumnTest.testMovingAverageFollowsCalendarOrderOnValueSortedPartDateDim` encodes binding7's expected values. Confirmed to fail with **either** half of the fix reverted — `expected: <253.6667> but was: <297.5>` without the `MovingColumn` half, and an error without the router half.
- `testPreviousOnPartDateGroupFollowsLabelSortWithNullGroup` (#76059) and `testPreviousOnPartDateGroupWithOthersLabel` (#75743 / no-sort "Others" fallback) untouched and still passing.
- 127 tests green across `inetsoft.graph.**` and `inetsoft.report.composition.graph.**`.

## Not yet verified

The datatest suite itself has not been re-run against this branch (no local datatest checkout) — `Binding_Spec` / `binding7` `Chart3.txt` and `filter_Chart3.txt` should now match with **no** baseline edits. The two originally-reported scenarios share this single code path and are worth a manual pass since they are what #4658 was for:

- #76059: auto chart, `SecondOfMinute(order_datetime)` on X, Sort (Ascending), "As time series" off, with a null group — `Value of previous` for second 1 must still resolve to the null group, and `Moving Average of 5` windows must not slide.
- #75743: part-date dim with no sort and a Top-N "group others" — must still use calendar order and not throw `ClassCastException` building the router.

Community-only change; no enterprise files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
