### PR TITLE
feat(wiz): add bearer-token OAuth endpoints to WizTabularController

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -35,9 +35,14 @@ import inetsoft.uql.tabular.TabularQuerySchema;
 import inetsoft.uql.tabular.TabularSchemaExtractor;
 import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.uql.tabular.TabularView;
+import inetsoft.uql.tabular.oauth.AuthorizationClient;
+import inetsoft.uql.tabular.oauth.Tokens;
 import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
+import inetsoft.web.composer.model.ws.TabularOAuthParams;
 import inetsoft.web.portal.data.DataSourceDefinition;
+import inetsoft.web.portal.data.DataSourceOAuthParamsRequest;
+import inetsoft.web.portal.data.DataSourceOAuthTokens;
 import inetsoft.web.portal.data.DatasourcesService;
 import inetsoft.web.security.PermissionPath;
 import inetsoft.web.security.RequiredPermission;
@@ -549,6 +554,70 @@ public class WizTabularController {
       requireCreatePermission(emptyToNull(parentOf(name)), principal);
 
       return Map.of("duplicate", datasourcesService.checkDuplicate(name));
+   }
+
+   // ─── OAuth authorization ───────────────────────────────────────────────────────────────────
+
+   /**
+    * Resolves a connector's OAuth parameters (client id/secret, scope, authorization/token URIs,
+    * license) from the live bean, for the caller to hand to whichever authorization flow those
+    * parameters describe.
+    *
+    * <p>No path-level permission, for the same reason {@link #refreshTabularView} has none: the
+    * datasource may still be an unsaved draft, so the only question this endpoint can answer is
+    * whether the caller may configure data sources at all.</p>
+    */
+   @PostMapping(value = "/tabular/oauth-params", produces = MediaType.APPLICATION_JSON_VALUE)
+   public TabularOAuthParams getOAuthParameters(
+      @RequestBody DataSourceOAuthParamsRequest request, Principal principal) throws Exception
+   {
+      requireConnectorPermission(principal);
+      beginConnectorSession(principal);
+
+      try {
+         return datasourcesService.getOAuthParams(request);
+      }
+      finally {
+         endConnectorSession();
+      }
+   }
+
+   /**
+    * Writes OAuth tokens obtained by whichever flow {@code /tabular/oauth-params} pointed the
+    * caller at back onto the connector bean, and returns the recomputed form.
+    */
+   @PostMapping(value = "/tabular/oauth-tokens", produces = MediaType.APPLICATION_JSON_VALUE)
+   public DataSourceDefinition setOAuthTokens(
+      @RequestBody DataSourceOAuthTokens tokens, Principal principal) throws Exception
+   {
+      requireConnectorPermission(principal);
+      beginConnectorSession(principal);
+
+      try {
+         return datasourcesService.setOAuthTokens(tokens);
+      }
+      finally {
+         endConnectorSession();
+      }
+   }
+
+   /**
+    * The password-grant OAuth variant: exchanges a username/password directly for tokens against
+    * {@code tokenUri}, with no popup and no third-party broker involved.
+    *
+    * <p>No connector session binding — unlike the two endpoints above, this never reaches
+    * {@code TabularUtil.refreshView} or any other connector reflection call; it is a stateless
+    * HTTP call to the provider's own token endpoint.</p>
+    */
+   @PostMapping(value = "/tabular/oauth-grant-password", produces = MediaType.APPLICATION_JSON_VALUE)
+   public Tokens getPasswordGrantResponse(
+      @RequestBody TabularOAuthParams request, Principal principal) throws Exception
+   {
+      requireConnectorPermission(principal);
+
+      return AuthorizationClient.doPasswordGrantAuth(
+         request.user(), request.password(), request.clientId(), request.clientSecret(),
+         request.scope(), request.tokenUri());
    }
 
    // ─── Browsing a file-based connector, and probing what a target holds ─────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
@@ -26,10 +26,15 @@ import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.tabular.*;
+import inetsoft.uql.tabular.oauth.AuthorizationClient;
+import inetsoft.uql.tabular.oauth.Tokens;
 import inetsoft.uql.util.Config;
 import inetsoft.util.ConfigurationContext;
 import inetsoft.util.MessageException;
+import inetsoft.web.composer.model.ws.TabularOAuthParams;
 import inetsoft.web.portal.data.DataSourceDefinition;
+import inetsoft.web.portal.data.DataSourceOAuthParamsRequest;
+import inetsoft.web.portal.data.DataSourceOAuthTokens;
 import inetsoft.web.portal.data.DatasourcesService;
 import inetsoft.web.wiz.model.WizTabularBrowseResult;
 import inetsoft.web.wiz.model.WizTabularListing;
@@ -428,6 +433,108 @@ class WizTabularControllerTest {
       when(datasourcesService.checkDuplicate("mongo")).thenReturn(true);
 
       assertEquals(Boolean.TRUE, controller.checkDuplicate("mongo", principal).get("duplicate"));
+   }
+
+   @Test
+   void oauthParamsDelegatesToTheService() throws Exception {
+      DataSourceOAuthParamsRequest request = DataSourceOAuthParamsRequest.builder()
+         .clientId("clientId")
+         .clientSecret("clientSecret")
+         .scope("scope")
+         .authorizationUri("authorizationUri")
+         .tokenUri("tokenUri")
+         .flags("oauthFlags")
+         .dataSource(definition("github"))
+         .build();
+      TabularOAuthParams resolved = TabularOAuthParams.builder()
+         .license("key")
+         .clientId("resolved-client-id")
+         .build();
+      when(datasourcesService.getOAuthParams(request)).thenReturn(resolved);
+
+      assertSame(resolved, controller.getOAuthParameters(request, principal));
+   }
+
+   @Test
+   void oauthParamsRefusesWithoutConnectorPermission() throws Exception {
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+                                          any(ResourceAction.class))).thenReturn(false);
+
+      DataSourceOAuthParamsRequest request = DataSourceOAuthParamsRequest.builder()
+         .clientId("clientId")
+         .clientSecret("clientSecret")
+         .scope("scope")
+         .authorizationUri("authorizationUri")
+         .tokenUri("tokenUri")
+         .flags("oauthFlags")
+         .dataSource(definition("github"))
+         .build();
+
+      assertThrows(SecurityException.class,
+                   () -> controller.getOAuthParameters(request, principal));
+      verify(datasourcesService, never()).getOAuthParams(any());
+   }
+
+   @Test
+   void oauthTokensDelegatesToTheService() throws Exception {
+      DataSourceOAuthTokens tokens = DataSourceOAuthTokens.builder()
+         .accessToken("token")
+         .dataSource(definition("github"))
+         .method("updateTokens")
+         .build();
+      DataSourceDefinition recomputed = definition("github");
+      when(datasourcesService.setOAuthTokens(tokens)).thenReturn(recomputed);
+
+      assertSame(recomputed, controller.setOAuthTokens(tokens, principal));
+   }
+
+   @Test
+   void oauthTokensRefusesWithoutConnectorPermission() throws Exception {
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+                                          any(ResourceAction.class))).thenReturn(false);
+
+      DataSourceOAuthTokens tokens = DataSourceOAuthTokens.builder()
+         .dataSource(definition("github"))
+         .method("updateTokens")
+         .build();
+
+      assertThrows(SecurityException.class, () -> controller.setOAuthTokens(tokens, principal));
+      verify(datasourcesService, never()).setOAuthTokens(any());
+   }
+
+   @Test
+   void oauthGrantPasswordCallsAuthorizationClientDirectly() throws Exception {
+      TabularOAuthParams request = TabularOAuthParams.builder()
+         .license("key")
+         .user("bob")
+         .password("secret")
+         .tokenUri("https://example.com/token")
+         .build();
+      Tokens tokens = Tokens.builder().accessToken("token").issued(0L).expiration(0L).build();
+
+      try(MockedStatic<AuthorizationClient> client = mockStatic(AuthorizationClient.class)) {
+         client.when(() -> AuthorizationClient.doPasswordGrantAuth(
+                        "bob", "secret", null, null, null, "https://example.com/token"))
+            .thenReturn(tokens);
+
+         assertSame(tokens, controller.getPasswordGrantResponse(request, principal));
+      }
+   }
+
+   @Test
+   void oauthGrantPasswordRefusesWithoutConnectorPermission() throws Exception {
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+                                          any(ResourceAction.class))).thenReturn(false);
+
+      TabularOAuthParams request = TabularOAuthParams.builder()
+         .license("key")
+         .user("bob")
+         .password("secret")
+         .tokenUri("https://example.com/token")
+         .build();
+
+      assertThrows(SecurityException.class,
+                   () -> controller.getPasswordGrantResponse(request, principal));
    }
 
    /*


### PR DESCRIPTION
## Summary
- Adds three new endpoints to `WizTabularController` (`/api/wiz/tabular/oauth-params`, `/oauth-tokens`, `/oauth-grant-password`) so the Wiz portal (bearer-token authenticated) can drive OAuth authorization for tabular datasource connectors (GitHub, Box, OneDrive, etc.) the same way StyleBI's own Angular data portal already does today via `DataSourceController` (session-cookie authenticated).
- No OAuth logic is reimplemented — all three delegate to the exact same existing calls `DataSourceController` uses (`DatasourcesService.getOAuthParams`/`setOAuthTokens`, `AuthorizationClient.doPasswordGrantAuth`).
- Gated with this file's existing `requireConnectorPermission`/`beginConnectorSession`/`endConnectorSession` pattern (same as `/tabular/refresh` and `/tabular/create`), since these endpoints may operate on unsaved draft datasources with no stable repository path — a deliberate, explicit permission check the portal-session originals don't have (a bearer caller has no session-level gate to rely on).

Companion PR (wiz-services proxy routes + portal OAuth UI): inetsoft-technology/stylebi-wiz#feature/tabular-oauth-portal (pushed, PR link follows).

## Test plan
- [x] `WizTabularControllerTest` — 36/36 passing (6 new tests covering delegation + permission-denial for all three endpoints), verified independently via the surefire report, not just self-reported
- [x] Task-level and final whole-branch code review both completed with "Ready to merge" verdicts

🤖 Generated with a multi-agent Claude Code plan/implement/review pipeline