### PR TITLE
Bug #76508: fix the shape drop shadow in Print Layout preview and export

### DIFF
--- a/core/src/main/java/inetsoft/report/PageLayout.java
+++ b/core/src/main/java/inetsoft/report/PageLayout.java
@@ -19,13 +19,15 @@ package inetsoft.report;
 
 import inetsoft.graph.internal.GTool;
 import inetsoft.report.internal.*;
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.sree.SreeEnv;
 import inetsoft.uql.viewsheet.ShapeShadow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.*;
-import java.awt.geom.Point2D;
+import java.awt.geom.*;
+import java.awt.image.BufferedImage;
 import java.io.Serializable;
 
 /**
@@ -135,6 +137,85 @@ public class PageLayout implements Serializable, Cloneable {
        */
       public ShapeShadow getShadow() {
          return shadow;
+      }
+
+      /**
+       * Paint this shape's drop shadow, if it has one, behind the shape's own
+       * fill and outline.
+       *
+       * The shadow is rendered off-screen into a translucent image and drawn
+       * with drawImage rather than being filled straight onto g. That is not a
+       * detour: the tint (AlphaComposite.SrcIn) and the gaussian blur
+       * (ConvolveOp) that give a shadow its soft edge are both ignored by the
+       * PDF Graphics this is painted through, and so is the alpha of a plain
+       * setColor, which is why filling the offset shape directly produced a
+       * hard, fully opaque bar. PDFPrinter does emit a real 8-bit /SMask soft
+       * mask for a translucent image, so the blur and the configured opacity
+       * both survive this way, and the result matches what the viewsheet draws
+       * for the same shape.
+       *
+       * @param g the graphics to paint on.
+       * @param silhouette the shape's outline in the same (already scaled)
+       *                   coordinates paint() draws in.
+       */
+      protected void paintShadow(Graphics g, java.awt.Shape silhouette) {
+         ShapeShadow shadow = getShadow();
+
+         if(shadow == null || silhouette == null || !(g instanceof Graphics2D)) {
+            return;
+         }
+
+         java.awt.Rectangle bounds = silhouette.getBounds();
+
+         if(bounds.width <= 0 || bounds.height <= 0) {
+            return;
+         }
+
+         ShapeShadow scaled = scaleShadow(shadow);
+         Insets insets = ShapeShadowUtil.getShadowInsets(scaled);
+         BufferedImage img = new BufferedImage(bounds.width, bounds.height,
+                                               BufferedImage.TYPE_INT_ARGB);
+         Graphics2D ig = img.createGraphics();
+
+         try {
+            ig.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                                RenderingHints.VALUE_ANTIALIAS_ON);
+            ig.translate(-bounds.x, -bounds.y);
+            // only the alpha channel of this is used, the color is replaced
+            // by the shadow's own
+            ig.setColor(Color.BLACK);
+            ig.fill(silhouette);
+         }
+         finally {
+            ig.dispose();
+         }
+
+         BufferedImage layer = ShapeShadowUtil.createShadowLayer(img, scaled, insets);
+
+         if(layer != null) {
+            g.drawImage(layer, bounds.x - insets.left, bounds.y - insets.top, null);
+         }
+      }
+
+      /**
+       * Scale the shadow's distance and blur by the shape's own scale, so the
+       * shadow tracks the shape. They are configured in the viewsheet's pixel
+       * space and there is a single distance for both axes, so a non-uniform
+       * scale is averaged; in practice nothing sets a scale at all and this is
+       * the identity.
+       */
+      private ShapeShadow scaleShadow(ShapeShadow shadow) {
+         double scale = (xs + ys) / 2;
+
+         if(scale == 1) {
+            return shadow;
+         }
+
+         ShapeShadow scaled = (ShapeShadow) shadow.clone();
+         scaled.setDistance((int) Math.round(shadow.getDistance() * scale));
+         scaled.setBlur((int) Math.round(shadow.getBlur() * scale));
+
+         return scaled;
       }
 
       /**
@@ -537,26 +618,10 @@ public class PageLayout implements Serializable, Cloneable {
       public void paint(Graphics g) {
          Color oc = g.getColor();
 
-         // draw behind the shape's own fill/outline, matching the shadow
-         // direction convention ShapeShadow already establishes on the
-         // viewsheet side. paint(Graphics) is fed whatever the active
-         // export/print pipeline provides (PDF content-stream graphics,
-         // raster graphics, etc.) rather than a single BufferedImage, so this
-         // draws the shadow as its own filled shape offset by direction and
-         // distance instead of reusing VSFaceUtil.addShadow's raster blur --
-         // the blur radius is not applied here, a simplification accepted
-         // because a genuine Gaussian blur is not practical in a
-         // Graphics-only context.
-         ShapeShadow shadow = getShadow();
-
-         if(shadow != null) {
-            Graphics2D sg = (Graphics2D) g.create();
-            sg.translate((int) (shadow.getOffsetX() * xs), (int) (shadow.getOffsetY() * ys));
-            sg.setColor(shadow.getShadowColor());
-            sg.fillRect((int) (getX() * xs), (int) (getY() * ys),
-               (int) (getWidth() * xs), (int) (getHeight() * ys));
-            sg.dispose();
-         }
+         // behind the shape's own fill/outline, see Shape.paintShadow()
+         paintShadow(g, new Rectangle2D.Double(
+            (int) (getX() * xs), (int) (getY() * ys),
+            (int) (getWidth() * xs), (int) (getHeight() * ys)));
 
          if(fill != null) {
             Graphics2D g2 = (Graphics2D) g.create();
@@ -1038,18 +1103,10 @@ public class PageLayout implements Serializable, Cloneable {
       public void paint(Graphics g) {
          Color oc = g.getColor();
 
-         // see Rectangle.paint() for why this is an unblurred offset fill
-         // rather than VSFaceUtil.addShadow's raster blur.
-         ShapeShadow shadow = getShadow();
-
-         if(shadow != null) {
-            Graphics2D sg = (Graphics2D) g.create();
-            sg.translate((int) (shadow.getOffsetX() * xs), (int) (shadow.getOffsetY() * ys));
-            sg.setColor(shadow.getShadowColor());
-            sg.fillOval((int) (getX() * xs), (int) (getY() * ys),
-               (int) (getWidth() * xs), (int) (getHeight() * ys));
-            sg.dispose();
-         }
+         // behind the shape's own fill/outline, see Shape.paintShadow()
+         paintShadow(g, new Ellipse2D.Double(
+            (int) (getX() * xs), (int) (getY() * ys),
+            (int) (getWidth() * xs), (int) (getHeight() * ys)));
 
          if(fill != null) {
             Graphics2D g2 = (Graphics2D) g.create();

--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSFaceUtil.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSFaceUtil.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.report.gui.viewsheet;
 
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.sree.portal.PortalThemesManager;
 import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.uql.viewsheet.internal.VSUtil;
@@ -157,36 +158,15 @@ public class VSFaceUtil {
          return img;
       }
 
-      // tint the shape's alpha channel with the shadow color, positioned where
-      // the shadow falls, then blur that layer on its own so the blur can
-      // spread into the margins without softening the shape itself
-      BufferedImage layer = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_ARGB);
-      Graphics2D g2 = layer.createGraphics();
-
-      try {
-         g2.drawImage(img, insets.left + shadow.getOffsetX(),
-                      insets.top + shadow.getOffsetY(), null);
-         g2.setComposite(AlphaComposite.SrcIn);
-         g2.setColor(shadow.getShadowColor());
-         g2.fillRect(0, 0, outW, outH);
-      }
-      finally {
-         g2.dispose();
-      }
-
-      int blur = shadow.getBlurRadius();
-
-      // getGaussianBlurFilter requires a radius of at least 1
-      if(blur >= 1) {
-         layer = getGaussianBlurFilter(blur, true).filter(layer, null);
-         layer = getGaussianBlurFilter(blur, false).filter(layer, null);
-      }
-
+      BufferedImage layer = ShapeShadowUtil.createShadowLayer(img, shadow, insets);
       BufferedImage out = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_ARGB);
       Graphics2D g3 = out.createGraphics();
 
       try {
-         g3.drawImage(layer, 0, 0, null);
+         if(layer != null) {
+            g3.drawImage(layer, 0, 0, null);
+         }
+
          g3.drawImage(img, insets.left, insets.top, null);
       }
       finally {
@@ -215,50 +195,12 @@ public class VSFaceUtil {
       g2.fillRect(0, 0, shadow.getWidth(), shadow.getHeight());       
       g2.dispose();
       
-      shadow = getGaussianBlurFilter(size, true).filter(shadow, null);
-      shadow = getGaussianBlurFilter(size, false).filter(shadow, null);
+      shadow = ShapeShadowUtil.getGaussianBlurFilter(size, true).filter(shadow, null);
+      shadow = ShapeShadowUtil.getGaussianBlurFilter(size, false).filter(shadow, null);
       
       return shadow;
    }
     
-   private static ConvolveOp getGaussianBlurFilter(int radius,
-                                                   boolean horizontal) 
-   {
-      if(radius < 1) {
-         throw new IllegalArgumentException("Radius must be >= 1");
-      }
-      
-      int size = radius * 2 + 1;
-      float[] data = new float[size];
-      
-      float sigma = radius / 3.0f;
-      float twoSigmaSquare = 2.0f * sigma * sigma;
-      float sigmaRoot = (float) Math.sqrt(twoSigmaSquare * Math.PI);
-      float total = 0.0f;
-      
-      for(int i = -radius; i <= radius; i++) {
-         float distance = i * i;
-         int index = i + radius;
-         data[index] = (float) Math.exp(-distance / twoSigmaSquare) / sigmaRoot;
-         total += data[index];
-      }
-      
-      for(int i = 0; i < data.length; i++) {
-         data[i] /= total;
-      }        
-      
-      Kernel kernel = null;
-
-      if(horizontal) {
-         kernel = new Kernel(size, 1, data);
-      }
-      else {
-         kernel = new Kernel(1, size, data);
-      }
-
-      return new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, null);
-   }
-
    /**
     * Get theme id from theme name.
     * @param dsize the default size.

--- a/core/src/main/java/inetsoft/report/internal/ShapePaintable.java
+++ b/core/src/main/java/inetsoft/report/internal/ShapePaintable.java
@@ -18,6 +18,7 @@
 package inetsoft.report.internal;
 
 import inetsoft.report.*;
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.util.Encoder;
 import inetsoft.util.Tool;
 
@@ -87,6 +88,10 @@ public class ShapePaintable extends BasePaintable {
       Point trans = null;
       Rectangle vclip = getVirtualClip();
       boolean changed = false; // if clip or center changed
+      // a drop shadow falls outside the shape, so the band/page clip below has
+      // to be opened up by however far it reaches or a shape sitting flush
+      // against an edge of its band loses that side of its shadow
+      Insets shadow = ShapeShadowUtil.getShadowInsets(shape.getShadow());
 
       // set clipping region
       if(vclip != null && pageBox != null) {
@@ -117,7 +122,9 @@ public class ShapePaintable extends BasePaintable {
          int x2 = adjX(vclip.x + adj.x + vclip.width, true);
          int y2 = adjY(vclip.y + adj.y + vclip.height, true);
 
-         g.clipRect(x1, y1, x2 - x1, y2 - y1);
+         g.clipRect(x1 - shadow.left, y1 - shadow.top,
+                    (x2 - x1) + shadow.left + shadow.right,
+                    (y2 - y1) + shadow.top + shadow.bottom);
       }
       // if vclip is not set, use pageBox as the container
       else if(pageBox != null) {
@@ -130,8 +137,9 @@ public class ShapePaintable extends BasePaintable {
          }
 
          g.translate(adjX(trans.x, false), adjY(trans.y, false));
-         g.clipRect(0, 0, adjX(pageBox.width, true),
-		    adjY(pageBox.height, true));
+         g.clipRect(-shadow.left, -shadow.top,
+                    adjX(pageBox.width, true) + shadow.left + shadow.right,
+                    adjY(pageBox.height, true) + shadow.top + shadow.bottom);
       }
 
       // this avoids using DimGraphics in designer master layout mode

--- a/core/src/main/java/inetsoft/report/io/viewsheet/ShapeShadowUtil.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/ShapeShadowUtil.java
@@ -23,6 +23,7 @@ import inetsoft.uql.viewsheet.internal.*;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.*;
 
 /**
  * Helper for laying out the drop shadow of a shape assembly when exporting.
@@ -149,6 +150,116 @@ public final class ShapeShadowUtil {
     */
    public static Rectangle2D expandForShadow(Rectangle2D bounds, VSAssemblyInfo info) {
       return expandForShadow(bounds, info, 1);
+   }
+
+   /**
+    * Create just the blurred shadow layer of an image, with nothing of the
+    * image itself composited on top.
+    *
+    * This is the shared half of VSFaceUtil.addShadow(BufferedImage,
+    * ShapeShadow, Insets): the shape's alpha channel is tinted with the
+    * shadow color,
+    * positioned where the shadow falls, and blurred on its own so the blur can
+    * spread into the margins without softening the shape itself. Callers that
+    * paint the shape themselves -- the Print Layout shapes in
+    * PageLayout.Rectangle/Oval draw their own fill and outline through the
+    * export Graphics -- need the layer alone, and must get it from here so the
+    * blur stays defined in one place.
+    *
+    * The tint uses AlphaComposite.SrcIn and the blur a ConvolveOp, neither of
+    * which a PDF Graphics honours, so both must happen here on an off-screen
+    * image rather than against the destination.
+    *
+    * @param img the shape image, at its natural size. Only its alpha channel
+    *            matters; the color of its pixels is replaced by the shadow's.
+    * @param shadow the shadow settings.
+    * @param insets how far the shadow extends past each side of the shape, as
+    *               returned by {@link #getShadowInsets(ShapeShadow)}. The
+    *               shape occupies (insets.left, insets.top) in the layer.
+    * @return the shadow layer, or null if there is nothing to draw.
+    */
+   public static BufferedImage createShadowLayer(BufferedImage img,
+                                                 ShapeShadow shadow,
+                                                 Insets insets)
+   {
+      if(img == null || shadow == null || insets == null) {
+         return null;
+      }
+
+      int outW = img.getWidth() + insets.left + insets.right;
+      int outH = img.getHeight() + insets.top + insets.bottom;
+
+      if(outW <= 0 || outH <= 0) {
+         return null;
+      }
+
+      BufferedImage layer = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g2 = layer.createGraphics();
+
+      try {
+         g2.drawImage(img, insets.left + shadow.getOffsetX(),
+                      insets.top + shadow.getOffsetY(), null);
+         g2.setComposite(AlphaComposite.SrcIn);
+         g2.setColor(shadow.getShadowColor());
+         g2.fillRect(0, 0, outW, outH);
+      }
+      finally {
+         g2.dispose();
+      }
+
+      int blur = shadow.getBlurRadius();
+
+      // getGaussianBlurFilter requires a radius of at least 1
+      if(blur >= 1) {
+         layer = getGaussianBlurFilter(blur, true).filter(layer, null);
+         layer = getGaussianBlurFilter(blur, false).filter(layer, null);
+      }
+
+      return layer;
+   }
+
+   /**
+    * Build one axis of a separable gaussian blur kernel. Lives here rather
+    * than in VSFaceUtil so the report engine can blur a shadow without
+    * pulling in VSFaceUtil's static initializer, which reaches into the
+    * portal theme manager.
+    */
+   public static ConvolveOp getGaussianBlurFilter(int radius,
+                                                   boolean horizontal) 
+   {
+      if(radius < 1) {
+         throw new IllegalArgumentException("Radius must be >= 1");
+      }
+      
+      int size = radius * 2 + 1;
+      float[] data = new float[size];
+      
+      float sigma = radius / 3.0f;
+      float twoSigmaSquare = 2.0f * sigma * sigma;
+      float sigmaRoot = (float) Math.sqrt(twoSigmaSquare * Math.PI);
+      float total = 0.0f;
+      
+      for(int i = -radius; i <= radius; i++) {
+         float distance = i * i;
+         int index = i + radius;
+         data[index] = (float) Math.exp(-distance / twoSigmaSquare) / sigmaRoot;
+         total += data[index];
+      }
+      
+      for(int i = 0; i < data.length; i++) {
+         data[i] /= total;
+      }        
+      
+      Kernel kernel = null;
+
+      if(horizontal) {
+         kernel = new Kernel(size, 1, data);
+      }
+      else {
+         kernel = new Kernel(1, size, data);
+      }
+
+      return new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, null);
    }
 
    private static final Insets NO_SHADOW = new Insets(0, 0, 0, 0);

--- a/core/src/test/java/inetsoft/report/PageLayoutShapeShadowTest.java
+++ b/core/src/test/java/inetsoft/report/PageLayoutShapeShadowTest.java
@@ -28,11 +28,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Bug #76416 (#1): Print Layout rectangles/ovals never carried any shadow
- * state and never drew one. These are lightweight, scaffolding-free checks
- * (no existing PageLayout/PageLayout.Shape test coverage to extend) proving
- * the shadow field round-trips and paint() renders without throwing --
- * not a pixel-level assertion of the (intentionally unblurred, see
- * PageLayout.Rectangle/Oval.paint()) shadow rendering itself.
+ * state and never drew one. The follow-up to that fix replaced the unblurred,
+ * fully opaque offset fill it introduced with a real blurred, translucent
+ * shadow layer, so these go past "the field round-trips and paint() does not
+ * throw" and assert the pixels: that the shadow lands on the side the
+ * direction names, that it is translucent, and that it fades.
  */
 @Tag("core")
 class PageLayoutShapeShadowTest {
@@ -122,8 +122,97 @@ class PageLayoutShapeShadowTest {
       assertDoesNotThrow(() -> paintOnABlankCanvas(rect));
    }
 
-   private static void paintOnABlankCanvas(PageLayout.Shape shape) {
-      BufferedImage img = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+   @Test
+   void rectangleShadowFallsOnTheSideTheDirectionNames() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(40, 40, 40, 40);
+      rect.setColor(Color.BLACK);
+      rect.setFillColor(Color.WHITE);
+      rect.setShadow(shadow(ShapeShadow.SOUTH_EAST, 10, 6));
+
+      BufferedImage img = paintOnABlankCanvas(rect);
+
+      // just past the bottom-right corner, where an SE shadow falls
+      assertTrue(alphaAt(img, 85, 85) > 0,
+                 "an SE shadow should reach past the bottom-right corner");
+      // the opposite corner is outside the shape and outside the shadow
+      assertEquals(0, alphaAt(img, 35, 35),
+                   "an SE shadow must not reach past the top-left corner");
+   }
+
+   @Test
+   void rectangleShadowIsTranslucentAndFades() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(40, 40, 40, 40);
+      rect.setColor(Color.BLACK);
+      rect.setFillColor(Color.WHITE);
+      // 30% opacity, the shipped default
+      rect.setShadow(shadow(ShapeShadow.SOUTH_EAST, 10, 6));
+
+      BufferedImage img = paintOnABlankCanvas(rect);
+      int near = alphaAt(img, 84, 84);
+      int far = alphaAt(img, 95, 95);
+
+      assertTrue(near > 0 && near < 255,
+                 "the configured opacity should survive, alpha was " + near);
+      assertTrue(far < near,
+                 "the blur should fade with distance, " + far + " vs " + near);
+   }
+
+   @Test
+   void rectangleShadowStaysHardEdgedWithNoBlur() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(40, 40, 40, 40);
+      rect.setColor(Color.BLACK);
+      rect.setFillColor(Color.WHITE);
+      rect.setShadow(shadow(ShapeShadow.SOUTH_EAST, 10, 0));
+
+      BufferedImage img = paintOnABlankCanvas(rect);
+
+      // the whole offset band carries the same alpha, and it stops dead at
+      // the offset rather than fading past it
+      assertEquals(alphaAt(img, 84, 84), alphaAt(img, 89, 89));
+      assertEquals(0, alphaAt(img, 91, 91));
+   }
+
+   @Test
+   void ovalShadowFallsOnTheSideTheDirectionNames() {
+      PageLayout.Oval oval = new PageLayout.Oval(40, 40, 40, 40);
+      oval.setColor(Color.BLACK);
+      oval.setFillColor(Color.WHITE);
+      oval.setShadow(shadow(ShapeShadow.NORTH_WEST, 10, 6));
+
+      BufferedImage img = paintOnABlankCanvas(oval);
+
+      assertTrue(alphaAt(img, 50, 33) > 0,
+                 "a NW shadow should reach past the top of the oval");
+      assertEquals(0, alphaAt(img, 50, 87),
+                   "a NW shadow must not reach past the bottom of the oval");
+   }
+
+   @Test
+   void shapeWithNoShadowLeavesEverythingOutsideItAlone() {
+      PageLayout.Rectangle rect = new PageLayout.Rectangle(40, 40, 40, 40);
+      rect.setColor(Color.BLACK);
+      rect.setFillColor(Color.WHITE);
+
+      BufferedImage img = paintOnABlankCanvas(rect);
+
+      assertEquals(0, alphaAt(img, 85, 85));
+   }
+
+   private static ShapeShadow shadow(String direction, int distance, int blur) {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(direction);
+      shadow.setDistance(distance);
+      shadow.setBlur(blur);
+
+      return shadow;
+   }
+
+   private static int alphaAt(BufferedImage img, int x, int y) {
+      return (img.getRGB(x, y) >> 24) & 0xff;
+   }
+
+   private static BufferedImage paintOnABlankCanvas(PageLayout.Shape shape) {
+      BufferedImage img = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);
       Graphics2D g = img.createGraphics();
 
       try {
@@ -132,5 +221,7 @@ class PageLayoutShapeShadowTest {
       finally {
          g.dispose();
       }
+
+      return img;
    }
 }

--- a/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.html
+++ b/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.html
@@ -21,6 +21,7 @@
             interact-layout-object-{{removeSpaces(model.name)}}"
   [class.horizontal-line]="isHLine()"
   [class.vertical-line]="isVLine()"
+  [class.shape-shadow]="hasShapeShadow()"
   [ngClass]="{'txt-primary active': selected}"
   [style.left.px]="model.left - 2"
   [style.top.px]="model.top - 2"

--- a/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.scss
+++ b/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.scss
@@ -77,6 +77,14 @@ span.wrapper {
   overflow: visible;
 }
 
+// a shape's drop shadow falls outside its own box; the container clips it flat
+// otherwise, leaving only the 4px of slack the width/height carry
+.shape-shadow {
+  .object-container {
+    overflow: visible;
+  }
+}
+
 .horizontal-line, .vertical-line {
   .object-container {
     overflow: visible;

--- a/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, expect, it } from "vitest";
+import { ComposerObjectService } from "../composer-object.service";
+import { LayoutObject } from "./layout-object.component";
+
+/**
+ * A rectangle/oval drop shadow is painted outside the assembly's own box, and
+ * .object-container clips it away unless the host carries .shape-shadow. This
+ * covers the predicate that adds that class.
+ */
+describe("LayoutObject shadow clipping", () => {
+   function createComponent(objectModel: any): LayoutObject {
+      const composerObjectService: any = {
+         addLayoutObjectKeyEventAdapter: () => {}
+      };
+
+      const component = new LayoutObject(
+         null, null, null, null, null, null, null,
+         <ComposerObjectService> composerObjectService, null);
+      component.model = <any> { name: "obj", objectModel };
+
+      return component;
+   }
+
+   it("should report a shadow for a rectangle that has one", () => {
+      const component = createComponent({ objectType: "VSRectangle", shadow: true });
+      expect(component.hasShapeShadow()).toBe(true);
+   });
+
+   it("should report a shadow for an oval that has one", () => {
+      const component = createComponent({ objectType: "VSOval", shadow: true });
+      expect(component.hasShapeShadow()).toBe(true);
+   });
+
+   it("should not report a shadow for a shape with the shadow turned off", () => {
+      const component = createComponent({ objectType: "VSRectangle", shadow: false });
+      expect(component.hasShapeShadow()).toBe(false);
+   });
+
+   it("should not report a shadow for a non-shape object", () => {
+      const component = createComponent({ objectType: "VSTable" });
+      expect(component.hasShapeShadow()).toBe(false);
+   });
+
+   it("should not report a shadow before the object model is loaded", () => {
+      const component = createComponent(null);
+      expect(component.hasShapeShadow()).toBe(false);
+   });
+});

--- a/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/layouts/layout-object.component.ts
@@ -37,6 +37,7 @@ import { ViewsheetInfo } from "../../../../vsobjects/data/viewsheet-info";
 import { VSInputModel } from "../../../../vsobjects/model/vs-input-model";
 import { VSLineModel } from "../../../../vsobjects/model/vs-line-model";
 import { VSObjectModel } from "../../../../vsobjects/model/vs-object-model";
+import { VSShapeModel } from "../../../../vsobjects/model/vs-shape-model";
 import { VSSelectionContainerModel } from "../../../../vsobjects/model/vs-selection-container-model";
 import { VSTabModel } from "../../../../vsobjects/model/vs-tab-model";
 import { DebounceService } from "../../../../widget/services/debounce.service";
@@ -474,6 +475,18 @@ export class LayoutObject implements OnInit, OnDestroy {
       return this.model.objectModel &&
          this.model.objectModel.objectType == "VSLine" &&
          this.lineModel.startLeft == this.lineModel.endLeft;
+   }
+
+   /**
+    * A rectangle/oval with a drop shadow paints outside its own box, so the
+    * object container must not clip it. Only these two object types can, so
+    * the .object-container overflow stays hidden for everything else.
+    */
+   hasShapeShadow(): boolean {
+      const objectType = this.model.objectModel?.objectType;
+
+      return (objectType == "VSRectangle" || objectType == "VSOval") &&
+         !!(<VSShapeModel> this.model.objectModel).shadow;
    }
 
    get resizeable(): boolean {


### PR DESCRIPTION
Follow-up to the shape shadow work in #4767 (feature #76073) and #4974 (bug #76416): QA reported that Print Layout preview and PDF export were still wrong.

There turned out to be **two independent defects**, one per rendering path. The shadow was only correct on the viewsheet canvas.

## 1. The Print Layout pane clipped the shadow

The pane reuses the real `<vs-rectangle>`/`<vs-oval>` components, so the CSS `box-shadow` was drawn correctly and then cut off. `.object-container` is `overflow: hidden` and only carries 4px of slack, while a distance-5/blur-6 shadow reaches ~14px past the shape.

A `.shape-shadow` class now opens that container's overflow, gated on a rectangle or oval that actually has a shadow — the hidden overflow is there to keep an oversized object inside its layout cell, and only these two object types paint outside their own box. This follows the override `.horizontal-line`/`.vertical-line` already use for the same class of problem.

## 2. The PDF drew a hard opaque bar, not a shadow

`PageLayout.Rectangle/Oval.paint()` filled an offset copy of the shape and then painted the shape's own opaque fill over it, so all that showed was a hard band the width of the offset. `PDFPrinter` also ignores the alpha of a plain `setColor`, so it came out fully saturated.

#4974 documented the missing blur as an accepted limitation, on the grounds that a Gaussian blur "is not practical in a Graphics-only context". That premise does not hold: `PDFPrinter extends Graphics2D` and emits a real 8-bit `/SMask` soft mask for a translucent image, so a pre-blurred ARGB image drawn with `drawImage` keeps both its blur and its opacity. `Shape.paintShadow()` now renders the silhouette off-screen, runs it through the existing blur, and draws that.

To keep the blur defined in one place, the tint and blur move out of `VSFaceUtil.addShadow` into `ShapeShadowUtil.createShadowLayer()`, which `addShadow` now calls. That relocation is forced rather than cosmetic: `VSFaceUtil`'s static initializer reaches into `PortalThemesManager`, so having `PageLayout` touch that class fails with `ExceptionInInitializerError` outside a configured server. The tint (`AlphaComposite.SrcIn`) and the blur (`ConvolveOp`) both have to happen off-screen anyway, since `PDFPrinter` honours neither.

## 3. The band clip cut off one side

`ShapePaintable.paint()` narrowed the clip to the band/page box before painting, so a shape sitting flush against an edge of its band lost that side of its shadow — the missing bottom band on the large rectangle in the report. Those two `clipRect` calls now open up by the shadow insets.

Deliberately **not** done in `Shape.getBounds()`/`ShapePaintable.getBounds()`, which feed hit testing and `SectionElementDef`'s page-breaking, where widening by up to ~150px would move where pages break.

## Notes

Print Layout preview and export are the same code path — the preview hits the export endpoint with no `format` param, which defaults to PDF — so one fix covers both.

Left alone: the pre-existing `getX() + xs` typo in both fill blocks, where the sibling lines use `getX() * xs`. Nothing calls `Shape.setScale()`, so it degrades to a one-point offset; it predates this bug and wants its own ticket.

## Testing

- `PageLayoutShapeShadowTest` goes from asserting that `paint()` does not throw to asserting the pixels: that the shadow lands on the side the direction names, that it is translucent, that it fades with distance, and that `blur 0` stays hard-edged.
- New `layout-object.component.spec.ts` covers the `hasShapeShadow()` predicate.
- `VSFaceUtilShadowTest`, `ShapeShadowTest`, `ShapeVSAssemblyInfoShadowTest` and the whole `inetsoft.report.**` package pass.
- Verified end-to-end against the reported repro asset: imported it, switched to Print Layout, previewed and exported to PDF. Direction, opacity and blur now match the viewsheet canvas for all three shapes (SE, NE and SW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
