### PR TITLE
fix(#76555): relocate variable-table normalization into wiz-only layer

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -3794,25 +3794,16 @@ public class VSInputService {
     *
     * <p>Accepts the correct {@code "$(varName)"} reference form as-is, provided the variable
     * actually exists; accepts any real worksheet table/assembly name as-is (a genuine
-    * table+column binding); and normalizes three unambiguous natural mistakes into the
+    * table+column binding); and normalizes two unambiguous natural mistakes into the
     * {@code "$(varName)"} form the runtime requires: a bare variable name with no
-    * {@code $(...)} wrapping, the Composer's own "Variables" tree folder label (not a
+    * {@code $(...)} wrapping, and the Composer's own "Variables" tree folder label (not a
     * selectable leaf -- see {@link #getInputTablesTree}) paired with a {@code columnValue}
-    * that names a real variable, and (bug #76530) {@code table} left unset entirely while
-    * {@code columnValue} itself already carries the {@code "$(varName)"} reference -- the shape
-    * a caller naturally reaches for when only one field looks like it should hold the variable.
-    * Anything else is rejected loud, by field name, rather than silently persisted as a broken
-    * binding.
+    * that names a real variable. Anything else is rejected loud, by field name, rather than
+    * silently persisted as a broken binding.
     */
    private static String resolveInputTableBinding(Worksheet ws, Viewsheet vs, String table,
                                                    String columnValue)
    {
-      if((table == null || table.isEmpty()) && columnValue != null &&
-         columnValue.startsWith("$(") && columnValue.endsWith(")"))
-      {
-         table = columnValue;
-      }
-
       if(table == null || table.isEmpty() || ws == null) {
          return table;
       }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -309,21 +309,10 @@ public class AssemblyPropertyService {
    }
 
    /**
-    * Bug #76530, relocated here from {@code VSInputService.resolveInputTableBinding} by bug
-    * #76555: {@code table} left unset entirely while {@code columnValue} itself already carries
-    * the {@code "$(varName)"} reference is the shape an AI caller naturally reaches for when only
-    * one field looks like it should hold the variable. {@code VSInputService} is shared with the
-    * interactive Composer UI's own property-dialog save path, so this AI-caller-specific
-    * accommodation lives here instead, in the wiz-only layer -- {@code isKnownVariableName}
-    * itself still runs inside {@code resolveInputTableBinding}'s own raw-{@code $(...)} branch
-    * once the real setter is invoked downstream with the now-normalized {@code table}.
-    *
-    * <p>Runs for every patch to one of {@link PropertyAliases#derivesVariableFlagFromTable}'s
-    * four types, not only when the patch touches {@code dataInputPaneModel.variable} specifically
-    * -- {@code table} needs normalizing from {@code columnValue} regardless of which field this
-    * particular patch happened to touch, matching how {@code VSInputService}'s own setters always
-    * ran this unconditionally on every save. Must run before {@code requireVariableFlagAchievable}
-    * and {@code writeModel} so both see the already-normalized {@code table}.
+    * Normalizes an unset {@code table} to {@code columnValue} when the latter is already a
+    * {@code "$(varName)"} reference (bug #76530/#76555) -- kept AI-only here since
+    * {@code VSInputService} is shared with the interactive UI's save path. Must run before
+    * {@code requireVariableFlagAchievable}/{@code writeModel}.
     */
    private Object normalizeVariableTableBinding(Object model) {
       String table = (String) PropertyPath.get(model, "dataInputPaneModel.table");
@@ -339,25 +328,10 @@ public class AssemblyPropertyService {
    }
 
    /**
-    * Bug #76530: textinput/combobox/slider/spinner's own setter never reads back
-    * {@code dataInputPaneModel.variable} -- the real, persisted flag is always derived from
-    * whether {@code dataInputPaneModel.table} (after {@code VSInputService}'s own
-    * {@code resolveInputTableBinding} normalization, and, before that, this class's own
-    * {@code normalizeVariableTableBinding} above) resolves to a {@code "$(varName)"} reference.
-    * Only invoked when this call's own patch explicitly touches {@code dataInputPaneModel.variable}
-    * (see the caller).
-    *
-    * <p>Bug #76552 (follow-up): the achievable state must be compared against the value the
-    * patch actually <em>requested</em>, not just checked for being merely possible. Checking
-    * achievability alone let {@code variable:false} through unguarded even when the table still
-    * resolves to a variable (the real setter derives {@code true} from the table regardless, so
-    * that write silently failed to take effect -- the same "reports success, changes nothing"
-    * defect this whole check exists to catch, just from the opposite direction), and also
-    * refused a harmless {@code variable:false} on a table that was never a variable to begin
-    * with. {@code dataInputPaneModel.variable} is a primitive {@code boolean}
-    * ({@link inetsoft.web.composer.model.vs.DataInputPaneModel#isVariable()}), and {@code model}
-    * already has this call's patch applied by the caller, so the read below is always the
-    * requested value, never null.
+    * Refuses a {@code dataInputPaneModel.variable} write that doesn't match what the resolved
+    * {@code table}/{@code columnValue} binding can actually achieve (bug #76530/#76552) -- the
+    * real setter always derives the persisted flag from the binding, never from this field
+    * directly, so a mismatched request would otherwise silently no-op or be wrongly refused.
     */
    private void requireVariableFlagAchievable(String type, Object model, Viewsheet vs) {
       boolean requested = (Boolean) PropertyPath.get(model, "dataInputPaneModel.variable");

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -247,6 +247,10 @@ public class AssemblyPropertyService {
             model = PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
          }
 
+         if(PropertyAliases.derivesVariableFlagFromTable(type)) {
+            model = normalizeVariableTableBinding(model);
+         }
+
          if(type.equals("gauge") && resolved.values().stream()
             .anyMatch(path -> path.startsWith("gaugeAdvancedPaneModel.rangePaneModel")))
          {
@@ -305,13 +309,43 @@ public class AssemblyPropertyService {
    }
 
    /**
+    * Bug #76530, relocated here from {@code VSInputService.resolveInputTableBinding} by bug
+    * #76555: {@code table} left unset entirely while {@code columnValue} itself already carries
+    * the {@code "$(varName)"} reference is the shape an AI caller naturally reaches for when only
+    * one field looks like it should hold the variable. {@code VSInputService} is shared with the
+    * interactive Composer UI's own property-dialog save path, so this AI-caller-specific
+    * accommodation lives here instead, in the wiz-only layer -- {@code isKnownVariableName}
+    * itself still runs inside {@code resolveInputTableBinding}'s own raw-{@code $(...)} branch
+    * once the real setter is invoked downstream with the now-normalized {@code table}.
+    *
+    * <p>Runs for every patch to one of {@link PropertyAliases#derivesVariableFlagFromTable}'s
+    * four types, not only when the patch touches {@code dataInputPaneModel.variable} specifically
+    * -- {@code table} needs normalizing from {@code columnValue} regardless of which field this
+    * particular patch happened to touch, matching how {@code VSInputService}'s own setters always
+    * ran this unconditionally on every save. Must run before {@code requireVariableFlagAchievable}
+    * and {@code writeModel} so both see the already-normalized {@code table}.
+    */
+   private Object normalizeVariableTableBinding(Object model) {
+      String table = (String) PropertyPath.get(model, "dataInputPaneModel.table");
+      String columnValue = (String) PropertyPath.get(model, "dataInputPaneModel.columnValue");
+
+      if((table == null || table.isEmpty()) && columnValue != null &&
+         columnValue.startsWith("$(") && columnValue.endsWith(")"))
+      {
+         return PropertyPath.set(model, "dataInputPaneModel.table", columnValue);
+      }
+
+      return model;
+   }
+
+   /**
     * Bug #76530: textinput/combobox/slider/spinner's own setter never reads back
     * {@code dataInputPaneModel.variable} -- the real, persisted flag is always derived from
     * whether {@code dataInputPaneModel.table} (after {@code VSInputService}'s own
-    * {@code resolveInputTableBinding} normalization, which now also accepts a {@code columnValue}
-    * already shaped {@code "$(varName)"} with {@code table} left unset) resolves to a
-    * {@code "$(varName)"} reference. Only invoked when this call's own patch explicitly touches
-    * {@code dataInputPaneModel.variable} (see the caller).
+    * {@code resolveInputTableBinding} normalization, and, before that, this class's own
+    * {@code normalizeVariableTableBinding} above) resolves to a {@code "$(varName)"} reference.
+    * Only invoked when this call's own patch explicitly touches {@code dataInputPaneModel.variable}
+    * (see the caller).
     *
     * <p>Bug #76552 (follow-up): the achievable state must be compared against the value the
     * patch actually <em>requested</em>, not just checked for being merely possible. Checking

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
@@ -148,13 +148,9 @@ class VSInputTableBindingResolutionTest {
    }
 
    /**
-    * Bug #76555: the "{@code table} left unset, {@code columnValue} alone carries the
-    * {@code "$(varName)"} reference" normalization (added for bug #76530) has been relocated out
-    * of this method into {@code AssemblyPropertyService.normalizeVariableTableBinding} (the
-    * AI-only wiz layer), since this class is also shared with the interactive Composer UI's own
-    * property-dialog save path. {@code resolveInputTableBinding} on its own must therefore leave
-    * an unset {@code table} genuinely unset/unchanged now, even when {@code columnValue} looks
-    * exactly like a variable reference.
+    * Bug #76555: this normalization moved to the AI-only {@code AssemblyPropertyService} layer,
+    * so an unset {@code table} must stay unset here even when {@code columnValue} looks like a
+    * variable reference.
     */
    @Test
    void leavesTableUnsetWhenOnlyColumnValueLooksLikeAVariableReference() throws Exception {
@@ -165,11 +161,9 @@ class VSInputTableBindingResolutionTest {
    }
 
    /**
-    * Same relocation: since this method no longer normalizes the columnValue-only shape at all,
-    * it also no longer validates the variable name referenced that way -- {@code table} comes
-    * back unchanged regardless of whether the variable actually exists (that existence check now
-    * only ever runs, downstream, once a real setter is invoked with a {@code table} that is
-    * itself {@code "$(...)"}-shaped).
+    * Same relocation: no columnValue-only normalization means no existence check on that path
+    * either -- it now only runs downstream, once a real {@code "$(...)"}-shaped {@code table}
+    * reaches a setter.
     */
    @Test
    void leavesTableUnsetEvenWhenTheColumnValueReferencesAVariableThatDoesNotExist()
@@ -181,9 +175,8 @@ class VSInputTableBindingResolutionTest {
    }
 
    /**
-    * The new shape only fires when {@code table} is unset -- an explicit {@code table} value
-    * (even a plain, non-variable table binding) must not be silently overridden by a {@code
-    * columnValue} that happens to look like a variable reference.
+    * An explicit {@code table} value must not be overridden by a {@code columnValue} that happens
+    * to look like a variable reference.
     */
    @Test
    void doesNotOverrideAnExplicitTableWithAColumnValueThatLooksLikeAVariable() throws Exception {
@@ -194,13 +187,9 @@ class VSInputTableBindingResolutionTest {
    }
 
    /**
-    * {@link VSInputService#resolvesToVariableBinding} is the public entry point {@code
-    * AssemblyPropertyService} uses (bug #76530 part b) to decide whether an explicit {@code
-    * dataInputPaneModel.variable} write is achievable. It must agree with {@code
-    * resolveInputTableBinding} on a raw {@code table} value, whether literal or already
-    * {@code "$(...)"}-shaped. The columnValue-only shape (bug #76555) is no longer this method's
-    * concern -- callers (i.e. {@code AssemblyPropertyService}) normalize {@code table} from
-    * {@code columnValue} themselves, before ever reaching this helper.
+    * {@link VSInputService#resolvesToVariableBinding} must agree with
+    * {@code resolveInputTableBinding} on a raw {@code table} value. The columnValue-only shape
+    * (bug #76555) is no longer this method's concern -- callers normalize that themselves first.
     */
    @Test
    void resolvesToVariableBindingAgreesWithTheUnderlyingResolution() {

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSInputTableBindingResolutionTest.java
@@ -148,31 +148,36 @@ class VSInputTableBindingResolutionTest {
    }
 
    /**
-    * Bug #76530's exact reported repro shape: {@code table} left unset and {@code columnValue}
-    * itself already carrying the {@code "$(varName)"} reference (the natural mistake a caller
-    * makes when only one field looks like it should hold the variable). Must resolve exactly like
-    * setting {@code table} to that same value would.
+    * Bug #76555: the "{@code table} left unset, {@code columnValue} alone carries the
+    * {@code "$(varName)"} reference" normalization (added for bug #76530) has been relocated out
+    * of this method into {@code AssemblyPropertyService.normalizeVariableTableBinding} (the
+    * AI-only wiz layer), since this class is also shared with the interactive Composer UI's own
+    * property-dialog save path. {@code resolveInputTableBinding} on its own must therefore leave
+    * an unset {@code table} genuinely unset/unchanged now, even when {@code columnValue} looks
+    * exactly like a variable reference.
     */
    @Test
-   void resolvesAColumnValueOnlyVariableReferenceWhenTableIsUnset() throws Exception {
+   void leavesTableUnsetWhenOnlyColumnValueLooksLikeAVariableReference() throws Exception {
       Worksheet ws = worksheetWithVariable("StartDate");
 
-      assertEquals("$(StartDate)", resolve(ws, null, "$(StartDate)"));
-      assertEquals("$(StartDate)", resolve(ws, "", "$(StartDate)"));
+      assertNull(resolve(ws, null, "$(StartDate)"));
+      assertEquals("", resolve(ws, "", "$(StartDate)"));
    }
 
    /**
-    * The columnValue-only shape must reuse the exact same existence check the raw {@code
-    * "$(...)"}-on-{@code table} branch already gets -- an unknown variable name still throws,
-    * it is not silently accepted just because it arrived via {@code columnValue} instead.
+    * Same relocation: since this method no longer normalizes the columnValue-only shape at all,
+    * it also no longer validates the variable name referenced that way -- {@code table} comes
+    * back unchanged regardless of whether the variable actually exists (that existence check now
+    * only ever runs, downstream, once a real setter is invoked with a {@code table} that is
+    * itself {@code "$(...)"}-shaped).
     */
    @Test
-   void rejectsAColumnValueOnlyVariableReferenceToAVariableThatDoesNotExist() {
+   void leavesTableUnsetEvenWhenTheColumnValueReferencesAVariableThatDoesNotExist()
+      throws Exception
+   {
       Worksheet ws = new Worksheet();
 
-      MessageException ex = assertThrows(MessageException.class,
-         () -> resolve(ws, null, "$(StartDate)"));
-      assertTrue(ex.getMessage().contains("StartDate"), ex.getMessage());
+      assertNull(resolve(ws, null, "$(StartDate)"));
    }
 
    /**
@@ -192,14 +197,17 @@ class VSInputTableBindingResolutionTest {
     * {@link VSInputService#resolvesToVariableBinding} is the public entry point {@code
     * AssemblyPropertyService} uses (bug #76530 part b) to decide whether an explicit {@code
     * dataInputPaneModel.variable} write is achievable. It must agree with {@code
-    * resolveInputTableBinding} on both the columnValue-only shape and a plain literal table.
+    * resolveInputTableBinding} on a raw {@code table} value, whether literal or already
+    * {@code "$(...)"}-shaped. The columnValue-only shape (bug #76555) is no longer this method's
+    * concern -- callers (i.e. {@code AssemblyPropertyService}) normalize {@code table} from
+    * {@code columnValue} themselves, before ever reaching this helper.
     */
    @Test
    void resolvesToVariableBindingAgreesWithTheUnderlyingResolution() {
       Worksheet ws = worksheetWithVariable("StartDate");
       ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
 
-      assertTrue(VSInputService.resolvesToVariableBinding(ws, null, null, "$(StartDate)"));
+      assertFalse(VSInputService.resolvesToVariableBinding(ws, null, null, "$(StartDate)"));
       assertTrue(VSInputService.resolvesToVariableBinding(ws, null, "$(StartDate)", null));
       assertFalse(VSInputService.resolvesToVariableBinding(ws, null, "Query1", null));
       assertFalse(VSInputService.resolvesToVariableBinding(ws, null, null, null));

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -315,6 +315,11 @@ class AssemblyPropertyServiceTest {
     * carrying the {@code "$(varName)"} reference, {@code table} never set). Before this fix, the
     * write silently no-opped -- {@code variable} was never read back regardless. Part (a) makes
     * this shape resolve, so the write must now go through rather than being refused.
+    *
+    * <p>Bug #76555: part (a)'s normalization has since relocated from {@code VSInputService} into
+    * this class's own {@code normalizeVariableTableBinding}, which runs before the achievability
+    * check below -- this test still exercises the same end-to-end shape, just through the new
+    * owner.
     */
    @Test
    void allowsTheExactReportedReproNowThatColumnValueAloneResolvesToAKnownVariable()
@@ -332,6 +337,30 @@ class AssemblyPropertyServiceTest {
 
       assertDoesNotThrow(
          () -> service.set("tok", principal(), "StartDateInput", patch, ""));
+   }
+
+   /**
+    * Bug #76555: proves this class owns the "{@code table} left unset, {@code columnValue} alone
+    * carries the reference" normalization directly -- not just indirectly, via the write above not
+    * throwing -- by asserting {@code normalizeVariableTableBinding} actually mutated {@code
+    * model}'s {@code dataInputPaneModel.table} in place.
+    */
+   @Test
+   void normalizesColumnValueOnlyIntoTableBeforeTheAchievabilityCheck() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      TextInputPropertyDialogModel model = new TextInputPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithTextInput(mock(TextInputVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", true);
+
+      service.set("tok", principal(), "StartDateInput", patch, "");
+
+      assertEquals("$(StartDate)", model.getDataInputPaneModel().getTable(),
+                   "normalizeVariableTableBinding must write 'table', not just avoid throwing");
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -311,15 +311,8 @@ class AssemblyPropertyServiceTest {
    }
 
    /**
-    * Bug #76530 part (b): the exact reported repro (a from-scratch TextInput, {@code columnValue}
-    * carrying the {@code "$(varName)"} reference, {@code table} never set). Before this fix, the
-    * write silently no-opped -- {@code variable} was never read back regardless. Part (a) makes
-    * this shape resolve, so the write must now go through rather than being refused.
-    *
-    * <p>Bug #76555: part (a)'s normalization has since relocated from {@code VSInputService} into
-    * this class's own {@code normalizeVariableTableBinding}, which runs before the achievability
-    * check below -- this test still exercises the same end-to-end shape, just through the new
-    * owner.
+    * The exact reported repro (bug #76530): {@code columnValue} carries the reference,
+    * {@code table} never set. Must resolve and go through, not be refused.
     */
    @Test
    void allowsTheExactReportedReproNowThatColumnValueAloneResolvesToAKnownVariable()
@@ -339,12 +332,7 @@ class AssemblyPropertyServiceTest {
          () -> service.set("tok", principal(), "StartDateInput", patch, ""));
    }
 
-   /**
-    * Bug #76555: proves this class owns the "{@code table} left unset, {@code columnValue} alone
-    * carries the reference" normalization directly -- not just indirectly, via the write above not
-    * throwing -- by asserting {@code normalizeVariableTableBinding} actually mutated {@code
-    * model}'s {@code dataInputPaneModel.table} in place.
-    */
+   /** Proves the normalization actually mutates {@code table}, not just avoids throwing. */
    @Test
    void normalizesColumnValueOnlyIntoTableBeforeTheAchievabilityCheck() throws Exception {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
## Summary

Redmine #76555 is a design-scoping follow-up, not a functional bug fix -- the
current behavior (from #5100 + #5104, both already merged onto
`stylebi-wiz-main-rebase`) is already correct. This PR only relocates *which
class owns* one piece of normalization logic, per an explicit architectural
preference: keep the shared, UI-facing `VSInputService` free of AI-caller-only
accommodation logic, since the wiz-only package (`PropertyAliases`,
`AssemblyPropertyService`) is where this kind of AI-ergonomics logic already
lives.

- Reverted `VSInputService.resolveInputTableBinding()`'s "`table` unset,
  `columnValue` alone is `$(varName)`-shaped" normalization block (added for
  #76530) back out -- this method is also used by the interactive Composer
  UI's own property-dialog save path, so it should not carry AI-caller-specific
  accommodation logic. `resolvesToVariableBinding()` is unchanged (still
  delegates).
- Added the equivalent normalization to `AssemblyPropertyService.set()` as a
  new `normalizeVariableTableBinding()` step, operating on the in-memory
  `model` via the same `PropertyPath.get`/`PropertyPath.set` mechanism already
  used elsewhere in this class. It runs for every patch to one of
  `PropertyAliases.derivesVariableFlagFromTable()`'s four types
  (textinput/combobox/slider/spinner), not only when the patch touches
  `dataInputPaneModel.variable` specifically -- `table` needs normalizing from
  `columnValue` regardless of which field a given patch happens to touch,
  matching how `VSInputService`'s own setters always ran this
  unconditionally on every save. It runs before both
  `requireVariableFlagAchievable` and `writeModel`, so both see the
  already-normalized `table`.

## Tests

- `VSInputTableBindingResolutionTest`: flipped the two tests that exercised
  the now-removed normalization into tests confirming `resolveInputTableBinding()`
  leaves `table` genuinely unset/unchanged for the columnValue-only shape
  (`leavesTableUnsetWhenOnlyColumnValueLooksLikeAVariableReference`,
  `leavesTableUnsetEvenWhenTheColumnValueReferencesAVariableThatDoesNotExist`),
  and fixed `resolvesToVariableBindingAgreesWithTheUnderlyingResolution`'s
  columnValue-only assertion (now `false`, since that public helper's
  columnValue-only case is no longer normalized at this layer).
- `AssemblyPropertyServiceTest`: confirmed
  `allowsTheExactReportedReproNowThatColumnValueAloneResolvesToAKnownVariable`
  still passes given the relocation, and added
  `normalizesColumnValueOnlyIntoTableBeforeTheAchievabilityCheck`, which
  asserts the normalization actually mutates `model`'s
  `dataInputPaneModel.table` (not just that no exception is thrown), so this
  class's own test suite directly proves it owns the behavior now.

```
./mvnw -pl core test -Dtest=VSInputTableBindingResolutionTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0

./mvnw -pl core test -Dtest=AssemblyPropertyServiceTest
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0

./mvnw -pl core test -Dtest=PropertyAliasesTest,PropertyPathTest
Tests run: 91, Failures: 0, Errors: 0, Skipped: 0
```

## Note

Per the requester's instruction, this PR is intentionally left **unmerged**
for manual review regardless of CI outcome -- not delegated to a reviewer
seat's judgment call this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)