### PR TITLE
fix(#76530): make dataInputPaneModel.variable writes take effect or refuse loudly

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -3794,16 +3794,25 @@ public class VSInputService {
     *
     * <p>Accepts the correct {@code "$(varName)"} reference form as-is, provided the variable
     * actually exists; accepts any real worksheet table/assembly name as-is (a genuine
-    * table+column binding); and normalizes two unambiguous natural mistakes into the
+    * table+column binding); and normalizes three unambiguous natural mistakes into the
     * {@code "$(varName)"} form the runtime requires: a bare variable name with no
-    * {@code $(...)} wrapping, and the Composer's own "Variables" tree folder label (not a
+    * {@code $(...)} wrapping, the Composer's own "Variables" tree folder label (not a
     * selectable leaf -- see {@link #getInputTablesTree}) paired with a {@code columnValue}
-    * that names a real variable. Anything else is rejected loud, by field name, rather than
-    * silently persisted as a broken binding.
+    * that names a real variable, and (bug #76530) {@code table} left unset entirely while
+    * {@code columnValue} itself already carries the {@code "$(varName)"} reference -- the shape
+    * a caller naturally reaches for when only one field looks like it should hold the variable.
+    * Anything else is rejected loud, by field name, rather than silently persisted as a broken
+    * binding.
     */
    private static String resolveInputTableBinding(Worksheet ws, Viewsheet vs, String table,
                                                    String columnValue)
    {
+      if((table == null || table.isEmpty()) && columnValue != null &&
+         columnValue.startsWith("$(") && columnValue.endsWith(")"))
+      {
+         table = columnValue;
+      }
+
       if(table == null || table.isEmpty() || ws == null) {
          return table;
       }
@@ -3836,6 +3845,25 @@ public class VSInputService {
       throw new MessageException("Unknown table binding '" + table + "' for this input. " +
          "It does not match a worksheet table or a worksheet variable; use " +
          "\"$(variableName)\" to bind to a variable.");
+   }
+
+   /**
+    * Whether {@code table}/{@code columnValue}, once run through {@link
+    * #resolveInputTableBinding}'s normalization above, resolve to a {@code "$(varName)"}
+    * worksheet-variable reference.
+    *
+    * <p>Exposed (bug #76530) so {@code AssemblyPropertyService} can refuse an explicit
+    * {@code dataInputPaneModel.variable} write that this class's own setters would otherwise
+    * silently fail to honor: {@code setTextInputPropertyDialogModel}/
+    * {@code setComboboxPropertyDialogModel}/{@code setSliderPropertyDialogModel}/
+    * {@code setSpinnerPropertyDialogModel} never read {@code dataInputPaneModel.isVariable()} at
+    * all -- the persisted flag is always this method's own answer, derived from {@code table}.
+    */
+   public static boolean resolvesToVariableBinding(Worksheet ws, Viewsheet vs, String table,
+                                                    String columnValue)
+   {
+      String resolved = resolveInputTableBinding(ws, vs, table, columnValue);
+      return resolved != null && resolved.startsWith("$(") && resolved.endsWith(")");
    }
 
    private static boolean isKnownVariableName(Worksheet ws, Viewsheet vs, String name) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.model.vs.RangePaneModel;
 import inetsoft.web.composer.vs.dialog.*;
@@ -252,6 +253,12 @@ public class AssemblyPropertyService {
             requireNoInteriorGapInGaugeRangeValues(model);
          }
 
+         if(PropertyAliases.derivesVariableFlagFromTable(type) &&
+            resolved.containsValue("dataInputPaneModel.variable"))
+         {
+            requireVariableFlagAchievable(type, model, rvs.getViewsheet());
+         }
+
          writeModel(runtimeId, type, assemblyName, model, linkUri, user, dispatcher);
       });
    }
@@ -294,6 +301,35 @@ public class AssemblyPropertyService {
                "only have a blank trailing entry (meaning \"extend to the gauge's own max\"), " +
                "not a gap in the middle.");
          }
+      }
+   }
+
+   /**
+    * Bug #76530: textinput/combobox/slider/spinner's own setter never reads back
+    * {@code dataInputPaneModel.variable} -- the real, persisted flag is always derived from
+    * whether {@code dataInputPaneModel.table} (after {@code VSInputService}'s own
+    * {@code resolveInputTableBinding} normalization, which now also accepts a {@code columnValue}
+    * already shaped {@code "$(varName)"} with {@code table} left unset) resolves to a
+    * {@code "$(varName)"} reference. Only invoked when this call's own patch explicitly touches
+    * {@code dataInputPaneModel.variable} (see the caller): when the resulting table binding will
+    * not actually resolve to a variable reference, that touch would otherwise report success and
+    * leave the flag exactly where it already was -- the same "populated on every read, never read
+    * back on write" shape {@link PropertyAliases}'s {@code DEAD_FIELDS} refuses elsewhere, just
+    * conditional on the resulting binding rather than unconditional on the field.
+    */
+   private void requireVariableFlagAchievable(String type, Object model, Viewsheet vs) {
+      String table = (String) PropertyPath.get(model, "dataInputPaneModel.table");
+      String columnValue = (String) PropertyPath.get(model, "dataInputPaneModel.columnValue");
+      Worksheet ws = vs == null ? null : vs.getBaseWorksheet();
+
+      if(!VSInputService.resolvesToVariableBinding(ws, vs, table, columnValue)) {
+         throw new IllegalArgumentException(
+            "'dataInputPaneModel.variable' cannot be set directly on " + type + ". Its real, " +
+            "persisted value is always derived from whether 'dataInputPaneModel.table' (or " +
+            "'columnValue', if shaped \"$(variableName)\") resolves to an existing worksheet " +
+            "variable -- neither does here, so this write would report success and leave " +
+            "'variable' unchanged. Set 'dataInputPaneModel.table' (or 'columnValue') to " +
+            "\"$(variableName)\" for a variable created with add_variable instead.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -107,6 +107,23 @@ public final class PropertyAliases {
                          "sortOthersLastEnabled", "dateComparisonSupport"));
 
    /**
+    * textinput/combobox/slider/spinner's {@code dataInputPaneModel.variable} (bug #76530): has a
+    * real getter/setter, populated correctly on every read from the persisted
+    * {@code InputVSAssemblyInfo.isVariable()} -- but every one of these four types' setters
+    * derives the real, persisted flag solely from whether {@code dataInputPaneModel.table} (after
+    * {@code VSInputService.resolveInputTableBinding}'s normalization) is shaped
+    * {@code "$(varName)"}. The client's own boolean here is never read back on write, for any of
+    * the four. Unlike a plain {@link #DEAD_FIELDS} entry, a write here is not refused
+    * unconditionally -- see {@code AssemblyPropertyService.requireVariableFlagAchievable}, which
+    * this set only marks as needing that check, because whether the write is actually honored
+    * depends on the resulting table binding, not on the field alone. CheckBox and RadioButton are
+    * deliberately absent: their setters read {@code dataInputPaneModel.isVariable()} directly (a
+    * different, separate defect -- tracked on its own, not this one).
+    */
+   private static final Set<String> VARIABLE_FLAG_DERIVED_TYPES =
+      Set.of("textinput", "combobox", "slider", "spinner");
+
+   /**
     * {@code refresh} is aliased through the shared {@link #basicGeneral} helper because it is
     * genuinely applied for the input assemblies (checkbox/combobox/radiobutton/slider/spinner/
     * textinput, via {@code VSInputService}) and for submit (via
@@ -155,6 +172,15 @@ public final class PropertyAliases {
 
    public static Set<String> coveredTypes() {
       return Collections.unmodifiableSet(REGISTRY.keySet());
+   }
+
+   /**
+    * Whether {@code assemblyType}'s setter derives {@code dataInputPaneModel.variable} from
+    * {@code dataInputPaneModel.table} rather than reading the field back -- see {@link
+    * #VARIABLE_FLAG_DERIVED_TYPES}.
+    */
+   public static boolean derivesVariableFlagFromTable(String assemblyType) {
+      return VARIABLE_FLAG_DERIVED_TYPES.contains(normalize(assemblyType));
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
@@ -147,6 +147,64 @@ class VSInputTableBindingResolutionTest {
       assertEquals("", resolve(ws, "", null));
    }
 
+   /**
+    * Bug #76530's exact reported repro shape: {@code table} left unset and {@code columnValue}
+    * itself already carrying the {@code "$(varName)"} reference (the natural mistake a caller
+    * makes when only one field looks like it should hold the variable). Must resolve exactly like
+    * setting {@code table} to that same value would.
+    */
+   @Test
+   void resolvesAColumnValueOnlyVariableReferenceWhenTableIsUnset() throws Exception {
+      Worksheet ws = worksheetWithVariable("StartDate");
+
+      assertEquals("$(StartDate)", resolve(ws, null, "$(StartDate)"));
+      assertEquals("$(StartDate)", resolve(ws, "", "$(StartDate)"));
+   }
+
+   /**
+    * The columnValue-only shape must reuse the exact same existence check the raw {@code
+    * "$(...)"}-on-{@code table} branch already gets -- an unknown variable name still throws,
+    * it is not silently accepted just because it arrived via {@code columnValue} instead.
+    */
+   @Test
+   void rejectsAColumnValueOnlyVariableReferenceToAVariableThatDoesNotExist() {
+      Worksheet ws = new Worksheet();
+
+      MessageException ex = assertThrows(MessageException.class,
+         () -> resolve(ws, null, "$(StartDate)"));
+      assertTrue(ex.getMessage().contains("StartDate"), ex.getMessage());
+   }
+
+   /**
+    * The new shape only fires when {@code table} is unset -- an explicit {@code table} value
+    * (even a plain, non-variable table binding) must not be silently overridden by a {@code
+    * columnValue} that happens to look like a variable reference.
+    */
+   @Test
+   void doesNotOverrideAnExplicitTableWithAColumnValueThatLooksLikeAVariable() throws Exception {
+      Worksheet ws = worksheetWithVariable("StartDate");
+      ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
+
+      assertEquals("Query1", resolve(ws, "Query1", "$(StartDate)"));
+   }
+
+   /**
+    * {@link VSInputService#resolvesToVariableBinding} is the public entry point {@code
+    * AssemblyPropertyService} uses (bug #76530 part b) to decide whether an explicit {@code
+    * dataInputPaneModel.variable} write is achievable. It must agree with {@code
+    * resolveInputTableBinding} on both the columnValue-only shape and a plain literal table.
+    */
+   @Test
+   void resolvesToVariableBindingAgreesWithTheUnderlyingResolution() {
+      Worksheet ws = worksheetWithVariable("StartDate");
+      ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
+
+      assertTrue(VSInputService.resolvesToVariableBinding(ws, null, null, "$(StartDate)"));
+      assertTrue(VSInputService.resolvesToVariableBinding(ws, null, "$(StartDate)", null));
+      assertFalse(VSInputService.resolvesToVariableBinding(ws, null, "Query1", null));
+      assertFalse(VSInputService.resolvesToVariableBinding(ws, null, null, null));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static Worksheet worksheetWithVariable(String name) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -19,8 +19,11 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.test.*;
+import inetsoft.uql.asset.DefaultVariableAssembly;
+import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
+import inetsoft.web.composer.model.vs.TextInputPropertyDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -307,11 +310,85 @@ class AssemblyPropertyServiceTest {
                    "the unrelated property must still have been written");
    }
 
+   /**
+    * Bug #76530 part (b): the exact reported repro (a from-scratch TextInput, {@code columnValue}
+    * carrying the {@code "$(varName)"} reference, {@code table} never set). Before this fix, the
+    * write silently no-opped -- {@code variable} was never read back regardless. Part (a) makes
+    * this shape resolve, so the write must now go through rather than being refused.
+    */
+   @Test
+   void allowsTheExactReportedReproNowThatColumnValueAloneResolvesToAKnownVariable()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      TextInputPropertyDialogModel model = new TextInputPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithTextInput(mock(TextInputVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", true);
+
+      assertDoesNotThrow(
+         () -> service.set("tok", principal(), "StartDateInput", patch, ""));
+   }
+
+   /**
+    * Bug #76530 part (b): a patch that explicitly touches {@code dataInputPaneModel.variable}
+    * but leaves both {@code table} and {@code columnValue} unset cannot possibly resolve to a
+    * variable reference -- this write must be refused, by field name, instead of reporting
+    * {@code {"ok":true}} while silently changing nothing (the originally-reported symptom).
+    */
+   @Test
+   void refusesAnExplicitVariableWriteWhenNeitherTableNorColumnValueResolveToAVariable() {
+      TextInputPropertyDialogModel model = new TextInputPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithTextInput(mock(TextInputVSAssembly.class), model, new Worksheet());
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "StartDateInput",
+            Map.of("dataInputPaneModel.variable", true), ""));
+
+      assertTrue(thrown.getMessage().contains("dataInputPaneModel.variable"),
+                 "must name the refused field: " + thrown.getMessage());
+   }
+
+   /**
+    * The achievability check must only fire when the patch actually touches {@code variable} --
+    * an unrelated field write on a TextInput whose current binding is not a variable (the common
+    * case: most TextInputs write back to a literal cell, not a variable) must not be blocked by
+    * state the patch never touched.
+    */
+   @Test
+   void doesNotCheckVariableAchievabilityWhenThePatchDoesNotTouchVariable() throws Exception {
+      TextInputPropertyDialogModel model = new TextInputPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithTextInput(mock(TextInputVSAssembly.class), model, new Worksheet());
+
+      assertDoesNotThrow(() -> service.set("tok", principal(), "StartDateInput",
+         Map.of("dataInputPaneModel.rowValue", "0"), ""));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {
+      return serviceWith(assembly, model, null, null);
+   }
+
+   private static AssemblyPropertyService serviceWithTextInput(
+      VSAssembly assembly, TextInputPropertyDialogModel model, Worksheet baseWorksheet)
+   {
+      return serviceWith(assembly, model, model, baseWorksheet);
+   }
+
+   private static AssemblyPropertyService serviceWith(
+      VSAssembly assembly, Object model, TextInputPropertyDialogModel textInputModel,
+      Worksheet baseWorksheet)
+   {
       Viewsheet vs = mock(Viewsheet.class);
       when(vs.getAssembly(anyString())).thenReturn(assembly);
+      when(vs.getBaseWorksheet()).thenReturn(baseWorksheet);
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
       when(rvs.getID()).thenReturn("rt1");
@@ -343,6 +420,20 @@ class AssemblyPropertyServiceTest {
          }
       }
 
+      inetsoft.web.viewsheet.service.VSInputService inputService =
+         mock(inetsoft.web.viewsheet.service.VSInputService.class);
+
+      if(textInputModel != null) {
+         try {
+            when(inputService.getTextInputPropertyDialogModel(anyString(), anyString(),
+                                                               any(Principal.class)))
+               .thenReturn(textInputModel);
+         }
+         catch(Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
       return new AssemblyPropertyService(
          sessions, gauge, mock(ImagePropertyDialogService.class),
          mock(TextPropertyDialogService.class),
@@ -350,7 +441,7 @@ class AssemblyPropertyServiceTest {
          mock(CrosstabPropertyDialogService.class),
          mock(SelectionListPropertyDialogService.class),
          mock(SelectionTreePropertyDialogService.class),
-         mock(inetsoft.web.viewsheet.service.VSInputService.class),
+         inputService,
          mock(RangeSliderPropertyDialogService.class),
          mock(CalendarPropertyDialogService.class), mock(TabPropertyDialogService.class),
          mock(CalcTablePropertyDialogService.class),


### PR DESCRIPTION
## Summary
- `set_assembly_properties({"dataInputPaneModel.variable": true})` on TextInput/ComboBox/Slider/Spinner reported `{ok:true}` while silently no-op'ing: PR #5024's `resolveInputTableBinding()` wiring made these four types' setters derive the real, persisted `isVariable()` flag purely from whether `dataInputPaneModel.table` resolves to a `"$(varName)"` reference — the client's own `dataInputPaneModel.variable` boolean is read nowhere in any of the four setters (`setTextInputPropertyDialogModel`/`setComboboxPropertyDialogModel`/`setSliderPropertyDialogModel`/`setSpinnerPropertyDialogModel`), dead code on write unconditionally. The exact reported repro (`columnValue:"$(StartDate)"`, `variable:true`, `table` never set) hit the one shape `resolveInputTableBinding` didn't accept: `table` empty/absent with the variable reference carried in `columnValue` instead.
- **(a)** `resolveInputTableBinding()` now also accepts `table` null/empty + `columnValue` already shaped `"$(varName)"` as equivalent to `table:"$(varName)"` — reusing the exact same `isKnownVariableName` existence check and throw-if-unknown behavior the raw-`$(...)`-on-`table` branch already has. This directly fixes the reported repro.
- **(b)** A patch that explicitly touches `dataInputPaneModel.variable`, when the resulting table binding still doesn't resolve to a variable reference, is now refused via a new `PropertyAliases.derivesVariableFlagFromTable()`-gated check in `AssemblyPropertyService.set()` (`VSInputService.resolvesToVariableBinding()` exposes the shared resolution logic), naming `dataInputPaneModel.table`/`columnValue` as the field that actually needs to be a variable reference — rather than reporting success and leaving the flag silently unchanged. Mirrors the style of the existing `PropertyAliases` `DEAD_FIELDS` write-refusal registry, though the actual gating logic lives in `AssemblyPropertyService` since (unlike `DEAD_FIELDS`) it depends on the resulting table binding, not on the field alone.
- CheckBox/RadioButton (`setCheckboxPropertyModel`/`setRadioButtonPropertyModel`) are a separate, structurally different gap — they trust the client's `isVariable()` boolean directly, with no validation at all (the opposite shape of defect from this one) — deliberately **not touched** here, per this bug's own diagnosis/refutation (both independently confirmed this and recommended against folding the two together). Tracked as its own follow-up Redmine bug.

Root-caused via `stylebi-wiz` bug #76530 (Redmine); full diagnosis/refute/fix write-up at `stylebi-wiz` repo `docs/teams/2026-09-09-bug-76530-input-variable-flag/bug-76530/`.

## Test plan
- [x] Extended regression test `VSInputTableBindingResolutionTest` (4 new cases: columnValue-only `$(varName)` resolves when table is unset, rejects an unknown variable in that same shape, an explicit table is not overridden by a columnValue that looks like a variable, and `resolvesToVariableBinding` agrees with the underlying resolution) — `./mvnw -q -pl core test -Dtest=VSInputTableBindingResolutionTest` — 13/13 pass
- [x] Extended `AssemblyPropertyServiceTest` (3 new cases: the exact reported repro now succeeds, an explicit `variable` write with no resolvable table/columnValue is refused by field name, and an unrelated patch that doesn't touch `variable` is unaffected) — `./mvnw -q -pl core test -Dtest=AssemblyPropertyServiceTest` — 19/19 pass
- [x] No regression in neighboring suites — `./mvnw -q -pl core test -Dtest="PropertyAliasesTest,PropertyPathTest"` (44/44, 47/47) and the full `inetsoft.web.wiz.viewsheet` package (28 test classes, including `ViewsheetAssemblyAgentControllerTest` 71/71) — all green, 0 failures
- [ ] Live verification via `set_assembly_properties`/`get_assembly_properties` (not possible this session — no live pairing session reachable; both diagnosis and refutation phases already attempted and documented this gap, judged acceptable per this workflow's own precedent, same as PR #5024)

No LLM-facing prompt/schema/tool-description text was touched by this PR — Java-side only, no merge hold needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)