### PR TITLE
Bug #76515, order the "Others" bucket by its own group level

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/RunningTotalColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/RunningTotalColumn.java
@@ -159,7 +159,13 @@ public class RunningTotalColumn extends AbstractColumn {
 
          Object firstBreakByVal = baseData.getData(breakBy, row);
          long interval = getInterval(data, sortedRow);
-         Object currentInnerVal = (innerDim != null) ? baseData.getData(innerDim, row) : null;
+         // only accumulate by date when the accumulation dimension is a dimension of its
+         // own. when innerDim IS the breakBy column, every row of a group carries the
+         // same date, so a date walk would add the whole group to every row; the order
+         // then lives in the row order and nowhere else -- it may even be a dimension
+         // innerDim cannot see, such as a colour aesthetic. (74910)
+         Object currentInnerVal = innerDim != null && !Tool.equals(innerDim, breakBy)
+            ? baseData.getData(innerDim, row) : null;
 
          if(currentInnerVal instanceof Date) {
             // Root dataset row order may not be chronological when sort-by-value
@@ -203,6 +209,10 @@ public class RunningTotalColumn extends AbstractColumn {
                }
             }
          }
+         // accumulate backwards through the root dataset until the breakBy value
+         // changes. the query is responsible for establishing that row order, and for
+         // the "Others" bucket SummaryFilter.MergedGroupNode.sortMergedNodes() is what
+         // puts the merged rows back into their own group level's order.
          else {
             for(int i = row; i >= 0; i--) {
                Object breakByVal = baseData.getData(breakBy, i);

--- a/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/SummaryFilter.java
@@ -2388,7 +2388,9 @@ public class SummaryFilter extends AbstractGroupedTable
          this.row = first.row;
 
          includedRows = new SparseBitSet();
-         Map<String, List<GroupNode>> subgroups = new HashMap<>();
+         // linked so the gathered order is at least deterministic; sortMergedNodes()
+         // below puts the children back into their own group level's order
+         Map<String, List<GroupNode>> subgroups = new LinkedHashMap<>();
 
          for(GroupNode node : list) {
             // copy named group values. (51822)
@@ -2412,6 +2414,44 @@ public class SummaryFilter extends AbstractGroupedTable
                   nodes.add(subgroup.get(0));
                }
             }
+
+            sortMergedNodes();
+         }
+      }
+
+      /**
+       * Restore the group ordering of the merged children.
+       *
+       * The children are gathered from several parent groups, so the order they end up
+       * in here is the order the sub-groups happened to be collected in, not the order
+       * defined for their own group level. Every other group at this level is ordered,
+       * and the order-dependent calculations (running total, moving, change/previous)
+       * read the resulting row order, so the "Others" bucket has to be ordered the same
+       * way. (74910)
+       */
+      private void sortMergedNodes() {
+         if(nodes == null || nodes.size() < 2) {
+            return;
+         }
+
+         int lvl = nodes.get(0).level;
+
+         // only a uniform level has a single group order to sort by. a hierarchy merge
+         // mixes levels, so it is left in the order it was gathered in
+         for(GroupNode child : nodes) {
+            if(child.level != lvl) {
+               return;
+            }
+         }
+
+         if(lvl < 0 || lvl >= cols.length) {
+            return;
+         }
+
+         SortOrder order = getGroupOrder(cols[lvl]);
+
+         if(order != null && order.getOrder() != StyleConstants.SORT_NONE) {
+            nodes.sort(new GroupNodeComparer2(order));
          }
       }
 

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/RunningTotalColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/RunningTotalColumnTest.java
@@ -444,6 +444,165 @@ public class RunningTotalColumnTest {
       assertEquals(10.0, result);
    }
 
+   /**
+    * Break-by running sum where several rows share the same break-by value, and the
+    * break-by column is also the inner dimension (the shape produced by a point chart
+    * whose second dimension is a colour aesthetic, so it is not part of innerDim).
+    *
+    * Each row must get its own running value in root row order -- not the group total.
+    */
+   @Test
+   void testRunningSumBreakByRunsWithinGroup() {
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         {"order_date", "hour", "id"},
+         {toDate("2002-02-06"), null, 2},
+         {toDate("2002-02-06"), toDate("2002-02-06"), 2},
+         {toDate("2002-02-08"), toDate("2002-02-08"), 2}
+      });
+
+      runningTotalColumn = new RunningTotalColumn("id", "sum(id)");
+      runningTotalColumn.setInnerDim("order_date");
+      runningTotalColumn.setBreakBy("order_date");
+      runningTotalColumn.setResetLevel(RunningTotalColumn.NONE);
+      runningTotalColumn.setFormula(new SumFormula());
+
+      vsDataSet = createVSDataSet(tb, new String[]{"order_date", "hour"});
+
+      // first row of the 2002-02-06 group: its own value only, not the group total
+      assertEquals(2.0, runningTotalColumn.calculate(vsDataSet, 0, false, false));
+
+      // second row of the same group: 2+2
+      assertEquals(4.0, runningTotalColumn.calculate(vsDataSet, 1, false, false));
+
+      // break-by value changed, so the total resets
+      assertEquals(2.0, runningTotalColumn.calculate(vsDataSet, 2, false, false));
+   }
+
+   /**
+    * Break-by running sum over a non-date break-by value -- the "Others" bucket label a
+    * top-N ranking produces on a date dimension -- including a null measure. The running
+    * sum must be monotonically increasing across the bucket and reset when the label
+    * changes.
+    */
+   @Test
+   void testRunningSumBreakByOthersBucket() {
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         {"order_date", "hour", "id"},
+         {"Others", toDate("2002-01-05"), 4},
+         {"Others", toDate("2002-01-06"), null},
+         {"Others", toDate("2002-01-11"), 3},
+         {"Others", toDate("2002-01-12"), 4},
+         {toDate("2002-01-15"), toDate("2002-01-15"), 2}
+      });
+
+      runningTotalColumn = new RunningTotalColumn("id", "sum(id)");
+      runningTotalColumn.setInnerDim("order_date");
+      runningTotalColumn.setBreakBy("order_date");
+      runningTotalColumn.setResetLevel(RunningTotalColumn.NONE);
+      runningTotalColumn.setFormula(new SumFormula());
+
+      vsDataSet = createVSDataSet(tb, new String[]{"order_date", "hour"});
+
+      List<Object> results = Arrays.asList(
+         runningTotalColumn.calculate(vsDataSet, 0, false, false),
+         runningTotalColumn.calculate(vsDataSet, 1, false, false),
+         runningTotalColumn.calculate(vsDataSet, 2, false, false),
+         runningTotalColumn.calculate(vsDataSet, 3, false, false));
+
+      // null counts as 0, so the sequence still never decreases
+      assertEquals(Arrays.asList(4.0, 4.0, 7.0, 11.0), results);
+
+      // the label changed, so the total resets
+      assertEquals(2.0, runningTotalColumn.calculate(vsDataSet, 4, false, false));
+   }
+
+   /**
+    * A break-by group spanning many rows must never produce a decreasing running sum
+    * when all the accumulated values are non-negative.
+    */
+   @Test
+   void testRunningSumBreakByIsMonotonic() {
+      Object[][] rows = new Object[8][];
+      rows[0] = new Object[]{"order_date", "hour", "id"};
+
+      for(int i = 1; i < rows.length; i++) {
+         rows[i] = new Object[]{ "Others", toDate("2002-03-0" + i), i };
+      }
+
+      DefaultTableLens tb = new DefaultTableLens(rows);
+
+      runningTotalColumn = new RunningTotalColumn("id", "sum(id)");
+      runningTotalColumn.setInnerDim("order_date");
+      runningTotalColumn.setBreakBy("order_date");
+      runningTotalColumn.setResetLevel(RunningTotalColumn.NONE);
+      runningTotalColumn.setFormula(new SumFormula());
+
+      vsDataSet = createVSDataSet(tb, new String[]{"order_date", "hour"});
+
+      double previous = 0;
+
+      for(int row = 0; row < rows.length - 1; row++) {
+         double current = (Double) runningTotalColumn.calculate(vsDataSet, row, false, false);
+
+         assertTrue(current >= previous,
+                    "running sum decreased at row " + row + ": " + previous + " -> " + current);
+         previous = current;
+      }
+
+      // 1+2+...+7
+      assertEquals(28.0, previous);
+   }
+
+   /**
+    * Break-by running max where the accumulation dimension (innerDim) is a date column
+    * distinct from the break-by column, and the rows are NOT in chronological order
+    * because the date dimension is sorted by value.
+    *
+    * The running value must follow the dates, not the row order. (74910)
+    */
+   @Test
+   void testRunningMaxBreakByFollowsDateNotRowOrder() {
+      // rows deliberately out of chronological order, as sort-by-value leaves them
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         {"reseller", "quarter", "sd"},
+         {"false", toDate("2003-01-01"), 13.4748},
+         {"false", toDate("2002-01-01"), 11.3225},
+         {"false", toDate("2002-10-01"), 8.2967},
+         {"true", toDate("2005-07-01"), 11.6802},
+         {"true", toDate("2002-01-01"), 9.8476},
+         {"true", toDate("2002-04-01"), 9.3286}
+      });
+
+      runningTotalColumn = new RunningTotalColumn("sd", "max(sd)");
+      runningTotalColumn.setInnerDim("quarter");
+      runningTotalColumn.setBreakBy("reseller");
+      runningTotalColumn.setResetLevel(RunningTotalColumn.NONE);
+      runningTotalColumn.setFormula(new MaxFormula());
+
+      vsDataSet = createVSDataSet(tb, new String[]{"reseller", "quarter"});
+
+      // 2003-01-01 is chronologically last in its group, so it sees all three
+      assertEquals(13.4748, (Double) runningTotalColumn.calculate(vsDataSet, 0, false, false),
+                   1e-9);
+
+      // 2002-01-01 is chronologically first: its own value only, even though a larger
+      // value sits above it in row order
+      assertEquals(11.3225, (Double) runningTotalColumn.calculate(vsDataSet, 1, false, false),
+                   1e-9);
+
+      // 2002-10-01 follows 2002-01-01, so the max is still 11.3225
+      assertEquals(11.3225, (Double) runningTotalColumn.calculate(vsDataSet, 2, false, false),
+                   1e-9);
+
+      // second break-by group accumulates independently
+      assertEquals(11.6802, (Double) runningTotalColumn.calculate(vsDataSet, 3, false, false),
+                   1e-9);
+      assertEquals(9.8476, (Double) runningTotalColumn.calculate(vsDataSet, 4, false, false),
+                   1e-9);
+      assertEquals(9.8476, (Double) runningTotalColumn.calculate(vsDataSet, 5, false, false),
+                   1e-9);
+   }
+
    private CrossFilter.Tuple createCrosstabFilterTuple(Object value) {
       return new CrossFilter.Tuple(new Object[] { value });
    }

--- a/core/src/test/java/inetsoft/report/filter/SummaryFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/SummaryFilterTest.java
@@ -367,6 +367,78 @@ public class SummaryFilterTest {
       Assertions.assertEquals(SummaryFilter.class, deserializedTable.getClass());
    }
 
+   /**
+    * The rows merged into the "Others" bucket must be ordered by their own group level's
+    * sort order, the same as every other group at that level. Gathering them from
+    * several parent groups must not leave them in the order the parents were ranked in.
+    *
+    * This is the shape a chart with a top-N "sort by value" outer dimension produces, and
+    * order-dependent calculations (running total, moving, change/previous) read the
+    * resulting row order. (74910)
+    */
+   @Test
+   public void othersBucketKeepsInnerGroupOrder() {
+      // col1 is ranked by value so the outer groups are gathered out of col2 order;
+      // "d"/"e"/"f"/"g" all fall outside the top 2 and merge into "Others"
+      DefaultTableLens tbl1 = new DefaultTableLens(new Object[][] {
+         {"col1", "col2", "col3"},
+         {"a", 1, 50},
+         {"b", 2, 40},
+         {"d", 7, 4},
+         {"e", 3, 3},
+         {"f", 9, 2},
+         {"g", 5, 1}
+      });
+
+      final SummaryFilter summary =
+         new SummaryFilter(tbl1, new int[] {0, 1}, new int[] {2}, new SumFormula(), null);
+      summary.setGroupOrder(1, new SortOrder(XConstants.SORT_ASC));
+      summary.setTopN(0, 0, 2, false, true, true);
+      summary.moreRows(Integer.MAX_VALUE);
+
+      XTableUtil.assertEquals(summary, new Object[][] {
+         {"col1", "col2", "col3"},
+         {"a", 1, 50.0},
+         {"b", 2, 40.0},
+         {"Others", 3, 3.0},
+         {"Others", 5, 1.0},
+         {"Others", 7, 4.0},
+         {"Others", 9, 2.0},
+      });
+   }
+
+   /**
+    * A descending inner group order must be honoured inside the "Others" bucket too.
+    */
+   @Test
+   public void othersBucketKeepsInnerGroupOrderDesc() {
+      DefaultTableLens tbl1 = new DefaultTableLens(new Object[][] {
+         {"col1", "col2", "col3"},
+         {"a", 1, 50},
+         {"b", 2, 40},
+         {"d", 7, 4},
+         {"e", 3, 3},
+         {"f", 9, 2},
+         {"g", 5, 1}
+      });
+
+      final SummaryFilter summary =
+         new SummaryFilter(tbl1, new int[] {0, 1}, new int[] {2}, new SumFormula(), null);
+      summary.setGroupOrder(1, new SortOrder(XConstants.SORT_DESC));
+      summary.setTopN(0, 0, 2, false, true, true);
+      summary.moreRows(Integer.MAX_VALUE);
+
+      XTableUtil.assertEquals(summary, new Object[][] {
+         {"col1", "col2", "col3"},
+         {"a", 1, 50.0},
+         {"b", 2, 40.0},
+         {"Others", 9, 2.0},
+         {"Others", 7, 4.0},
+         {"Others", 5, 1.0},
+         {"Others", 3, 3.0},
+      });
+   }
+
    private Date date(String date) {
       return new Date(LocalDate.parse(date).atStartOfDay()
                          .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());


### PR DESCRIPTION
## Problem

A chart with a "Running Sum" calc broken by a dimension produced a non-monotonic sequence whenever a dimension bucket spanned more than one row — a cumulative sum of non-negative values that decreases.

Both the buggy and the correct output are internally consistent running sums totalling 40; only the accumulation order differed. Reconstructing the root row order from the values shows the correct order is chronological by the inner dimension, while the buggy one was arbitrary.

## Cause

**`SummaryFilter.MergedGroupNode`** gathered the children of the "Others" bucket into a `HashMap` and built the merged node by iterating its values, so the bucket's rows came out in hash order. `topNFilter` recurses bottom-up, so the bucket is assembled *after* its children have been sorted, and nothing put the gathered list back in order. Every other group at that level is ordered, and the order-dependent calculations (running total, moving, change/previous) read the resulting row order, so the bucket has to be ordered the same way.

**`RunningTotalColumn`** separately summed the whole group onto every row of it when the break-by column was itself the innermost dimension. The date walk added by #74910 compares `innerDim` dates, and with `innerDim == breakBy` every row of a group carries the same date, so `date <= currentDate` matched all of them.

## Fix

- Gather into a `LinkedHashMap` and sort the merged children by their own group level's `SortOrder`, reusing the existing `GroupNodeComparer2`. A `hierarchy` merge mixes levels and has no single order to apply, so it is left as gathered.
- Take the date walk only when the accumulation dimension is a dimension of its own. Otherwise the order lives in the row order and nowhere else, since it may be a dimension `innerDim` cannot see — such as a colour aesthetic, which `GraphUtil.getSeriesDimensionsForCalc` excludes.

## Verification

Both assets exported from the same build:

| Issue | Result |
|---|---|
| #76515 — `Others` running sum | 25/25 rows identical to the accepted `expectData` baseline |
| #74910 — chronological running max | 32/32 rows match a chronological running max recomputed from the exported aggregate values |

#74910's baseline file is from an older data snapshot, so it was verified by recomputing the expected values from the export itself rather than diffing the stale text.

191 tests pass across 51 classes in `report.filter`, `report.composition.execution`, `report.composition.graph` and `report.composition.graph.calc`.

## Tests

6 new tests; `RunningTotalColumn`'s break-by path previously had no coverage at all. Each was verified to fail without its half of the fix:

- `SummaryFilterTest.othersBucketKeepsInnerGroupOrder` / `...Desc` — fail `expected: <3> but was: <5>` without `sortMergedNodes()`
- `RunningTotalColumnTest.testRunningSumBreakByRunsWithinGroup` — fails `expected: <2.0> but was: <4.0>` without the `innerDim != breakBy` guard
- `RunningTotalColumnTest.testRunningMaxBreakByFollowsDateNotRowOrder` — fails `expected: <11.3225> but was: <13.4748>` without the date walk

The last two are the important pair: they pin the two cases apart, so neither fix can be reintroduced in a way that regresses the other.

## Notes for review

- `SummaryFilter` is shared with crosstabs and reports, so this reaches further than a calculator-only change. The suites above pass, but crosstab top-N-with-Others output is worth a look.
- **#74916 is unverified** — I had no repro asset, and its group-ordering change is adjacent to this area.
- Unrelated, noted while tracing: `Plotter.java:337` passes `GTool.getDims(graph)[0]`, the *outermost* dimension, where every other call site passes the innermost. Not triggered by these charts (single X dimension) but it looks like a latent bug worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
