### PR TITLE
Fix bug 76544: refuse a typo'd set_selection value instead of silently dropping it

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
@@ -21,6 +21,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.Tool;
 import inetsoft.web.viewsheet.event.ApplySelectionListEvent;
 import inetsoft.web.viewsheet.event.SortSelectionListEvent;
 import inetsoft.web.viewsheet.service.VSSelectionService;
@@ -158,6 +159,23 @@ public class SelectionRuntimeService {
                   "'" + assemblyName + "' is single-select, so it cannot hold " + values.size() +
                   " values. Select one value, or pass singleSelect=false in the same call to make " +
                   "it multi-select first.");
+            }
+
+            if(isValueMatchable(assembly)) {
+               // doApplySelection matches each requested value against the live domain and
+               // silently drops anything that doesn't resolve -- no exception, no counter,
+               // nothing the caller could observe. Refuse a typo'd value by name, atomically,
+               // before applying anything, rather than reporting an inflated count for a
+               // partially-applied result.
+               boolean idMode = assembly instanceof SelectionTreeVSAssembly tree && tree.isIDMode();
+               List<List<String>> unmatched =
+                  findUnmatchedPaths(selectionListOf(assembly), values, idMode);
+
+               if(!unmatched.isEmpty()) {
+                  throw new IllegalArgumentException(
+                     "'" + assemblyName + "' has no value matching " + unmatched + " -- confirm " +
+                     "the exact spelling via browse_condition_values before selecting it.");
+               }
             }
 
             String search = searchString(info);
@@ -488,6 +506,129 @@ public class SelectionRuntimeService {
       }
 
       return assembly instanceof SelectionTreeVSAssembly tree && !tree.isIDMode();
+   }
+
+   /**
+    * Whether {@code doApplySelection} matches this assembly's values against a live domain via
+    * {@code updateSelectionOfChangedAssembly}/{@code updateIDSelectionTree} at all -- the only two
+    * types the value-validation below can meaningfully apply to.
+    *
+    * <p>Mirrors {@code doApplySelection}'s own top-level branch exactly (unlike
+    * {@link #isPathDiffable}, which further excludes ID-mode trees for a diff-specific reason, not
+    * a matching one). A {@code TimeSliderVSAssembly} ignores the requested value paths entirely --
+    * it selects by index range ({@code event.getSelectStart()}/{@code getSelectEnd()}) -- and a
+    * {@code CalendarVSAssembly}'s values-apply path is a no-op, so validating value strings against
+    * either would be meaningless.
+    */
+   private static boolean isValueMatchable(SelectionVSAssembly assembly) {
+      return assembly instanceof SelectionListVSAssembly || assembly instanceof SelectionTreeVSAssembly;
+   }
+
+   /** Skipped when the domain isn't known yet -- a cannot-tell case, not a does-not-exist case. */
+   private static List<List<String>> findUnmatchedPaths(SelectionList domain,
+                                                         List<List<String>> values, boolean idMode)
+   {
+      if(domain == null) {
+         return List.of();
+      }
+
+      return findUnmatchedPaths(domain.getSelectionValues(), values, idMode);
+   }
+
+   /**
+    * Split out from its {@code SelectionList} container so it is testable -- {@code SelectionList}
+    * cannot be constructed or mocked outside a Spring context (see {@link #selectedPaths(SelectionValue[])}).
+    *
+    * <p>Mirrors exactly what {@code updateSelectionOfChangedAssembly}/{@code updateIDSelectionTree}
+    * will do when the values are actually applied, rather than a stricter approximation of it -- the
+    * point is to predict the real apply outcome, not to reject something the backend would have
+    * happily accepted.
+    */
+   static List<List<String>> findUnmatchedPaths(SelectionValue[] domain, List<List<String>> values,
+                                                boolean idMode)
+   {
+      List<List<String>> unmatched = new ArrayList<>();
+
+      for(List<String> path : values) {
+         String[] segments = path.toArray(new String[0]);
+         boolean matched = idMode ? matchesAnywhere(domain, segments) : matchesPath(domain, segments, 0);
+
+         if(!matched) {
+            unmatched.add(path);
+         }
+      }
+
+      return unmatched;
+   }
+
+   /**
+    * Mirrors {@code updateSelectionOfChangedAssembly}: resolve {@code path[index]} at this level via
+    * an exact-match lookup (the same match {@code SelectionList.findValue(val, false)} does); if it
+    * resolves to a {@code CompositeSelectionValue} and segments remain, descend into its children;
+    * otherwise -- found and not composite, or the last segment -- stop and call it matched. An
+    * over-long path whose resolvable prefix bottoms out at a leaf before the path ends is still a
+    * match, since that is what the real apply does with it (it just ignores the leftover segments).
+    */
+   private static boolean matchesPath(SelectionValue[] level, String[] path, int index) {
+      if(level == null) {
+         return false;
+      }
+
+      SelectionValue value = findByValue(level, path[index]);
+
+      if(value == null) {
+         return false;
+      }
+
+      if(value instanceof CompositeSelectionValue composite && index < path.length - 1) {
+         SelectionList childList = composite.getSelectionList();
+         return matchesPath(childList == null ? null : childList.getSelectionValues(), path,
+                            index + 1);
+      }
+
+      return true;
+   }
+
+   /** The one-level, non-recursive exact match {@code SelectionList.findValue(val, false)} does. */
+   private static SelectionValue findByValue(SelectionValue[] level, String target) {
+      for(SelectionValue value : level) {
+         if(value != null && Tool.equals(target, value.getValue())) {
+            return value;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Mirrors {@code updateIDSelectionTree}: a flat "does this path array contain a node's value
+    * anywhere in the tree" scan, not a segment-by-segment descent -- ID-mode matches every node
+    * whose value appears anywhere in the requested path array.
+    */
+   private static boolean matchesAnywhere(SelectionValue[] level, String[] path) {
+      if(level == null) {
+         return false;
+      }
+
+      for(SelectionValue value : level) {
+         if(value == null) {
+            continue;
+         }
+
+         if(Tool.contains(path, value.getValue(), true, true, true)) {
+            return true;
+         }
+
+         if(value instanceof CompositeSelectionValue composite) {
+            SelectionList childList = composite.getSelectionList();
+
+            if(matchesAnywhere(childList == null ? null : childList.getSelectionValues(), path)) {
+               return true;
+            }
+         }
+      }
+
+      return false;
    }
 
    private static SelectionList selectionListOf(SelectionVSAssembly assembly) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
@@ -239,6 +239,12 @@ class SelectionRuntimeServiceTest {
     * Single-select already gets a full reset for free via {@code unselectChildren}, so the new
     * diff-and-deselect step must not also fire for it — that would be redundant at best and could
     * race the reset at worst.
+    *
+    * <p>{@code getSelectionList()} is still called exactly once here — not zero times — because
+    * value validation (bug-76544) reads the domain regardless of single-vs-multi select; a typo'd
+    * value can be silently dropped on a single-select assembly the same way it can on a multi-select
+    * one. What this test actually guards is that no second {@code applySelection} (the deselect)
+    * fires.
     */
    @Test
    void skipsTheDiffStepForASingleSelectAssembly() throws Exception {
@@ -247,7 +253,7 @@ class SelectionRuntimeServiceTest {
 
       h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null, "");
 
-      verify(assembly, never()).getSelectionList();
+      verify(assembly, times(1)).getSelectionList();
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
                                                     any(Principal.class), any(), anyString());
    }
@@ -269,6 +275,111 @@ class SelectionRuntimeServiceTest {
       verify(slider, never()).getSelectionList();
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
                                                     any(Principal.class), any(), anyString());
+   }
+
+   // ── value validation (bug-76544: a typo'd value is silently dropped, not refused) ─────────────
+
+   /**
+    * The direct regression test for the reported symptom: {@code updateSelectionOfChangedAssembly}
+    * silently drops any value that doesn't exactly string-match a domain entry, with nothing at any
+    * layer above it ever learning that happened. Refusing atomically, by name, before applying
+    * anything is the fix — not reporting a corrected count for a partially-applied result.
+    */
+   @Test
+   void refusesATypoedValueRatherThanSilentlyDroppingIt() {
+      SelectionValue george = mock(SelectionValue.class);
+      when(george.getValue()).thenReturn("George Services");
+      SelectionValue interstate = mock(SelectionValue.class);
+      when(interstate.getValue()).thenReturn("Interstate Shop");
+      SelectionValue oldWorld = mock(SelectionValue.class);
+      when(oldWorld.getValue()).thenReturn("Old World Insurance");
+
+      SelectionValue[] domain = { george, interstate, oldWorld };
+
+      List<List<String>> unmatched = SelectionRuntimeService.findUnmatchedPaths(domain,
+         List.of(List.of("George Services"), List.of("Interstate Shop"),
+                 List.of("OldWorld Insurance")),
+         false);
+
+      assertEquals(List.of(List.of("OldWorld Insurance")), unmatched);
+   }
+
+   /** Every requested value resolves, so nothing is unmatched — the happy path is unaffected. */
+   @Test
+   void matchesEveryRequestedValueOnTheHappyPath() {
+      SelectionValue east = mock(SelectionValue.class);
+      when(east.getValue()).thenReturn("East");
+      SelectionValue west = mock(SelectionValue.class);
+      when(west.getValue()).thenReturn("West");
+
+      List<List<String>> unmatched = SelectionRuntimeService.findUnmatchedPaths(
+         new SelectionValue[]{ east, west }, List.of(List.of("East"), List.of("West")), false);
+
+      assertEquals(List.of(), unmatched);
+   }
+
+   /**
+    * If the domain isn't known yet, that is a cannot-tell case, not a does-not-exist case — failing
+    * closed here would reject calls that have nothing wrong with them. This is also what keeps every
+    * existing test above passing, since none of the {@code list(...)}/{@code tree(...)} fixtures stub
+    * {@code getSelectionList()}.
+    */
+   @Test
+   void skipsValidationWhenTheDomainIsntKnownYet() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      assertDoesNotThrow(() -> h.service.setSelection(
+         "tok", principal(), "Filter1", List.of(List.of("Anything At All")), null, null, ""));
+   }
+
+   /**
+    * The revision-round edge case: a tree path with more segments than the domain has levels, whose
+    * resolvable prefix bottoms out at a non-composite leaf before the path ends. The real
+    * {@code updateSelectionOfChangedAssembly} applies the selection to that leaf and silently ignores
+    * the leftover segments (it does not require them to resolve to anything) — so this must be a
+    * match, not a false rejection, or the validation would reject values the real backend already
+    * accepts.
+    */
+   @Test
+   void treatsAnOverLongPathThatBottomsOutAtALeafAsAMatch() {
+      SelectionValue east = mock(SelectionValue.class);
+      when(east.getValue()).thenReturn("East");
+      // Not a CompositeSelectionValue: it has no children for the trailing "NY" segment to
+      // resolve against, and the real apply code does not require it to.
+
+      List<List<String>> unmatched = SelectionRuntimeService.findUnmatchedPaths(
+         new SelectionValue[]{ east }, List.of(List.of("East", "NY")), false);
+
+      assertEquals(List.of(), unmatched);
+   }
+
+   /**
+    * ID-mode matches by {@code Tool.contains} against the whole path array — a flat "does this
+    * node's value appear anywhere in the requested array" scan — not by segment-by-segment descent.
+    * A domain node matching only the second element of a two-element requested path still counts as
+    * matched, which a descent-based match (as used for non-ID-mode) would not allow.
+    */
+   @Test
+   void matchesAnIdModeValueAnywhereInTheRequestedPathArray() {
+      SelectionValue ny = mock(SelectionValue.class);
+      when(ny.getValue()).thenReturn("NY");
+
+      List<List<String>> unmatched = SelectionRuntimeService.findUnmatchedPaths(
+         new SelectionValue[]{ ny }, List.of(List.of("East", "NY")), true);
+
+      assertEquals(List.of(), unmatched);
+   }
+
+   /** An ID that appears nowhere in the domain is refused the same as any other unmatched value. */
+   @Test
+   void refusesAnIdModeValueThatMatchesNothing() {
+      SelectionValue east = mock(SelectionValue.class);
+      when(east.getValue()).thenReturn("East");
+
+      List<List<String>> unmatched = SelectionRuntimeService.findUnmatchedPaths(
+         new SelectionValue[]{ east }, List.of(List.of("Nope")), true);
+
+      assertEquals(List.of(List.of("Nope")), unmatched);
    }
 
    // ── the diff-and-deselect step (bug-76548: set_selection accumulated instead of replacing) ────


### PR DESCRIPTION
## Root cause

`SelectionRuntimeService.setSelection` reported `values.size()` (the requested count) as `valuesSelected` unconditionally. The real matching, one layer down in `VSSelectionService.updateSelectionOfChangedAssembly`/`updateIDSelectionTree`, silently drops any value that doesn't exactly string-match an existing `SelectionValue` — no exception, no signal, nothing observable by the caller. A typo'd value (e.g. `"OldWorld Insurance"` vs. the real `"Old World Insurance"`) got silently dropped while the response confidently reported full success.

## Fix

In `SelectionRuntimeService.setSelection`, before applying anything, validate every requested value against the assembly's live domain by mirroring the real matching logic exactly (not a stricter approximation of it):

- **Non-ID-mode** (flat `SelectionList`, or a non-ID-mode tree path): descend segment-by-segment the same way `updateSelectionOfChangedAssembly` does. A path whose resolvable prefix bottoms out at a non-composite leaf before the path ends is still a match — the real apply code doesn't require the trailing segments to resolve to anything either.
- **ID-mode tree**: mirror `updateIDSelectionTree`'s flat `Tool.contains(path, value.getValue(), true, true, true)` scan over the whole tree.
- If the domain isn't known yet (`getSelectionList()` returns null), skip validation — that's a cannot-tell case, not a does-not-exist case.
- Skipped entirely for assembly types whose apply path doesn't match string values this way: `TimeSliderVSAssembly` selects by index range, and `CalendarVSAssembly`'s values-apply path is a no-op.

Any unmatched value throws `IllegalArgumentException` naming the exact unmatched value(s), before `applySelection` is called — the whole apply is atomic: either every requested value is confirmed to exist and all get applied, or none do.

## Base branch note

This branch is rebased onto `stylebi-wiz-main-rebase` @ `b9a9b1668`, which already includes bug-76548's squash-merged fix (#5105, "set_selection replaces the selection instead of merging it"). The diff now shows only this bug's actual changes: the new `isValueMatchable`/`findUnmatchedPaths`/`matchesPath`/`findByValue`/`matchesAnywhere` methods and their call site in `setSelection`, plus the corresponding test additions.

## Tests

`mvn -pl core test -Dtest=SelectionRuntimeServiceTest -o` (run with `WorksheetEventServiceTest.java` temporarily moved out of the source tree per the known, pre-existing, unrelated compile break at this base commit — documented in the batch's `00-triage.md` — then restored before committing):

```
Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
```

33 pre-existing tests pass unchanged (one, `skipsTheDiffStepForASingleSelectAssembly`, had its `getSelectionList()` call-count assertion updated from `never()` to `times(1)`, since validation now legitimately reads the domain for single-select assemblies too — a typo can be silently dropped there exactly the same way). 6 new tests:

- `refusesATypoedValueRatherThanSilentlyDroppingIt` — the core regression test for the reported symptom
- `matchesEveryRequestedValueOnTheHappyPath`
- `skipsValidationWhenTheDomainIsntKnownYet`
- `treatsAnOverLongPathThatBottomsOutAtALeafAsAMatch` — the edge case a mirror-matching helper could over-reject if implemented too strictly
- `matchesAnIdModeValueAnywhereInTheRequestedPathArray`
- `refusesAnIdModeValueThatMatchesNothing`

## Known coverage gap (same limitation as bug-76548's PR)

`SelectionList` extends `XSwappable`, whose static initializer needs a live Spring context, so it cannot be constructed or mocked in a plain unit test. This means no test can drive the full `setSelection` call through a real, populated `SelectionList` domain — the matching logic is instead tested directly via the package-visible `findUnmatchedPaths(SelectionValue[], ...)` overload, which is a faithful decomposition of the same logic the `SelectionList`-based production entry point delegates to.

Redmine bug: 76544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
