### PR TITLE
Fix #76519: add viewsheet-scoped structure read (GET /vs/structure/{id})

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/DatasourceMetaApiController.java
@@ -141,6 +141,26 @@ public class DatasourceMetaApiController {
    }
 
    /**
+    * #76519 — the viewsheet-scoped sibling {@code /ws/structure/{id}} never had: given a
+    * VIEWSHEET's own asset entry identifier (not a worksheet's), reports the structure of
+    * whatever it is actually bound to — a real base worksheet, or (when there is none) the
+    * viewsheet's own direct logical-model/physical-table binding, via
+    * {@link MetadataApiService#getViewsheetStructure}. Distinguish the two by the response's
+    * {@code sourceKind}.
+    *
+    * @param id the viewsheet asset entry identifier.
+    */
+   @GetMapping("/vs/structure/{id}")
+   public WorksheetStructure getViewsheetStructure(
+      @PathVariable("id") String id,
+      @RequestParam(value = "generation", required = false) Integer generation,
+      Principal principal) throws Exception
+   {
+      return metadataService.getViewsheetStructure(
+         WizUtil.decodeId(id), generation, (XPrincipal) principal);
+   }
+
+   /**
     * Gets all tables and FK relationships for the specified datasource.
     *
     * <p>{@code nameContains}/{@code limit}/{@code cursor} are all optional; omitting all three

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetStructure.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetStructure.java
@@ -26,6 +26,11 @@ public class WorksheetStructure {
    private String name;
    private String primaryTable;
    private List<StructureTable> tables = new ArrayList<>();
+   // #76519 — only set by getViewsheetStructure: what kind of base the viewsheet actually has
+   // ("worksheet" | "logicalModel" | "physicalTable"), and that base entry's own path. null for
+   // a plain getWorksheetStructure (worksheet-id) call, which has no viewsheet wrapper to report.
+   private String sourceKind;
+   private String baseEntryPath;
 
    public String getPath() { return path; }
    public void setPath(String path) { this.path = path; }
@@ -35,6 +40,10 @@ public class WorksheetStructure {
    public void setPrimaryTable(String primaryTable) { this.primaryTable = primaryTable; }
    public List<StructureTable> getTables() { return tables; }
    public void setTables(List<StructureTable> tables) { this.tables = tables; }
+   public String getSourceKind() { return sourceKind; }
+   public void setSourceKind(String sourceKind) { this.sourceKind = sourceKind; }
+   public String getBaseEntryPath() { return baseEntryPath; }
+   public void setBaseEntryPath(String baseEntryPath) { this.baseEntryPath = baseEntryPath; }
 
    public static class StructureTable {
       private String name;

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -35,6 +35,7 @@ import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.util.DefaultMetaDataProvider;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.uql.util.XUtil;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.ThreadContext;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.AssetTreeService;
@@ -644,16 +645,121 @@ public class MetadataApiService {
       AssetEntry entry = AssetEntry.createAssetEntry(wsId);
       AbstractSheet sheet = assetRepository.getSheet(entry, principal, true, AssetContent.ALL);
 
-      if(!(sheet instanceof Worksheet worksheet)) {
-         throw new Exception("Worksheet " + wsId + " not found.");
+      if(sheet instanceof Worksheet worksheet) {
+         return buildStructure(worksheet, entry, generation);
       }
 
+      throw new Exception("Worksheet " + wsId + " not found.");
+   }
+
+   /**
+    * #76519 — a viewsheet has no {@code /ws/structure} analogue of its own: when it has no base
+    * worksheet (bound directly to a logical model or physical table), the only structural
+    * description of what it queries is {@link Viewsheet#getBaseWorksheet()}, which the repository
+    * ({@link inetsoft.uql.asset.AbstractAssetEngine#getSheet}, via {@code sheet.update(...)} on any
+    * {@code AssetContent.ALL} load — the same load this method already performs) populates
+    * automatically and generically for ALL three base kinds:
+    *
+    * <ul>
+    *   <li>a real worksheet base ({@code getBaseEntry().isWorksheet()}) — {@code getBaseWorksheet()}
+    *       is that worksheet itself, fetched by the repository;</li>
+    *   <li>a physical table or logical model direct source ({@link Viewsheet#isDirectSource()}) —
+    *       {@code getBaseWorksheet()} is a synthesized, single-table {@code Worksheet}
+    *       ({@code Viewsheet.getWorksheet(...)}, private) whose one {@code TableAssembly}
+    *       ({@code PhysicalBoundTableAssembly}/{@code BoundTableAssembly}) carries a real
+    *       {@code ColumnSelection} built from the entry's own metadata — the exact same table-walk
+    *       this method already performs against a real worksheet's assemblies applies to it
+    *       unchanged, no new column-mapping logic needed.</li>
+    * </ul>
+    *
+    * This is NOT itself the read/write query-execution path — {@code getBaseWorksheet()}'s
+    * synthesized worksheet is never persisted as its own asset, so nothing here lets a caller open
+    * it by a worksheet id of its own. Actually querying it (not just describing its columns) goes
+    * through {@code RuntimeViewsheet.getRuntimeWorksheet()} (wraps the SAME
+    * {@code getBaseWorksheet()} result together with the live viewsheet sandbox's
+    * {@code AssetQuerySandbox}) + {@code WorksheetPreviewService.preview(...)} — confirmed to exist
+    * and already exercised for the logical-model case specifically (see
+    * {@code RuntimeViewsheet.getRuntimeWorksheet()}'s own {@code isLMSource()} shrink-table comment)
+    * — but wiring that up is deliberately out of scope for this method; see
+    * {@code docs/teams/2026-09-08-bug-76519-viewsheet-external-binding/04-fix.md} for the citations
+    * and the follow-up this leaves specified.
+    *
+    * @param vsId the viewsheet asset entry identifier (as returned by, e.g.,
+    *             {@code create_viewsheet}/{@code save_viewsheet}/{@code reload_saved_visualization}).
+    * @throws Exception naming the specific reason: not a viewsheet, or a viewsheet with no base at
+    *                    all (never attached to anything).
+    */
+   public WorksheetStructure getViewsheetStructure(String vsId, Integer generation, XPrincipal principal)
+      throws Exception
+   {
+      if(vsId == null || Tool.isEmptyString(vsId)) {
+         throw new Exception("Invalid request.");
+      }
+
+      AssetEntry entry = AssetEntry.createAssetEntry(vsId);
+      AbstractSheet sheet = assetRepository.getSheet(entry, principal, true, AssetContent.ALL);
+
+      if(!(sheet instanceof Viewsheet viewsheet)) {
+         throw new Exception("Viewsheet " + vsId + " not found.");
+      }
+
+      AssetEntry baseEntry = viewsheet.getBaseEntry();
+
+      if(baseEntry == null) {
+         throw new Exception(
+            "Viewsheet " + vsId + " has no base worksheet or direct binding (never attached).");
+      }
+
+      Worksheet baseWorksheet = viewsheet.getBaseWorksheet();
+
+      if(baseWorksheet == null) {
+         throw new Exception(
+            "Viewsheet " + vsId + " has a base (\"" + baseEntry.toView() +
+            "\") that failed to load.");
+      }
+
+      WorksheetStructure structure = buildStructure(baseWorksheet, entry, generation);
+      structure.setSourceKind(sourceKindOf(baseEntry));
+      structure.setBaseEntryPath(baseEntry.getPath());
+      return structure;
+   }
+
+   /**
+    * Classifies a viewsheet's base entry for {@code WorksheetStructure.sourceKind} — "worksheet"
+    * for a real worksheet base, "logicalModel"/"physicalTable" for a direct source ({@link
+    * Viewsheet#isDirectSource()}'s own two non-query cases), "unknown" only if StyleBI ever adds a
+    * base-entry type this method doesn't recognize (never observed; not reachable via
+    * attach_base_worksheet, which only ever sets one of these three).
+    */
+   static String sourceKindOf(AssetEntry baseEntry) {
+      if(baseEntry.isWorksheet()) {
+         return "worksheet";
+      }
+      else if(baseEntry.isLogicModel()) {
+         return "logicalModel";
+      }
+      else if(baseEntry.isPhysicalTable()) {
+         return "physicalTable";
+      }
+
+      return "unknown";
+   }
+
+   /**
+    * The table-walk shared by {@link #getWorksheetStructure} (a real, persisted worksheet asset)
+    * and {@link #getViewsheetStructure} (a viewsheet's base worksheet, real or synthesized) —
+    * operates purely on an in-memory {@link Worksheet} object, so it does not care which case
+    * produced it.
+    */
+   private WorksheetStructure buildStructure(Worksheet worksheet, AssetEntry entry, Integer generation)
+      throws Exception
+   {
       // Enumerate table assemblies once in sheet order. That order is dependency order: a base /
       // upstream table is added to the sheet before the table that references it, so emitting the
       // kept tables in this order keeps an upstream table ahead of its dependents.
       List<TableAssembly> tableAssemblies = new ArrayList<>();
 
-      for(Assembly assembly : sheet.getAssemblies()) {
+      for(Assembly assembly : worksheet.getAssemblies()) {
          if(assembly instanceof TableAssembly tableAssembly) {
             tableAssemblies.add(tableAssembly);
          }

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -710,6 +710,20 @@ public class MetadataApiService {
             "Viewsheet " + vsId + " has no base worksheet or direct binding (never attached).");
       }
 
+      // #76519 P6 review round 1, Finding 2 — the read above only checked READ on the VIEWSHEET's
+      // own entry (via assetRepository.getSheet). For a real-worksheet base specifically,
+      // Viewsheet.update() (the method that load reaches to populate getBaseWorksheet()) loads that
+      // worksheet with principal=null/permission=false — its own READ is never checked at all. A
+      // principal with READ on the viewsheet but explicitly denied READ on its underlying
+      // worksheet (a legitimate, existing StyleBI configuration — share a finished dashboard, keep
+      // the raw query private) could otherwise read the full table/column/join/condition/aggregate
+      // structure through this endpoint, which /ws/structure/{worksheetId} would never let that same
+      // principal see directly. Check explicitly here, uniformly across all three base kinds
+      // (worksheet / logical model / physical table) rather than relying on whatever the internal
+      // synthesis path happens to enforce for each — same READ check /ws/structure performs on the
+      // worksheet entry it's handed directly.
+      assetRepository.checkAssetPermission(principal, baseEntry, ResourceAction.READ);
+
       Worksheet baseWorksheet = viewsheet.getBaseWorksheet();
 
       if(baseWorksheet == null) {

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -515,6 +515,29 @@ class MetadataApiServiceStructureTest {
          "a_only", java.util.List.of(), java.util.List.of(), null));
    }
 
+   // ---- sourceKindOf (#76519) ----
+
+   @Test
+   void sourceKindOfWorksheetBase() {
+      AssetEntry entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
+                                        "Sample Queries/customers", null);
+      assertEquals("worksheet", MetadataApiService.sourceKindOf(entry));
+   }
+
+   @Test
+   void sourceKindOfLogicalModelBase() {
+      AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.LOGIC_MODEL,
+                                        "MyDataSource/MyModel", null);
+      assertEquals("logicalModel", MetadataApiService.sourceKindOf(entry));
+   }
+
+   @Test
+   void sourceKindOfPhysicalTableBase() {
+      AssetEntry entry = new AssetEntry(AssetRepository.QUERY_SCOPE, AssetEntry.Type.PHYSICAL_TABLE,
+                                        "accounts", null);
+      assertEquals("physicalTable", MetadataApiService.sourceKindOf(entry));
+   }
+
    // ---- collectUpstreamRefs ----
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceViewsheetStructureSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceViewsheetStructureSecurityTest.java
@@ -1,0 +1,143 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.util.MessageException;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * #76519 P6 review round 1, Finding 2 (BLOCKER) — {@code getViewsheetStructure} must check the
+ * caller's READ permission on the viewsheet's RESOLVED BASE ENTRY (the worksheet, logical model,
+ * or physical table it is actually bound to), not just on the viewsheet's own entry.
+ *
+ * <p>{@code assetRepository.getSheet(entry, principal, true, AssetContent.ALL)} only checks READ
+ * on the viewsheet's own entry. For a real-worksheet base specifically, {@code Viewsheet.update()}
+ * (the method that load reaches internally to populate {@code getBaseWorksheet()}) loads that
+ * worksheet with {@code principal=null, permission=false} — its own READ is never checked. A
+ * principal with READ on the viewsheet but explicitly denied READ on its underlying worksheet (a
+ * legitimate, existing StyleBI configuration) could otherwise read the full worksheet structure
+ * through this endpoint. This suite drives {@code getViewsheetStructure} with a mocked
+ * {@link AssetRepository} to assert the explicit {@code checkAssetPermission} call this fix adds.
+ */
+@Tag("core")
+class MetadataApiServiceViewsheetStructureSecurityTest {
+
+   // AssetEntry.createAssetEntry(String) returns null for an identifier it can't parse (no '^'
+   // and no "ws:" prefix — confirmed by reading AssetEntry.java's else-branch) — a plain "vs-1"
+   // silently produces a null entry, which then makes assetRepository.getSheet(...) return the
+   // mock's default (null) regardless of stubbing, since the ACTUAL argument passed is null. Use
+   // the documented "ws:SCOPE:path" shorthand so the entry this test drives through is a real,
+   // non-null AssetEntry, same as production always receives.
+   private static final String VS_ID = "ws:global:vs-1";
+
+   @Test
+   void getViewsheetStructure_throwsAndSkipsBaseWorksheetReadWhenBasePermissionDenied() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetTreeService assetTreeService = mock(AssetTreeService.class);
+      ObjectMapper objectMapper = new ObjectMapper();
+      XPrincipal principal = mock(XPrincipal.class);
+
+      AssetEntry baseEntry = mock(AssetEntry.class); // the base worksheet's own entry
+      Viewsheet viewsheet = mock(Viewsheet.class);
+      Worksheet baseWorksheet = mock(Worksheet.class);
+
+      doReturn(viewsheet).when(assetRepository)
+         .getSheet(any(AssetEntry.class), any(), anyBoolean(), any(AssetContent.class));
+      when(viewsheet.getBaseEntry()).thenReturn(baseEntry);
+      when(viewsheet.getBaseWorksheet()).thenReturn(baseWorksheet);
+
+      // Denied: READ on the base entry (the worksheet/model/table the viewsheet is actually
+      // bound to) throws, exactly what a real denial does (see AbstractAssetEngine.checkAssetPermission).
+      doThrow(new MessageException("Access denied"))
+         .when(assetRepository).checkAssetPermission(eq(principal), eq(baseEntry), eq(ResourceAction.READ));
+
+      MetadataApiService service = new MetadataApiService(
+         xrepository, dataSourceService, assetRepository, assetTreeService, objectMapper);
+
+      MessageException ex = assertThrows(MessageException.class,
+         () -> service.getViewsheetStructure(VS_ID, null, principal));
+
+      assertEquals("Access denied", ex.getMessage());
+
+      // The denial must fire BEFORE the base worksheet's structure is ever walked — a caller
+      // denied READ on the base must never see any of its table/column/join/condition data.
+      verify(assetRepository).checkAssetPermission(principal, baseEntry, ResourceAction.READ);
+      verify(viewsheet, never()).getBaseWorksheet();
+   }
+
+   @Test
+   void getViewsheetStructure_checksBasePermissionThenProceedsWhenGranted() throws Exception {
+      XRepository xrepository = mock(XRepository.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetTreeService assetTreeService = mock(AssetTreeService.class);
+      ObjectMapper objectMapper = new ObjectMapper();
+      XPrincipal principal = mock(XPrincipal.class);
+
+      AssetEntry baseEntry = mock(AssetEntry.class);
+      Viewsheet viewsheet = mock(Viewsheet.class);
+
+      doReturn(viewsheet).when(assetRepository)
+         .getSheet(any(AssetEntry.class), any(), anyBoolean(), any(AssetContent.class));
+      when(viewsheet.getBaseEntry()).thenReturn(baseEntry);
+      // checkAssetPermission granted (default mock behavior: returns normally, no throw).
+
+      // getBaseWorksheet() returns null past the permission check, so the method throws its own
+      // "failed to load" exception — a distinctive marker proving execution reached PAST the
+      // permission gate rather than being denied by it.
+      when(viewsheet.getBaseWorksheet()).thenReturn(null);
+      when(baseEntry.toView()).thenReturn("Sample Queries/accounts");
+
+      MetadataApiService service = new MetadataApiService(
+         xrepository, dataSourceService, assetRepository, assetTreeService, objectMapper);
+
+      Exception ex = assertThrows(Exception.class,
+         () -> service.getViewsheetStructure(VS_ID, null, principal));
+
+      assertEquals("Viewsheet " + VS_ID + " has a base (\"Sample Queries/accounts\") that failed to load.",
+         ex.getMessage());
+
+      verify(assetRepository).checkAssetPermission(principal, baseEntry, ResourceAction.READ);
+   }
+}


### PR DESCRIPTION
## Summary

Companion Java-side change for wiz bug #76519 (see the `stylebi-wiz` PR for the wiz-services half). `GET /ws/structure/{id}` hard-required the entry to resolve to a `Worksheet`, throwing otherwise — there was no way for the wiz backend to read what a viewsheet with no base worksheet is actually bound to (a logical model or a physical table).

## Changes

- `MetadataApiService`: refactored `getWorksheetStructure`'s table-walk body into a shared private `buildStructure` helper. Added `getViewsheetStructure(vsId, generation, principal)`: loads the viewsheet, requires a non-null `getBaseEntry()`/`getBaseWorksheet()` (loud, specific exceptions otherwise), and calls the same `buildStructure` against `viewsheet.getBaseWorksheet()` — this reuses `Viewsheet`'s own existing, production-exercised base-entry synthesis (`isDirectSource()` → `getWorksheet()`, the same generic path every normal viewsheet load already takes for a `LOGIC_MODEL`/`PHYSICAL_TABLE` base entry — not new runtime machinery). Added a `sourceKindOf(AssetEntry)` classifier (worksheet/logicalModel/physicalTable/unknown).
- `WorksheetStructure`: new `sourceKind`/`baseEntryPath` fields.
- `DatasourceMetaApiController`: new `GET /vs/structure/{id}` mapping, mirroring `/ws/structure/{id}` exactly (same `generation` param, same `WizUtil.decodeId`).
- 3 new unit tests for `sourceKindOf`, following the file's existing hand-built-`AssetEntry` convention.

## Evidence

- Full main-source compile: clean, 0 errors (6896 files).
- `MetadataApiServiceStructureTest`: `Tests run: 47, Failures: 0, Errors: 0, Skipped: 0` — real JUnit execution, independently re-run twice (once by the builder, once by an independent verifier).

Base is `stylebi-wiz-main-rebase` (this repo's own integration branch for wiz-driven fixes), matching the convention used by bug #76523's PR #5091.

🤖 Generated with a `/deep-debug-workflow` agent team run in `stylebi-wiz` — see `stylebi-wiz`'s `docs/teams/2026-09-08-bug-76519-viewsheet-external-binding/` for the full archive.