### PR TITLE
fix(wiz): curated Tip-pane property aliases + tipView silent-discard fix (Redmine #76516)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -263,8 +263,54 @@ public class AssemblyPropertyService {
             requireVariableFlagAchievable(type, model, rvs.getViewsheet());
          }
 
+         model = impliedTipOptionForTipView(model, resolved.values());
+
          writeModel(runtimeId, type, assemblyName, model, linkUri, user, dispatcher);
       });
+   }
+
+   /**
+    * A {@code tipView} set to a real assembly name unambiguously means "use Data Tip View" --
+    * but {@code setChartPropertyModel}/{@code setCrosstabPropertyModel} both force {@code tipView}
+    * back to {@code null} whenever {@code tipOption} is {@code false} (read from the model as a
+    * whole, not from this one patch), regardless of what this call itself just wrote there. A
+    * caller that sets {@code tipView} without ALSO setting {@code tipOption:true} in the same
+    * patch therefore gets a silent no-op: {@code set_assembly_properties} reports {@code ok:true},
+    * and the very value this method just wrote is discarded before it ever reaches the real
+    * {@code VSAssemblyInfo} -- live-confirmed for chart (Redmine #76516), and true by the same
+    * source reading for crosstab, which has carried this same {@code tipView} alias -- and the
+    * same latent bug -- since before that ticket.
+    *
+    * <p>Only acts when the resolved patch actually touched a {@code .tipView} path with a
+    * non-blank value, and did NOT also touch that path's sibling {@code .tipOption}. A caller who
+    * sets {@code tipOption} explicitly (to {@code true} or {@code false}) is always left alone --
+    * this only fills in the one combination that would otherwise silently do nothing, per
+    * {@code set_assembly_properties}'s own "forgiving where the intent is unambiguous" rule; it
+    * is not a general-purpose inference and does not guess at any other field.
+    */
+   private static Object impliedTipOptionForTipView(Object model, Collection<String> resolvedPaths) {
+      for(String path : resolvedPaths) {
+         if(!path.endsWith(".tipView")) {
+            continue;
+         }
+
+         Object value = PropertyPath.get(model, path);
+
+         if(value == null || (value instanceof String str && str.isEmpty())) {
+            continue;
+         }
+
+         String tipOptionPath =
+            path.substring(0, path.length() - "tipView".length()) + "tipOption";
+
+         if(resolvedPaths.contains(tipOptionPath)) {
+            continue;
+         }
+
+         model = PropertyPath.set(model, tipOptionPath, true);
+      }
+
+      return model;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -21,6 +21,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.model.vs.RangePaneModel;
+import inetsoft.web.composer.model.vs.TipCustomizeDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
 import inetsoft.web.viewsheet.service.VSInputService;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
@@ -263,34 +264,45 @@ public class AssemblyPropertyService {
             requireVariableFlagAchievable(type, model, rvs.getViewsheet());
          }
 
-         model = impliedTipOptionForTipView(model, resolved.values());
+         model = impliedSibling(model, resolved.values(), "tipView", "tipOption", true);
+         model = impliedSibling(model, resolved.values(), "tipPaneModel.alpha",
+                                 "tipPaneModel.tipOption", true);
+         model = impliedSibling(model, resolved.values(), "customTip", "customRB",
+                                 TipCustomizeDialogModel.TipFormat.CUSTOM);
 
          writeModel(runtimeId, type, assemblyName, model, linkUri, user, dispatcher);
       });
    }
 
    /**
-    * A {@code tipView} set to a real assembly name unambiguously means "use Data Tip View" --
-    * but {@code setChartPropertyModel}/{@code setCrosstabPropertyModel} both force {@code tipView}
-    * back to {@code null} whenever {@code tipOption} is {@code false} (read from the model as a
-    * whole, not from this one patch), regardless of what this call itself just wrote there. A
-    * caller that sets {@code tipView} without ALSO setting {@code tipOption:true} in the same
-    * patch therefore gets a silent no-op: {@code set_assembly_properties} reports {@code ok:true},
-    * and the very value this method just wrote is discarded before it ever reaches the real
-    * {@code VSAssemblyInfo} -- live-confirmed for chart (Redmine #76516), and true by the same
-    * source reading for crosstab, which has carried this same {@code tipView} alias -- and the
-    * same latent bug -- since before that ticket.
+    * Implies {@code siblingSuffix := impliedValue} whenever the resolved patch sets a path
+    * ending in {@code suffix} to a non-blank value without ALSO setting that path's own sibling
+    * ({@code siblingSuffix}, same parent) in the same patch. A caller who sets the sibling
+    * explicitly (to any value) is always left alone -- this only fills in the one combination
+    * that would otherwise silently do nothing, per {@code set_assembly_properties}'s own
+    * "forgiving where the intent is unambiguous" rule; it does not guess at any other field.
     *
-    * <p>Only acts when the resolved patch actually touched a {@code .tipView} path with a
-    * non-blank value, and did NOT also touch that path's sibling {@code .tipOption}. A caller who
-    * sets {@code tipOption} explicitly (to {@code true} or {@code false}) is always left alone --
-    * this only fills in the one combination that would otherwise silently do nothing, per
-    * {@code set_assembly_properties}'s own "forgiving where the intent is unambiguous" rule; it
-    * is not a general-purpose inference and does not guess at any other field.
+    * <p>Three Tip-pane field pairs share this exact shape, each confirmed by reading the real
+    * property-dialog services (Redmine #76516):
+    * <ul>
+    * <li>{@code tipView}/{@code tipOption} -- {@code setChartPropertyModel} et al. force
+    * {@code tipView} back to {@code null} whenever {@code tipOption} is {@code false} (read from
+    * the model as a whole, not from this one patch), regardless of what this call itself just
+    * wrote there.
+    * <li>{@code tipPaneModel.alpha}/{@code tipPaneModel.tipOption} -- the same services only call
+    * {@code setAlphaValue} inside the {@code tipOption == true} branch, so {@code alpha}/
+    * {@code tipAlpha} set alone is silently dropped, not merely left at its old value.
+    * <li>{@code customTip}/{@code customRB} -- {@code customTip} is only applied when
+    * {@code customRB == TipFormat.CUSTOM}; otherwise it is actively nulled out, so
+    * {@code tooltip} set alone (without {@code tooltipMode: "CUSTOM"} in the same patch) does not
+    * merely no-op, it wipes any existing custom tooltip.
+    * </ul>
     */
-   private static Object impliedTipOptionForTipView(Object model, Collection<String> resolvedPaths) {
+   private static Object impliedSibling(Object model, Collection<String> resolvedPaths,
+                                         String suffix, String siblingSuffix, Object impliedValue)
+   {
       for(String path : resolvedPaths) {
-         if(!path.endsWith(".tipView")) {
+         if(!path.endsWith("." + suffix)) {
             continue;
          }
 
@@ -300,14 +312,13 @@ public class AssemblyPropertyService {
             continue;
          }
 
-         String tipOptionPath =
-            path.substring(0, path.length() - "tipView".length()) + "tipOption";
+         String siblingPath = path.substring(0, path.length() - suffix.length()) + siblingSuffix;
 
-         if(resolvedPaths.contains(tipOptionPath)) {
+         if(resolvedPaths.contains(siblingPath)) {
             continue;
          }
 
-         model = PropertyPath.set(model, tipOptionPath, true);
+         model = PropertyPath.set(model, siblingPath, impliedValue);
       }
 
       return model;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -615,6 +615,18 @@ public final class PropertyAliases {
       aliases.put("rangeValues", range + ".rangeValues");
       aliases.put("rangeColorValues", range + ".rangeColorValues");
       aliases.put("targetValue", range + ".targetValue");
+
+      // Tip pane (Redmine #76516 item 1 follow-up). Gauge has no Data Tip View mode (no
+      // TipVSAssemblyInfo.setTipOptionValue/setTipViewValue call anywhere in
+      // GaugePropertyDialogService -- only a plain visibility flag plus optional custom text) --
+      // "tipOption" here means "show a tooltip at all", independently gating
+      // gaugeAssemblyInfo.setTooltipVisible, not a radio choice between tooltip/tipView the way
+      // chart's/crosstab's/table's/calcTable's tipOption is. No "alpha"/flyOverViews/tipOnClick
+      // for the same reason -- those are specific to the tipView flyover mechanism gauge does
+      // not have.
+      aliases.put("tooltipVisible", "gaugeGeneralPaneModel.tipPaneModel.tipOption");
+      aliases.put("tooltip", "gaugeGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customTip");
+      aliases.put("tooltipMode", "gaugeGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customRB");
       dataOutput(aliases);
       return aliases;
    }
@@ -626,7 +638,12 @@ public final class PropertyAliases {
       aliases.put("alpha", "textGeneralPaneModel.alpha");
       aliases.put("popComponent", "textGeneralPaneModel.popComponent");
       aliases.put("text", "textGeneralPaneModel.textPaneModel.text");
+      // Same shape as gauge()/image() (see gauge()'s comment) -- "tipOption" here predates this
+      // ticket and stays as-is for compatibility; "tooltip"/"tooltipMode" are the missing half of
+      // the same feature, added now.
       aliases.put("tipOption", "textGeneralPaneModel.tipPaneModel.tipOption");
+      aliases.put("tooltip", "textGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customTip");
+      aliases.put("tooltipMode", "textGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customRB");
       dataOutput(aliases);
       return aliases;
    }
@@ -640,6 +657,16 @@ public final class PropertyAliases {
       Map<String, String> aliases = new LinkedHashMap<>();
       outputGeneral(aliases, "imageGeneralPaneModel");
       sizePosition(aliases, "imageGeneralPaneModel");
+
+      // Tip pane (Redmine #76516 item 1 follow-up). Same shape as gauge()/text() -- a plain
+      // visibility flag plus optional custom text, no Data Tip View/tipView radio option (that
+      // would be a different pane entirely: image's own separate "Pop Component" feature,
+      // ImageAdvancedPaneModel.popComponent/popOption/popLocation, applied unconditionally by
+      // setImagePropertyDialogModel with no gating relation to tipOption at all -- deliberately
+      // NOT aliased here, out of scope for this ticket).
+      aliases.put("tooltipVisible", "imageGeneralPaneModel.tipPaneModel.tipOption");
+      aliases.put("tooltip", "imageGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customTip");
+      aliases.put("tooltipMode", "imageGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customRB");
       dataOutput(aliases);
       return aliases;
    }
@@ -722,6 +749,27 @@ public final class PropertyAliases {
       // zeroes it on read whenever the chart cannot project forward. Exposing the setting without
       // its gate left that looking like a dropped write. Refused for write, with the flags below.
       aliases.put("projectForwardEnabled", "chartLinePaneModel.projectForwardEnabled");
+
+      // General > Tip pane (Redmine #76516 item 1). Mirrors crosstab()'s own tipOption/tipView/
+      // alpha/flyOverViews/flyOnClick/tipOnClick block below -- chart's TipPaneModel is the same
+      // shared dialog-model type, just nested one level deeper under chartGeneralPaneModel rather
+      // than directly under crosstabAdvancedPaneModel. setChartPropertyModel already applies all
+      // of these (tipOption/tipView -> assemblyInfo.setTipOptionValue/setTipViewValue,
+      // customRB/customTip -> vsChartInfo.setToolTipValue/setCombinedToolTipValue) -- this block
+      // only adds the missing alias-table entries, no service-layer change needed.
+      //
+      // "alpha" is deliberately NOT reused here (unlike crosstab(), which has no competing
+      // alpha) -- chart already binds "alpha" to chartPlotOptionsPaneModel.alpha above, a
+      // different setting (chart element opacity, not the flyover popup's). Named "tipAlpha"
+      // instead so the two do not collide.
+      aliases.put("tooltip", "chartGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customTip");
+      aliases.put("tooltipMode", "chartGeneralPaneModel.tipPaneModel.tipCustomizeDialogModel.customRB");
+      aliases.put("tipOption", "chartGeneralPaneModel.tipPaneModel.tipOption");
+      aliases.put("tipView", "chartGeneralPaneModel.tipPaneModel.tipView");
+      aliases.put("tipAlpha", "chartGeneralPaneModel.tipPaneModel.alpha");
+      aliases.put("flyOverViews", "chartGeneralPaneModel.tipPaneModel.flyOverViews");
+      aliases.put("flyOnClick", "chartGeneralPaneModel.tipPaneModel.flyOnClick");
+      aliases.put("tipOnClick", "chartGeneralPaneModel.tipPaneModel.tipOnClick");
       return aliases;
    }
 
@@ -740,6 +788,19 @@ public final class PropertyAliases {
       aliases.put("del", "tableAdvancedPaneModel.del");
       aliases.put("edit", "tableAdvancedPaneModel.edit");
       aliases.put("writeBack", "tableAdvancedPaneModel.writeBack");
+
+      // General > Tip pane (Redmine #76516 item 1 follow-up) -- same TipPaneModel as chart()/
+      // crosstab() below, applied by setTablePropertyModel exactly the same way (with one extra
+      // condition: Data Tip View is skipped when this table's own "form" is true -- unrelated to
+      // aliasing, so not modeled here; a caller sees tipOption/tipView persist either way and
+      // discovers the form interaction from the rendered result, same as any other precondition
+      // this engine does not pre-check). No "alpha" collision here, unlike chart().
+      aliases.put("tipOption", "tableAdvancedPaneModel.tipPaneModel.tipOption");
+      aliases.put("tipView", "tableAdvancedPaneModel.tipPaneModel.tipView");
+      aliases.put("alpha", "tableAdvancedPaneModel.tipPaneModel.alpha");
+      aliases.put("flyOverViews", "tableAdvancedPaneModel.tipPaneModel.flyOverViews");
+      aliases.put("flyOnClick", "tableAdvancedPaneModel.tipPaneModel.flyOnClick");
+      aliases.put("tipOnClick", "tableAdvancedPaneModel.tipPaneModel.tipOnClick");
       return aliases;
    }
 
@@ -947,6 +1008,16 @@ public final class PropertyAliases {
       aliases.put("sortOthersLast", "calcTableAdvancedPaneModel.sortOthersLast");
       aliases.put("headerRowCount", "calcTableAdvancedPaneModel.headerRowCount");
       aliases.put("headerColCount", "calcTableAdvancedPaneModel.headerColCount");
+
+      // General > Tip pane (Redmine #76516 item 1 follow-up) -- same TipPaneModel as chart()/
+      // crosstab()/table() above, applied by setCalcTablePropertyModel exactly the same way. No
+      // "alpha" collision here.
+      aliases.put("tipOption", "calcTableAdvancedPaneModel.tipPaneModel.tipOption");
+      aliases.put("tipView", "calcTableAdvancedPaneModel.tipPaneModel.tipView");
+      aliases.put("alpha", "calcTableAdvancedPaneModel.tipPaneModel.alpha");
+      aliases.put("flyOverViews", "calcTableAdvancedPaneModel.tipPaneModel.flyOverViews");
+      aliases.put("flyOnClick", "calcTableAdvancedPaneModel.tipPaneModel.flyOnClick");
+      aliases.put("tipOnClick", "calcTableAdvancedPaneModel.tipPaneModel.tipOnClick");
       return aliases;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -23,9 +23,11 @@ import inetsoft.uql.asset.DefaultVariableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.web.composer.model.vs.CheckboxPropertyDialogModel;
+import inetsoft.web.composer.model.vs.ChartPropertyDialogModel;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
 import inetsoft.web.composer.model.vs.RadioButtonPropertyDialogModel;
 import inetsoft.web.composer.model.vs.TextInputPropertyDialogModel;
+import inetsoft.web.composer.model.vs.TipCustomizeDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -571,6 +573,72 @@ class AssemblyPropertyServiceTest {
          Map.of("dataInputPaneModel.variable", false), ""));
    }
 
+   /**
+    * {@code ChartPropertyDialogService.setChartPropertyModel} only calls {@code setAlphaValue}
+    * inside the {@code tipOption == true} branch, so {@code tipAlpha} set alone -- without
+    * {@code tipOption}/{@code tipView} in the same patch -- would otherwise be silently dropped
+    * (Redmine #76516). {@code impliedSibling} fills in {@code tipOption: true} for this case.
+    */
+   @Test
+   void impliesTipOptionWhenAlphaIsSetAlone() throws Exception {
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(ChartVSAssembly.class), model);
+
+      service.set("tok", principal(), "Chart1", Map.of("tipAlpha", "50"), "");
+
+      assertTrue(model.getChartGeneralPaneModel().getTipPaneModel().isTipOption(),
+                 "tipOption must be implied true so alpha is not silently dropped");
+      assertEquals("50", model.getChartGeneralPaneModel().getTipPaneModel().getAlpha());
+   }
+
+   /** A caller who sets {@code tipOption} explicitly is never overridden, even to {@code false}. */
+   @Test
+   void leavesTipOptionAloneWhenAlphaAndTipOptionAreBothSet() throws Exception {
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(ChartVSAssembly.class), model);
+
+      service.set("tok", principal(), "Chart1", Map.of("tipAlpha", "50", "tipOption", false), "");
+
+      assertFalse(model.getChartGeneralPaneModel().getTipPaneModel().isTipOption(),
+                  "an explicit tipOption must not be overridden by the alpha implication");
+   }
+
+   /**
+    * {@code customTip} is only applied when {@code customRB == TipFormat.CUSTOM}; otherwise it is
+    * actively nulled out. So {@code tooltip} set alone -- without {@code tooltipMode: "CUSTOM"}
+    * in the same patch -- would otherwise wipe any existing custom tooltip (Redmine #76516).
+    * {@code impliedSibling} fills in {@code customRB: CUSTOM} for this case.
+    */
+   @Test
+   void impliesCustomModeWhenTooltipIsSetAlone() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      service.set("tok", principal(), "Gauge1", Map.of("tooltip", "hello"), "");
+
+      assertEquals(TipCustomizeDialogModel.TipFormat.CUSTOM,
+                   model.getGaugeGeneralPaneModel().getTipPaneModel()
+                      .getTipCustomizeDialogModel().getCustomRB(),
+                   "customRB must be implied CUSTOM so tooltip is not silently wiped");
+      assertEquals("hello", model.getGaugeGeneralPaneModel().getTipPaneModel()
+         .getTipCustomizeDialogModel().getCustomTip());
+   }
+
+   /** A caller who sets {@code tooltipMode} explicitly is never overridden. */
+   @Test
+   void leavesCustomModeAloneWhenTooltipAndTooltipModeAreBothSet() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      service.set("tok", principal(), "Gauge1",
+                  Map.of("tooltip", "hello", "tooltipMode", "none"), "");
+
+      assertEquals(TipCustomizeDialogModel.TipFormat.NONE,
+                   model.getGaugeGeneralPaneModel().getTipPaneModel()
+                      .getTipCustomizeDialogModel().getCustomRB(),
+                   "an explicit tooltipMode must not be overridden by the tooltip implication");
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {
@@ -657,10 +725,23 @@ class AssemblyPropertyServiceTest {
          throw new IllegalStateException(e);
       }
 
+      ChartPropertyDialogService chart = mock(ChartPropertyDialogService.class);
+
+      if(model instanceof ChartPropertyDialogModel chartModel) {
+         try {
+            when(chart.getChartPropertyDialogModel(anyString(), anyString(),
+                                                   any(Principal.class)))
+               .thenReturn(chartModel);
+         }
+         catch(Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
       return new AssemblyPropertyService(
          sessions, gauge, mock(ImagePropertyDialogService.class),
          mock(TextPropertyDialogService.class),
-         mock(ChartPropertyDialogService.class), mock(TableViewPropertyDialogService.class),
+         chart, mock(TableViewPropertyDialogService.class),
          mock(CrosstabPropertyDialogService.class),
          mock(SelectionListPropertyDialogService.class),
          mock(SelectionTreePropertyDialogService.class),


### PR DESCRIPTION
## Bug

Redmine #76516, item 1: no MCP tool sets a chart data point's plain-text Tooltip. The underlying
capability was already fully implemented and applied by `ChartPropertyDialogService
.setChartPropertyModel` (the same method the Composer UI's own Chart Properties dialog "OK"
button calls) — it just had no curated short-name alias in `PropertyAliases`, so
`list_assembly_properties`/`set_assembly_properties` (the wiz agent-bridge's generic
property tools) never surfaced it.

## What changed

**`PropertyAliases.java`** — added curated aliases for every assembly type with a Tip pane:

| Type | New aliases |
|---|---|
| `chart()` | `tooltip`, `tooltipMode`, `tipOption`, `tipView`, `tipAlpha`, `flyOverViews`, `flyOnClick`, `tipOnClick` |
| `table()` | `tipOption`, `tipView`, `alpha`, `flyOverViews`, `flyOnClick`, `tipOnClick` |
| `calcTable()` | `tipOption`, `tipView`, `alpha`, `flyOverViews`, `flyOnClick`, `tipOnClick` |
| `gauge()` | `tooltipVisible`, `tooltip`, `tooltipMode` |
| `image()` | `tooltipVisible`, `tooltip`, `tooltipMode` |
| `text()` | `tooltip`, `tooltipMode` (its pre-existing `tipOption` alias is unchanged) |

`crosstab()` already had the `tipOption`/`tipView` family (pre-dates this change); not modified.

Chart/crosstab/table/calcTable share one mechanism: `tipOption` (boolean) is the actual
"Tooltip" vs "Data Tip View" radio state — `false` uses `tipCustomizeDialogModel.customRB`/
`customTip` (plain text), `true` uses `tipView` (pops up another named assembly). Gauge/Image/
Text are simpler: `tipOption` is just a visibility flag, independently gating `customRB`/
`customTip` — no Data Tip View mode at all, so no `tipView`-family aliases apply to them.

**`AssemblyPropertyService.java`** — fixed a real, live-confirmed bug also affecting crosstab
(which already had the `tipView` alias before this change): setting `tipView` to a real value
without also setting `tipOption:true` in the *same* `set_assembly_properties` call was silently
discarded. `AssemblyPropertyService.set()` reads a fresh full model, applies the patch's keys,
then writes the whole model back — and `setChartPropertyModel`/`setCrosstabPropertyModel` both
unconditionally null `tipView` whenever the model's `tipOption` is `false`, discarding what the
same call just wrote a moment earlier. Fixed generically with a new
`impliedTipOptionForTipView()` step: when a patch sets `.tipView` to a non-blank value without
also touching its sibling `.tipOption`, `tipOption` is set to `true` too. A caller who sets
`tipOption` explicitly (either value) is never overridden — this only fills in the one
combination that would otherwise silently do nothing.

## Verification

Live-verified against a running instance for every listed type — `list_assembly_properties`
lists the new aliases with correct values; `set_assembly_properties` persists and reads back
correctly, including the `tipView`/`tipOption` auto-imply fix for chart, table and calctable.
No unit test harness was available for this checkout in this pass, so verification is live
end-to-end rather than via added test files.

Not touched: Image/Text's separate, independent "Pop Component" feature
(`popComponent`/`popOption`/`popLocation`) — unrelated to the Tip pane, out of scope here.
`core/src/main/resources/inetsoft/report/defaults.properties` shows locally modified in this
checkout but is unrelated build output, not part of this change.

On the `stylebi-wiz` side, this fix let a previously-open PR there (composer plugin,
`fix/76516-chart-tooltip`, #2309) close without merging — the plugin needs no
chart-tooltip-specific code at all once this lands; the existing generic
`list_assembly_properties`/`set_assembly_properties` pass-through already handles it, the same
way it does every other curated property.