### PR TITLE
Bug #76506: fix DataTipView popup positioned outside viewport after Enlarge

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.spec.ts
@@ -138,4 +138,133 @@ describe("VSDataTip Directive Tests", () => {
 
       expect(markForCheckSpy).not.toHaveBeenCalled();
    });
+
+   // Bug #76506: on a fresh trigger (transitioning from the "not active" branch's
+   // display:none), the boundary check must measure the element's size only after display
+   // has been set back to "block" -- otherwise clientWidth/clientHeight read 0 and the
+   // overflow correction never applies.
+   it("should measure size only after display is set to block, not while still display:none", () => {
+      fixture.detectChanges();
+      dataTipService.isCurrentDataTip.mockReturnValue(false);
+      fixture.detectChanges();
+      const el: HTMLElement = div.nativeElement;
+      expect(el.style.display).toBe("none");
+
+      let displayWhenWidthMeasured: string | undefined;
+      let displayWhenHeightMeasured: string | undefined;
+      Object.defineProperty(el, "clientWidth", {
+         configurable: true,
+         get: () => {
+            displayWhenWidthMeasured = el.style.display;
+            return 500;
+         }
+      });
+      Object.defineProperty(el, "clientHeight", {
+         configurable: true,
+         get: () => {
+            displayWhenHeightMeasured = el.style.display;
+            return 500;
+         }
+      });
+
+      dataTipService.isCurrentDataTip.mockReturnValue(true);
+      fixture.detectChanges();
+
+      expect(displayWhenWidthMeasured).toBe("block");
+      expect(displayWhenHeightMeasured).toBe("block");
+      expect(el.style.display).toBe("block");
+   });
+});
+
+// Bug #76506: when the data tip content belongs to a registered container, the boundary
+// check must use the container's *current* on-screen size, not the PopInfo snapshot taken
+// once when the container was added (which is never refreshed, e.g. when the container
+// later enters max mode and grows well past its original design-time size).
+describe("VSDataTip Directive container boundary check (#76506)", () => {
+   @Component({
+      standalone: true,
+      imports: [VSDataTipDirective],
+      template: `
+         <div id="Container1_main"></div>
+         <div class="table-container" VSDataTip [dataTipName]="'Tip1'"
+              [popContainerName]="'Container1'"></div>
+      `
+   })
+   class ContainerTestApp {
+   }
+
+   let fixture: ComponentFixture<ContainerTestApp>;
+   let div: DebugElement;
+   let dataTipService: any;
+   let popService: any;
+   const viewerOffsetValue = {width: 1000, height: 1000, scrollLeft: 0, scrollTop: 0};
+
+   // Stale snapshot captured at Add*ObjectCommand time -- much smaller than the container's
+   // actual current size (simulating the container having since entered max mode).
+   const staleContainerInfo = {
+      top: 0, left: 0, width: 100, height: 100,
+      absoluteName: "Container1", vsObject: {}
+   };
+
+   beforeEach(() => {
+      dataTipService = {
+         isDataTip: vi.fn((name: string) => name === "Tip1"),
+         isCurrentDataTip: vi.fn(() => true),
+         isDataTipVisible: vi.fn(() => true),
+         isFrozen: vi.fn(() => false),
+         getVSObjectId: vi.fn((name: string) => name === "Tip1" ? "Tip1_main" : "Container1_main"),
+         dataTipX: 300,
+         dataTipY: 300,
+         dataTipName: "Tip1",
+         dataTipAlpha: 1,
+         scrolled: new Subject<void>(),
+         get viewerOffset() {
+            return viewerOffsetValue;
+         }
+      };
+      popService = {
+         getPopComponent: vi.fn(() => null),
+         hasPopUpComponentShowing: vi.fn(() => false),
+         getPopInfo: vi.fn((name: string) => {
+            if(name === "Tip1") {
+               return {top: 0, left: 0, width: 50, height: 50, absoluteName: "Tip1", vsObject: {}};
+            }
+
+            if(name === "Container1") {
+               return staleContainerInfo;
+            }
+
+            return null;
+         })
+      };
+
+      fixture = TestBed.configureTestingModule({
+         imports: [ContainerTestApp, VSDataTipDirective],
+         providers: [
+            {provide: DataTipService, useValue: dataTipService},
+            {provide: PopComponentService, useValue: popService},
+            {provide: DebounceService, useValue: {debounce: vi.fn(), cancel: vi.fn()}}
+         ]
+      }).createComponent(ContainerTestApp);
+
+      div = fixture.debugElement.query(By.directive(VSDataTipDirective));
+   });
+
+   it("should use the container's live on-screen size instead of the stale PopInfo snapshot", () => {
+      const containerEl = fixture.nativeElement.querySelector("#Container1_main");
+      Object.defineProperty(containerEl, "clientWidth", {configurable: true, get: () => 800});
+      Object.defineProperty(containerEl, "clientHeight", {configurable: true, get: () => 800});
+
+      fixture.detectChanges();
+      const el: HTMLElement = div.nativeElement;
+
+      // With the stale 100x100 PopInfo size, tipX/tipY of 300 would never overflow a
+      // 1000x1000 viewport and no correction would be applied (left/top would be 301px).
+      // The live 800x800 container size does overflow, so a leftward/upward correction
+      // must be applied instead.
+      expect(el.style.left).not.toBe("301px");
+      expect(el.style.top).not.toBe("301px");
+      expect(el.style.left).toBe("1px");
+      expect(el.style.top).toBe("1px");
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/data-tip/vs-data-tip.directive.ts
@@ -159,6 +159,24 @@ export class VSDataTipDirective implements DoCheck, OnInit, OnDestroy {
             const mainComponent = !this.miniToolbar ? nativeElement :
                document.getElementById(this.dataTipService.getVSObjectId(this.dataTipName));
 
+            if(!this.miniToolbar) {
+               // Set display to block before mainComponent.clientWidth/clientHeight are read
+               // below for the boundary check -- mainComponent is this same nativeElement, and
+               // reading its size while still display:none (e.g. right after a fresh trigger
+               // transitions out of the "not active" branch below) would measure 0x0 and skip
+               // the overflow correction entirely (#76506).
+               this.renderer.setStyle(nativeElement, "display", "block");
+            }
+
+            // Live measurement of the container's actual on-screen size, instead of the
+            // PopInfo snapshot in PopComponentService, which is written once (with the
+            // container's design-time objectFormat.width/height) when the container is added
+            // and is never refreshed -- e.g. when the container later enters max mode and
+            // grows well past that original size (#76506).
+            const containerElement = containerInfo
+               ? document.getElementById(this.dataTipService.getVSObjectId(this.popContainerName))
+               : null;
+
             let top = tipY;
             let left = tipX;
             let parentElem: any = nativeElement;
@@ -185,9 +203,12 @@ export class VSDataTipDirective implements DoCheck, OnInit, OnDestroy {
             let topOffset: number = DataTipService.DATA_TIP_OFFSET;
             let leftOffset: number = DataTipService.DATA_TIP_OFFSET;
 
-            if(containerInfo && left + reducedEmbeddedVsLeft + containerInfo.width > viewportSize[0]) {
+            const containerWidth = containerInfo
+               ? (containerElement ? containerElement.clientWidth : containerInfo.width) : 0;
+
+            if(containerInfo && left + reducedEmbeddedVsLeft + containerWidth > viewportSize[0]) {
                // place on left
-               leftOffset = -Math.min(left, containerInfo.width + leftOffset -
+               leftOffset = -Math.min(left, containerWidth + leftOffset -
                   viewerRect.scrollLeft);
             }
             // same as above for container itself or if not in container
@@ -202,7 +223,7 @@ export class VSDataTipDirective implements DoCheck, OnInit, OnDestroy {
             }
 
             const containerHeight = containerInfo
-               ? (<any>containerInfo.vsObject).objectHeight || containerInfo.height : 0;
+               ? (containerElement ? containerElement.clientHeight : containerInfo.height) : 0;
 
             if(containerInfo && top + reducedEmbeddedVsTop + containerHeight > viewportSize[1]) {
                topOffset = -Math.min(top, containerHeight + reducedEmbeddedVsTop + topOffset - viewerRect.scrollTop);
@@ -252,8 +273,8 @@ export class VSDataTipDirective implements DoCheck, OnInit, OnDestroy {
             this.renderer.addClass(nativeElement, this.dataTipClass);
 
             if(!this.miniToolbar) {
-               this.renderer.setStyle(nativeElement, "display", "block");
-
+               // display was already set to "block" above, before the boundary-check
+               // measurements were taken.
                if(tipAlpha != null && tipAlpha != 1) {
                   this.renderer.setStyle(nativeElement, "opacity", tipAlpha / 100);
                }


### PR DESCRIPTION
## Summary
- Clicking "Enlarge" on a Data Tip View's mini-toolbar to switch a container to max mode could leave the data tip popup positioned partly/fully outside the browser viewport.
- `VSDataTipDirective.ngDoCheck()`'s boundary/overflow check compared the popup's target position against a container size that could be stale in two ways:
  1. When the tip content has a registered container (`popContainerName`), the check used `PopComponentService`'s cached `PopInfo` width/height. That cache is written exactly once, at `Add*ObjectCommand` time, using the container's design-time `objectFormat.width`/`height`, and is never refreshed (e.g. when the container later enters max mode and grows well past that original size).
  2. Independently, `clientWidth`/`clientHeight` were read for the boundary check before `display` was flipped from `"none"` to `"block"` on a fresh trigger, which could measure a 0x0 box and skip the overflow correction entirely.
- Fix: measure the container's actual on-screen size via its live DOM element (`document.getElementById` + `clientWidth`/`clientHeight`) instead of the frozen `PopInfo` snapshot, falling back to the cached value only if the element can't be found; and read size only after `display` is set to `"block"`.

## Test plan
- [x] Added `vs-data-tip.directive.spec.ts` coverage:
  - the boundary check measures size only after `display` is set to `"block"`, not while still `display:none`
  - the boundary check uses the container's live on-screen size (via a `#Container1_main` stand-in element) rather than a stale cached `PopInfo` snapshot
- [x] `npx ng test portal --include='**/vs-data-tip.directive.spec.ts'` — 7/7 passed
- [x] `npx ng test portal --include='**/data-tip/**/*.spec.ts' --include='**/vs-object-container*.spec.ts' --include='**/mini-toolbar*.spec.ts'` — 13/13 passed, no regressions
- [ ] Not verified with a live browser in this run (no bundled sample "chart" viewsheet asset exists in this repo to reproduce with); a live check of the actual repro (Enlarge → click yellow bar, narrow viewport) would still be valuable to confirm end-to-end.

Redmine #76506

🤖 Generated with [Claude Code](https://claude.com/claude-code)