### PR TITLE
Fix #76527: stale ValueOfColumn.minDate cache across facet cells

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -779,6 +779,7 @@ public class ValueOfColumn extends AbstractColumn {
    public void complete() {
       subs = null;
       subsRoot = null;
+      minDate = null;
    }
 
    @Override

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -113,6 +113,52 @@ public class ValueOfColumnTest {
    }
 
    /**
+    * Regression test for Bug #76527: PREVIOUS_YEAR's minDate cache (getMinDate()) must not
+    * leak stale state across facet cells that reuse the same ValueOfColumn instance.
+    *
+    * A faceted chart shares one ValueOfColumn instance across all facet cells
+    * (DataSetIndex.wrapDataSet()), calling calculate() against each cell's own narrower
+    * DataSet in turn. Before the fix, getMinDate() computed its minimum date once and never
+    * recomputed, so a cell whose local data only contained a later year (here, a single
+    * 2022-01-01 row) would freeze minDate at 2022-01-01. A later cell that legitimately
+    * contains both 2021-01-01 and 2022-01-01 would then wrongly have its 2022 row's
+    * "previous year" guard (ValueOfColumn.java ~455-459) evaluate against the stale
+    * 2022-01-01 minDate instead of its own data's true minimum (2021-01-01), incorrectly
+    * returning INVALID instead of the real previous-year value.
+    */
+   @Test
+   void testMinDateNotStaleAcrossFacetCells() {
+      valueOfColumn = new ValueOfColumn("id", "sum(id)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS_YEAR);
+      valueOfColumn.setDim("date");
+
+      // Facet cell A: single row, only year 2022.
+      DefaultTableLens cellATable = new DefaultTableLens(new Object[][]{
+         { "date", "id" },
+         { toDate("2022-01-01"), 99 }
+      });
+      VSDataSet cellA = createVSDataSet(cellATable, "date");
+      Object cellAResult = valueOfColumn.calculate(cellA, 0, false, false);
+      assertEquals(CalcColumn.INVALID, cellAResult);
+      valueOfColumn.complete();
+
+      // Facet cell B: same shape as testCalculateWithDataSetOfPreviousYear (known-good in
+      // isolation): 2021 and 2022. Reuses the same valueOfColumn instance, simulating the
+      // next facet cell in a faceted chart.
+      DefaultTableLens cellBTable = new DefaultTableLens(new Object[][]{
+         { "date", "id" },
+         { toDate("2021-01-01"), 4 },
+         { toDate("2022-01-01"), 3 }
+      });
+      VSDataSet cellB = createVSDataSet(cellBTable, "date");
+
+      // Without the fix, getMinDate() is still frozen at cell A's 2022-01-01, so this
+      // wrongly returns INVALID instead of the previous year's value (4).
+      Object cellBResult = valueOfColumn.calculate(cellB, 1, true, false);
+      assertEquals(4, cellBResult);
+   }
+
+   /**
     * check previous range of a dc values
     */
    @Test


### PR DESCRIPTION
## Summary

`ValueOfColumn.minDate` (used by `PREVIOUS_YEAR`/`PREVIOUS_QUARTER`/`PREVIOUS_MONTH`/`PREVIOUS_WEEK` calcs' "first period" guard) was computed lazily and cached forever, never invalidated when the same `ValueOfColumn` instance is reused across a different `DataSet`. In a faceted chart, `DataSetIndex.wrapDataSet()` shares one `ValueOfColumn` instance across all facet cells, each running its own `prepareCalc()`/`calculate()` pass against its own narrower per-cell `DataSet`. `minDate` froze on whichever facet cell was processed first and was then wrongly reused as the guard for every other cell, producing a spurious `INVALID` result (which renders with a fallback/undefined color) for rows that should have had a valid previous-period value — reported against `TrendComparison_Spec`'s `previous2`/`previous4` cases.

Every other per-dataset cache on this class (`subs`/`subsRoot`, `AbstractColumn.cachrouter`) already invalidates correctly on dataset change; `minDate` was the one exception.

## Fix

Null `minDate` out in `complete()`, alongside the existing `subs = null; subsRoot = null;` reset — `complete()` already fires once per facet cell, right after that cell's rows are computed and before the next cell's `prepareCalc()` runs on the same shared instance, so this is sufficient without needing to track dataset identity.

## Test plan

- [x] Added `ValueOfColumnTest.testMinDateNotStaleAcrossFacetCells`: simulates two facet cells sharing one `ValueOfColumn` (cell A = single 2022 row, cell B = 2021+2022 rows matching the existing known-good `testCalculateWithDataSetOfPreviousYear` case), asserting cell B's 2022 row still correctly resolves to its previous-year value after cell A has already run.
- [x] Confirmed the new test fails without the fix (`expected: <4> but was: <4.9E-324>`, i.e. `CalcColumn.INVALID`) and passes with it.
- [x] Full class run: `./mvnw -pl community/core -Dtest=ValueOfColumnTest test` — 24/24 tests pass.

Note: this fixes the confirmed calc-engine staleness defect itself. It does not independently confirm which of `previous2`/`previous4` (or both) it resolves in `TrendComparison_Spec`, since the real chart bindings/fixtures for that suite weren't available in this checkout — worth a live/screenshot-diff re-run of that suite once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)