### PR TITLE
fix(wiz): report a silently-inactive date comparison (bug 76522, DCG-004/DCG-012)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.graph.GraphTypeUtil;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
@@ -147,7 +148,11 @@ public class DateComparisonService {
     * {@code retargetedFromLevel} / {@code retargetedToLevel}. Empty when nothing was retargeted.
     * For a chart, also reports {@code chartTypeOverridden}/{@code chartTypeBefore}/
     * {@code chartTypeAfter} when applying the comparison forced the chart's runtime style to
-    * change (see {@link #describeChartTypeOverride}).
+    * change (see {@link #describeChartTypeOverride}). For a chart where the comparison had no
+    * effect at all — its date field isn't on x/y, or its chart type doesn't support date
+    * comparison to begin with — reports {@code dateComparisonInactive:true} and a {@code reason}
+    * (see {@link #describeDateComparisonInactive}) instead of silently returning as if it
+    * applied.
     */
    public Map<String, Object> set(String sessionToken, Principal user, String assemblyName,
                                   Comparison comparison, String linkUri) throws Exception
@@ -174,6 +179,7 @@ public class DateComparisonService {
                                             dispatcher);
          result.putAll(describeRetargetedDimension(rvs, assemblyName));
          result.putAll(describeChartTypeOverride(rvs, assemblyName, beforeChartType));
+         result.putAll(describeDateComparisonInactive(rvs, assemblyName));
       });
 
       return result;
@@ -313,6 +319,62 @@ public class DateComparisonService {
       }
 
       return cinfo.getRTChartType();
+   }
+
+   /**
+    * {@code ChartDcProcessor} only ever finds "the" date dimension to compare on by searching
+    * {@code VSChartInfo.getRTXFields()}/{@code getRTYFields()} — never group/color/shape/text —
+    * and {@code DateComparisonUtil.supportDateComparison()} rejects the attempt even earlier for
+    * any chart type outside {auto, bar, line, area, interval, point} (a pie's sliced dimension is
+    * always forced onto color, so it can never satisfy the x/y search either). Either gate leaves
+    * {@code VSChartInfo.getDateComparisonRef()} null — set only inside {@code ChartDcProcessor
+    * .process()}'s body, which never runs when a gate fires — with {@link #set} otherwise
+    * returning {@code {ok:true}} exactly as if the comparison had applied.
+    *
+    * <p>The chart-type check here mirrors {@code DateComparisonUtil.supportDateComparison()}'s own
+    * inline predicate rather than calling it (that method also runs the x/y field search this
+    * helper doesn't need, and short-circuits true once a comparison has ever applied once before,
+    * neither of which this disclosure wants) — if that shared engine class's allow-list changes,
+    * this predicate needs updating to match.
+    *
+    * <p>Not a chart, or the comparison actually took effect: returns an empty map.
+    */
+   private static Map<String, Object> describeDateComparisonInactive(RuntimeViewsheet rvs,
+                                                                     String assemblyName)
+   {
+      Map<String, Object> out = new LinkedHashMap<>();
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(!(assembly instanceof ChartVSAssembly)) {
+         return out;
+      }
+
+      VSChartInfo cinfo = ((ChartVSAssembly) assembly).getVSChartInfo();
+
+      if(cinfo == null || cinfo.getDateComparisonRef() != null) {
+         return out;
+      }
+
+      boolean invalidChartType = GraphTypeUtil.checkType(cinfo, type ->
+         !GraphTypes.isAuto(type) && !GraphTypes.isBar(type) && !GraphTypes.isLine(type) &&
+         !GraphTypes.isArea(type) && !GraphTypes.isInterval(type) && !GraphTypes.isPoint(type));
+
+      out.put("dateComparisonInactive", true);
+
+      if(invalidChartType) {
+         out.put("reason", GraphTypes.getDisplayName(effectiveRTChartType(cinfo)) +
+            " charts don't support date comparison — only Bar, Line, Area, Interval, and Point " +
+            "(or Auto resolving to one of those) do. Convert the chart type first if a " +
+            "comparison is needed.");
+      }
+      else {
+         out.put("reason", "no date-typed field is bound to this chart's x or y axis — date " +
+            "comparison (own or shared) only applies to a date dimension on x or y, never " +
+            "group, color, shape, or text.");
+      }
+
+      return out;
    }
 
    public void clear(String sessionToken, Principal user, String assemblyName, String linkUri)

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -632,6 +632,10 @@ class DateComparisonServiceTest {
       when(cinfo.isMultiStyles()).thenReturn(true);
       when(cinfo.getAestheticAggregateRefs(true))
          .thenReturn(java.util.List.of(agg));
+      // The per-aggregate chart-type override this test asserts on only ever happens inside
+      // ChartDcProcessor.process()'s body — the same body that sets dateComparisonRef — so a
+      // real chart reaching this state always has a non-null one.
+      when(cinfo.getDateComparisonRef()).thenReturn(mock(VSDataRef.class));
 
       ChartVSAssembly assembly = mock(ChartVSAssembly.class);
       when(assembly.getVSChartInfo()).thenReturn(cinfo);
@@ -642,6 +646,79 @@ class DateComparisonServiceTest {
 
       assertEquals("Point", result.get("chartTypeBefore"));
       assertEquals("Stack Bar", result.get("chartTypeAfter"));
+   }
+
+   // ── reporting a silently-inactive date comparison ───────────────────────────
+
+   /**
+    * DCG-004: a chart with a category dimension on x, an aggregate on y, and a date-typed
+    * dimension bound only to {@code group} — never searched by {@code ChartDcProcessor}/
+    * {@code DateComparisonUtil}, which only ever look at x/y. The comparison silently applies to
+    * nothing ({@code getDateComparisonRef()} stays null), and this chart type is otherwise
+    * date-comparison-compatible (Bar), so the generic "no date field on x/y" reason must be used,
+    * not a chart-type-specific one.
+    */
+   @Test
+   void reportsDateComparisonInactiveWhenNoDateFieldReachesXOrY() throws Exception {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+      when(cinfo.getDateComparisonRef()).thenReturn(null);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertEquals(true, result.get("dateComparisonInactive"));
+      String reason = (String) result.get("reason");
+      assertTrue(reason.contains("x or y"), reason);
+      assertFalse(reason.contains("Bar"), "a compatible chart type should get the generic " +
+                  "reason, not a chart-type-specific one: " + reason);
+   }
+
+   /**
+    * DCG-012: a pie chart — {@code DateComparisonUtil.supportDateComparison()} rejects any chart
+    * type outside {auto, bar, line, area, interval, point} before ever searching x/y, so a pie's
+    * forced {@code color}-channel dimension (or no date field at all) never gets a chance to
+    * satisfy the x/y search. The reason must name the chart type, not the generic x/y wording.
+    */
+   @Test
+   void reportsDateComparisonInactiveWithAChartTypeReasonForAnIncompatibleChartType()
+      throws Exception
+   {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_PIE);
+      when(cinfo.getDateComparisonRef()).thenReturn(null);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertEquals(true, result.get("dateComparisonInactive"));
+      String reason = (String) result.get("reason");
+      assertTrue(reason.contains("Pie"), reason);
+   }
+
+   /** A chart where the comparison actually applied must not be flagged inactive. */
+   @Test
+   void doesNotReportDateComparisonInactiveWhenItActuallyApplied() throws Exception {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+      when(cinfo.getDateComparisonRef()).thenReturn(mock(VSDataRef.class));
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertFalse(result.containsKey("dateComparisonInactive"));
    }
 
    // ── comparisonOption ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `DateComparisonService.set()` (the wiz-only `set_date_comparison` backend) returned `{ok:true}` even when the mutation had no visible effect on a chart, because two upstream gates can silently no-op the whole thing with nothing checking for it:
  - `ChartDcProcessor`/`DateComparisonUtil.findDateDimension()` only ever searches a chart's x/y shelves for a date-typed dimension — a date field bound to `group`/color/shape/text is invisible to it (DCG-004).
  - `DateComparisonUtil.supportDateComparison()` rejects any chart type outside `{auto,bar,line,area,interval,point}` before that x/y search even runs — a pie chart's slicing dimension is unconditionally forced onto `color` by `fixPieDimensions()`, so it can never reach the x/y search regardless of chart type (DCG-012).
  - Either way, `VSChartInfo.getDateComparisonRef()` — set only inside `ChartDcProcessor.process()`'s body, which never runs when either gate fires — stays `null`, and nothing downstream reported it.
- `set()` now reads that post-mutation signal for a chart assembly and, when it's null, adds `dateComparisonInactive:true` plus a `reason` string: chart-type-specific (naming the incompatible type) when the chart type itself is the blocker, or the generic "no date field bound to x or y" wording otherwise. This is additive-only — a new optional response field — and does not touch `ChartDcProcessor`/`DateComparisonUtil`, which are shared with the interactive Composer UI's own date-comparison dialog.
- Follows the same post-mutation-inspection pattern already established in this file by `describeRetargetedDimension()`/`describeChartTypeOverride()`.

## Test plan
- [x] `./mvnw test -pl core -Dtest=DateComparisonServiceTest` — 85 tests, 0 failures (adds 3 new cases: group-shelf date field on a compatible chart type, pie chart, and a normal working case asserting the field's absence; also fixes one pre-existing multi-style test's mock to stub a non-null `getDateComparisonRef()`, matching the reality that its asserted chart-type override only ever happens after `ChartDcProcessor.process()` completes)

Companion PR (plugin-side disclosure surfacing) tracked separately in `inetsoft-technology/stylebi-wiz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)