### PR TITLE
Bug #76520, fix RangeSlider Edit dialog for time-of-day bindings

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/range-slider-edit-dialog.component.html
+++ b/web/projects/portal/src/app/vsobjects/dialog/range-slider-edit-dialog.component.html
@@ -26,11 +26,14 @@
         @if (!isDateType) {
           <input type="number" step="any" class="form-control" formControlName="min">
         }
-        @if (isDateType && timeIncrement !== 't') {
+        @if (isDateType && timeIncrement !== 't' && timeIncrement !== 'time') {
           <input type="date" class="form-control" formControlName="min">
         }
         @if (isDateType && timeIncrement === 't') {
           <input type="datetime-local" class="form-control" formControlName="min">
+        }
+        @if (isDateType && timeIncrement === 'time') {
+          <input type="time" class="form-control" formControlName="min">
         }
         <label>_#(From)</label>
         @if (rangeForm.get('min')?.errors?.['required']) {
@@ -55,11 +58,14 @@
         @if (!isDateType) {
           <input type="number" step="any" class="form-control" formControlName="max">
         }
-        @if (isDateType && timeIncrement !== 't') {
+        @if (isDateType && timeIncrement !== 't' && timeIncrement !== 'time') {
           <input type="date" class="form-control" formControlName="max">
         }
         @if (isDateType && timeIncrement === 't') {
           <input type="datetime-local" class="form-control" formControlName="max">
+        }
+        @if (isDateType && timeIncrement === 'time') {
+          <input type="time" class="form-control" formControlName="max">
         }
         <label>_#(To)</label>
         @if (rangeForm.get('max')?.errors?.['required']) {

--- a/web/projects/portal/src/app/vsobjects/dialog/range-slider-edit-dialog.component.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/range-slider-edit-dialog.component.tl.spec.ts
@@ -28,6 +28,8 @@
  *   Group 6 [Risk 2] — minBeforeMax (group validator): numeric vs. date comparison mode
  *   Group 7 [Risk 2] — minMaxNotEqual (group validator): numeric vs. date comparison mode
  *   Group 8 [Risk 2] — close / ok: output emission contracts, numeric fallback-to-0, OK button disabled state
+ *   Group 9 [Risk 1] — time-of-day increment (XSchema.TIME binding): <input type="time">, HH:mm
+ *                      seeding, and time-only parsing anchored to TIME_BASE_DATE
  *
  * Confirmed bugs (it.fails): none
  *
@@ -39,7 +41,8 @@ import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { render } from "@testing-library/angular";
 import { firstValueFrom } from "rxjs";
 
-import { RangeSliderEditDialog } from "./range-slider-edit-dialog.component";
+import { RangeSliderEditDialog, TIME_BASE_DATE, TIME_OF_DAY_INCREMENT }
+   from "./range-slider-edit-dialog.component";
 import { ModalHeaderComponent } from "../../widget/modal-header/modal-header.component";
 
 afterEach(() => {
@@ -522,5 +525,84 @@ describe("RangeSliderEditDialog — ok", () => {
       const okButton = fixture.nativeElement.querySelector("button.btn-primary") as HTMLButtonElement;
 
       expect(okButton.disabled).toBe(false);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 9: time-of-day increment (XSchema.TIME binding)
+//
+// A range slider bound to an XSchema.TIME column gets tick values of the form {t 'HH:mm:ss'},
+// which the host maps to the TIME_OF_DAY_INCREMENT increment. The dialog must then render
+// time-only inputs pre-filled with the current selection instead of empty datetime-local
+// inputs (and must not report the min/max as equal).
+// ---------------------------------------------------------------------------
+
+describe("RangeSliderEditDialog — time-of-day increment", () => {
+   const timeOfDay = (hhmm: string) => new Date(`${TIME_BASE_DATE}T${hhmm}`);
+
+   async function renderTimeOfDay() {
+      return renderComponent({
+         currentMin: timeOfDay("01:30"),
+         currentMax: timeOfDay("06:30"),
+         rangeMin: timeOfDay("00:00"),
+         rangeMax: timeOfDay("23:59"),
+         timeIncrement: TIME_OF_DAY_INCREMENT,
+      });
+   }
+
+   it("should render a single time input for both From and To", async () => {
+      const { fixture } = await renderTimeOfDay();
+
+      expect(fixture.nativeElement.querySelectorAll("input[type=time]").length).toBe(2);
+      expect(fixture.nativeElement.querySelectorAll("input[type=datetime-local]").length).toBe(0);
+      expect(fixture.nativeElement.querySelectorAll("input[type=date]").length).toBe(0);
+   });
+
+   // 🔁 Regression-sensitive: the reported defect was both fields rendering empty because
+   // formatDate produced a full date-time string from an Invalid Date.
+   it("should seed the controls with the HH:mm selection and leave the form valid", async () => {
+      const { comp } = await renderTimeOfDay();
+
+      expect(comp.isDateType).toBe(true);
+      expect(comp.rangeForm.get("min")?.value).toBe("01:30");
+      expect(comp.rangeForm.get("max")?.value).toBe("06:30");
+      expect(comp.rangeForm.errors?.["minMaxEqual"]).toBeFalsy();
+      expect(comp.rangeForm.valid).toBe(true);
+   });
+
+   it("should format a Date as HH:mm", async () => {
+      const { comp } = await renderComponent({
+         skipInitForm: true, timeIncrement: TIME_OF_DAY_INCREMENT });
+
+      expect(comp.formatDate(timeOfDay("08:05"))).toBe("08:05");
+   });
+
+   it("should parse an emitted HH:mm value against the base date", async () => {
+      const { comp } = await renderTimeOfDay();
+
+      comp.rangeForm.get("min")?.setValue("02:15");
+
+      expect(comp.currentMin).toEqual(timeOfDay("02:15"));
+   });
+
+   it("should flag a value outside the slider range", async () => {
+      const { comp } = await renderTimeOfDay();
+      const belowMin = comp.dateRangeValidatorMin(timeOfDay("01:00"));
+      const aboveMax = comp.dateRangeValidatorMax(timeOfDay("07:00"));
+
+      expect(belowMin({ value: "00:30" } as any)?.["dateMinError"]).toBeTruthy();
+      expect(belowMin({ value: "01:30" } as any)).toBeNull();
+      expect(aboveMax({ value: "08:00" } as any)?.["dateMaxError"]).toBeTruthy();
+      expect(aboveMax({ value: "06:30" } as any)).toBeNull();
+   });
+
+   it("should report equal and out-of-order values through the group validators", async () => {
+      const { comp } = await renderTimeOfDay();
+
+      comp.rangeForm.get("max")?.setValue("01:30");
+      expect(comp.rangeForm.errors?.["minMaxEqual"]).toBe(true);
+
+      comp.rangeForm.get("max")?.setValue("00:30");
+      expect(comp.rangeForm.errors?.["minAfterMax"]).toBe(true);
    });
 });

--- a/web/projects/portal/src/app/vsobjects/dialog/range-slider-edit-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/range-slider-edit-dialog.component.ts
@@ -22,6 +22,18 @@ import { takeUntil } from "rxjs/operators";
 
 import { ModalHeaderComponent } from "../../widget/modal-header/modal-header.component";
 
+/**
+ * Time increment used when the bound column holds a time of day only (XSchema.TIME), as
+ * opposed to "t" which is used for a full timestamp (date + time).
+ */
+export const TIME_OF_DAY_INCREMENT = "time";
+
+/**
+ * Base date used to anchor a time of day so that it can be represented as a Date and
+ * compared against the other time of day values.
+ */
+export const TIME_BASE_DATE = "1970-01-01";
+
 @Component({
     selector: "range-slider-edit-dialog",
     templateUrl: "range-slider-edit-dialog.component.html",
@@ -80,12 +92,12 @@ export class RangeSliderEditDialog implements OnDestroy {
          ]));
          this.rangeForm.get("min")?.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(value => {
             if(value) {
-               this.currentMin = new Date(value + (this.timeIncrement !== "t" ? "T00:00" : ""));
+               this.currentMin = this.toDate(value);
             }
          });
          this.rangeForm.get("max")?.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(value => {
             if(value) {
-               this.currentMax = new Date(value + (this.timeIncrement !== "t" ? "T00:00" : ""));
+               this.currentMax = this.toDate(value);
             }
          });
       }
@@ -93,6 +105,14 @@ export class RangeSliderEditDialog implements OnDestroy {
 
    formatDate(date: number | Date): string {
       const d = new Date(date);
+      const hours = d.getHours().toString().padStart(2, "0");
+      const minutes = d.getMinutes().toString().padStart(2, "0");
+
+      // time of day only, the value of an <input type="time"> is HH:mm
+      if (this.timeIncrement === TIME_OF_DAY_INCREMENT) {
+         return `${hours}:${minutes}`;
+      }
+
       const year = d.getFullYear();
       const month = ("0" + (d.getMonth() + 1)).slice(-2);
       const day = ("0" + d.getDate()).slice(-2);
@@ -100,10 +120,19 @@ export class RangeSliderEditDialog implements OnDestroy {
       if (this.timeIncrement != "t") {
          return `${year}-${month}-${day}`;
       } else {
-         const hours = d.getHours().toString().padStart(2, "0");
-         const minutes = d.getMinutes().toString().padStart(2, "0");
          return `${year}-${month}-${day}T${hours}:${minutes}`;
       }
+   }
+
+   /**
+    * Parses an input value back into a Date according to the current time increment.
+    */
+   private toDate(value: string): Date {
+      if (this.timeIncrement === TIME_OF_DAY_INCREMENT) {
+         return new Date(`${TIME_BASE_DATE}T${value}`);
+      }
+
+      return this.timeIncrement !== "t" ? new Date(value + "T00:00") : new Date(value);
    }
 
    dateRangeValidatorMin(min: Date): ValidatorFn {
@@ -116,8 +145,7 @@ export class RangeSliderEditDialog implements OnDestroy {
             return null;
          }
 
-         const valueTime = this.timeIncrement !== "t" ? new Date(value + "T00:00").getTime() :
-                                                         new Date(value).getTime();
+         const valueTime = this.toDate(value).getTime();
 
          if (valueTime < minTime){
             return {
@@ -142,8 +170,7 @@ export class RangeSliderEditDialog implements OnDestroy {
             return null;
          }
 
-         const valueTime = this.timeIncrement !== "t" ? new Date(value + "T00:00").getTime() :
-                                                                  new Date(value).getTime();
+         const valueTime = this.toDate(value).getTime();
 
          if (valueTime > maxTime) {
             return {

--- a/web/projects/portal/src/app/vsobjects/objects/range-slider/vs-range-slider.component.timeofday.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/range-slider/vs-range-slider.component.timeofday.tl.spec.ts
@@ -1,0 +1,187 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * VSRangeSlider – time increment mapping and the Edit dialog round-trip
+ *
+ * The server writes range slider tick values as JDBC-style escapes: {y 'yyyy'}, {m 'yyyy-MM'},
+ * {d 'yyyy-MM-dd'}, {t 'HH:mm:ss'} (time of day, XSchema.TIME columns bound with the
+ * HOUR_OF_DAY/MINUTE_OF_DAY range type) and {ts 'yyyy-MM-dd HH:mm:ss'} (timestamp).
+ *
+ * Coverage:
+ *   Group 1 - extractTimeIncrement: one increment per value token, {t} kept apart from {ts}
+ *   Group 2 - labelToTimestamp / toIncrementTimestamp: finite, comparable timestamps per increment
+ *   Group 3 - showRangeSliderEditDialog: dialog seeded with valid Dates for a time-of-day binding
+ *   Group 4 - commit round-trip: committed min/max snap to the matching tick indexes
+ */
+
+import { XSchema } from "../../../common/data/xschema";
+import { ComponentTool } from "../../../common/util/component-tool";
+import { GuiTool } from "../../../common/util/gui-tool";
+import { TIME_BASE_DATE, TIME_OF_DAY_INCREMENT }
+   from "../../dialog/range-slider-edit-dialog.component";
+import { createVSRangeSlider } from "./vs-range-slider.component.test-helpers";
+
+/** {t 'HH:mm:ss'} tick values, on the half hour from 00:00 to 23:30. */
+const TIME_VALUES: string[] = [];
+const TIME_LABELS: string[] = [];
+
+for(let hour = 0; hour < 24; hour++) {
+   for(const minute of ["00", "30"]) {
+      const hh = String(hour).padStart(2, "0");
+      TIME_VALUES.push("{t '" + hh + ":" + minute + ":00'}");
+      TIME_LABELS.push(hh + ":" + minute);
+   }
+}
+
+const timeOfDay = (hhmm: string) => new Date(TIME_BASE_DATE + "T" + hhmm);
+
+describe("VSRangeSlider – time of day (XSchema.TIME) binding", () => {
+   beforeEach(() => {
+      vi.spyOn(GuiTool, "measureText").mockReturnValue(10);
+   });
+
+   afterEach(() => {
+      vi.restoreAllMocks();
+   });
+
+   // ─── Group 1: extractTimeIncrement ────────────────────────────────────────
+
+   describe("Group 1 – extractTimeIncrement", () => {
+      // 🔁 Regression-sensitive: {t ...} and {ts ...} used to collapse to the same "t"
+      // increment, which made a time-of-day slider open a datetime-local editor seeded
+      // from an Invalid Date.
+      it("should map {t ...} to the time-of-day increment and {ts ...} to 't'", () => {
+         const { comp } = createVSRangeSlider();
+
+         expect(comp["extractTimeIncrement"]("{t '01:30:00'}")).toBe(TIME_OF_DAY_INCREMENT);
+         expect(comp["extractTimeIncrement"]("{ts '2024-01-05 01:30:00'}")).toBe("t");
+      });
+
+      it("should keep the year/month/day increments unchanged", () => {
+         const { comp } = createVSRangeSlider();
+
+         expect(comp["extractTimeIncrement"]("{y '2024'}")).toBe("y");
+         expect(comp["extractTimeIncrement"]("{m '2024-01'}")).toBe("m");
+         expect(comp["extractTimeIncrement"]("{d '2024-01-05'}")).toBe("d");
+      });
+
+      it("should distinguish time-only from date-time in the unescaped fallback", () => {
+         const { comp } = createVSRangeSlider();
+
+         expect(comp["extractTimeIncrement"]("01:30:00")).toBe(TIME_OF_DAY_INCREMENT);
+         expect(comp["extractTimeIncrement"]("2024-01-05 01:30:00")).toBe("t");
+         expect(comp["extractTimeIncrement"]("2024")).toBe("y");
+         expect(comp["extractTimeIncrement"]("2024-01")).toBe("m");
+         expect(comp["extractTimeIncrement"]("2024-01-05")).toBe("d");
+      });
+   });
+
+   // ─── Group 2: label / increment timestamps ────────────────────────────────
+
+   describe("Group 2 – labelToTimestamp and toIncrementTimestamp", () => {
+      it("should anchor a {t ...} value to the base date instead of returning NaN", () => {
+         const { comp } = createVSRangeSlider();
+
+         const timestamp = comp["labelToTimestamp"](TIME_OF_DAY_INCREMENT, "{t '01:30:00'}");
+
+         expect(Number.isFinite(timestamp)).toBe(true);
+         expect(timestamp).toBe(timeOfDay("01:30").getTime());
+      });
+
+      it("should return the raw time for a time-of-day Date", () => {
+         const { comp } = createVSRangeSlider();
+         const date = timeOfDay("06:30");
+
+         expect(comp["toIncrementTimestamp"](TIME_OF_DAY_INCREMENT, date)).toBe(date.getTime());
+      });
+
+      it("should keep {ts ...} parsing on the 't' increment", () => {
+         const { comp } = createVSRangeSlider();
+
+         expect(comp["labelToTimestamp"]("t", "{ts '2024-01-05 01:30:00'}"))
+            .toBe(new Date("2024-01-05T01:30:00").getTime());
+      });
+   });
+
+   // ─── Group 3 & 4: Edit dialog seeding and commit ──────────────────────────
+
+   describe("Groups 3 & 4 – Edit dialog round-trip", () => {
+      /**
+       * Stubs ComponentTool.showDialog so the dialog instance the component configures can be
+       * inspected, and the commit callback it registers can be fired directly.
+       */
+      function openEditDialog(overrides: any = {}) {
+         const { comp, viewsheetClient } = createVSRangeSlider({
+            labels: TIME_LABELS,
+            values: TIME_VALUES,
+            dataType: XSchema.TIME,
+            selectStart: TIME_LABELS.indexOf("01:30"),
+            selectEnd: TIME_LABELS.indexOf("06:30"),
+            ...overrides,
+         }, { viewer: true });
+
+         const dialog: any = { initForm: vi.fn() };
+         let commit: (range: { min: number | Date, max: number | Date }) => void;
+         const showDialog = vi.spyOn(ComponentTool, "showDialog")
+            .mockImplementation((_modal: any, _type: any, onCommit: any) => {
+               commit = onCommit;
+               return dialog;
+            });
+
+         comp["showRangeSliderEditDialog"]();
+
+         expect(showDialog).toHaveBeenCalledTimes(1);
+
+         return { comp, dialog, viewsheetClient, commit: (range: any) => commit(range) };
+      }
+
+      it("should use the time-of-day increment and valid Dates for the current selection", () => {
+         const { dialog } = openEditDialog();
+
+         expect(dialog.timeIncrement).toBe(TIME_OF_DAY_INCREMENT);
+         expect(dialog.currentMin).toEqual(timeOfDay("01:30"));
+         expect(dialog.currentMax).toEqual(timeOfDay("06:30"));
+         expect(dialog.initForm).toHaveBeenCalledTimes(1);
+      });
+
+      it("should seed the dialog range from the first and last tick", () => {
+         const { dialog } = openEditDialog();
+
+         expect(dialog.rangeMin).toEqual(timeOfDay("00:00"));
+         expect(dialog.rangeMax).toEqual(timeOfDay("23:30"));
+      });
+
+      it("should snap a committed time range onto the matching tick indexes", () => {
+         const { comp, commit } = openEditDialog({ selectStart: 0, selectEnd: 1 });
+
+         commit({ min: timeOfDay("03:00"), max: timeOfDay("08:30") });
+
+         expect(comp.model.labels[comp.model.selectStart]).toBe("03:00");
+         expect(comp.model.labels[comp.model.selectEnd]).toBe("08:30");
+      });
+
+      it("should send the updated selection to the server after a commit", () => {
+         const { commit, viewsheetClient } = openEditDialog({ selectStart: 0, selectEnd: 1 });
+
+         commit({ min: timeOfDay("03:00"), max: timeOfDay("08:30") });
+
+         expect(viewsheetClient.sendEvent).toHaveBeenCalled();
+      });
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/objects/range-slider/vs-range-slider.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/range-slider/vs-range-slider.component.ts
@@ -44,7 +44,8 @@ import { ModelService } from "../../../widget/services/model.service";
 import { DialogService } from "../../../widget/slide-out/dialog-service.service";
 import { RangeSliderActions } from "../../action/range-slider-actions";
 import { ContextProvider } from "../../context-provider.service";
-import { RangeSliderEditDialog } from "../../dialog/range-slider-edit-dialog.component";
+import { RangeSliderEditDialog, TIME_BASE_DATE, TIME_OF_DAY_INCREMENT }
+   from "../../dialog/range-slider-edit-dialog.component";
 import { RangeSliderPropertyDialog } from "../../dialog/range-slider-property-dialog.component";
 import { ApplySelectionListEvent } from "../../event/apply-selection-list-event";
 import { ChangeVSObjectTextEvent } from "../../event/change-vs-object-text-event";
@@ -772,6 +773,7 @@ export class VSRangeSlider extends NavigationComponent<VSRangeSliderModel>
                                           this.model.values[this.model.labels.length - 1]);
 
          const normalizeStr = (s: string) =>
+            timeIncrement === TIME_OF_DAY_INCREMENT ? `${TIME_BASE_DATE}T${s}` :
             timeIncrement === "t" ? s.replace(" ", "T") : s + "T00:00";
 
          editDialog.currentMin = new Date(normalizeStr(currMinStr));
@@ -794,11 +796,22 @@ export class VSRangeSlider extends NavigationComponent<VSRangeSliderModel>
    private extractTimeIncrement(value: string): string {
       const typeMatch = value.match(/^\{([a-zA-Z]+)\s+'/);
       if(typeMatch) {
-         return typeMatch[1].charAt(0);
+         // the server writes the tick values as y/m/d (date levels), t (time of day) or
+         // ts (timestamp). t and ts must be kept apart, they need different input types.
+         switch(typeMatch[1]) {
+         case "t":
+            return TIME_OF_DAY_INCREMENT;
+         case "ts":
+            return "t";
+         default:
+            return typeMatch[1].charAt(0);
+         }
       }
       const sanitized = value.replace(/[a-zA-Z'"{}]/g, "").trim();
-      if(sanitized.includes(":")) { return "t"; }
       const dashCount = (sanitized.match(/-/g) || []).length;
+      if(sanitized.includes(":")) {
+         return dashCount === 0 ? TIME_OF_DAY_INCREMENT : "t";
+      }
       return dashCount === 0 ? "y" : dashCount === 1 ? "m" : "d";
    }
 
@@ -811,6 +824,7 @@ export class VSRangeSlider extends NavigationComponent<VSRangeSliderModel>
          case "d":
             return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
          case "t":
+         case TIME_OF_DAY_INCREMENT:
             return date.getTime();
          default:
             throw new Error(`Unrecognised timeIncrement value: "${timeIncrement}"`);
@@ -820,6 +834,10 @@ export class VSRangeSlider extends NavigationComponent<VSRangeSliderModel>
    private labelToTimestamp(timeIncrement: string, value: string): number {
       const match = value.match(/\{[a-zA-Z]+\s+'(.+)'\s*}/);
       const sanitized = match ? match[1] : value.replace(/[a-zA-Z'"{}]/g, "").trim();
+
+      if (timeIncrement === TIME_OF_DAY_INCREMENT) {
+         return new Date(`${TIME_BASE_DATE}T${sanitized}`).getTime();
+      }
 
       if (timeIncrement === "t") {
          return new Date(sanitized.replace(" ", "T")).getTime();
@@ -878,7 +896,8 @@ export class VSRangeSlider extends NavigationComponent<VSRangeSliderModel>
             return { currMinStr, currMaxStr, rangeMinStr, rangeMaxStr };
          }
          case "d":
-         case "t": {
+         case "t":
+         case TIME_OF_DAY_INCREMENT: {
             return this.sanitizeDateLabels(selectStart, selectEnd, rangeMin, rangeMax);
          }
          default : {


### PR DESCRIPTION
Redmine Bug #76520

## Problem

Right-clicking a RangeSlider bound to a column of data type `time` (time of day only, e.g. `01:30`, `06:30`) and choosing **Edit** opened a broken dialog:

- From/To rendered as `datetime-local` inputs (`mm/dd/yyyy --:-- --`) instead of time-only inputs.
- Both fields were empty even though the slider had a valid selected range.
- A spurious "From and To values cannot be equal" error was shown while both fields were blank.

## Root cause

A `TIME` column gets `rangeType = MINUTE_OF_DAY` (`VSBindingService`; `HOUR_OF_DAY`/`MINUTE_OF_DAY` are the only range types offered for `TIME`). That range type serializes tick values with `Tool.timeFmt` = `{'t' ''HH:mm:ss''}`, so `VSRangeSliderModel.values[]` holds strings like `{t '01:30:00'}` while the labels are `HH:mm`.

`VSRangeSlider.extractTimeIncrement()` returned `typeMatch[1].charAt(0)`. The five value tokens the server writes are `y`, `m`, `d`, `t` and `ts`, so taking the first character collapsed **`t` (time of day) and `ts` (timestamp) into the same `"t"` increment** — a single defect that produced all three symptoms:

1. `"t"` means "date + time" downstream, so `normalizeStr` built the dialog bounds as `new Date("01:30:00")` → **Invalid Date**.
2. `rangeMin instanceof Date` is still `true` for an Invalid Date, so `isDateType = true` with `timeIncrement === "t"` selected the `datetime-local` input.
3. `formatDate()` on an Invalid Date returned `"NaN-NaN-NaNTNaN:NaN"`, which the browser rejects → **blank fields**; and both controls held that identical string, so `minMaxNotEqual()` fired → **the equality error**.

The commit path was broken the same way: `labelToTimestamp("t", "{t '01:30:00'}")` also evaluated `new Date("01:30:00")` → `NaN`, so no tick could ever match even if valid input were entered.

## Fix

Give time of day its own increment, keyed off the **value token** rather than the column data type — the value format is the actual source of truth and stays correct however range type and column type combine.

**`vs-range-slider.component.ts`**
- `extractTimeIncrement()` maps the brace token exactly: `t` → the new time-of-day increment, `ts` → `"t"`, `y`/`m`/`d` unchanged. The unescaped fallback now uses the dash count to tell time-only from date-time.
- `normalizeStr`, `getDateStrings()`, `toIncrementTimestamp()` and `labelToTimestamp()` handle the new increment, anchoring the time to a fixed base date so all client-side comparisons stay consistent.

**`range-slider-edit-dialog.component.ts` / `.html`**
- Exports the shared `TIME_OF_DAY_INCREMENT` / `TIME_BASE_DATE` constants so the host and the dialog cannot drift apart.
- Renders `<input type="time">` for the new increment; `formatDate()` emits `HH:mm`, matching the labels the slider itself shows.
- The duplicated parse ternaries in the two range validators and both `valueChanges` subscriptions are consolidated into one private `toDate()` helper.

`isDateType`, `minBeforeMax()` and `minMaxNotEqual()` needed no change — the bounds are now valid `Date`s, and `"01:30"` vs `"06:30"` compares correctly as strings.

Frontend only; no backend change.

### Side effects considered

- `extractTimeIncrement()` has exactly one call site, so the token-mapping change is contained.
- `y`/`m`/`d`/`ts` keep their existing increment codes, so date and timestamp sliders behave exactly as before.
- `<input type="time">` yields `HH:mm`, dropping the `:ss` from the server value. `MINUTE_OF_DAY`/`HOUR_OF_DAY` ticks always land on whole minutes/hours and the commit handler snaps to the nearest tick index, so no precision is lost.
- Composite (multi-column) range sliders leave `dataType` null and already fall into the numeric branch — a separate pre-existing gap, out of scope here.

## Testing

- New `vs-range-slider.component.timeofday.tl.spec.ts` (10 tests): token mapping (`{t}` vs `{ts}` vs `y`/`m`/`d`, plus the unescaped fallback), timestamp anchoring, dialog seeding with valid `Date`s, and the commit snap-to-tick round-trip.
- New Group 9 in `range-slider-edit-dialog.component.tl.spec.ts` (7 tests): a single `input[type=time]` per field, `HH:mm` seeding, absence of the spurious `minMaxEqual` error, time-only parsing, and the boundary validators.
- All new tests fail against the pre-fix code.
- All 5 range-slider TL spec files pass (152 tests). All `vsobjects` standard specs pass (304 tests). ESLint clean on the changed files.
- Verified manually against a running server on a `time`-typed binding: From/To are time pickers pre-filled with the current selection, no validation error, and editing the range updates the slider and dependent assemblies.

Note: the full `portal:test-tl` suite is unstable on `main` independently of this change (baseline with the change stashed: 28 failed files / 265 failed tests; with the change: 29 / 202 — counts vary run to run, and no failures are in range-slider specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
