### PR TITLE
Fix #76523: restore open_base_worksheet's runtime-attach after #76408 collision

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
@@ -132,10 +132,12 @@ public class OpenWorksheetController extends WorksheetController {
       entry.setProperty("gettingStarted", event.gettingStartedWs() + "");
       // event.runtimeId() is set when the server already opened this worksheet and told the
       // browser to attach to it; opening a second runtime of the same asset would leave the
-      // agent and the user editing different copies. See WorksheetEventService.openWorksheet.
+      // agent and the user editing different copies. event.vsId() is unrelated -- the viewsheet
+      // this worksheet is being opened FROM, for sandbox linking. See
+      // WorksheetEventService.openWorksheet.
       String runtimeId = eventService.openWorksheet(
          principal, entry, event.openAutoSavedFile(), event.createQuery(), event.runtimeId(),
-         commandDispatcher);
+         event.vsId(), commandDispatcher);
 
       getRuntimeViewsheetRef().setRuntimeId(runtimeId);
       runtimeViewsheetManager.sheetOpened(principal, runtimeId);

--- a/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
@@ -55,15 +55,36 @@ public class WorksheetEventService {
                                boolean gettingStartedCreateQuery,
                                CommandDispatcher commandDispatcher) throws Exception
    {
-      return openWorksheet(user, entry, openAutoSaved, gettingStartedCreateQuery, null,
+      return openWorksheet(user, entry, openAutoSaved, gettingStartedCreateQuery, null, null,
                            commandDispatcher);
    }
 
+   /**
+    * Open the worksheet, or attach to a runtime that is already open, optionally linking the
+    * new/attached worksheet's sandbox back to an originating viewsheet.
+    *
+    * <p>{@code existingRuntimeId} is set when the server opened the runtime itself and told the
+    * browser to attach to it — the {@code open_base_worksheet} agent flow. Opening a second
+    * runtime of the same asset there is the defect this parameter exists to prevent: the agent
+    * edits one runtime while the user watches the other, both ends report success, and nothing
+    * surfaces until one save clobbers the other. An id naming a runtime that does not exist, or
+    * one owned by another user, fails inside {@code engine.getWorksheet} on the proxy call rather
+    * than quietly opening a fresh one.
+    *
+    * <p>{@code vsId} is independent of {@code existingRuntimeId} — it names the viewsheet this
+    * worksheet is being opened FROM (e.g. the base worksheet link in the composer's bottom status
+    * bar), so its sandbox can link back for script expressions like
+    * {@code worksheet['TextInput1'].value}. Either, both, or neither may be set on a given call.
+    *
+    * @param existingRuntimeId a runtime to attach to, or {@code null} to open a new one
+    * @param vsId the originating viewsheet's runtime id, or {@code null} if none
+    */
    public String openWorksheet(Principal user, AssetEntry entry, boolean openAutoSaved,
-                               boolean gettingStartedCreateQuery, String vsId,
-                               CommandDispatcher commandDispatcher) throws Exception
+                               boolean gettingStartedCreateQuery, String existingRuntimeId,
+                               String vsId, CommandDispatcher commandDispatcher) throws Exception
    {
-      String runtimeId = engine.openWorksheet(entry, user);
+      String runtimeId = existingRuntimeId != null
+         ? existingRuntimeId : engine.openWorksheet(entry, user);
       WorksheetEventServiceProxy p = proxy.getIfAvailable();
 
       if(p != null) {

--- a/core/src/test/java/inetsoft/web/composer/ws/assembly/WorksheetEventServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/assembly/WorksheetEventServiceTest.java
@@ -30,12 +30,19 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Whether opening a worksheet creates a runtime or attaches to one that already exists.
+ * Whether opening a worksheet creates a runtime or attaches to one that already exists, and
+ * whether it links the new/attached worksheet's sandbox back to an originating viewsheet.
  *
  * <p>An agent tool ({@code open_base_worksheet}) opens a worksheet runtime server-side and tells
  * the browser to attach to it. If the browser opens its own runtime instead, both ends report
  * success and diverge silently: the agent edits one worksheet, the user watches another, and
  * nothing surfaces until a save overwrites one with the other.
+ *
+ * <p>{@code existingRuntimeId} (the attach target) and {@code vsId} (the viewsheet to link the
+ * sandbox to) are independent parameters -- bug #76409 collapsed them into the same slot when
+ * #76408 added {@code vsId} without adding its own parameter, so a supplied {@code runtimeId} was
+ * silently read as a {@code vsId} and the attach branch never fired. Every case below exercises
+ * both parameters together to guard against that collision recurring.
  */
 @Tag("core")
 class WorksheetEventServiceTest {
@@ -48,11 +55,11 @@ class WorksheetEventServiceTest {
    void attachesToTheSuppliedRuntimeInsteadOfOpeningASecondOne() throws Exception {
       Fixture f = new Fixture();
 
-      f.service.openWorksheet(f.user, f.entry, false, false, "ws-server-1", f.dispatcher);
+      f.service.openWorksheet(f.user, f.entry, false, false, "ws-server-1", null, f.dispatcher);
 
       verify(f.engine, never()).openWorksheet(any(AssetEntry.class), any(Principal.class));
       verify(f.proxy).openWorksheet(eq("ws-server-1"), eq(f.user), eq(f.entry), eq(false),
-                                    eq(false), eq(f.dispatcher));
+                                    eq(false), eq((String) null), eq(f.dispatcher));
    }
 
    /**
@@ -64,11 +71,29 @@ class WorksheetEventServiceTest {
       Fixture f = new Fixture();
       when(f.engine.openWorksheet(f.entry, f.user)).thenReturn("ws-fresh-1");
 
-      f.service.openWorksheet(f.user, f.entry, false, false, null, f.dispatcher);
+      f.service.openWorksheet(f.user, f.entry, false, false, null, null, f.dispatcher);
 
       verify(f.engine).openWorksheet(f.entry, f.user);
       verify(f.proxy).openWorksheet(eq("ws-fresh-1"), eq(f.user), eq(f.entry), eq(false),
-                                    eq(false), eq(f.dispatcher));
+                                    eq(false), eq((String) null), eq(f.dispatcher));
+   }
+
+   /**
+    * Regression test for bug #76409: attaching to a server-opened runtime (the
+    * {@code open_base_worksheet} agent flow) and linking the new worksheet's sandbox to an
+    * originating viewsheet are independent and must both take effect when both are supplied --
+    * neither parameter may shadow or overwrite the other.
+    */
+   @Test
+   void attachesToSuppliedRuntimeAndLinksVsIdSimultaneously() throws Exception {
+      Fixture f = new Fixture();
+
+      f.service.openWorksheet(f.user, f.entry, false, false, "ws-server-1", "vs-origin-1",
+                              f.dispatcher);
+
+      verify(f.engine, never()).openWorksheet(any(AssetEntry.class), any(Principal.class));
+      verify(f.proxy).openWorksheet(eq("ws-server-1"), eq(f.user), eq(f.entry), eq(false),
+                                    eq(false), eq("vs-origin-1"), eq(f.dispatcher));
    }
 
    @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Fixes Redmine #76523: `#76408` (commit `944a9c0ca`) added a `vsId` parameter to
`WorksheetEventService.openWorksheet` for viewsheet-sandbox linking by repurposing the same
positional parameter slot `7ee0203c6`'s `existingRuntimeId` (the `open_base_worksheet` agent
attach flow) already occupied, instead of adding its own parameter.

Net effect of that collision, confirmed by direct code inspection:
- `WorksheetEventService.openWorksheet`'s mid-level method now unconditionally calls
  `engine.openWorksheet(entry, user)` — the "attach to an already-open runtime" branch is gone
  entirely, silently reintroducing the exact bug `7ee0203c6` fixed (the `open_base_worksheet`
  agent tool opens a runtime server-side, but the browser opens a second one of its own instead
  of attaching — both ends report success, and a save silently clobbers one with the other).
- `OpenWorksheetController.openWorksheet` still passes `event.runtimeId()` into that same slot
  (now interpreted as `vsId`), and never reads `event.vsId()` at all — so `#76408`'s own
  sandbox-link fix never actually fires in its intended case either.
- This also explains an already-flagged, unrelated finding from PR #5076's review
  (`docs/teams/2026-09-07-bug-76400-group-aggregate-chart-poison/06-review-r1.md` §6 in the
  `stylebi-wiz` repo): the `WorksheetEventServiceTest.java` compile break blocking CI on
  `stylebi-wiz-main-rebase` — that test's call sites still assumed the pre-`#76408` 6-argument
  signature.

## Fix

Minimal: give `WorksheetEventService.openWorksheet` two independent parameters
(`existingRuntimeId`, `vsId`) instead of one repurposed slot, and update
`OpenWorksheetController` to pass both `event.runtimeId()` and `event.vsId()`.

## Test plan

- [x] Updated `WorksheetEventServiceTest` for the new 7-arg signature (both existing tests).
- [x] Added `attachesToSuppliedRuntimeAndLinksVsIdSimultaneously` — a regression test exercising
      both parameters together, so this exact collision can't silently recur.
- [x] `WorksheetEventServiceTest` (3 tests), `OpenWorksheetControllerSandboxLinkTest` (2 tests,
      `#76408`'s own test, unmodified), and `SheetOpenServiceTest` (38 tests) all pass — 43/43,
      0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)