### PR TITLE
feat(wiz): classify a tabular source by its declared runtime's catalog SPI, and give listRelationships a caller

### DIFF
--- a/connectors/inetsoft-rest/src/test/java/inetsoft/web/wiz/controller/RestSourceTypesAnnotationClassTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/web/wiz/controller/RestSourceTypesAnnotationClassTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.uql.rest.datasource.graphql.GraphQLQuery;
+import inetsoft.uql.rest.datasource.graphql.GraphQLRuntime;
+import inetsoft.uql.rest.datasource.shopify.ShopifyQuery;
+import inetsoft.uql.rest.xml.RestXMLQuery;
+import inetsoft.uql.rest.xml.RestXMLRuntime;
+import inetsoft.uql.tabular.TabularCatalogProvider;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Charter A8 (counter-assertion): none of the four source types this round's classifier is
+ * theoretically able to reclassify -- {@code Rest.XML}, {@code graphql}, {@code shopify},
+ * {@code monday.com} -- may actually change classification, because none of their runtimes
+ * implements {@link TabularCatalogProvider} today. Lives in this connector module (not core,
+ * which cannot depend on connector classes) and declares itself in {@code
+ * WizDatabaseController}'s package so it can call the package-private {@code classifyQueryClass}
+ * directly, the same reason {@code ODataDatasourceAnnotationClassTest} lives in the OData module.
+ *
+ * <p>{@code shopify} and {@code monday.com} both declare {@link GraphQLRuntime} as their runtime
+ * class ({@code ShopifyService.getRuntimeClass()} / {@code MondayService.getRuntimeClass()}), so
+ * asserting {@code GraphQLRuntime} does not implement the SPI covers both, plus {@code graphql}
+ * itself; {@code Rest.XML} declares {@link RestXMLRuntime}.</p>
+ */
+@Tag("core")
+class RestSourceTypesAnnotationClassTest {
+   @Test
+   void graphQLRuntimeDoesNotImplementTheCatalogSpi() {
+      // Covers graphql, shopify, and monday.com -- all three declare this as their runtime class.
+      assertFalse(TabularCatalogProvider.class.isAssignableFrom(GraphQLRuntime.class),
+         "GraphQLRuntime now implements TabularCatalogProvider -- this round's classifier would " +
+         "silently reclassify graphql/shopify/monday.com to METADATA; that is a real behavior " +
+         "change requiring explicit sign-off, not a passing regression test");
+   }
+
+   @Test
+   void restXMLRuntimeDoesNotImplementTheCatalogSpi() {
+      assertFalse(TabularCatalogProvider.class.isAssignableFrom(RestXMLRuntime.class),
+         "RestXMLRuntime now implements TabularCatalogProvider -- this round's classifier would " +
+         "silently reclassify Rest.XML to METADATA; that is a real behavior change requiring " +
+         "explicit sign-off, not a passing regression test");
+   }
+
+   /**
+    * Confirms the classification LOGIC itself still yields DOCUMENT_REQUIRED for these query
+    * classes when their real runtime is passed through -- not just that the runtime classes lack
+    * the interface (the two tests above), but that feeding the real runtime through the actual
+    * two-arg classifier produces the unchanged verdict end to end.
+    */
+   @Test
+   void allFourSourceTypesStillRequireDocumentation() {
+      assertEquals("DOCUMENT_REQUIRED",
+                   WizDatabaseController.classifyQueryClass(RestXMLQuery.class, RestXMLRuntime.class));
+      assertEquals("DOCUMENT_REQUIRED",
+                   WizDatabaseController.classifyQueryClass(GraphQLQuery.class, GraphQLRuntime.class));
+      assertEquals("DOCUMENT_REQUIRED",
+                   WizDatabaseController.classifyQueryClass(ShopifyQuery.class, GraphQLRuntime.class));
+      // monday.com declares GraphQLQuery itself as its query class (no separate Monday query
+      // type) -- see MondayService.getQueryClass().
+      assertEquals("DOCUMENT_REQUIRED",
+                   WizDatabaseController.classifyQueryClass(GraphQLQuery.class, GraphQLRuntime.class));
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -27,6 +27,7 @@ import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.model.osi.OsiDataset;
+import inetsoft.web.wiz.request.DatasourceRelationshipsRequest;
 import inetsoft.web.wiz.request.FkIntegrityRequest;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
 import inetsoft.web.wiz.request.SchemaSearchRequest;
@@ -164,6 +165,21 @@ public class DatasourceMetaApiController {
       throws Exception
    {
       return metadataService.getDatabaseTables(dsPath, nameContains, limit, cursor, principal);
+   }
+
+   /**
+    * Declared relationships among a caller-chosen subset of one tabular data source's datasets --
+    * the subset counterpart of {@code GET /datasource/tables}' full relationship set. See
+    * {@link MetadataApiService#getDatasourceRelationships}.
+    */
+   @PostMapping("/datasource/relationships")
+   public DatasourceRelationshipsResponse getDatasourceRelationships(
+      @RequestBody DatasourceRelationshipsRequest request,
+      Principal principal)
+      throws Exception
+   {
+      return metadataService.getDatasourceRelationships(
+         request.dsPath(), request.datasetIds(), principal);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -31,6 +31,7 @@ import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.SQLHelper;
 import inetsoft.uql.tabular.ScriptedQuery;
 import inetsoft.uql.tabular.SelectableTabularQuery;
+import inetsoft.uql.tabular.TabularCatalogProvider;
 import inetsoft.uql.util.Config;
 import inetsoft.util.MessageException;
 import inetsoft.util.audit.ActionRecord;
@@ -1222,14 +1223,55 @@ public class WizDatabaseController {
          return UNKNOWN;
       }
 
-      return queryClass == null ? UNKNOWN : classifyQueryClass(queryClass);
+      if(queryClass == null) {
+         return UNKNOWN;
+      }
+
+      Class<?> runtimeClass;
+
+      try {
+         runtimeClass = resolveRuntimeClass(type);
+      }
+      catch(Throwable ex) {
+         // Same "plugin absent" reasoning as the query-class load above: a declared runtime that
+         // fails to load must not silently fall through into classifyQueryClass and get sorted as
+         // DOCUMENT_REQUIRED/METADATA by default. It is UNKNOWN, full stop.
+         LOG.debug("Failed to load the runtime class for type {}: {}", type, ex.getMessage());
+         return UNKNOWN;
+      }
+
+      return classifyQueryClass(queryClass, runtimeClass);
+   }
+
+   /**
+    * The runtime class {@code Config} has on file for this data source type, or {@code null} when
+    * none is declared (a type with no declared runtime is not the same as a plugin that failed to
+    * load, which this method signals by throwing, mirroring {@code annotationClassOf}'s existing
+    * query-class handling above).
+    *
+    * <p>Pure class lookup -- {@code Config.getClass} calls {@code Class.forName}, never a
+    * constructor -- so this instantiates nothing.</p>
+    *
+    * <p>Package-private, not private: so a unit test can resolve a runtime class through the
+    * real {@code Config} registry directly, the same way {@code classifyQueryClass} was pulled
+    * out of this method so it can be exercised without standing up a plugin registry.</p>
+    */
+   Class<?> resolveRuntimeClass(String type) throws ClassNotFoundException {
+      String runtimeClassName = uqlConfig.getRuntime(type);
+      return runtimeClassName == null ? null : uqlConfig.getClass(type, runtimeClassName);
    }
 
    /**
     * The classification itself, separated from how the class was obtained so it can be exercised
     * without standing up a plugin registry.
+    *
+    * @param runtimeClass the data source type's declared {@code TabularRuntime} class, or
+    *                      {@code null} when it declares none -- passing {@code null} here is
+    *                      indistinguishable from omitting the check entirely, which is exactly the
+    *                      pre-existing behavior this parameter must not disturb for every type that
+    *                      declares no runtime.
     */
-   static String classifyQueryClass(Class<?> queryClass) {
+   static String classifyQueryClass(Class<?> queryClass, Class<?> runtimeClass) {
       if(ScriptedQuery.class.isAssignableFrom(queryClass)) {
          return UNSUPPORTED;
       }
@@ -1238,6 +1280,17 @@ public class WizDatabaseController {
       // being asked about, and core cannot reference the connector classes to test them directly.
       if(queryClass.getResource("endpoints.json") != null) {
          return ENDPOINT_CATALOG;
+      }
+
+      // The runtime is the authoritative "can this be annotated without a document" fact --
+      // TabularCatalogService.resolveProvider tests the SAME interface on the SAME class of
+      // object at call time, so this makes the two agree by construction. Placed before
+      // isRestQuery, not before ScriptedQuery/endpoints.json: a query that is unsupported or
+      // already catalogued must stay that way even if its runtime happens to also implement the
+      // SPI -- those two questions ("can this run at all", "does it ship a machine-readable
+      // catalog already") are more specific than "does the runtime know how to list datasets".
+      if(runtimeClass != null && TabularCatalogProvider.class.isAssignableFrom(runtimeClass)) {
+         return METADATA;
       }
 
       if(isRestQuery(queryClass)) {
@@ -1249,6 +1302,20 @@ public class WizDatabaseController {
       }
 
       return METADATA;
+   }
+
+   /**
+    * Convenience overload for a caller with no runtime-class information. Equivalent to passing
+    * {@code null}: with no runtime class, the SPI check above cannot fire, so this behaves exactly
+    * as {@code classifyQueryClass} did before the runtime signal was added.
+    *
+    * <p>{@code annotationClassOf} above is the only production caller of the two-argument form,
+    * and it always passes a runtime class (resolved via {@link #resolveRuntimeClass}); a new
+    * production caller reaching for this single-argument overload is opting out of the SPI
+    * signal, not picking a convenient default.</p>
+    */
+   static String classifyQueryClass(Class<?> queryClass) {
+      return classifyQueryClass(queryClass, null);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/model/DatasourceRelationshipsResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DatasourceRelationshipsResponse.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import inetsoft.web.wiz.model.osi.OsiRelationship;
+
+import java.util.List;
+
+/**
+ * Response of {@code POST /datasource/relationships}. Wrapped in an object (not a bare array) so
+ * a later field can be added without a breaking wire-shape change -- the same reason
+ * {@code DatasourceTablesResponse} wraps its own {@code relationships} list rather than exposing
+ * it as the top-level response body.
+ */
+public record DatasourceRelationshipsResponse(List<OsiRelationship> relationships) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/DatasourceRelationshipsRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/DatasourceRelationshipsRequest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+import java.util.List;
+
+/**
+ * Body of {@code POST /datasource/relationships}: the caller's already-chosen subset of one
+ * tabular data source's datasets, whose declared relationships are wanted.
+ *
+ * @param dsPath     the datasource name/path, same slot {@code GetDatabaseTableMetaRequest.dsName}
+ *                    and {@code /datasource/tables}'s {@code dsPath} query param use.
+ * @param datasetIds the caller's chosen {@link inetsoft.uql.tabular.TabularDatasetRef#id()} subset.
+ *                    {@code null} or empty is legal -- see
+ *                    {@link inetsoft.uql.tabular.TabularCatalogProvider#listRelationships} -- and
+ *                    answers with an empty relationships list, not an error. A POST body (not a GET
+ *                    query string) because the id list can be large and ids are opaque, possibly
+ *                    containing {@code .}/{@code /} -- a query string handles that badly (charter Q3).
+ */
+public record DatasourceRelationshipsRequest(String dsPath, List<String> datasetIds) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1194,6 +1194,32 @@ public class MetadataApiService {
    }
 
    /**
+    * The declared relationships among a caller-chosen subset of one tabular data source's datasets.
+    * Serves {@code POST /datasource/relationships} (item 2, scaled-annotation-target-selection).
+    *
+    * <p>Tabular-only by construction, with no JDBC branch: {@link TabularCatalogService#resolveProvider}
+    * already throws {@link UnsupportedDatasourceException} (mapped to this controller's existing
+    * 422 handler) for a JDBC data source, whose runtime never implements {@code TabularCatalogProvider}.
+    * A caller passing a JDBC path gets a clean, already-wired 422 -- not a gap, since JDBC subset
+    * annotation isn't even wired for paging yet (see {@link #getDatabaseTables}'s own doc).</p>
+    *
+    * @param dsPath     the datasource name/path.
+    * @param datasetIds the caller's chosen dataset id subset. {@code null}/empty is legal and
+    *                    answers with an empty relationships list.
+    * @param principal  the current user; must have READ on {@code dsPath}.
+    */
+   public DatasourceRelationshipsResponse getDatasourceRelationships(
+      String dsPath, List<String> datasetIds, Principal principal) throws Exception
+   {
+      if(!dataSourceService.checkPermission(dsPath, ResourceAction.READ, principal)) {
+         throw new SecurityException("Access denied to data source: " + dsPath);
+      }
+
+      List<OsiRelationship> relationships = tabularCatalogService.listRelationships(dsPath, datasetIds);
+      return new DatasourceRelationshipsResponse(relationships);
+   }
+
+   /**
     * Gets all tables and their FK relationships for the specified datasource.
     *
     * @param dsName       the datasource name/path.

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularCatalogService.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -177,6 +178,108 @@ public class TabularCatalogService {
                "); they must be positionally paired.");
          }
       }
+   }
+
+   /**
+    * The relationships the source declares among a caller-chosen SUBSET of its datasets -- the
+    * tabular counterpart of {@link #listTables(String)}'s full relationship set, for a caller that
+    * has already selected which datasets it wants. Serves {@code POST /datasource/relationships}.
+    *
+    * Unlike {@link #listTables(String)}, an out-of-scope endpoint here is DROPPED, not fatal (see
+    * {@link #filterAndConvertSubsetRelationships} for why) -- {@link #validateRelationshipEndpoints}
+    * is deliberately not reused and not modified.
+    */
+   public List<OsiRelationship> listRelationships(String dsName, Collection<String> datasetIds)
+      throws Exception
+   {
+      TabularCatalogProvider provider = resolveProvider(dsName);
+      TabularDataSource<?> tds = resolveTabularDataSource(dsName);
+
+      List<TabularRelationship> relationships = provider.listRelationships(tds, datasetIds);
+
+      if(relationships == null) {
+         throw new Exception("Data source '" + dsName + "' returned a null relationships list " +
+            "from listRelationships; TabularCatalogProvider implementations must return an empty " +
+            "list, not null, when there are no relationships.");
+      }
+
+      return filterAndConvertSubsetRelationships(dsName, datasetIds, relationships);
+   }
+
+   /**
+    * Validates and converts a SUBSET relationship answer to the wire type.
+    *
+    * Deliberately NOT {@link #validateRelationshipEndpoints}, and does not call it: that method
+    * takes a full {@link TabularCatalog} and throws -- aborting the WHOLE call -- the moment one
+    * endpoint falls outside the dataset id set, which is correct for the full listing (any dangling
+    * endpoint there is a genuine connector defect) but wrong here. {@code listRelationships}'s own
+    * contract already promises both endpoints inside {@code datasetIds}; a connector that violates
+    * it (a bad override -- the default implementation cannot) should have that ONE edge silently
+    * dropped, not take down every other edge in the caller's subset, because "an edge referencing a
+    * dataset outside the current selection" is the EXPECTED case here (spec §5), not a corruption
+    * signal the way it is for the full listing.
+    *
+    * Name-uniqueness and column-shape checks ARE still enforced (same failure mode as
+    * {@link #validateRelationshipEndpoints}: throw, aborting the call) -- those indicate a genuinely
+    * malformed relationship record, independent of subset semantics. The name-uniqueness check runs
+    * over EVERY returned relationship, including ones later dropped for having an out-of-scope
+    * endpoint: a duplicate name is a whole-catalog defect regardless of which subset was asked for,
+    * same reasoning as the full-listing check above -- and the exact trap the tabular-catalog-spi-
+    * connector skill names ("a duplicate relationship name makes TabularCatalogService throw,
+    * taking down the whole catalog"), so the uniqueness check must not be moved after the
+    * out-of-scope `continue` below.
+    */
+   private static List<OsiRelationship> filterAndConvertSubsetRelationships(
+      String dsName, Collection<String> datasetIds, List<TabularRelationship> relationships)
+      throws Exception
+   {
+      Set<String> ids = datasetIds == null ? Set.of() : new HashSet<>(datasetIds);
+      Set<String> seenNames = new HashSet<>();
+      List<OsiRelationship> result = new ArrayList<>();
+
+      for(TabularRelationship rel : relationships) {
+         if(rel == null) {
+            throw new Exception("Data source '" + dsName + "' returned a null relationship entry " +
+               "from listRelationships.");
+         }
+         if(rel.name() == null || rel.name().isBlank()) {
+            throw new Exception("Data source '" + dsName + "' declared a relationship with a " +
+               "blank name from listRelationships.");
+         }
+         if(!seenNames.add(rel.name())) {
+            throw new Exception("Data source '" + dsName + "' declared the relationship name '" +
+               rel.name() + "' more than once from listRelationships; every relationship name " +
+               "must be unique within one catalog.");
+         }
+
+         if(!ids.contains(rel.fromDataset()) || !ids.contains(rel.toDataset())) {
+            continue;   // Expected, not an error -- see this method's javadoc.
+         }
+
+         if(rel.fromColumns() == null || rel.fromColumns().isEmpty() ||
+            rel.toColumns() == null || rel.toColumns().isEmpty())
+         {
+            throw new Exception("Data source '" + dsName + "' declared relationship '" +
+               rel.name() + "' with an empty fromColumns/toColumns list; both must be non-empty " +
+               "and positionally paired.");
+         }
+         if(rel.fromColumns().size() != rel.toColumns().size()) {
+            throw new Exception("Data source '" + dsName + "' declared relationship '" +
+               rel.name() + "' with fromColumns/toColumns of different sizes (" +
+               rel.fromColumns().size() + " vs " + rel.toColumns().size() +
+               "); they must be positionally paired.");
+         }
+
+         OsiRelationship osiRelationship = new OsiRelationship();
+         osiRelationship.setName(rel.name());
+         osiRelationship.setFrom(rel.fromDataset());
+         osiRelationship.setTo(rel.toDataset());
+         osiRelationship.setFromColumns(rel.fromColumns());
+         osiRelationship.setToColumns(rel.toColumns());
+         result.add(osiRelationship);
+      }
+
+      return result;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceAnnotationClassTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceAnnotationClassTest.java
@@ -77,6 +77,70 @@ class WizDatasourceAnnotationClassTest {
                    WizDatabaseController.classifyQueryClass(CatalogedTestQueries.CatalogedRestQuery.class));
    }
 
+   /**
+    * The runtime is the authoritative "can this be annotated without a document" signal: a REST
+    * query whose declared runtime implements {@link TabularCatalogProvider} is METADATA, not
+    * DOCUMENT_REQUIRED, even though its query class descends from {@code AbstractRestQuery}.
+    */
+   @Test
+   void aQueryWhoseRuntimeImplementsTheCatalogSpiIsMetadata() {
+      assertEquals("METADATA", WizDatabaseController.classifyQueryClass(
+         PlainRestTestQuery.class, SpiRuntimeStub.class));
+   }
+
+   /**
+    * A REST query whose runtime does NOT implement the SPI is unaffected by the new check --
+    * same verdict as before the runtime signal existed, this time asserted with an explicit
+    * "no runtime declared" (null) second argument rather than the one-arg overload.
+    */
+   @Test
+   void aRestQueryWithNoSpiRuntimeStillRequiresDocumentation() {
+      assertEquals("DOCUMENT_REQUIRED",
+                   WizDatabaseController.classifyQueryClass(PlainRestTestQuery.class, null));
+   }
+
+   /**
+    * The ordering guard for a query that is BOTH catalogued (ships endpoints.json) AND has a
+    * runtime implementing the SPI. Unreachable by any shipped connector today (charter: zero
+    * overlap between the two sets) -- exactly why this must be asserted, not argued: the ordering
+    * inside {@code classifyQueryClass} places the SPI check after the endpoints.json check, so a
+    * future connector that is both must still come out as the catalogue it already ships.
+    */
+   @Test
+   void aCatalogedQueryThatAlsoImplementsTheSpiIsStillACatalog() {
+      assertEquals("ENDPOINT_CATALOG", WizDatabaseController.classifyQueryClass(
+         CatalogedTestQueries.CatalogedRestQuery.class, SpiRuntimeStub.class));
+   }
+
+   /**
+    * Same ordering guard for {@code ScriptedQuery}: a scripted query's output shape is arbitrary
+    * user script output with no stable target, regardless of what its runtime declares.
+    */
+   @Test
+   void aScriptedQueryIsStillUnsupportedEvenWithASpiRuntime() {
+      assertEquals("UNSUPPORTED", WizDatabaseController.classifyQueryClass(
+         ScriptedTestQuery.class, SpiRuntimeStub.class));
+   }
+
+   /**
+    * Charter A2b: the one-arg overload must be provably the same as the two-arg form called with
+    * a null runtime class -- for one query class of each of the five verdicts -- so the overload
+    * cannot silently drift from "no runtime signal" behavior as this method evolves.
+    */
+   @Test
+   void theOneArgOverloadMatchesTheTwoArgFormWithNullRuntimeForEveryVerdict() {
+      assertEquals(WizDatabaseController.classifyQueryClass(ScriptedTestQuery.class),
+                   WizDatabaseController.classifyQueryClass(ScriptedTestQuery.class, null));
+      assertEquals(WizDatabaseController.classifyQueryClass(CatalogedTestQueries.CatalogedQuery.class),
+                   WizDatabaseController.classifyQueryClass(CatalogedTestQueries.CatalogedQuery.class, null));
+      assertEquals(WizDatabaseController.classifyQueryClass(PlainRestTestQuery.class),
+                   WizDatabaseController.classifyQueryClass(PlainRestTestQuery.class, null));
+      assertEquals(WizDatabaseController.classifyQueryClass(SelectableTestQuery.class),
+                   WizDatabaseController.classifyQueryClass(SelectableTestQuery.class, null));
+      assertEquals(WizDatabaseController.classifyQueryClass(PlainTestQuery.class),
+                   WizDatabaseController.classifyQueryClass(PlainTestQuery.class, null));
+   }
+
    private static class PlainTestQuery extends TabularQuery {
       PlainTestQuery() {
          super("TEST");
@@ -113,6 +177,25 @@ class WizDatasourceAnnotationClassTest {
    private static class PlainRestTestQuery extends AbstractRestQuery {
       PlainRestTestQuery() {
          super("TEST");
+      }
+   }
+
+   /**
+    * A minimal SPI implementer used only as a {@code .class} literal -- never instantiated or
+    * called. Classification is a pure {@code Class}-level {@code isAssignableFrom} test (charter
+    * A6: no runtime is ever instantiated), so every method here throws, making this class double
+    * as a live tripwire: any test above that used it as a runtime signal would itself fail loudly
+    * if classification ever tried to construct or call it.
+    */
+   private static class SpiRuntimeStub implements TabularCatalogProvider {
+      @Override
+      public TabularCatalog listDatasets(TabularDataSource<?> dataSource) {
+         throw new UnsupportedOperationException("must never be called by classification");
+      }
+
+      @Override
+      public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId) {
+         throw new UnsupportedOperationException("must never be called by classification");
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceRuntimeSignalTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceRuntimeSignalTest.java
@@ -1,0 +1,169 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.util.Config;
+import inetsoft.web.admin.content.database.DatabaseTypeService;
+import inetsoft.web.admin.content.repository.DatabaseDatasourcesService;
+import inetsoft.web.admin.model.NameLabelTuple;
+import inetsoft.web.portal.data.DataSourceBrowserService;
+import inetsoft.web.portal.data.DataSourceInfo;
+import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.portal.service.datasource.DataSourceStatusService;
+import inetsoft.web.wiz.model.WizDatasourceBrowserModel;
+import inetsoft.web.wiz.model.WizDatasourceEntry;
+import inetsoft.web.wiz.service.EndpointCatalogReader;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Charter A5 and D2: the declared-runtime resolution step this round adds to
+ * {@code annotationClassOf}, and the reachable test seam for it (03-reconcile.md Δ8).
+ *
+ * <p>{@link WizDatabaseController#resolveRuntimeClass} is package-private specifically so this
+ * class can call it directly -- the same reason {@code classifyQueryClass} was already pulled out
+ * of {@code annotationClassOf} "so it can be exercised without standing up a plugin registry".
+ * {@code Config} is mocked rather than built from a real plugin registry, following the pattern
+ * {@code WizDatasourceAnnotationTargetThresholdTest} already established for this controller.</p>
+ */
+@Tag("core")
+class WizDatasourceRuntimeSignalTest {
+   /** D2: a type that declares no runtime at all resolves to {@code null}, not an exception. */
+   @Test
+   void resolveRuntimeClass_returnsNullWhenNoRuntimeIsDeclared() throws Exception {
+      Config uqlConfig = mock(Config.class);
+      when(uqlConfig.getRuntime("TEST")).thenReturn(null);
+
+      WizDatabaseController controller = newController(uqlConfig);
+
+      assertNull(controller.resolveRuntimeClass("TEST"));
+   }
+
+   /** A declared runtime that resolves cleanly is returned as the {@code Class} itself. */
+   @Test
+   void resolveRuntimeClass_returnsTheClassWhenTheRuntimeLoads() throws Exception {
+      Config uqlConfig = mock(Config.class);
+      when(uqlConfig.getRuntime("TEST")).thenReturn("java.lang.Object");
+      when(uqlConfig.getClass("TEST", "java.lang.Object")).thenReturn((Class) Object.class);
+
+      WizDatabaseController controller = newController(uqlConfig);
+
+      assertEquals(Object.class, controller.resolveRuntimeClass("TEST"));
+   }
+
+   /**
+    * A5's converse at the resolution seam: a declared runtime whose class cannot be loaded
+    * propagates the failure rather than silently returning null (which {@code annotationClassOf}
+    * would then be unable to distinguish from "no runtime declared" -- D2's whole point).
+    */
+   @Test
+   void resolveRuntimeClass_propagatesFailureWhenTheDeclaredRuntimeCannotLoad() throws Exception {
+      Config uqlConfig = mock(Config.class);
+      when(uqlConfig.getRuntime("TEST")).thenReturn("does.not.Exist");
+      when(uqlConfig.getClass("TEST", "does.not.Exist"))
+         .thenThrow(new ClassNotFoundException("does.not.Exist"));
+
+      WizDatabaseController controller = newController(uqlConfig);
+
+      assertThrows(ClassNotFoundException.class, () -> controller.resolveRuntimeClass("TEST"));
+   }
+
+   /**
+    * A5, the full round trip: a query class that loads fine but a runtime class that fails to
+    * load must classify UNKNOWN -- never DOCUMENT_REQUIRED or METADATA. "Plugin absent" must stay
+    * distinct from "classified as not annotatable", which the portal reports very differently
+    * (the same reasoning the existing query-class load-failure branch already documents).
+    *
+    * Exercised through the real {@code getDatasourceBrowser} -> toEntries -> toEntry ->
+    * annotationClassOf path (mirroring {@code WizDatasourceAnnotationTargetThresholdTest}'s
+    * pattern), not by calling a private method via reflection -- this is the one case that cannot
+    * be pinned purely through {@code classifyQueryClass}'s pure {@code Class}-based signature,
+    * because "the runtime class failed to load" is a fact {@code annotationClassOf} resolves
+    * before {@code classifyQueryClass} is ever reached.
+    */
+   @Test
+   void aRuntimeClassThatFailsToLoadClassifiesUnknownNotDocumentRequiredOrMetadata() throws Exception {
+      DataSourceInfo info = DataSourceInfo.builder()
+         .name("ds1")
+         .path("Test/ds1")
+         .type(NameLabelTuple.builder().name("DATA_SOURCE").label("ds1").build())
+         .createdBy("admin")
+         .createdDateLabel("")
+         .dateFormat("")
+         .editable(true)
+         .deletable(true)
+         .hasSubFolder(false)
+         .build();
+
+      DataSourceBrowserService browserService = mock(DataSourceBrowserService.class);
+      when(browserService.getDataSources(anyString(), eq(false), any(), any(Principal.class)))
+         .thenReturn(List.of(info));
+      when(browserService.getBreadcrumbs(anyString(), eq(true), any(Principal.class)))
+         .thenReturn(List.of());
+
+      // A bare mock, not a real JDBCDataSource -- see WizDatasourceAnnotationTargetThresholdTest
+      // for why (constructing one needs a live Spring context this plain unit test does not
+      // stand up).
+      XDataSource dataSource = mock(XDataSource.class);
+      when(dataSource.getType()).thenReturn("TEST");
+      XRepository xrepository = mock(XRepository.class);
+      when(xrepository.getDataSource("Test/ds1")).thenReturn(dataSource);
+
+      Config uqlConfig = mock(Config.class);
+      // The query class loads fine -- this is NOT the failure this test is about.
+      when(uqlConfig.getQueryClass("TEST")).thenReturn("java.lang.Object");
+      when(uqlConfig.getClass("TEST", "java.lang.Object")).thenReturn((Class) Object.class);
+      // The declared runtime class does not exist -- THIS is the failure under test.
+      when(uqlConfig.getRuntime("TEST")).thenReturn("does.not.Exist");
+      when(uqlConfig.getClass("TEST", "does.not.Exist"))
+         .thenThrow(new ClassNotFoundException("does.not.Exist"));
+
+      WizDatabaseController controller = new WizDatabaseController(
+         browserService, mock(DataSourceStatusService.class),
+         mock(DatabaseDatasourcesService.class), mock(DatabaseTypeService.class),
+         mock(SecurityEngine.class), uqlConfig, xrepository,
+         mock(EndpointCatalogReader.class), mock(DatasourcesService.class));
+
+      WizDatasourceBrowserModel model = controller.getDatasourceBrowser("Test", mock(Principal.class));
+
+      assertEquals(1, model.entries().size());
+      WizDatasourceEntry entry = model.entries().get(0);
+      assertEquals("UNKNOWN", entry.annotationClass(),
+                   "a runtime class that fails to load must classify UNKNOWN, not fall through " +
+                      "to DOCUMENT_REQUIRED/METADATA via classifyQueryClass");
+   }
+
+   private static WizDatabaseController newController(Config uqlConfig) {
+      return new WizDatabaseController(
+         mock(DataSourceBrowserService.class), mock(DataSourceStatusService.class),
+         mock(DatabaseDatasourcesService.class), mock(DatabaseTypeService.class),
+         mock(SecurityEngine.class), uqlConfig, mock(XRepository.class),
+         mock(EndpointCatalogReader.class), mock(DatasourcesService.class));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceDatasourceRelationshipsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceDatasourceRelationshipsTest.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.wiz.model.DatasourceRelationshipsResponse;
+import inetsoft.web.wiz.model.osi.OsiRelationship;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Charter B12 (added at P2 reconcile): {@code POST /datasource/relationships} enforces READ on
+ * {@code dsPath}; a caller without it gets 403 and no provider call is made. Modeled directly on
+ * {@link MetadataApiServiceNonJdbcBranchTest}'s established pattern for this exact class.
+ */
+@Tag("core")
+class MetadataApiServiceDatasourceRelationshipsTest {
+
+   @Test
+   void deniedReadPermission_throwsSecurityException_andNeverCallsTheProvider() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq("Secret/Source"), eq(ResourceAction.READ), any()))
+         .thenReturn(false);
+
+      TabularCatalogService tabularCatalogService = mock(TabularCatalogService.class);
+      MetadataApiService service = new MetadataApiService(xrepository, dataSourceService,
+         mock(AssetRepository.class), mock(AssetTreeService.class), new ObjectMapper(),
+         tabularCatalogService);
+
+      assertThrows(SecurityException.class, () -> service.getDatasourceRelationships(
+         "Secret/Source", List.of("A", "B"), mock(Principal.class)));
+
+      verifyNoInteractions(tabularCatalogService);
+   }
+
+   @Test
+   void grantedReadPermission_delegatesToTabularCatalogServiceAndReturnsItsResult() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq("OData Source"), eq(ResourceAction.READ), any()))
+         .thenReturn(true);
+
+      OsiRelationship rel = new OsiRelationship();
+      rel.setName("R_A_B");
+      rel.setFrom("A");
+      rel.setTo("B");
+      TabularCatalogService tabularCatalogService = mock(TabularCatalogService.class);
+      when(tabularCatalogService.listRelationships("OData Source", List.of("A", "B")))
+         .thenReturn(List.of(rel));
+
+      MetadataApiService service = new MetadataApiService(xrepository, dataSourceService,
+         mock(AssetRepository.class), mock(AssetTreeService.class), new ObjectMapper(),
+         tabularCatalogService);
+
+      DatasourceRelationshipsResponse response = service.getDatasourceRelationships(
+         "OData Source", List.of("A", "B"), mock(Principal.class));
+
+      assertEquals(1, response.relationships().size());
+      assertEquals("R_A_B", response.relationships().get(0).getName());
+      verify(tabularCatalogService).listRelationships("OData Source", List.of("A", "B"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceSubsetRelationshipsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularCatalogServiceSubsetRelationshipsTest.java
@@ -1,0 +1,248 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.XTableNode;
+import inetsoft.uql.tabular.*;
+import inetsoft.web.wiz.model.osi.OsiRelationship;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Item 2, {@code TabularCatalogService.listRelationships} + its private
+ * {@code filterAndConvertSubsetRelationships} validator -- charter B1, B2, B6, and the reconcile
+ * Δ4 duplicate-name-across-out-of-scope-edges case the verify plan could not have anticipated
+ * (it was written blind to this method, which did not exist yet).
+ */
+@Tag("core")
+class TabularCatalogServiceSubsetRelationshipsTest {
+
+   private static final String DS_NAME = "Fake Subset Source";
+
+   /** B1: both-endpoints-in-subset edges are converted to the wire type. */
+   @Test
+   void bothEndpointsInSubset_areReturned() throws Exception {
+      TabularCatalog fullCatalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B"), new TabularDatasetRef("C")),
+         List.of(new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of("y"))));
+
+      TabularCatalogService service = serviceFor(new FakeCatalogRuntime(fullCatalog, Map.of()));
+
+      List<OsiRelationship> result = service.listRelationships(DS_NAME, Set.of("A", "B"));
+
+      assertEquals(1, result.size());
+      assertEquals("R_A_B", result.get(0).getName());
+      assertEquals("A", result.get(0).getFrom());
+      assertEquals("B", result.get(0).getTo());
+   }
+
+   /**
+    * B2: an edge with one endpoint outside the subset is dropped, not thrown -- and this must
+    * hold even when the connector's OWN {@code listRelationships} override violates the
+    * both-endpoints contract (the default implementation cannot; this exercises the defensive
+    * path in {@code filterAndConvertSubsetRelationships} directly, per 03-reconcile.md Δ3/Δ4).
+    */
+   @Test
+   void oneEndpointOutsideSubset_isDroppedWithoutThrowing() throws Exception {
+      TabularRuntime runtime = new OverridingRelationshipsRuntime(List.of(
+         new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of("y")),
+         new TabularRelationship("R_A_C", "A", "C", List.of("x"), List.of("y"))));
+
+      TabularCatalogService service = serviceFor(runtime);
+
+      List<OsiRelationship> result = service.listRelationships(DS_NAME, Set.of("A", "B"));
+
+      assertEquals(1, result.size());
+      assertEquals("R_A_B", result.get(0).getName());
+   }
+
+   /**
+    * B6: the subset path must reach {@code provider.listRelationships(tds, ids)} itself, not
+    * re-derive the answer by calling {@code listDatasets} and filtering client-side. A runtime
+    * whose {@code listRelationships} override returns something a client-side filter of
+    * {@code listDatasets()} could never produce (an edge {@code listDatasets} does not declare at
+    * all) proves the service used the override.
+    */
+   @Test
+   void callsProviderListRelationships_notAClientSideFilterOfListDatasets() throws Exception {
+      TabularCatalog catalogWithNoRelationships = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")), List.of());
+
+      TabularRuntime runtime = new OverridingRelationshipsRuntime(
+         catalogWithNoRelationships,
+         List.of(new TabularRelationship("R_ONLY_VIA_OVERRIDE", "A", "B", List.of("x"), List.of("y"))));
+
+      TabularCatalogService service = serviceFor(runtime);
+
+      List<OsiRelationship> result = service.listRelationships(DS_NAME, Set.of("A", "B"));
+
+      // listDatasets() alone declares NO relationships -- if the service filtered that instead of
+      // calling the override, this would come back empty.
+      assertEquals(1, result.size());
+      assertEquals("R_ONLY_VIA_OVERRIDE", result.get(0).getName());
+   }
+
+   /**
+    * Reconcile Δ4: the duplicate-name check must run over EVERY returned relationship, including
+    * ones later dropped for being out of scope -- proving the uniqueness check is not accidentally
+    * moved after the scope {@code continue}. Both edges here are entirely out-of-scope for the
+    * requested subset {A}.
+    */
+   @Test
+   void duplicateNameAmongTwoOutOfScopeEdges_stillThrows() throws Exception {
+      TabularRuntime runtime = new OverridingRelationshipsRuntime(List.of(
+         new TabularRelationship("DUP", "X", "Y", List.of("x"), List.of("y")),
+         new TabularRelationship("DUP", "Y", "Z", List.of("x"), List.of("y"))));
+
+      TabularCatalogService service = serviceFor(runtime);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.listRelationships(DS_NAME, Set.of("A")));
+      assertTrue(ex.getMessage().contains("DUP"),
+         "the duplicate name must be named in the failure even though both edges are out of scope");
+   }
+
+   /** A null relationships list from the provider is a connector defect, not an empty answer. */
+   @Test
+   void nullRelationshipsListFromProvider_throws() {
+      TabularRuntime runtime = new OverridingRelationshipsRuntime((List<TabularRelationship>) null);
+
+      TabularCatalogService service = serviceFor(runtime);
+
+      assertThrows(Exception.class, () -> service.listRelationships(DS_NAME, Set.of("A")));
+   }
+
+   /** A blank relationship name is rejected the same way the full-listing validator rejects it. */
+   @Test
+   void blankRelationshipName_throws() {
+      TabularRuntime runtime = new OverridingRelationshipsRuntime(List.of(
+         new TabularRelationship("", "A", "B", List.of("x"), List.of("y"))));
+
+      TabularCatalogService service = serviceFor(runtime);
+
+      assertThrows(Exception.class, () -> service.listRelationships(DS_NAME, Set.of("A", "B")));
+   }
+
+   /** Mismatched fromColumns/toColumns sizes on an in-scope edge is a malformed record. */
+   @Test
+   void mismatchedColumnSizesOnInScopeEdge_throws() {
+      TabularRuntime runtime = new OverridingRelationshipsRuntime(List.of(
+         new TabularRelationship("R", "A", "B", List.of("x", "y"), List.of("z"))));
+
+      TabularCatalogService service = serviceFor(runtime);
+
+      assertThrows(Exception.class, () -> service.listRelationships(DS_NAME, Set.of("A", "B")));
+   }
+
+   /**
+    * Charter B4, regression pin: the PAGED listing route must still carry no relationships after
+    * this round -- the risk is a builder "helpfully" wiring relationships into the paged route
+    * while adding the new subset one. {@code TabularCatalogProviderPagingTest} already pins this
+    * structurally at the {@code TabularCatalogPage} record level (no relationships field exists at
+    * all); this pins it at the {@code TabularCatalogService.listTables} call this round did not
+    * touch.
+    */
+   @Test
+   void pagedListing_stillCarriesNoRelationshipsAfterThisRound() throws Exception {
+      TabularCatalog catalog = new TabularCatalog(
+         List.of(new TabularDatasetRef("A"), new TabularDatasetRef("B")),
+         List.of(new TabularRelationship("R_A_B", "A", "B", List.of("x"), List.of("y"))));
+
+      TabularCatalogService service = serviceFor(new FakeCatalogRuntime(catalog, Map.of()));
+
+      inetsoft.web.wiz.model.DatasourceTablesResponse page =
+         service.listTables(DS_NAME, null, 10, null);
+
+      assertTrue(page.getRelationships().isEmpty(),
+         "the paged route must carry no relationships even though the same source declares one");
+   }
+
+   private static TabularCatalogService serviceFor(TabularRuntime runtime) {
+      XRepository xrepository = mock(XRepository.class);
+      try {
+         when(xrepository.getDataSource(DS_NAME)).thenReturn(new FakeTabularDataSource());
+      }
+      catch(java.rmi.RemoteException e) {
+         throw new RuntimeException(e);
+      }
+      return new TabularCatalogService(xrepository, new ObjectMapper(), dsName -> runtime);
+   }
+
+   /**
+    * A runtime whose {@code listRelationships} is overridden directly, bypassing the default
+    * both-endpoints filter entirely -- lets these tests feed {@code TabularCatalogService} an
+    * answer the default implementation could never itself produce, exercising the SERVICE's own
+    * defensive checks rather than the SPI default's.
+    */
+   private static class OverridingRelationshipsRuntime extends TabularRuntime
+      implements TabularCatalogProvider
+   {
+      OverridingRelationshipsRuntime(List<TabularRelationship> relationships) {
+         this(new TabularCatalog(List.of(), List.of()), relationships);
+      }
+
+      OverridingRelationshipsRuntime(TabularCatalog listDatasetsCatalog,
+                                      List<TabularRelationship> relationshipsOverride)
+      {
+         this.listDatasetsCatalog = listDatasetsCatalog;
+         this.relationshipsOverride = relationshipsOverride;
+      }
+
+      @Override
+      public TabularCatalog listDatasets(TabularDataSource<?> dataSource) {
+         return listDatasetsCatalog;
+      }
+
+      @Override
+      public TabularDatasetSchema describeDataset(TabularDataSource<?> dataSource, String datasetId) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+
+      @Override
+      public List<TabularRelationship> listRelationships(TabularDataSource<?> dataSource,
+                                                           Collection<String> datasetIds)
+      {
+         return relationshipsOverride;
+      }
+
+      @Override
+      public XTableNode runQuery(TabularQuery query, VariableTable params) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+
+      @Override
+      public void testDataSource(TabularDataSource<?> ds, VariableTable params) {
+         throw new UnsupportedOperationException("not used by these tests");
+      }
+
+      private final TabularCatalog listDatasetsCatalog;
+      private final List<TabularRelationship> relationshipsOverride;
+   }
+}


### PR DESCRIPTION
Two changes to how wiz discovers what a tabular data source can offer.

## 1. Classification asks the runtime, not the query class's ancestry

`classifyQueryClass` sent `Rest.XML`, `graphql`, `shopify` and `monday.com` to
`DOCUMENT_REQUIRED` purely because their query classes descend from `AbstractRestQuery`.
That is an inheritance fact, not a statement about whether the connector can be annotated.

The authoritative fact is whether the declared runtime implements `TabularCatalogProvider` —
which is already exactly what `TabularCatalogService.resolveProvider` tests at call time. Until
now the two could disagree in both directions: a source classified `METADATA` could be refused by
`resolveProvider`, and one classified `DOCUMENT_REQUIRED` could be perfectly capable. They now
agree by construction.

`classifyQueryClass` takes a second, nullable `Class<?> runtimeClass` and checks it immediately
before `isRestQuery`. `annotationClassOf` resolves the class through
`Config.getRuntime`/`Config.getClass` — a pure `Class.forName` lookup, nothing is instantiated.
A runtime that fails to **load** yields `UNKNOWN`, never `DOCUMENT_REQUIRED`, keeping "the plugin
is absent" distinct from "classified as not annotatable"; the portal reports those very
differently. A type that simply declares no runtime falls through unchanged.

**This unlocks recognition and integrates zero connectors.** None of `Rest.XML`, `graphql`,
`shopify` or `monday.com` has a runtime implementing the SPI, so **no source type's
classification changes when this lands**. What changes is that implementing the SPI will now be
recognised. It should not be read as "four source types integrated".

**Order in `classifyQueryClass` is load-bearing.** The new check runs after `ScriptedQuery` and
after `endpoints.json`, so a query that is unsupported, or already ships a machine-readable
catalogue, stays that way even if its runtime also implements the SPI. No connector ships that
combination today, which is exactly why it is pinned by a test rather than argued in a comment.

The pre-existing one-argument `classifyQueryClass` is kept as an overload delegating to
`(queryClass, null)`, so all seven existing call sites pass unmodified — stronger evidence that
nothing reclassifies than migrated call sites would be. A test asserts the two forms agree for
every one of the five verdicts.

## 2. `listRelationships` gets a production caller

`listRelationships` merged with no caller anywhere in `community/core/src/main`, so annotating a
hand-picked subset of a source's datasets carried **zero** relationships — not "only edges with
both endpoints inside the set". The whole-database path still carried them, so the two paths
behaved differently.

New `POST /api/wiz/datasource/relationships`, body `{ dsPath, datasetIds }`, reaching
`provider.listRelationships(tds, ids)`. A POST body rather than a GET query string because the id
list can be large and `TabularDatasetRef.id` is opaque — it may contain `.` or `/`.

`validateRelationshipEndpoints` is **not** modified. The subset path uses its own validator, which
differs deliberately in one respect: an edge whose endpoint falls outside the requested subset is
**dropped**, where the full listing **throws**. In a full listing a dangling endpoint is a genuine
connector defect; in a subset it is the expected case. Name-uniqueness and column-shape violations
still throw on both paths, and the uniqueness check deliberately runs over every returned
relationship including ones later dropped, because a duplicate name is a whole-catalogue defect
regardless of which subset was asked for.

The paged listing route still carries no relationships, unchanged.

## Testing

`./mvnw -pl core -am test` — 9108 tests, green. New coverage includes the ordering guard, the
runtime-load-failure path, the enumeration that all four REST-descended source types still
classify `DOCUMENT_REQUIRED`, subset relationship filtering, the permission gate on the new route,
and a duplicate relationship name declared across two out-of-scope edges.

Paired with stylebi-wiz's branch of the same name, which carries the wiz-side consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
