### PR TITLE
fix(wiz): note when export can't render dropdown-mode SelectionList (bug #76541)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -194,9 +194,15 @@ public class ScriptImageService {
 
          if(decoded == null || decoded.getWidth() <= 1 || decoded.getHeight() <= 1) {
             ChartImage whole = getViewsheetImage(rvs, width, height, principal);
+            String fallbackNote = "\"" + assemblyName + "\" can't be rendered on its own — " +
+               "showing the whole viewsheet instead.";
+
+            if(whole.note() != null) {
+               fallbackNote = fallbackNote + " " + whole.note();
+            }
+
             return new ChartImage(whole.pngBytes(), whole.isPng(), whole.width(), whole.height(),
-               "\"" + assemblyName + "\" can't be rendered on its own — showing the whole " +
-               "viewsheet instead.");
+               fallbackNote);
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -21,7 +21,10 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.FileFormatInfo;
+import inetsoft.uql.viewsheet.SelectionListVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.SelectionListVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.TitledVSAssemblyInfo;
 import inetsoft.util.Tool;
 import inetsoft.web.service.BinaryTransferService;
@@ -242,7 +245,51 @@ public class ScriptImageService {
       BufferedImage scaled = scaleToFit(full, w, h);
       byte[] encoded = encodePng(scaled, "the viewsheet");
 
-      return new ChartImage(encoded, true, scaled.getWidth(), scaled.getHeight(), null);
+      return new ChartImage(encoded, true, scaled.getWidth(), scaled.getHeight(),
+         dropdownSelectionListNote(rvs.getViewsheet()));
+   }
+
+   /**
+    * {@code VSSelectionListHelper.write} — the code every export format (SVG/PNG/HTML/PDF) shares
+    * for drawing a selection list — only calls {@code writeList()} (the method that draws the
+    * rows/values) when {@code getShowType() == SelectionVSAssemblyInfo.LIST_SHOW_TYPE}. For
+    * {@code DROPDOWN_SHOW_TYPE}, nothing substitutes: no export format draws any arrow, border, or
+    * selected-value chrome, so the assembly comes out as a blank box in this image. That's a real
+    * gap in the export pipeline, not something this render can paper over — Composer/Viewer render
+    * dropdown mode correctly, so note the discrepancy rather than let a blank box pass as a
+    * plausible result (see class doc's title-bar/tables-crosstabs fallback for the same pattern).
+    */
+   private static String dropdownSelectionListNote(Viewsheet vs) {
+      if(vs == null) {
+         return null;
+      }
+
+      StringBuilder names = new StringBuilder();
+
+      for(Assembly assembly : vs.getAssemblies()) {
+         if(assembly instanceof SelectionListVSAssembly selectionList &&
+            selectionList.getVSAssemblyInfo() instanceof SelectionListVSAssemblyInfo info &&
+            info.getShowType() == SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE)
+         {
+            if(names.length() > 0) {
+               names.append(", ");
+            }
+
+            names.append('"').append(selectionList.getAbsoluteName()).append('"');
+         }
+      }
+
+      if(names.length() == 0) {
+         return null;
+      }
+
+      boolean plural = names.indexOf(",") >= 0;
+
+      return names + (plural ? " are dropdown-mode selection lists" : " is a dropdown-mode " +
+         "selection list") + " that will render as an empty box in this export — StyleBI's " +
+         "export pipeline (SVG/PNG/HTML/PDF) doesn't draw dropdown chrome for any format. The " +
+         "interactive Composer/Viewer renders " + (plural ? "them" : "it") + " correctly, " +
+         "including the arrow, border, and selected value; only this static image is affected.";
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -20,7 +20,10 @@ package inetsoft.web.wiz.script;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.SelectionListVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.SelectionListVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import inetsoft.util.cachefs.BinaryTransfer;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
@@ -64,6 +67,18 @@ class ScriptImageServiceTest {
       ChartVSAssembly chart = new ChartVSAssembly(vs, chartName);
       chart.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Table1"));
       vs.addAssembly(chart);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   /** Builds a viewsheet with a single SelectionList assembly set to the given show type. */
+   private RuntimeViewsheet viewsheetWithSelectionList(String name, int showType) {
+      Viewsheet vs = new Viewsheet();
+      SelectionListVSAssembly selectionList = new SelectionListVSAssembly(vs, name);
+      ((SelectionListVSAssemblyInfo) selectionList.getVSAssemblyInfo()).setShowType(showType);
+      vs.addAssembly(selectionList);
 
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);
@@ -318,6 +333,48 @@ class ScriptImageServiceTest {
    @Test
    void getViewsheetImageNeverAttachesATitleNote() throws Exception {
       RuntimeViewsheet rvs = viewsheetWithChart("Chart1");
+      VSExportService exportService = mock(VSExportService.class);
+      stubExport(exportService, fakePng(400, 300));
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNull(img.note());
+   }
+
+   /**
+    * Bug #76541: {@code VSSelectionListHelper.write} only draws a selection list's rows/values
+    * when {@code getShowType() == SelectionVSAssemblyInfo.LIST_SHOW_TYPE} — no export format
+    * (SVG/PNG/HTML/PDF) substitutes any dropdown chrome, so a dropdown-mode selection list renders
+    * as a blank box with no warning. Composer/Viewer render it correctly; only static exports are
+    * affected.
+    */
+   @Test
+   void attachesANoteWhenTheViewsheetHasADropdownSelectionList() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithSelectionList(
+         "Selection1", SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+      VSExportService exportService = mock(VSExportService.class);
+      stubExport(exportService, fakePng(400, 300));
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNotNull(img.note());
+      assertTrue(img.note().contains("Selection1"));
+   }
+
+   /**
+    * Regression guard for the note added for bug #76541 — a list-mode SelectionList is drawn
+    * correctly by the export pipeline, so it must not start firing this note too.
+    */
+   @Test
+   void doesNotAttachANoteWhenTheSelectionListIsInListMode() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithSelectionList(
+         "Selection1", SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
       VSExportService exportService = mock(VSExportService.class);
       stubExport(exportService, fakePng(400, 300));
 

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -259,6 +259,47 @@ class ScriptImageServiceTest {
    }
 
    /**
+    * Bug #76541 round 2: {@code getAssemblyImage}'s own fallback branch was constructing a brand
+    * new {@code ChartImage} with only its own "can't be rendered on its own" text, discarding
+    * whatever note the internal {@code getViewsheetImage} call had already computed — so a caller
+    * targeting a dropdown-mode SelectionList by name directly (the most natural way to
+    * investigate this bug) got no disclosure at all. SelectionList is never one of the types
+    * {@code AssemblyImageService} supports directly, so it always takes this fallback branch.
+    */
+   @Test
+   void assemblyFallbackNoteIncludesTheDropdownDisclosureWhenTargetIsADropdownSelectionList() throws Exception {
+      RuntimeViewsheet rvs = viewsheetWithSelectionList(
+         "Selection1", SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+
+      byte[] placeholder = fakePng(1, 1);
+      BinaryTransfer transfer = mock(BinaryTransfer.class);
+      AssemblyImageService.ImageRenderResult result =
+         new AssemblyImageService.ImageRenderResult(true, transfer, 1, 1);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      when(imageService.processGetAssemblyImage(
+         eq(rvs), anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+         isNull(), eq(0), eq(0), eq(0), any(), eq(false), eq(true)))
+         .thenReturn(result);
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      when(binaryTransferService.getData(transfer)).thenReturn(placeholder);
+
+      VSExportService exportService = mock(VSExportService.class);
+      stubExport(exportService, fakePng(400, 300));
+
+      ScriptImageService svc = new ScriptImageService(imageService, binaryTransferService, exportService);
+      ScriptImageService.ChartImage img = svc.getAssemblyImage(
+         rvs, "Selection1", null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNotNull(img.note());
+      assertTrue(img.note().contains("can't be rendered on its own"),
+                 "must keep the fallback's own explanation, got: [" + img.note() + "]");
+      assertTrue(img.note().contains("dropdown-mode selection list") && img.note().contains("empty box"),
+                 "must include the dropdown disclosure, got: [" + img.note() + "]");
+   }
+
+   /**
     * Charts default to {@code titleVisible=true} ({@code ChartVSAssemblyInfo}'s own
     * {@code titleInfo} field init), so this hides the title explicitly — otherwise it would be
     * indistinguishable from {@link #attachesATitleNoteWhenTheChartsTitleIsVisible}.
@@ -384,6 +425,74 @@ class ScriptImageServiceTest {
          rvs, null, null, TestPrincipals.user("alice", "host-org"));
 
       assertNull(img.note());
+   }
+
+   /**
+    * Multiple dropdown-mode SelectionLists in one viewsheet must all be named, comma-joined, with
+    * plural grammar ("are ... lists" / "them") rather than the singular phrasing used for one.
+    */
+   @Test
+   void notesAllDropdownSelectionListsWithPluralPhrasingWhenThereAreTwoOrMore() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      SelectionListVSAssembly first = new SelectionListVSAssembly(vs, "Selection1");
+      ((SelectionListVSAssemblyInfo) first.getVSAssemblyInfo())
+         .setShowType(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+      vs.addAssembly(first);
+      SelectionListVSAssembly second = new SelectionListVSAssembly(vs, "Selection2");
+      ((SelectionListVSAssemblyInfo) second.getVSAssemblyInfo())
+         .setShowType(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+      vs.addAssembly(second);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      VSExportService exportService = mock(VSExportService.class);
+      stubExport(exportService, fakePng(400, 300));
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNotNull(img.note());
+      assertTrue(img.note().contains("Selection1"));
+      assertTrue(img.note().contains("Selection2"));
+      assertTrue(img.note().contains("are dropdown-mode selection lists"));
+      assertTrue(img.note().contains("them"));
+   }
+
+   /**
+    * A list-mode SelectionList renders correctly and must not be swept into the note just because
+    * a sibling dropdown-mode SelectionList is also on the sheet — only the dropdown one is named,
+    * with singular phrasing.
+    */
+   @Test
+   void notesOnlyTheDropdownSelectionListWhenAListModeOneIsAlsoPresent() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      SelectionListVSAssembly listMode = new SelectionListVSAssembly(vs, "ListMode1");
+      ((SelectionListVSAssemblyInfo) listMode.getVSAssemblyInfo())
+         .setShowType(SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      vs.addAssembly(listMode);
+      SelectionListVSAssembly dropdown = new SelectionListVSAssembly(vs, "Dropdown1");
+      ((SelectionListVSAssemblyInfo) dropdown.getVSAssemblyInfo())
+         .setShowType(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+      vs.addAssembly(dropdown);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      VSExportService exportService = mock(VSExportService.class);
+      stubExport(exportService, fakePng(400, 300));
+
+      ScriptImageService svc = new ScriptImageService(
+         mock(AssemblyImageService.class), mock(BinaryTransferService.class), exportService);
+      ScriptImageService.ChartImage img = svc.getViewsheetImage(
+         rvs, null, null, TestPrincipals.user("alice", "host-org"));
+
+      assertNotNull(img.note());
+      assertTrue(img.note().contains("Dropdown1"));
+      assertFalse(img.note().contains("ListMode1"));
+      assertTrue(img.note().contains("is a dropdown-mode selection list"));
    }
 
    @Test


### PR DESCRIPTION
## Root cause

Bug #76541: a SelectionList assembly in dropdown mode (`showType:1`) renders as a completely
blank box via the Wiz agent's whole-viewsheet render (`get_viewsheet_image`, no `target`) — no
arrow, border, or selected-value chrome — while list mode renders correctly.

`VSSelectionListHelper.write()` (`core/src/main/java/inetsoft/report/io/viewsheet/VSSelectionListHelper.java:64-66`)
only calls `writeList()` (the method that draws rows/values) when
`info.getShowType() == SelectionVSAssemblyInfo.LIST_SHOW_TYPE`. For dropdown mode
(`DROPDOWN_SHOW_TYPE`), nothing substitutes — no export format (SVG/PNG/HTML/PDF) draws any
dropdown chrome. This is a structural gap in the export pipeline itself, present in every
export format, not something introduced by the Wiz agent code.

Actually implementing dropdown-chrome drawing in the export pipeline is out of scope for this
fix — it's a rendering-design question (what should static dropdown chrome look like in a
PNG/PDF?), not a bug fix.

## Fix

`ScriptImageService.getViewsheetImage()` (`core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java`)
now attaches an explanatory `note` to its response when the rendered viewsheet contains one or
more dropdown-mode `SelectionListVSAssembly` instances, naming them and explaining that the
export pipeline doesn't draw dropdown chrome for any format while the interactive
Composer/Viewer render them correctly. This mirrors the existing precedent in
`getAssemblyImage()`, which already notes when a titled assembly's title bar won't appear in a
single-assembly tile render.

`wiz-services`/`plugin/composer` already pass this `note` field through generically end-to-end,
so no changes are needed there.

## Tests

Added to `core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java`:
- `attachesANoteWhenTheViewsheetHasADropdownSelectionList`
- `doesNotAttachANoteWhenTheSelectionListIsInListMode` (regression guard for the working case)

```
./mvnw.cmd -pl core test -Dtest=ScriptImageServiceTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)