### PR TITLE
Add inline value-list named-group binding for chart/table fields

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -42,7 +42,9 @@ import inetsoft.web.composer.model.condition.ConditionExpression;
 import inetsoft.web.composer.model.condition.ConditionUtil;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** Converts between StyleBI's ref models and the agent-facing {@link FieldRef}. */
 public final class FieldRefFactory {
@@ -175,6 +177,7 @@ public final class FieldRefFactory {
 
       NamedGroupInfoModel model = new NamedGroupInfoModel();
       model.setType(XNamedGroupInfo.SIMPLE_NAMEDGROUP_INFO);
+      Set<String> seenNames = new HashSet<>();
 
       for(FieldRef.NamedGroupValues.Clause clause : spec.groups()) {
          if(clause.name() == null || clause.name().isBlank()) {
@@ -187,6 +190,12 @@ public final class FieldRefFactory {
             throw new IllegalArgumentException(
                "Field '" + column + "'s 'namedGroupValues' group '" + clause.name() + "' needs " +
                "a non-empty 'values' list -- a group with no member values matches nothing.");
+         }
+
+         if(!seenNames.add(clause.name())) {
+            throw new IllegalArgumentException(
+               "Field '" + column + "'s 'namedGroupValues.groups' has a duplicate name '" +
+               clause.name() + "' -- list each group name at most once.");
          }
 
          model.addGroup(new GroupCondition(clause.name(), clause.values()));

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -32,6 +32,7 @@ import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BAggregateRefModel;
 import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.binding.model.GroupCondition;
 import inetsoft.web.binding.model.NamedGroupInfoModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
@@ -108,13 +109,90 @@ public final class FieldRefFactory {
          ref.setDateLevel(DateLevels.normalize(field.dateLevel()));
       }
 
-      if(field.namedGroup() != null) {
-         ref.setNamedGroupInfo(resolveNamedGroupInfo(
-            field.namedGroup(), rvs, source, field.column(), refModelService));
+      NamedGroupInfoModel namedGroupInfo = resolveNamedGroupInfo(field, rvs, source, refModelService);
+
+      if(namedGroupInfo != null) {
+         ref.setNamedGroupInfo(namedGroupInfo);
          ref.setOrder(XConstants.SORT_SPECIFIC);
       }
 
       return ref;
+   }
+
+   /**
+    * Resolves whichever of {@code namedGroup} (by name) or {@code namedGroupValues} (inline) the
+    * field carries, or {@code null} if it carries neither. Shared by the chart and table/crosstab
+    * binding paths so both learned this at once rather than one at a time.
+    */
+   public static NamedGroupInfoModel resolveNamedGroupInfo(
+      FieldRef field, RuntimeViewsheet rvs, SourceInfo source,
+      DataRefModelFactoryService refModelService) throws Exception
+   {
+      if(field.namedGroup() != null && field.namedGroupValues() != null) {
+         throw new IllegalArgumentException(
+            "Field '" + field.column() + "' carries both 'namedGroup' (a reference to an " +
+            "existing named group by name) and 'namedGroupValues' (an inline definition) -- " +
+            "pass exactly one.");
+      }
+
+      if(field.namedGroupValues() != null) {
+         return buildInlineNamedGroupInfo(field.namedGroupValues(), field.column());
+      }
+
+      if(field.namedGroup() != null) {
+         return resolveNamedGroupInfo(
+            field.namedGroup(), rvs, source, field.column(), refModelService);
+      }
+
+      return null;
+   }
+
+   /**
+    * Builds an inline, value-list-defined named group ({@code SIMPLE_NAMEDGROUP_INFO}) directly
+    * from the caller's own {@code {name, values}} pairs -- the same shape the Composer's
+    * right-click "Group columns" feature builds, and the one {@code NamedGroupInfoModel}'s own
+    * {@code createNamedGroupInfo} already knows how to turn into a live
+    * {@code SimpleNamedGroupInfo}. Nothing here needs a worksheet or repository lookup, unlike
+    * the by-name path above, because the caller supplied the membership directly.
+    */
+   public static NamedGroupInfoModel buildInlineNamedGroupInfo(
+      FieldRef.NamedGroupValues spec, String column)
+   {
+      if(spec.others() != null) {
+         throw new IllegalArgumentException(
+            "Field '" + column + "'s 'namedGroupValues.others' is not supported -- an inline " +
+            "named group here has no way to bucket unmatched values together (unlike a " +
+            "calc-table cell's inline named group); a value not named in any group renders as " +
+            "its own, ungrouped row. Remove 'others', or list every value that should be " +
+            "grouped explicitly.");
+      }
+
+      if(spec.groups() == null || spec.groups().isEmpty()) {
+         throw new IllegalArgumentException(
+            "Field '" + column + "'s 'namedGroupValues.groups' must be a non-empty list of " +
+            "{name, values} -- an inline named group with no groups in it buckets nothing.");
+      }
+
+      NamedGroupInfoModel model = new NamedGroupInfoModel();
+      model.setType(XNamedGroupInfo.SIMPLE_NAMEDGROUP_INFO);
+
+      for(FieldRef.NamedGroupValues.Clause clause : spec.groups()) {
+         if(clause.name() == null || clause.name().isBlank()) {
+            throw new IllegalArgumentException(
+               "Field '" + column + "'s 'namedGroupValues.groups' has an entry with no " +
+               "non-blank 'name'.");
+         }
+
+         if(clause.values() == null || clause.values().isEmpty()) {
+            throw new IllegalArgumentException(
+               "Field '" + column + "'s 'namedGroupValues' group '" + clause.name() + "' needs " +
+               "a non-empty 'values' list -- a group with no member values matches nothing.");
+         }
+
+         model.addGroup(new GroupCondition(clause.name(), clause.values()));
+      }
+
+      return model;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -42,6 +42,7 @@ import inetsoft.web.composer.model.condition.ConditionExpression;
 import inetsoft.web.composer.model.condition.ConditionUtil;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -279,10 +280,30 @@ public final class FieldRefFactory {
       }
 
       if(ref instanceof BDimensionRefModel dimension) {
+         NamedGroupInfoModel ngInfo = dimension.getNamedGroupInfo();
+
+         // An inline group (built by buildInlineNamedGroupInfo, on the write side) has no
+         // real name -- getName() is the hardcoded "Custom" literal, so reporting it as
+         // 'namedGroup' would read back as a reference to a group called "Custom" that
+         // doesn't exist. Reconstruct the inline definition instead, from the same
+         // {name, values} pairs the write side accepted, so a read-modify-write round trip
+         // through this field doesn't silently drop the grouping.
+         if(ngInfo != null && ngInfo.getType() == XNamedGroupInfo.SIMPLE_NAMEDGROUP_INFO) {
+            List<FieldRef.NamedGroupValues.Clause> clauses = new ArrayList<>();
+
+            if(ngInfo.getGroups() != null) {
+               for(GroupCondition group : ngInfo.getGroups()) {
+                  clauses.add(new FieldRef.NamedGroupValues.Clause(group.getName(), group.getValue()));
+               }
+            }
+
+            return new FieldRef(dimension.getColumnValue(), DIMENSION, null,
+                                dimension.getDateLevel(), null, null, null,
+                                new FieldRef.NamedGroupValues(clauses, null));
+         }
+
          return new FieldRef(dimension.getColumnValue(), DIMENSION, null,
-                             dimension.getDateLevel(),
-                             dimension.getNamedGroupInfo() == null
-                                ? null : dimension.getNamedGroupInfo().getName());
+                             dimension.getDateLevel(), ngInfo == null ? null : ngInfo.getName());
       }
 
       return new FieldRef(ref == null ? null : ref.getName(), null, null, null, null);

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -418,8 +418,10 @@ public final class TableBindingMutator {
 
    /**
     * @implNote {@link #addField}/{@link #moveField} reapply a shelf through this overload with
-    * no runtime context -- a field carrying {@code namedGroup} through that path is left
-    * unresolved, same as before this method learned to resolve it at all.
+    * no runtime context -- a field carrying a by-name {@code namedGroup} through that path is
+    * left unresolved, same as before this method learned to resolve it at all. An inline
+    * {@code namedGroupValues} needs no worksheet/repository lookup, so it resolves through this
+    * overload too.
     */
    private static List<BDimensionRefModel> dimensions(List<FieldRef> fields) {
       return dimensions(fields, null, null, null);
@@ -440,10 +442,10 @@ public final class TableBindingMutator {
             ref.setDateLevel(DateLevels.normalize(field.dateLevel()));
          }
 
-         if(field.namedGroup() != null && rvs != null) {
+         if(field.namedGroupValues() != null || (field.namedGroup() != null && rvs != null)) {
             try {
-               ref.setNamedGroupInfo(FieldRefFactory.resolveNamedGroupInfo(
-                  field.namedGroup(), rvs, source, field.column(), refModelService));
+               ref.setNamedGroupInfo(
+                  FieldRefFactory.resolveNamedGroupInfo(field, rvs, source, refModelService));
             }
             catch(RuntimeException e) {
                throw e; // preserve IllegalArgumentException's loud, field-named message as-is

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.binding.model;
 
+import java.util.List;
+
 /**
  * The agent-facing shape of one bound field, shared by every binding spec (2a–2e) and
  * embedded by highlights in spec #4.
@@ -48,12 +50,24 @@ package inetsoft.web.wiz.binding.model;
  * @param type             "dimension" or "measure"
  * @param aggregate        aggregate formula, measures only (e.g. "Sum", "Count")
  * @param dateLevel        date grouping level, dimensions only
- * @param namedGroup       named-group name, dimensions only
+ * @param namedGroup       named-group name, dimensions only — resolves against a worksheet-local
+ *                         group ({@code add_named_group}) or a repository-registered predefined
+ *                         one. Mutually exclusive with {@code namedGroupValues}: this names a
+ *                         group that already exists, the other defines one inline.
+ * @param namedGroupValues an inline, value-list-defined named group, dimensions only — the same
+ *                         kind the Composer's own right-click "Group columns" builds (renders
+ *                         with the {@code DataGroup(...)} axis/header label). Unlike
+ *                         {@code namedGroup}, nothing has to exist beforehand: the group and its
+ *                         membership are defined in this call. Has no "bucket the rest together"
+ *                         option — {@link inetsoft.uql.asset.SNamedGroupInfo}, what this builds,
+ *                         carries no such concept; a value not named in any group renders as its
+ *                         own, ungrouped row, the same as it would with no grouping at all.
  * @param chartType        the measure's own GraphTypes code under Multi Style; null everywhere else
  * @param runtimeChartType what that measure resolved to, when it differs from {@code chartType}
  */
 public record FieldRef(String column, String type, String aggregate, String dateLevel,
-                       String namedGroup, Integer chartType, Integer runtimeChartType) {
+                       String namedGroup, Integer chartType, Integer runtimeChartType,
+                       NamedGroupValues namedGroupValues) {
    /**
     * Every caller but the chart read builds a ref with no chart type. Kept so that adding the
     * components did not touch forty-odd construction sites that have nothing to do with charts.
@@ -61,13 +75,39 @@ public record FieldRef(String column, String type, String aggregate, String date
    public FieldRef(String column, String type, String aggregate, String dateLevel,
                    String namedGroup)
    {
-      this(column, type, aggregate, dateLevel, namedGroup, null, null);
+      this(column, type, aggregate, dateLevel, namedGroup, null, null, null);
    }
 
    /** A chart ref whose design-time type is all the read has to report. */
    public FieldRef(String column, String type, String aggregate, String dateLevel,
                    String namedGroup, Integer chartType)
    {
-      this(column, type, aggregate, dateLevel, namedGroup, chartType, null);
+      this(column, type, aggregate, dateLevel, namedGroup, chartType, null, null);
+   }
+
+   /**
+    * The full pre-existing shape (both chart-type components, no inline group) — kept so this
+    * addition did not touch every call site that already named both.
+    */
+   public FieldRef(String column, String type, String aggregate, String dateLevel,
+                   String namedGroup, Integer chartType, Integer runtimeChartType)
+   {
+      this(column, type, aggregate, dateLevel, namedGroup, chartType, runtimeChartType, null);
+   }
+
+   /**
+    * An inline, value-list-defined named group — see {@code namedGroupValues} above.
+    *
+    * @param groups one entry per group: its name and the raw member values that belong to it.
+    * @param others reserved, currently always refused when present — {@link #groups} carries
+    *               everything {@link inetsoft.uql.asset.SNamedGroupInfo} can hold; kept as its
+    *               own key (rather than silently accepted and dropped) so a caller who assumes
+    *               this mirrors a calc-table cell's inline named group — which does support
+    *               grouping the leftovers — is told why that assumption does not carry over here,
+    *               instead of the option quietly doing nothing.
+    */
+   public record NamedGroupValues(List<Clause> groups, String others) {
+      /** One named group's membership: {@code name} plus the raw values that belong to it. */
+      public record Clause(String name, List<Object> values) {}
    }
 }


### PR DESCRIPTION
## Summary
- `FieldRef` gains `namedGroupValues` (`{groups: [{name, values}]}`), mutually exclusive with the existing by-name `namedGroup` reference. All prior constructors kept for backward compatibility.
- `FieldRefFactory` builds a `SIMPLE_NAMEDGROUP_INFO` (`SNamedGroupInfo`) directly from the caller's own name+values pairs — the same shape the Composer's own right-click "Group columns" builds — via a new `buildInlineNamedGroupInfo`, dispatched through a shared `resolveNamedGroupInfo(FieldRef, ...)` entry point used by both the chart and table/crosstab binding paths.
- `TableBindingMutator.dimensions()` now resolves the inline form even through the no-runtime-context overload (`addField`/`moveField`), since it needs no worksheet/repository lookup, unlike the by-name form.
- `others` (bucket-the-rest-together) is explicitly refused rather than silently accepted or dropped: `SNamedGroupInfo` has no such concept.
- Pairs with `inetsoft-technology/stylebi-wiz` PR #2320 (same branch name), which declares and validates this shape on the agent-facing tool schema.

## Test plan
- [x] `mvnw compile -pl community/core -am` — clean
- [x] `mvnw test-compile -pl community/core -am` — clean (existing tests still compile against the changed record; no new tests added)
- [ ] Live: an inline named group applied via the paired plugin PR renders correctly on a chart/crosstab (needs both PRs merged and the deployment rebuilt)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>