### PR TITLE
Fix #76552: compare requested value in dataInputPaneModel.variable achievability check

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -311,25 +311,39 @@ public class AssemblyPropertyService {
     * {@code resolveInputTableBinding} normalization, which now also accepts a {@code columnValue}
     * already shaped {@code "$(varName)"} with {@code table} left unset) resolves to a
     * {@code "$(varName)"} reference. Only invoked when this call's own patch explicitly touches
-    * {@code dataInputPaneModel.variable} (see the caller): when the resulting table binding will
-    * not actually resolve to a variable reference, that touch would otherwise report success and
-    * leave the flag exactly where it already was -- the same "populated on every read, never read
-    * back on write" shape {@link PropertyAliases}'s {@code DEAD_FIELDS} refuses elsewhere, just
-    * conditional on the resulting binding rather than unconditional on the field.
+    * {@code dataInputPaneModel.variable} (see the caller).
+    *
+    * <p>Bug #76552 (follow-up): the achievable state must be compared against the value the
+    * patch actually <em>requested</em>, not just checked for being merely possible. Checking
+    * achievability alone let {@code variable:false} through unguarded even when the table still
+    * resolves to a variable (the real setter derives {@code true} from the table regardless, so
+    * that write silently failed to take effect -- the same "reports success, changes nothing"
+    * defect this whole check exists to catch, just from the opposite direction), and also
+    * refused a harmless {@code variable:false} on a table that was never a variable to begin
+    * with. {@code dataInputPaneModel.variable} is a primitive {@code boolean}
+    * ({@link inetsoft.web.composer.model.vs.DataInputPaneModel#isVariable()}), and {@code model}
+    * already has this call's patch applied by the caller, so the read below is always the
+    * requested value, never null.
     */
    private void requireVariableFlagAchievable(String type, Object model, Viewsheet vs) {
+      boolean requested = (Boolean) PropertyPath.get(model, "dataInputPaneModel.variable");
       String table = (String) PropertyPath.get(model, "dataInputPaneModel.table");
       String columnValue = (String) PropertyPath.get(model, "dataInputPaneModel.columnValue");
       Worksheet ws = vs == null ? null : vs.getBaseWorksheet();
+      boolean achieved = VSInputService.resolvesToVariableBinding(ws, vs, table, columnValue);
 
-      if(!VSInputService.resolvesToVariableBinding(ws, vs, table, columnValue)) {
+      if(requested != achieved) {
          throw new IllegalArgumentException(
-            "'dataInputPaneModel.variable' cannot be set directly on " + type + ". Its real, " +
-            "persisted value is always derived from whether 'dataInputPaneModel.table' (or " +
-            "'columnValue', if shaped \"$(variableName)\") resolves to an existing worksheet " +
-            "variable -- neither does here, so this write would report success and leave " +
-            "'variable' unchanged. Set 'dataInputPaneModel.table' (or 'columnValue') to " +
-            "\"$(variableName)\" for a variable created with add_variable instead.");
+            "'dataInputPaneModel.variable' cannot be set to " + requested + " on " + type +
+            ". Its real, persisted value is always derived from whether " +
+            "'dataInputPaneModel.table' (or 'columnValue', if shaped \"$(variableName)\") " +
+            "resolves to an existing worksheet variable -- it currently " +
+            (achieved ? "does" : "does not") + ", so this write would report success and leave " +
+            "'variable' " + achieved + ". " + (requested
+               ? "Set 'dataInputPaneModel.table' (or 'columnValue') to \"$(variableName)\" for " +
+                 "a variable created with add_variable instead."
+               : "Set 'dataInputPaneModel.table' (or 'columnValue') to a non-variable binding " +
+                 "instead, or leave 'dataInputPaneModel.variable' out of the patch."));
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -370,6 +370,53 @@ class AssemblyPropertyServiceTest {
          Map.of("dataInputPaneModel.rowValue", "0"), ""));
    }
 
+   /**
+    * Bug #76552 (follow-up to #76530/PR #5100): the achievability check must compare the
+    * <em>requested</em> value, not merely whether a variable binding is possible. A patch
+    * requesting {@code variable:false} while {@code columnValue} still resolves to a known
+    * variable must be refused -- the real setter would still derive {@code variable=true} from
+    * the table's shape regardless of this patch, so the write would report success and silently
+    * leave {@code variable} at {@code true}. This is the exact gap #5100's own 3 tests left
+    * uncovered: they only ever requested {@code variable:true}.
+    */
+   @Test
+   void refusesAnExplicitVariableFalseWriteWhenTheBindingStillResolvesToAVariable() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      TextInputPropertyDialogModel model = new TextInputPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithTextInput(mock(TextInputVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", false);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "StartDateInput", patch, ""));
+
+      assertTrue(thrown.getMessage().contains("dataInputPaneModel.variable"),
+                 "must name the refused field: " + thrown.getMessage());
+   }
+
+   /**
+    * Bug #76552 (follow-up to #76530/PR #5100): the mirror image of the case above -- requesting
+    * {@code variable:false} when the table was never a variable to begin with is a harmless
+    * no-op and must be allowed, not refused. Before this fix, the achievability check only asked
+    * "can this resolve to a variable" (no), which wrongly refused every {@code false} request
+    * regardless of whether it matched the current binding.
+    */
+   @Test
+   void allowsAnExplicitVariableFalseWriteWhenTheBindingAlreadyDoesNotResolveToAVariable()
+      throws Exception
+   {
+      TextInputPropertyDialogModel model = new TextInputPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithTextInput(mock(TextInputVSAssembly.class), model, new Worksheet());
+
+      assertDoesNotThrow(() -> service.set("tok", principal(), "StartDateInput",
+         Map.of("dataInputPaneModel.variable", false), ""));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {


### PR DESCRIPTION
## Summary

Follow-up to already-merged PR #5100 (Redmine bug #76530, merged as
`b8626889adc9f7c2aa64f9e28c3466be6fdcb460`). That PR's own automated `claude-review` bot posted a
real correctness finding on the PR's comment thread that this workflow's own reviewer seat missed
(it read the check's pass/fail status but not the comment content — see
`docs/teams/2026-09-09-bug-76530-input-variable-flag/bug-76530/05-review-r1.md`'s CORRECTION
section in the `stylebi-wiz` repo for the full account).

`AssemblyPropertyService.requireVariableFlagAchievable()` (added by #5100) only checked whether
`dataInputPaneModel.table`/`columnValue` **could** resolve to a variable binding — it never
compared against the boolean value actually *requested* in the patch. Consequences:

- `variable:false` was wrongly **allowed** when the table still resolves to a variable — but the
  real setter (unchanged by #5100) still unconditionally derives `variable=true` from the table's
  shape, so the write reports success and silently leaves `variable` at `true`. This is the exact
  "reports success, silently no-ops" bug class #5100 was written to fix, just triggered from the
  opposite (`false`) direction, completely unguarded.
- `variable:false` was wrongly **refused** with the "cannot be set directly" error when the table
  was already not a variable — a harmless no-op.

Fix: compare the requested value against what's achievable, and only throw when they differ.

## Regression tests

None of #5100's 3 original `AssemblyPropertyServiceTest` cases exercise `variable:false` at all —
exactly the coverage gap that let this through. Added:
- `refusesAnExplicitVariableFalseWriteWhenTheBindingStillResolvesToAVariable`
- `allowsAnExplicitVariableFalseWriteWhenTheBindingAlreadyDoesNotResolveToAVariable`

The existing `variable:true`-direction tests continue to pass unchanged.

## Test plan
- [x] `./mvnw -q -pl core test -Dtest=AssemblyPropertyServiceTest` — 21/21 pass (was 19, +2 new)
- [x] `./mvnw -q -pl core test -Dtest=PropertyAliasesTest` — 44/44 pass (unaffected, sanity check)
- [x] `./mvnw -q -pl core test -Dtest=VSInputTableBindingResolutionTest` — 13/13 pass (unaffected, sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)