### PR TITLE
Fix bug 76548: set_selection replaces the selection instead of merging it

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
@@ -168,6 +168,19 @@ public class SelectionRuntimeService {
                result.put("scopedBySearch", search);
             }
 
+            if(!single && isPathDiffable(assembly)) {
+               // Multi-select apply is a delta patch -- doApplySelection only ever turns matched
+               // values on, so anything currently selected but missing from the new values has to
+               // be turned off explicitly, or it stays selected alongside them. Single-select
+               // already gets a full reset for free via unselectChildren.
+               List<List<String>> toDeselect = toDeselect(selectedPaths(assembly), values);
+
+               if(!toDeselect.isEmpty()) {
+                  selections.applySelection(runtimeId, assemblyName, deselectEvent(toDeselect),
+                                            user, dispatcher, linkUri);
+               }
+            }
+
             selections.applySelection(runtimeId, assemblyName, applyEvent(values), user, dispatcher,
                                       linkUri);
             result.put("valuesSelected", values.size());
@@ -397,6 +410,13 @@ public class SelectionRuntimeService {
     * <p>{@code SelectionList} cannot be constructed or mocked in a plain unit test — the class fails
     * to initialise outside a Spring context — so the logic worth asserting lives here, over the array
     * the container hands back.
+    *
+    * <p>Recurses into a selected {@link CompositeSelectionValue}'s own children, mirroring
+    * {@code VSSelectionService.findSelectedPaths} (non-ID-mode shape) — a flat, single-level scan
+    * cannot represent a nested selection tree path like {@code ["East","NY"]}. If a selected
+    * composite has no selected child of its own, it still contributes a self-only path (matching
+    * {@code findSelectedPaths}'s empty-fallback), otherwise selecting a whole parent node without
+    * selecting any of its children would silently vanish from the result.
     */
    static List<List<String>> selectedPaths(SelectionValue[] values) {
       if(values == null) {
@@ -406,12 +426,68 @@ public class SelectionRuntimeService {
       List<List<String>> paths = new ArrayList<>();
 
       for(SelectionValue value : values) {
-         if(value != null && value.isSelected()) {
-            paths.add(List.of(value.getValue() == null ? "" : value.getValue()));
+         if(value == null || !value.isSelected()) {
+            continue;
+         }
+
+         int level = value.getLevel();
+         String ownValue = value.getValue() == null ? "" : value.getValue();
+
+         if(value instanceof CompositeSelectionValue composite) {
+            SelectionList childList = composite.getSelectionList();
+            List<List<String>> childPaths =
+               new ArrayList<>(selectedPaths(childList == null ? null :
+                                             childList.getSelectionValues()));
+
+            if(childPaths.isEmpty()) {
+               childPaths.add(new ArrayList<>(Collections.nCopies(level + 1, (String) null)));
+            }
+
+            for(List<String> path : childPaths) {
+               path.set(level, ownValue);
+            }
+
+            paths.addAll(childPaths);
+         }
+         else {
+            List<String> path = new ArrayList<>(Collections.nCopies(level + 1, (String) null));
+            path.set(level, ownValue);
+            paths.add(path);
          }
       }
 
       return paths;
+   }
+
+   /**
+    * What has to be turned off to make {@code current} become {@code requested} — split out from
+    * its caller so the diff itself is testable without a live assembly.
+    */
+   static List<List<String>> toDeselect(List<List<String>> current, List<List<String>> requested) {
+      List<List<String>> toDeselect = new ArrayList<>(current);
+      toDeselect.removeAll(requested);
+      return toDeselect;
+   }
+
+   /**
+    * Whether {@code doApplySelection} treats this assembly's apply as value-diffable (a per-value
+    * delta patch that leaves unmentioned values untouched), so the new diff-and-deselect step is the
+    * right fix for it.
+    *
+    * <p>{@code SelectionListVSAssembly} and a non-ID-mode {@code SelectionTreeVSAssembly} match; a
+    * {@code TimeSliderVSAssembly} already fully overwrites its selection every call and a
+    * {@code CalendarVSAssembly}'s values-apply path is a no-op, so neither needs (or should get) an
+    * extra deselect call. ID-mode {@code SelectionTreeVSAssembly} is deliberately excluded: it
+    * matches values by {@code Tool.contains} against the whole path array rather than the
+    * depth-indexed walk {@link #selectedPaths(SelectionValue[])} produces paths for, so reusing the
+    * same diff here would not be guaranteed correct.
+    */
+   static boolean isPathDiffable(SelectionVSAssembly assembly) {
+      if(assembly instanceof SelectionListVSAssembly) {
+         return true;
+      }
+
+      return assembly instanceof SelectionTreeVSAssembly tree && !tree.isIDMode();
    }
 
    private static SelectionList selectionListOf(SelectionVSAssembly assembly) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
@@ -220,6 +220,171 @@ class SelectionRuntimeServiceTest {
       assertFalse(result.containsKey("scopedBySearch"));
    }
 
+   /**
+    * A multi-select assembly with nothing previously selected has nothing to diff away, so the
+    * plain-apply behaviour above must be unchanged: exactly one {@code applySelection} call, not a
+    * spurious empty deselect first.
+    */
+   @Test
+   void sendsOnlyOneApplyWhenNothingWasPreviouslySelected() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null, "");
+
+      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
+                                                    any(Principal.class), any(), anyString());
+   }
+
+   /**
+    * Single-select already gets a full reset for free via {@code unselectChildren}, so the new
+    * diff-and-deselect step must not also fire for it — that would be redundant at best and could
+    * race the reset at worst.
+    */
+   @Test
+   void skipsTheDiffStepForASingleSelectAssembly() throws Exception {
+      SelectionListVSAssembly assembly = list(XConstants.SORT_ASC, true, null);
+      Harness h = harness(assembly);
+
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null, "");
+
+      verify(assembly, never()).getSelectionList();
+      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
+                                                    any(Principal.class), any(), anyString());
+   }
+
+   /**
+    * A range slider always fully overwrites its own selection per call (index range against every
+    * value), so it must never be diffed — reading its current selection at all would be wasted work
+    * and, unlike list/tree, {@code TimeSliderVSAssembly} was never in scope for this fix.
+    */
+   @Test
+   void neverReadsCurrentSelectionForARangeSlider() throws Exception {
+      TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
+      TimeSliderVSAssemblyInfo info = mock(TimeSliderVSAssemblyInfo.class);
+      doReturn(info).when(slider).getInfo();
+      Harness h = harness(slider);
+
+      h.service.setSelection("tok", principal(), "Slider1", List.of(List.of("2")), null, null, "");
+
+      verify(slider, never()).getSelectionList();
+      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
+                                                    any(Principal.class), any(), anyString());
+   }
+
+   // ── the diff-and-deselect step (bug-76548: set_selection accumulated instead of replacing) ────
+
+   /**
+    * The direct regression test for the reported symptom: a value selected by an earlier call and
+    * absent from the new values has to come back as a deselect, or the two calls' selections merge
+    * into a union instead of the second one replacing the first.
+    */
+   @Test
+   void computesADeselectForAValueDroppedFromTheNewSelection() {
+      List<List<String>> current = List.of(List.of("East"));
+      List<List<String>> requested = List.of(List.of("West"));
+
+      assertEquals(List.of(List.of("East")), SelectionRuntimeService.toDeselect(current, requested),
+                  "East was selected by a prior call and is absent from the new values, so it has " +
+                  "to be turned off explicitly -- doApplySelection's multi-select branch never " +
+                  "clears anything on its own");
+   }
+
+   /** Re-selecting exactly the current selection must not churn a spurious deselect/reselect. */
+   @Test
+   void leavesNothingToDeselectWhenTheRequestedValuesAlreadyMatchCurrent() {
+      List<List<String>> current = List.of(List.of("East"), List.of("West"));
+
+      assertEquals(List.of(), SelectionRuntimeService.toDeselect(current, current));
+   }
+
+   /** The diff has to work on whole paths, not just leaf names, once a tree is involved. */
+   @Test
+   void computesTheDeselectDiffForNestedTreePaths() {
+      List<List<String>> current = List.of(List.of("East", "NY"));
+      List<List<String>> requested = List.of(List.of("East", "LA"));
+
+      assertEquals(List.of(List.of("East", "NY")),
+                  SelectionRuntimeService.toDeselect(current, requested));
+   }
+
+   // ── the diffable-assembly gate ───────────────────────────────────────────
+
+   @Test
+   void treatsAFlatSelectionListAsDiffable() {
+      assertTrue(SelectionRuntimeService.isPathDiffable(list(XConstants.SORT_ASC, false, null)));
+   }
+
+   @Test
+   void treatsANonIdModeSelectionTreeAsDiffable() {
+      assertTrue(SelectionRuntimeService.isPathDiffable(tree(XConstants.SORT_ASC, false)));
+   }
+
+   /**
+    * ID mode matches values by {@code Tool.contains} against the whole path array rather than the
+    * depth-indexed walk {@code selectedPaths} produces paths for, so it is deliberately excluded
+    * rather than assumed to work with the same diff.
+    */
+   @Test
+   void excludesAnIdModeSelectionTreeFromTheDiff() {
+      SelectionTreeVSAssembly idTree = tree(XConstants.SORT_ASC, false);
+      when(idTree.isIDMode()).thenReturn(true);
+
+      assertFalse(SelectionRuntimeService.isPathDiffable(idTree));
+   }
+
+   @Test
+   void excludesARangeSliderFromTheDiff() {
+      assertFalse(SelectionRuntimeService.isPathDiffable(mock(TimeSliderVSAssembly.class)));
+   }
+
+   // ── selectedPaths recursion into a SelectionTree ────────────────────────
+
+   /**
+    * A leaf's path has to be sized and positioned by its own level, not hard-coded to length one —
+    * otherwise a value one level deep in a tree would be reported at the wrong position (or with the
+    * wrong path length) once it reaches {@code updateSelectionOfChangedAssembly}'s depth-indexed
+    * matching.
+    */
+   @Test
+   void sizesALeafPathByItsOwnLevelRatherThanAlwaysLengthOne() {
+      SelectionValue ny = mock(SelectionValue.class);
+      when(ny.isSelected()).thenReturn(true);
+      when(ny.getValue()).thenReturn("NY");
+      when(ny.getLevel()).thenReturn(1);
+
+      List<List<String>> paths = SelectionRuntimeService.selectedPaths(new SelectionValue[]{ ny });
+
+      assertEquals(List.of(Arrays.asList(null, "NY")), paths,
+                  "a value at level 1 belongs one segment deep -- a flat length-1 path would name " +
+                  "the wrong node once fed back into a tree apply");
+   }
+
+   /**
+    * Mirrors {@code VSSelectionService.findSelectedPaths}'s own empty-fallback rule: a composite
+    * selected as a whole, with none of its own children individually selected, must still produce a
+    * self-only path rather than vanishing from the result -- otherwise replacing a whole selected
+    * parent node (a common real operation) would compute zero deselect paths, reproducing a bug of
+    * the same shape as the one this fix addresses.
+    */
+   @Test
+   void aSelectedCompositeWithNoSelectedChildrenStillProducesASelfOnlyPath() {
+      CompositeSelectionValue east = mock(CompositeSelectionValue.class);
+      when(east.isSelected()).thenReturn(true);
+      when(east.getValue()).thenReturn("East");
+      when(east.getLevel()).thenReturn(0);
+      // getSelectionList() is left unstubbed (null): SelectionList cannot be constructed or mocked
+      // outside a Spring context (its XSwappable supertype's static initialiser reaches for
+      // SreeEnv), confirmed by executing this exact call in this test class -- Mockito throws
+      // "Cannot instrument class inetsoft.uql.viewsheet.SelectionList because it or one of its
+      // supertypes could not be initialized". A null list is the same "no selected child" shape the
+      // production code sees when a real SelectionList reports zero selected entries, so this
+      // exercises the same branch without needing a real container.
+
+      List<List<String>> paths = SelectionRuntimeService.selectedPaths(new SelectionValue[]{ east });
+
+      assertEquals(List.of(List.of("East")), paths);
+   }
+
    // ── clear ─────────────────────────────────────────────────────────────────
 
    /**


### PR DESCRIPTION
## Summary

- `SelectionRuntimeService.setSelection` forwarded new `values` to `VSSelectionService.applySelection` as a plain `APPLY` event. `doApplySelection`'s multi-select branch is a pure delta patcher (correct for its real caller, the interactive click UI, which only ever reports the one value that changed) — it turns the given values on and never turns off anything currently selected but absent from the new list. A second `set_selection` call therefore accumulated onto the first instead of replacing it. Single-select was unaffected: it already gets a full reset via `unselectChildren`.
- Fix: for a non-single-select apply on an assembly `doApplySelection` actually treats as value-diffable (`SelectionListVSAssembly` or non-ID-mode `SelectionTreeVSAssembly`), compute the values currently selected but absent from the new request and send them back as a `deselectEvent` (the same primitive `clearSelection` already uses) before applying the new values.
- A second, independent flaw surfaced during diagnosis: `selectedPaths(SelectionValue[])` (the helper `clearSelection` already used) was a flat, single-level scan that couldn't represent a nested `SelectionTree` path (e.g. `["East","NY"]`). Reusing it as-is for the new diff would have been broken for real tree selections. `selectedPaths` is now recursive, mirroring `VSSelectionService.findSelectedPaths` (including its empty-fallback rule: a selected composite with no individually-selected children still produces a self-only path, or replacing a whole selected parent node would silently compute zero deselect paths).
- Scope: `TimeSliderVSAssembly` (already fully overwrites its selection every call) and `CalendarVSAssembly` (values-apply path is currently a no-op) need no change. ID-mode `SelectionTreeVSAssembly` is deliberately excluded — it matches values by `Tool.contains` against the whole path array, a different shape than the depth-indexed paths this fix's diff produces, and was outside this bug's confirmed, reported scope.

Redmine bug 76548.

## Known, deliberate test-coverage gap

`SelectionList` (returned by `CompositeSelectionValue.getSelectionList()`) extends `XSwappable`, whose static initializer calls `SreeEnv.getProperty(...)`, which throws `ShutdownException: Spring application context is not available` outside a live Spring context — confirmed directly this pass with a throwaway probe test (`mock(SelectionList.class)` fails with `MockitoException: Cannot instrument class inetsoft.uql.viewsheet.SelectionList because it or one of its supertypes could not be initialized`). This means no test in this file can construct a *populated* nested `SelectionList` (a true depth-2+ selection with a real selected grandchild), so the literal "call `set_selection` twice, assert the second call's event contains a deselect for the first call's value" end-to-end regression test could not be written through a live assembly mock.

Worked around by testing the decomposed logic directly: `toDeselect(current, requested)` — split out of `setSelection` specifically so it's unit-testable without a live assembly — is tested directly for the core replace-not-merge diff, the no-op case, and multi-segment path diffing. The `selectedPaths` empty-fallback branch is exercised by leaving a `CompositeSelectionValue` mock's `getSelectionList()` unstubbed (`null`), which hits the identical "no selected child" code path a real, empty `SelectionList` would. `clearSelection` already had this same limitation before this fix (its own javadoc says so); this fix works within it, not around it.

## Test plan

- [x] `mvn -pl community/core clean test -Dtest=SelectionRuntimeServiceTest -o` — 33/33 passing (21 pre-existing unchanged + 12 new regression tests covering the diff computation, the diffable-assembly gate, and the recursive path-collection including the empty-fallback case)

## Out of scope / noticed but left alone

- `clearSelection`'s pre-existing nested-tree under-clearing bug is fixed as a side effect of making `selectedPaths` recursive (it already called this same helper) — no change to `clearSelection`'s own call site.
- Search-scoping interaction not addressed: the new diff step reads the *entire* unfiltered current selection, not the search-filtered subset `setSelection` already discloses via `scopedBySearch`. If a value outside the current search filter is already selected, it could be turned off by this diff even though the caller had no way to see or intend to touch it. Not raised during diagnosis/refute; flagging for a separate ticket if it matters in practice.
- ID-mode `SelectionTreeVSAssembly` still has the original accumulate bug (deliberately out of scope, see above).
- `CalendarVSAssembly`'s values-apply no-op is a separate, real gap, also out of scope for this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)