### PR TITLE
feat(wiz): add ScriptLibraryController for the sheet-independent Script Library asset

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ScriptLibraryController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ScriptLibraryController.java
@@ -72,6 +72,8 @@ public class ScriptLibraryController {
 
    public record CheckScriptSyntaxResult(boolean ok, String message, Integer line, Integer column) {}
 
+   public record CheckScriptSyntaxRequest(String script) {}
+
    @GetMapping
    public List<ScriptLibraryFunction> list(Principal principal) {
       LibManager lib = libManagerProvider.getManager(principal);
@@ -184,11 +186,11 @@ public class ScriptLibraryController {
    }
 
    @PostMapping("/check")
-   public CheckScriptSyntaxResult checkSyntax(@RequestBody String script) {
+   public CheckScriptSyntaxResult checkSyntax(@RequestBody CheckScriptSyntaxRequest request) {
       ScriptEnv env = ScriptEnvRepository.getScriptEnv();
 
       try {
-         env.checkFunction("script", script);
+         env.checkFunction("script", request.script());
       }
       catch(Exception e) {
          int line = 0;

--- a/core/src/main/java/inetsoft/web/wiz/controller/ScriptLibraryController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ScriptLibraryController.java
@@ -25,6 +25,7 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetObject;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.DependencyHandler;
 import inetsoft.uql.asset.sync.DependencyTransformer;
 import inetsoft.util.script.ScriptEnv;
 import inetsoft.util.script.ScriptEnvRepository;
@@ -139,7 +140,13 @@ public class ScriptLibraryController {
       LibManager lib = libManagerProvider.getManager(principal);
       requireExists(lib, name);
       requirePermission(principal, name, ResourceAction.WRITE);
-      lib.setScript(name, request.text() == null ? "" : request.text());
+      String oldText = lib.getScript(name);
+      String newText = request.text() == null ? "" : request.text();
+      // Keeps the outgoing dependency graph in sync with the new body, the same way
+      // OpenScriptController.saveScript does for a per-sheet script save -- otherwise delete()'s
+      // dependency-safety check above is only as accurate as the last create/update wrote.
+      DependencyHandler.getInstance().updateScriptDependencies(oldText, newText, scriptEntry(name));
+      lib.setScript(name, newText);
 
       if(request.comment() != null) {
          lib.setScriptComment(name, request.comment());
@@ -224,12 +231,16 @@ public class ScriptLibraryController {
    }
 
    /**
-    * Matches {@code checkScriptRemoveable}'s own dependency-lookup entry (GLOBAL_SCOPE) -- the
-    * scope a script's dependency records are actually keyed under, confirmed by reading that
-    * method rather than assumed.
+    * COMPONENT_SCOPE, not GLOBAL_SCOPE -- confirmed against where script dependency records are
+    * actually written and cleaned up: {@code LocalDependencyHandler.updateScriptDependencies} keys
+    * a called function's dependents under COMPONENT_SCOPE, and {@code RemoveAssetController}'s own
+    * post-delete cleanup deletes that same COMPONENT_SCOPE key for the script it just removed.
+    * {@code RemoveAssetController.checkScriptRemoveable} itself looks these records up under
+    * GLOBAL_SCOPE, which never matches and is a pre-existing bug in that method -- not a scope this
+    * controller should copy, even though it was the original model for this method.
     */
    private AssetEntry scriptEntry(String name) {
-      return new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.SCRIPT, name, null);
+      return new AssetEntry(AssetRepository.COMPONENT_SCOPE, AssetEntry.Type.SCRIPT, name, null);
    }
 
    private void requirePermission(Principal principal, String name, ResourceAction action) {

--- a/core/src/main/java/inetsoft/web/wiz/controller/ScriptLibraryController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ScriptLibraryController.java
@@ -1,0 +1,251 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.report.LibManager;
+import inetsoft.report.LibManagerProvider;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetObject;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.sync.DependencyTransformer;
+import inetsoft.util.script.ScriptEnv;
+import inetsoft.util.script.ScriptEnvRepository;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.SourceSection;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Wraps StyleBI's Script Library asset (LibManager, AssetEntry.Type.SCRIPT) -- a reusable script
+ * function created once and callable from any viewsheet's script by name, independent of any
+ * particular sheet -- under wiz's own JWT-authenticated, CSRF-exempt /api/wiz namespace (see
+ * WizServiceAuthenticationFilter / CSRFFilter#isWizApi). Same shape DatasourceMetaApiController
+ * already established for another repository-level, session-less asset.
+ *
+ * <p>Talks to LibManager directly rather than proxying OpenScriptController/ScriptController/
+ * AssetTreeController/RemoveAssetController -- StyleBI's own internal Composer-SPA REST paths
+ * (/api/composer/*, /api/script/*), which are session-cookie + CSRF protected and not reachable by
+ * a stateless bearer-token client. Reusing the real service directly, not the internal controller,
+ * is the same rule every other wiz agent controller already follows.
+ *
+ * <p>A script function is addressed by its plain name throughout -- LibManager's own key -- rather
+ * than by an AssetEntry identifier round-tripped through an asset-tree lookup, which is what the
+ * internal controllers do because they also render a tree UI. This surface has no tree to render.
+ */
+@RestController
+@RequestMapping("/api/wiz/v1/script-library")
+public class ScriptLibraryController {
+   public ScriptLibraryController(LibManagerProvider libManagerProvider,
+                                  SecurityEngine securityEngine)
+   {
+      this.libManagerProvider = libManagerProvider;
+      this.securityEngine = securityEngine;
+   }
+
+   public record ScriptLibraryFunction(String name, String comment) {}
+
+   public record ScriptLibraryFunctionDetail(String name, String text, String comment) {}
+
+   public record CreateScriptLibraryFunctionRequest(String name, String text, String comment) {}
+
+   public record UpdateScriptLibraryFunctionRequest(String text, String comment) {}
+
+   public record CheckScriptSyntaxResult(boolean ok, String message, Integer line, Integer column) {}
+
+   @GetMapping
+   public List<ScriptLibraryFunction> list(Principal principal) {
+      LibManager lib = libManagerProvider.getManager(principal);
+      List<ScriptLibraryFunction> out = new ArrayList<>();
+      Enumeration<String> names = lib.getScripts();
+
+      while(names.hasMoreElements()) {
+         String name = names.nextElement();
+
+         if(lib.isAuditScript(name) || !hasPermission(principal, name, ResourceAction.READ)) {
+            continue;
+         }
+
+         out.add(new ScriptLibraryFunction(name, lib.getScriptComment(name)));
+      }
+
+      out.sort(Comparator.comparing(ScriptLibraryFunction::name));
+      return out;
+   }
+
+   @GetMapping("/{name}")
+   public ScriptLibraryFunctionDetail read(@PathVariable String name, Principal principal) {
+      LibManager lib = libManagerProvider.getManager(principal);
+      requireExists(lib, name);
+      requirePermission(principal, name, ResourceAction.READ);
+      return new ScriptLibraryFunctionDetail(name, lib.getScript(name), lib.getScriptComment(name));
+   }
+
+   @PostMapping
+   public ScriptLibraryFunctionDetail create(@RequestBody CreateScriptLibraryFunctionRequest request,
+                                             Principal principal) throws Exception
+   {
+      String name = request.name();
+
+      if(name == null || name.isBlank()) {
+         throw new IllegalArgumentException("create_script_library_function requires 'name'.");
+      }
+
+      LibManager lib = libManagerProvider.getManager(principal);
+
+      if(lib.getScript(name) != null) {
+         throw new IllegalArgumentException(
+            "A script library function named '" + name + "' already exists. Use " +
+            "update_script_library_function to change it, or pick a different name.");
+      }
+
+      requirePermission(principal, name, ResourceAction.WRITE);
+      lib.setScript(name, request.text() == null ? "" : request.text());
+
+      if(request.comment() != null && !request.comment().isBlank()) {
+         lib.setScriptComment(name, request.comment());
+      }
+
+      lib.save();
+      return new ScriptLibraryFunctionDetail(name, lib.getScript(name), lib.getScriptComment(name));
+   }
+
+   @PutMapping("/{name}")
+   public ScriptLibraryFunctionDetail update(@PathVariable String name,
+                                             @RequestBody UpdateScriptLibraryFunctionRequest request,
+                                             Principal principal) throws Exception
+   {
+      LibManager lib = libManagerProvider.getManager(principal);
+      requireExists(lib, name);
+      requirePermission(principal, name, ResourceAction.WRITE);
+      lib.setScript(name, request.text() == null ? "" : request.text());
+
+      if(request.comment() != null) {
+         lib.setScriptComment(name, request.comment());
+      }
+
+      lib.save();
+      return new ScriptLibraryFunctionDetail(name, lib.getScript(name), lib.getScriptComment(name));
+   }
+
+   /**
+    * {@code force=false} (the default) refuses a delete that would break another asset -- the
+    * same dependency check {@code RemoveAssetController.checkScriptRemoveable} makes when the
+    * human Composer's own delete dialog is not pre-confirmed. Skipping it (as the earlier
+    * SPA-wrapping tool did by always sending {@code confirmed:true}) silently breaks whatever
+    * referenced this function.
+    */
+   @DeleteMapping("/{name}")
+   public void delete(@PathVariable String name,
+                      @RequestParam(required = false, defaultValue = "false") boolean force,
+                      Principal principal) throws Exception
+   {
+      LibManager lib = libManagerProvider.getManager(principal);
+      requireExists(lib, name);
+      requirePermission(principal, name, ResourceAction.DELETE);
+
+      if(!force) {
+         List<AssetObject> deps = DependencyTransformer.getDependencies(scriptEntry(name).toIdentifier());
+
+         if(!deps.isEmpty()) {
+            List<String> names = new ArrayList<>();
+
+            for(AssetObject dep : deps) {
+               names.add(dep instanceof AssetEntry entry ? entry.getDescription() : dep.toString());
+            }
+
+            throw new IllegalArgumentException(
+               "Script library function '" + name + "' is used by: " + String.join(", ", names) +
+               ". Deleting it would break those. Pass force=true to delete anyway.");
+         }
+      }
+
+      lib.removeScript(name);
+      lib.save();
+   }
+
+   @PostMapping("/check")
+   public CheckScriptSyntaxResult checkSyntax(@RequestBody String script) {
+      ScriptEnv env = ScriptEnvRepository.getScriptEnv();
+
+      try {
+         env.checkFunction("script", script);
+      }
+      catch(Exception e) {
+         int line = 0;
+         int column = 0;
+         Throwable cause = e;
+
+         // unwrap to the GraalJS PolyglotException to recover source location, same as
+         // OpenScriptController.checkScript.
+         while(cause != null && !(cause instanceof PolyglotException)) {
+            cause = cause.getCause();
+         }
+
+         if(cause instanceof PolyglotException polyglot && polyglot.getSourceLocation() != null) {
+            SourceSection loc = polyglot.getSourceLocation();
+            line = loc.getStartLine();
+            column = loc.getStartColumn();
+         }
+
+         return new CheckScriptSyntaxResult(false, e.getMessage(), line, column);
+      }
+
+      return new CheckScriptSyntaxResult(true, null, null, null);
+   }
+
+   private void requireExists(LibManager lib, String name) {
+      if(lib.getScript(name) == null) {
+         throw new IllegalArgumentException(
+            "No script library function named '" + name + "'. list_script_library reports what " +
+            "exists.");
+      }
+   }
+
+   /**
+    * Matches {@code checkScriptRemoveable}'s own dependency-lookup entry (GLOBAL_SCOPE) -- the
+    * scope a script's dependency records are actually keyed under, confirmed by reading that
+    * method rather than assumed.
+    */
+   private AssetEntry scriptEntry(String name) {
+      return new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.SCRIPT, name, null);
+   }
+
+   private void requirePermission(Principal principal, String name, ResourceAction action) {
+      if(!hasPermission(principal, name, action)) {
+         throw new SecurityException(
+            "No " + action + " permission on script library function '" + name + "'.");
+      }
+   }
+
+   private boolean hasPermission(Principal principal, String name, ResourceAction action) {
+      try {
+         return securityEngine.checkPermission(principal, ResourceType.SCRIPT, name, action);
+      }
+      catch(Exception e) {
+         return false;
+      }
+   }
+
+   private final LibManagerProvider libManagerProvider;
+   private final SecurityEngine securityEngine;
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/ScriptLibraryControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/ScriptLibraryControllerTest.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.report.LibManager;
+import inetsoft.report.LibManagerProvider;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetObject;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.DependencyHandler;
+import inetsoft.uql.asset.sync.DependencyTransformer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression coverage for the two dependency-tracking correctness issues code review found in
+ * {@code ScriptLibraryController}: {@code delete()}'s safety check was built against the wrong
+ * {@code AssetEntry} scope (so it could never find a real dependent), and {@code update()} never
+ * refreshed the dependency graph at all.
+ */
+@Tag("core")
+class ScriptLibraryControllerTest {
+   @Test
+   void delete_refusesWhenAComponentScopedDependentExists() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.lib.getScript("helper")).thenReturn("return 1;");
+      AssetEntry dependent = new AssetEntry(
+         AssetRepository.COMPONENT_SCOPE, AssetEntry.Type.VIEWSHEET, "report", null);
+
+      try(MockedStatic<DependencyTransformer> transformer = mockStatic(DependencyTransformer.class)) {
+         transformer.when(() -> DependencyTransformer.getDependencies(componentScopedId("helper")))
+            .thenReturn(List.<AssetObject>of(dependent));
+
+         assertThrows(IllegalArgumentException.class,
+                      () -> fixture.controller.delete("helper", false, fixture.principal));
+      }
+
+      verify(fixture.lib, never()).removeScript(anyString());
+   }
+
+   @Test
+   void delete_looksUpDependentsUnderComponentScopeNotGlobalScope() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.lib.getScript("helper")).thenReturn("return 1;");
+
+      // GLOBAL_SCOPE is the scope RemoveAssetController.checkScriptRemoveable's own (buggy) lookup
+      // used, and the bug this test guards against: a lookup keyed there never matches a real
+      // dependency record, so force=false would silently allow an unsafe delete.
+      try(MockedStatic<DependencyTransformer> transformer = mockStatic(DependencyTransformer.class)) {
+         transformer.when(() -> DependencyTransformer.getDependencies(anyString()))
+            .thenReturn(List.of());
+
+         assertDoesNotThrow(() -> fixture.controller.delete("helper", false, fixture.principal));
+
+         transformer.verify(() -> DependencyTransformer.getDependencies(componentScopedId("helper")));
+         transformer.verify(() -> DependencyTransformer.getDependencies(globalScopedId("helper")),
+                            never());
+      }
+
+      verify(fixture.lib).removeScript("helper");
+   }
+
+   @Test
+   void delete_allowsRemovalWhenNoDependentsExist() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.lib.getScript("helper")).thenReturn("return 1;");
+
+      try(MockedStatic<DependencyTransformer> transformer = mockStatic(DependencyTransformer.class)) {
+         transformer.when(() -> DependencyTransformer.getDependencies(anyString()))
+            .thenReturn(List.of());
+
+         assertDoesNotThrow(() -> fixture.controller.delete("helper", false, fixture.principal));
+      }
+
+      verify(fixture.lib).removeScript("helper");
+      verify(fixture.lib).save();
+   }
+
+   @Test
+   void update_refreshesTheOutgoingDependencyGraph() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.lib.getScript("helper")).thenReturn("return other();");
+
+      DependencyHandler dependencyHandler = mock(DependencyHandler.class);
+
+      try(MockedStatic<DependencyHandler> handler = mockStatic(DependencyHandler.class)) {
+         handler.when(DependencyHandler::getInstance).thenReturn(dependencyHandler);
+
+         fixture.controller.update(
+            "helper",
+            new ScriptLibraryController.UpdateScriptLibraryFunctionRequest("return 1;", null),
+            fixture.principal);
+
+         AssetEntry expectedEntry = new AssetEntry(
+            AssetRepository.COMPONENT_SCOPE, AssetEntry.Type.SCRIPT, "helper", null);
+         verify(dependencyHandler).updateScriptDependencies(
+            eq("return other();"), eq("return 1;"), eq(expectedEntry));
+      }
+
+      verify(fixture.lib).setScript("helper", "return 1;");
+   }
+
+   private static String componentScopedId(String name) {
+      return new AssetEntry(AssetRepository.COMPONENT_SCOPE, AssetEntry.Type.SCRIPT, name, null)
+         .toIdentifier();
+   }
+
+   private static String globalScopedId(String name) {
+      return new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.SCRIPT, name, null)
+         .toIdentifier();
+   }
+
+   /** The controller with every collaborator mocked, and every permission granted by default. */
+   private static final class Fixture {
+      Fixture() throws Exception {
+         when(securityEngine.checkPermission(any(), eq(ResourceType.SCRIPT), anyString(),
+                                             any(ResourceAction.class))).thenReturn(true);
+         when(libManagerProvider.getManager(any(Principal.class))).thenReturn(lib);
+         controller = new ScriptLibraryController(libManagerProvider, securityEngine);
+      }
+
+      final LibManagerProvider libManagerProvider = mock(LibManagerProvider.class);
+      final SecurityEngine securityEngine = mock(SecurityEngine.class);
+      final LibManager lib = mock(LibManager.class);
+      final Principal principal = mock(Principal.class);
+      final ScriptLibraryController controller;
+   }
+}


### PR DESCRIPTION
## Bug

Redmine #76516 item 4. `plugin/composer`'s Script Library tools (`list_script_library`, `create_script_library_function`, `read_script_library_function`, `update_script_library_function`, `delete_script_library_function`, `check_script_library_syntax`) had no working backend — they called StyleBI's own internal Composer-SPA REST controllers (`OpenScriptController`/`ScriptController`/`AssetTreeController`/`RemoveAssetController`, `/api/composer/*`, `/api/script/*`), which are session-cookie + CSRF protected and unreachable by the plugin's stateless bearer-token client. Confirmed by grep: the `inetsoft.web.wiz.*` agent-bridge package had no `ScriptAsset`/`LibManager`-backed endpoint at all.

## Fix

New controller mirrors `ViewsheetAssemblyAgentController`/`WorksheetAgentController`/`DatasourceMetaApiController`'s own pattern — mounted under the JWT-authenticated, CSRF-exempt `/api/wiz` namespace (`WizServiceAuthenticationFilter` / `CSRFFilter#isWizApi`), talking to `LibManager` directly (the same service `OpenScriptController`/`ScriptController` already use internally) rather than proxying either of them.

| Endpoint | Behavior |
|---|---|
| `GET /api/wiz/v1/script-library` | list every non-audit function this principal has READ permission for |
| `GET /api/wiz/v1/script-library/{name}` | read one function's text + comment |
| `POST /api/wiz/v1/script-library` | create; refuses a name collision instead of silently overwriting |
| `PUT /api/wiz/v1/script-library/{name}` | update; refuses if the name doesn't exist |
| `DELETE /api/wiz/v1/script-library/{name}?force=` | delete; `force=false` (default) refuses a delete that would break another asset — the same dependency check `RemoveAssetController.checkScriptRemoveable` makes for an unconfirmed human delete. The earlier tool always sent `confirmed:true` and silently skipped this |
| `POST /api/wiz/v1/script-library/check` | stateless syntax check (`ScriptEnv`, same as `OpenScriptController.checkScript`) |

A function is addressed by its plain name throughout — `LibManager`'s own key — rather than an `AssetEntry` identifier round-tripped through an asset-tree lookup, since this surface has no tree to render.

Permission checks use `SecurityEngine.checkPermission(principal, ResourceType.SCRIPT, name, action)` — the same by-name check `AbstractAssetEngine`/`AdHocQueryHandler` already use for a script function, rather than reconstructing an `AssetEntry` to call `AssetRepository.checkAssetPermission` (which needs a scope that isn't uniformly recorded across this codebase's own script-handling call sites).

## Verification

Live-verified against a running instance via the rewritten `plugin/composer` tools (companion PR [stylebi-wiz#2312](https://github.com/inetsoft-technology/stylebi-wiz/pull/2312)):
- `list`/`read` against real, pre-existing script library functions.
- `create` (+ name-collision refusal), `update` (+ not-found refusal).
- `check` against both valid and invalid script text (real GraalJS error → line/column extraction confirmed).
- `delete` confirmed removing the function (list/read no longer show it).

**Known caveat, left as-is**: a `delete` call can occasionally report success without the function disappearing yet if something else touches the library at the same moment — a `LibManager` change-listener race between `removeScript()`/`save()`. This is a pre-existing characteristic of `LibManager` itself, not introduced here: `RemoveAssetController`'s own human-initiated delete path uses the identical unsynchronized `removeScript()`+`save()` sequence. A verify-after-write retry (with a bounded attempt count) was discussed and deliberately not added this pass.

`core/src/main/resources/inetsoft/report/defaults.properties` intentionally left out of this commit — unrelated local change, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)