### PR TITLE
fix(wiz): apply an inbound calculateInfo (Trend/Calculator) on chart/table shelf writes

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -190,7 +190,8 @@ public class BindingReadService {
       boolean resolved = runtime != stored && runtime != GraphTypes.CHART_AUTO;
 
       return new FieldRef(ref.column(), ref.type(), ref.aggregate(), ref.dateLevel(),
-                          ref.namedGroup(), stored, resolved ? runtime : null);
+                          ref.namedGroup(), stored, resolved ? runtime : null,
+                          ref.namedGroupValues(), ref.calculateInfo());
    }
 
    private final VSBindingService binding;

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -101,6 +101,10 @@ public final class FieldRefFactory {
             ref.setFormula(field.aggregate());
          }
 
+         if(field.calculateInfo() != null) {
+            ref.setCalculateInfo(field.calculateInfo());
+         }
+
          return ref;
       }
 
@@ -276,7 +280,7 @@ public final class FieldRefFactory {
    public static FieldRef from(DataRefModel ref) {
       if(ref instanceof BAggregateRefModel aggregate) {
          return new FieldRef(aggregate.getColumnValue(), MEASURE, aggregate.getFormula(),
-                             null, null);
+                             null, null, null, null, null, aggregate.getCalculateInfo());
       }
 
       if(ref instanceof BDimensionRefModel dimension) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -475,6 +475,10 @@ public final class TableBindingMutator {
             ref.setFormula(field.aggregate());
          }
 
+         if(field.calculateInfo() != null) {
+            ref.setCalculateInfo(field.calculateInfo());
+         }
+
          out.add(ref);
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -69,9 +69,13 @@ import java.util.List;
  * @param calculateInfo    a per-measure Trend/Calculator (running total, change, moving, value-of,
  *                         percent, compound growth, or a custom expression), measures only —
  *                         mirrors the Composer binding pane's own Calculator button. {@code null}
- *                         leaves it unchanged; there is no separate "clear" signal because
- *                         clearing is just setting the aggregate's formula, which every caller
- *                         already does independently of this.
+ *                         leaves it unchanged. There is currently no signal that clears a
+ *                         previously-applied one through this agent surface — changing
+ *                         {@code aggregate} alone does not; {@code BAggregateRefModel.setFormula}/
+ *                         {@code ChartAggregateRefModel.setFormula} only ever touch the formula
+ *                         field, never {@code calculateInfo}. Removing a calculator once set
+ *                         requires a follow-up capability (a real "clear" signal), not something
+ *                         this record already supports.
  */
 public record FieldRef(String column, String type, String aggregate, String dateLevel,
                        String namedGroup, Integer chartType, Integer runtimeChartType,

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.binding.model;
 
+import inetsoft.web.binding.model.graph.CalculateInfo;
+
 import java.util.List;
 
 /**
@@ -64,10 +66,16 @@ import java.util.List;
  *                         own, ungrouped row, the same as it would with no grouping at all.
  * @param chartType        the measure's own GraphTypes code under Multi Style; null everywhere else
  * @param runtimeChartType what that measure resolved to, when it differs from {@code chartType}
+ * @param calculateInfo    a per-measure Trend/Calculator (running total, change, moving, value-of,
+ *                         percent, compound growth, or a custom expression), measures only —
+ *                         mirrors the Composer binding pane's own Calculator button. {@code null}
+ *                         leaves it unchanged; there is no separate "clear" signal because
+ *                         clearing is just setting the aggregate's formula, which every caller
+ *                         already does independently of this.
  */
 public record FieldRef(String column, String type, String aggregate, String dateLevel,
                        String namedGroup, Integer chartType, Integer runtimeChartType,
-                       NamedGroupValues namedGroupValues) {
+                       NamedGroupValues namedGroupValues, CalculateInfo calculateInfo) {
    /**
     * Every caller but the chart read builds a ref with no chart type. Kept so that adding the
     * components did not touch forty-odd construction sites that have nothing to do with charts.
@@ -75,14 +83,14 @@ public record FieldRef(String column, String type, String aggregate, String date
    public FieldRef(String column, String type, String aggregate, String dateLevel,
                    String namedGroup)
    {
-      this(column, type, aggregate, dateLevel, namedGroup, null, null, null);
+      this(column, type, aggregate, dateLevel, namedGroup, null, null, null, null);
    }
 
    /** A chart ref whose design-time type is all the read has to report. */
    public FieldRef(String column, String type, String aggregate, String dateLevel,
                    String namedGroup, Integer chartType)
    {
-      this(column, type, aggregate, dateLevel, namedGroup, chartType, null, null);
+      this(column, type, aggregate, dateLevel, namedGroup, chartType, null, null, null);
    }
 
    /**
@@ -92,7 +100,19 @@ public record FieldRef(String column, String type, String aggregate, String date
    public FieldRef(String column, String type, String aggregate, String dateLevel,
                    String namedGroup, Integer chartType, Integer runtimeChartType)
    {
-      this(column, type, aggregate, dateLevel, namedGroup, chartType, runtimeChartType, null);
+      this(column, type, aggregate, dateLevel, namedGroup, chartType, runtimeChartType, null, null);
+   }
+
+   /**
+    * The shape before {@code calculateInfo} was added — kept so that addition did not touch every
+    * call site that already named {@code namedGroupValues}.
+    */
+   public FieldRef(String column, String type, String aggregate, String dateLevel,
+                   String namedGroup, Integer chartType, Integer runtimeChartType,
+                   NamedGroupValues namedGroupValues)
+   {
+      this(column, type, aggregate, dateLevel, namedGroup, chartType, runtimeChartType,
+           namedGroupValues, null);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
@@ -25,6 +25,7 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
+import inetsoft.web.binding.model.graph.calc.RunningTotalCalcInfo;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.AssemblyBinding;
 import org.junit.jupiter.api.Tag;
@@ -162,6 +163,37 @@ class BindingReadServiceTest {
 
       assertEquals(Integer.valueOf(GraphTypes.CHART_AUTO), ref.chartType());
       assertEquals(Integer.valueOf(GraphTypes.CHART_BAR), ref.runtimeChartType());
+   }
+
+   /**
+    * {@code withTypes(FieldRef, ChartAestheticModel)} rebuilds the ref through the full
+    * 9-arg {@code FieldRef} constructor to stamp on the per-measure chart type — the same
+    * reconstruction shape that dropped {@code namedGroupValues} before this fix, and would
+    * just as silently drop {@code calculateInfo} if a trailing component were missed again.
+    * Asserted on the calculator's own concrete type and fields rather than on {@code FieldRef}
+    * equality: {@code CalculateInfo.equals()} treats any two non-null instances as equal, so an
+    * {@code assertEquals} on the ref alone would pass even if the calculator were dropped and
+    * replaced with the wrong one.
+    */
+   @Test
+   void preservesCalculateInfoWhenStampingAPerMeasureChartTypeUnderMultiStyle() {
+      RunningTotalCalcInfo calc = new RunningTotalCalcInfo();
+      calc.setAggregate("Sum");
+      calc.setResetLevel(-1);
+
+      ChartAggregateRefModel field = aggregate("PAID", "Sum");
+      field.setCalculateInfo(calc);
+
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setYFields(List.of(withChartType(field, 5)));
+
+      FieldRef ref = read(model).shelves().get("y").get(0);
+
+      assertInstanceOf(RunningTotalCalcInfo.class, ref.calculateInfo());
+      RunningTotalCalcInfo readBack = (RunningTotalCalcInfo) ref.calculateInfo();
+      assertEquals("Sum", readBack.getAggregate());
+      assertEquals(-1, readBack.getResetLevel());
    }
 
    /** Divergence-only: reported on every field it would be noise rather than a signal. */

--- a/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
@@ -39,8 +39,10 @@ import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BAggregateRefModel;
 import inetsoft.web.binding.model.BDimensionRefModel;
 import inetsoft.web.binding.model.NamedGroupInfoModel;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
+import inetsoft.web.binding.model.graph.calc.RunningTotalCalcInfo;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import org.junit.jupiter.api.Tag;
@@ -178,6 +180,51 @@ class FieldRefFactoryTest {
       assertEquals("measure", ref.type());
       assertEquals("Sum", ref.aggregate());
       assertNull(ref.dateLevel(), "a measure has no date level");
+   }
+
+   /**
+    * Asserted on the calculator's own concrete type/fields rather than on {@code FieldRef}
+    * equality — {@code CalculateInfo.equals()} treats any two non-null instances as equal
+    * regardless of subtype, so an {@code assertEquals} on the ref alone would pass even if the
+    * wrong calculator came back.
+    */
+   @Test
+   void readsAMeasuresCalculateInfo() {
+      RunningTotalCalcInfo calc = new RunningTotalCalcInfo();
+      calc.setAggregate("Sum");
+      calc.setResetLevel(-1);
+
+      BAggregateRefModel model = new BAggregateRefModel();
+      model.setColumnValue("Sales");
+      model.setFormula("Sum");
+      model.setCalculateInfo(calc);
+
+      FieldRef ref = FieldRefFactory.from(model);
+
+      assertInstanceOf(RunningTotalCalcInfo.class, ref.calculateInfo());
+      RunningTotalCalcInfo readBack = (RunningTotalCalcInfo) ref.calculateInfo();
+      assertEquals("Sum", readBack.getAggregate());
+      assertEquals(-1, readBack.getResetLevel());
+   }
+
+   /** The write-side mirror of {@link #readsAMeasuresCalculateInfo}. */
+   @Test
+   void toChartRefAppliesCalculateInfoOntoTheAggregate() {
+      RunningTotalCalcInfo calc = new RunningTotalCalcInfo();
+      calc.setAggregate("Sum");
+      calc.setResetLevel(-1);
+
+      FieldRef field = new FieldRef(
+         "Sales", "measure", "Sum", null, null, null, null, null, calc);
+
+      ChartRefModel ref = FieldRefFactory.toChartRef(field);
+
+      assertInstanceOf(ChartAggregateRefModel.class, ref);
+      Object written = ((ChartAggregateRefModel) ref).getCalculateInfo();
+      assertInstanceOf(RunningTotalCalcInfo.class, written);
+      RunningTotalCalcInfo readBack = (RunningTotalCalcInfo) written;
+      assertEquals("Sum", readBack.getAggregate());
+      assertEquals(-1, readBack.getResetLevel());
    }
 
    @Test


### PR DESCRIPTION
## Bug

Redmine #76516 item 3. `plugin/composer`'s `set_chart_shelf`/`set_chart_single_shelf`/`set_table_fields` (stylebi-wiz PR #2310) send an optional per-measure `calculateInfo` (Trend/Calculator). StyleBI's wiz agent endpoints these hit —
`POST /api/wiz/v1/agent/binding/{token}/chart/shelf` and `.../table/fields` — deserialize each field into `inetsoft.web.wiz.binding.model.FieldRef`, a record with no `calculateInfo` component and no `@JsonIgnoreProperties(ignoreUnknown = true)`. With Spring's default `FAIL_ON_UNKNOWN_PROPERTIES` on, a `calculateInfo`-bearing field made the **entire shelf write fail with a 400** — not a silent drop, every other field in the same patch failed too.

## Fix

The `CalculateInfo` → `Calculator` wiring already exists on `BAggregateRefModel`/`ChartAggregateRefModel` (`getCalculateInfo`/`setCalculateInfo`; `createDataRef()` already does `calc.toCalculator()`) — the same model the real Composer binding pane's own apply path uses (`ChangeChartRefService.changeChartRef` for charts; the shared crosstab/table binding write for `TableBindingMutator`). It just wasn't reachable from the wiz agent's incremental `FieldRef` conversion.

- `FieldRef.java` — add a trailing `CalculateInfo calculateInfo` component (new canonical 9-arg constructor; every shorter constructor kept as an overload defaulting it to `null`, matching this record's existing pattern).
- `FieldRefFactory.toChartRef()` — apply `field.calculateInfo()` to the built `ChartAggregateRefModel` (covers `set_chart_shelf` and `set_chart_single_shelf`).
- `FieldRefFactory.from()` — read a `BAggregateRefModel`'s `calculateInfo` back onto the echoed `FieldRef`, so `get_binding` reports it.
- `TableBindingMutator.aggregates()` — apply `field.calculateInfo()` to the built `BAggregateRefModel` (covers `set_table_fields`, table and crosstab).
- `BindingReadService.withTypes()` — the multi-style per-measure `chartType` overlay rebuilt the `FieldRef` via the 7-arg constructor, silently dropping `calculateInfo` (and `namedGroupValues`) the moment multi-style stamped in a `chartType`. Now passes both through.

`core/src/main/resources/inetsoft/report/defaults.properties` has an unrelated local change, intentionally left out of this commit.

## Verification

Live-verified against a running instance:
- `set_chart_shelf` with a `RUNNINGTOTAL` `calculateInfo` on a chart measure — previously 400, now applies and renders a running sum.
- `set_table_fields` with a `CHANGE` `calculateInfo` on a crosstab aggregate — previously 400, now applies and renders percent-change-from-previous-year.
- `get_binding` echoes `calculateInfo` correctly in both cases, including under multi-style with a per-measure `chartType` set alongside it (the `withTypes` fix).
- No regression on fields without `calculateInfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)