### PR TITLE
Bug #76509, fix mini-toolbar covered by outer content inside an embedded viewsheet

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -44,7 +44,8 @@
         [class.max-mode]="vsObject.maxMode"
         [class.force-show-toolbar]="forceShowMiniToolbar && isFocused(vsObject)"
         [style.z-index]="getContainerZIndex(vsObject)"
-        (click)="select(i, $event)" (mouseenter)="onMouseEnter(vsObject, $event)">
+        (click)="select(i, $event)" (mouseenter)="onMouseEnter(vsObject, $event)"
+        (mouseleave)="onMouseLeave(vsObject)">
         @if (vsObject.objectType == 'VSAnnotation') {
           <vs-annotation
             (remove)="removeAnnotations.emit()"

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.spec.ts
@@ -73,3 +73,81 @@ describe("VSObjectContainer z-index boost tiering", () => {
       expect(comp.getContainerZIndex(embeddedVs)).toBe(3 + comp.popUpContentBoostZIndex * 2);
    });
 });
+
+// Bug: the mini-toolbar of an assembly inside an embedded viewsheet is painted 28px *above*
+// that viewsheet's box (MiniToolbar.topY / the forceAbove binding) but is ranked inside the
+// embedded viewsheet assembly's own stacking context, so an outer assembly with a higher
+// z-index painted over it. Verified in a browser against Examples/Hurricane: the toolbar stayed
+// occluded even at z-index 999999, because no descendant z-index can escape its context --
+// which is why the #75916 MINI_TOOLBAR_MIN_ZINDEX floor cannot address this case and the
+// embedded viewsheet's own container has to be lifted instead.
+describe("VSObjectContainer embedded-viewsheet hover boost", () => {
+   const embeddedVs = () => makeVSObject({
+      absoluteName: "Map1", objectType: "VSViewsheet", objectFormat: { zIndex: 6 } as any,
+   });
+
+   it("leaves an un-hovered embedded viewsheet at its authored z-index", () => {
+      const { comp } = makeComponent();
+      expect(comp.getContainerZIndex(embeddedVs())).toBe(6);
+   });
+
+   it("lifts a hovered embedded viewsheet above an outer sibling that outranks it", () => {
+      const { comp } = makeComponent();
+      const vs = embeddedVs();
+      // Examples/Hurricane's real z-order: Map1=6 but Image1/Image2=1006/1007 and, in the
+      // reported case, the banner text outranked the embedded viewsheet too.
+      const outerSibling = makeVSObject({ absoluteName: "Text2", objectFormat: { zIndex: 1005 } as any });
+
+      comp.onMouseEnter(vs, null);
+
+      expect(comp.isHoveredEmbeddedViewsheet(vs)).toBe(true);
+      expect(comp.getContainerZIndex(vs)).toBeGreaterThan(comp.getContainerZIndex(outerSibling));
+      // the toolbar of an assembly inside it rides along on the lifted context
+      expect(comp.getMiniToolbarZIndex(vs)).toBeGreaterThan(comp.getContainerZIndex(outerSibling));
+   });
+
+   it("restores the authored z-index on mouseleave so outer assemblies layer normally again", () => {
+      const { comp } = makeComponent();
+      const vs = embeddedVs();
+
+      comp.onMouseEnter(vs, null);
+      comp.onMouseLeave(vs);
+
+      expect(comp.isHoveredEmbeddedViewsheet(vs)).toBe(false);
+      expect(comp.getContainerZIndex(vs)).toBe(6);
+   });
+
+   it("does not boost a non-embedded-viewsheet assembly on hover", () => {
+      const { comp } = makeComponent();
+      const chart = makeVSObject({ absoluteName: "Chart1", objectFormat: { zIndex: 6 } as any });
+
+      comp.onMouseEnter(chart, null);
+
+      expect(comp.isHoveredEmbeddedViewsheet(chart)).toBe(false);
+      expect(comp.getContainerZIndex(chart)).toBe(6);
+   });
+
+   it("only boosts the embedded viewsheet actually hovered", () => {
+      const { comp } = makeComponent();
+      const hovered = embeddedVs();
+      const other = makeVSObject({
+         absoluteName: "Viewsheet1", objectType: "VSViewsheet", objectFormat: { zIndex: 1008 } as any,
+      });
+
+      comp.onMouseEnter(hovered, null);
+
+      expect(comp.getContainerZIndex(other)).toBe(1008);
+      expect(comp.onMouseLeave(other as any)).toBeUndefined();
+      // a mouseleave from a *different* embedded viewsheet must not clear the hovered one
+      expect(comp.isHoveredEmbeddedViewsheet(hovered)).toBe(true);
+   });
+
+   it("keeps the hover boost below the pop-component/data-tip tiers", () => {
+      const { comp } = makeComponent();
+      const vs = embeddedVs();
+
+      comp.onMouseEnter(vs, null);
+
+      expect(comp.getContainerZIndex(vs)).toBeLessThan(6 + comp.popUpContentBoostZIndex);
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -194,6 +194,9 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
    public containerHasVerticalScrollbar = true;
    private subscriptions = new Subscription();
    public forceShowMiniToolbar: boolean = false;
+   // absoluteName of the embedded viewsheet (VSViewsheet) the pointer is currently inside, if
+   // any -- see getContainerZIndex/isHoveredEmbeddedViewsheet.
+   private hoveredEmbeddedVS: string = null;
    protected maxZIndex: number;
    private _keyNavigation: Observable<FocusObjectEventModel>;
    private focusSub: Subscription;
@@ -599,7 +602,19 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
    // embedded-viewsheet or max-mode assemblies), easily exceeding any hardcoded CSS z-index.
    getContainerZIndex(vsObject: VSObjectModel): number {
       if(!this.isActivePopComponent(vsObject) && !this.needsZIndexBoost(vsObject)) {
-         return this.zIndex(vsObject);
+         // The mini-toolbar of an assembly *inside* an embedded viewsheet is painted above that
+         // viewsheet's own box (MiniToolbar.topY subtracts MINI_TOOLBAR_HEIGHT, and the
+         // forceAbove binding forces that even for an assembly at the embedded viewsheet's very
+         // top) while still being ranked inside this element's stacking context. It therefore
+         // cannot escape this context no matter how large getMiniToolbarZIndex() makes it, so an
+         // outer assembly with a higher z-index paints over it (#75916 follow-up). Lift the whole
+         // embedded viewsheet while it is hovered. Only while hovered: outer assemblies are
+         // legitimately authored above an embedded viewsheet, and permanently reordering them
+         // would break those layouts. The boost stays well below popUpContentBoostZIndex so it
+         // never competes with the max-mode/pop-component/data-tip tiers below.
+         return this.isHoveredEmbeddedViewsheet(vsObject)
+            ? this.zIndex(vsObject) + GuiTool.MINI_TOOLBAR_MIN_ZINDEX
+            : this.zIndex(vsObject);
       }
 
       const isDataTipBoost = this.isActiveDataTipBoost(vsObject);
@@ -859,6 +874,28 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
 
    onMouseEnter(vsObject: VSObjectModel, event: any): void {
       this.miniToolbarService.handleMouseEnter(vsObject?.absoluteName, event);
+
+      if(vsObject?.objectType === "VSViewsheet") {
+         this.hoveredEmbeddedVS = vsObject.absoluteName;
+      }
+   }
+
+   // Paired with onMouseEnter's VSViewsheet arm. The mini-toolbars of the assemblies inside an
+   // embedded viewsheet are DOM descendants of that assembly's ".vs-object-parent-container",
+   // so moving the pointer from the embedded content onto one of those toolbars does not fire
+   // mouseleave here -- the boost survives long enough to click a toolbar button.
+   onMouseLeave(vsObject: VSObjectModel): void {
+      if(vsObject?.objectType === "VSViewsheet" &&
+         this.hoveredEmbeddedVS === vsObject.absoluteName)
+      {
+         this.hoveredEmbeddedVS = null;
+      }
+   }
+
+   // True while the pointer is inside this embedded viewsheet (or one of its assemblies'
+   // mini-toolbars). See getContainerZIndex for why that has to lift the whole subtree.
+   isHoveredEmbeddedViewsheet(vsObject: VSObjectModel): boolean {
+      return !!this.hoveredEmbeddedVS && this.hoveredEmbeddedVS === vsObject.absoluteName;
    }
 
    getChartDataAnnotations(vsObject: VSObjectModel): VSAnnotationModel[] {


### PR DESCRIPTION
## Problem

The per-assembly hover toolbar of a chart **inside an embedded viewsheet** renders only
partially — its upper portion is painted over by outer viewsheet content. Reported against
`Examples/Hurricane` embedded via the `<inetsoft-viewer>` web component.

The toolbar is drawn 28px *above* the embedded viewsheet's own box (`MiniToolbar.topY`
subtracts `MINI_TOOLBAR_HEIGHT`, and the `forceAbove` binding applies that even for an
assembly at the embedded viewsheet's very top) while still being **ranked inside** the
embedded viewsheet assembly's stacking context. Any outer assembly with a higher z-index
therefore paints over it.

Measured live on `Examples/Hurricane` (web component, 1250x830):

| element | z-index | painted rect |
|---|---|---|
| `Text1` / `Text2` (banner) | 2 / 3 | y 41–95 / y 92–128 (full width) |
| **`Map1`** → embedded `HurricaneL` | **6** | y 140 |
| `Image1` / `Image2` | 1006 / 1007 | y 48–92 |
| `Viewsheet1` → embedded `HurricaneR` | 1008 | y 140 |
| `Map1.Map` mini-toolbar | 9920 | **y 112–140**, confined by `embedded-viewsheet` z=6 |

## Why the z-index floor can't fix it

`getMiniToolbarZIndex()`'s `MINI_TOOLBAR_MIN_ZINDEX` floor (added in #75916) is the wrong
lever here. With an outer assembly at z-index 1005, the toolbar stayed occluded **even at
z-index 999999** — no descendant z-index escapes its stacking context. Verified in a browser.

Also worth recording, because it is easy to get wrong: the confining element is the **outer
`.vs-object-parent-container`** of the embedded viewsheet assembly, *not*
`div.embedded-viewsheet`. Both carry the same z-index and both are stacking contexts, but:

| experiment | hit-test on the toolbar's buttons |
|---|---|
| `Text2` → 1005 | occluded (bug reproduced) |
| `.embedded-viewsheet` → 99999 | **still occluded** |
| outer `.vs-object-parent-container` → 99999 | **toolbar on top** |

## Fix

`getContainerZIndex()` adds `GuiTool.MINI_TOOLBAR_MIN_ZINDEX` for the embedded viewsheet
currently under the pointer, tracked by `onMouseEnter` / a new `onMouseLeave`.

The boost is deliberately **transient**: outer assemblies are legitimately authored above an
embedded viewsheet (here `Map1`=6 vs `Image1`/`Image2`=1006/1007), so permanently lifting it
would break that layering. Hover scoping is reliable because the inner toolbars are DOM
descendants of the anchor, so moving the pointer onto a toolbar drawn *outside* the box does
not fire `mouseleave`. The boost stays well below `popUpContentBoostZIndex`, so it never
competes with the max-mode / pop-component / data-tip tiers.

## Verification

Page served from the data space `web-assets` folder at `/sree/WebComponentCase.html`, exactly
as the report specifies.

| scenario | `Map1` anchor z-index | result |
|---|---|---|
| Web component, as shipped, hovering left chart | 6 → 9926 | toolbar on top |
| Web component, `Text2` at 1005, not hovering | 6 | occluded (toolbar hidden anyway) |
| Web component, `Text2` at 1005, **hovering** | 6 → 9926 | **rescued** |
| Web component, right chart (`Viewsheet1`) | 1008 → 10928 | toolbar on top |
| Portal viewer, all of the above + the two selection lists | same | toolbar on top |

The anchor returns to its authored z-index when not hovered, so outer assemblies layer
normally again.

- 6 new regression tests in `vs-object-container.component.spec.ts`, including that the boost
  stays below the pop-component tier and that a mouseleave from a *different* embedded
  viewsheet does not clear the hovered one.
- Full portal suite: **106 files / 376 tests passed**. `tsc --noEmit` clean, eslint clean.

## Note for the reviewer

The shipped `Examples/Hurricane` does **not** reproduce the screenshot on current `main`:
`Text1`=2, `Text2`=3 and `Rectangle1`=1 all rank below `Map1`=6, at 1024/1280/1440 widths, in
both the embed and Portal routes. Reproducing the reported appearance required forcing an outer
assembly above the embedded viewsheet (`Text2` → 1005). This PR fixes the mechanism the
screenshot shows and the whole class of bug around it, but the trigger that put an outer
assembly above the embedded viewsheet in the reporter's run was not reproduced — worth checking
the banner text's layer order in the composer on the affected copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
