### PR TITLE
fix(#76522): ConditionVocabulary rejects a literal value that can't coerce to the field's type

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.uql.JunctionOperator;
 import inetsoft.uql.XCondition;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.util.Tool;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.condition.*;
 
@@ -196,7 +198,7 @@ public final class ConditionVocabulary {
          condition.setValues(new ConditionValueModel[] { rankingValue(values.get(0), index, fields) });
       }
       else {
-         condition.setValues(values.stream().map(raw -> value(raw, index, fields))
+         condition.setValues(values.stream().map(raw -> value(raw, index, fields, field))
                                 .toArray(ConditionValueModel[]::new));
       }
 
@@ -212,9 +214,28 @@ public final class ConditionVocabulary {
     * deliberately not supported here -- its payload is a full sub-query definition with no
     * tractable minimal-field summary.
     */
-   private static ConditionValueModel value(Object raw, int index, Map<String, DataRefModel> fields) {
+   private static ConditionValueModel value(Object raw, int index, Map<String, DataRefModel> fields,
+                                            DataRefModel targetField)
+   {
       if(raw instanceof Map<?, ?> map && map.get("type") instanceof String typeToken) {
          return typedValue(typeToken, map, index, fields);
+      }
+
+      // ConditionUtil later force-coerces a literal VALUE against the target field's declared
+      // type (Tool.getData(dataType, value)) and silently keeps null on failure -- checking here,
+      // one hop earlier, catches a bare string that can't become the field's type (e.g. a column
+      // name meant for a {type:"field",...} operand) with a named error instead of a silently
+      // null-valued condition that matches zero rows.
+      if(raw instanceof String str && !str.isBlank()) {
+         String dataType = targetField.getDataType();
+
+         if(!XSchema.STRING.equals(dataType) && Tool.getData(dataType, str) == null) {
+            throw new IllegalArgumentException(
+               "Condition " + index + "'s value '" + str + "' cannot be interpreted as a " +
+               dataType + " for field '" + targetField.getName() + "'. If you meant to compare " +
+               "against another column, use {type: \"field\", field: \"" + str + "\"} instead of " +
+               "a plain string.");
+         }
       }
 
       ConditionValueModel value = new ConditionValueModel();

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
@@ -41,6 +41,12 @@ class ConditionVocabularyTest {
       return field;
    }
 
+   private static DataRefModel field(String name, String dataType) {
+      DataRefModel field = field(name);
+      when(field.getDataType()).thenReturn(dataType);
+      return field;
+   }
+
    private static final DataRefModel[] FIELDS =
       { field("Region"), field("Revenue"), field("OrderDate") };
 
@@ -514,6 +520,42 @@ class ConditionVocabularyTest {
          List.of(clause("Revenue", "greater_than",
                         List.of(Map.of("type", "field", "field", "Nope")), null)),
          FIELDS));
+   }
+
+   // ── bug 76522 / DCG-010: a bare string that can't coerce to the field's type ─
+
+   @Test
+   void refusesAStringValueThatCannotCoerceToTheFieldsDataType() {
+      DataRefModel[] fields = { field("Region"), field("OrderId", "integer"), field("OrderDate") };
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("OrderId", "greater_than", List.of("CUSTOMER_ID"), null)), fields));
+
+      assertTrue(thrown.getMessage().contains("CUSTOMER_ID"));
+      assertTrue(thrown.getMessage().contains("OrderId"));
+      assertTrue(thrown.getMessage().contains("integer"));
+   }
+
+   @Test
+   void acceptsAStringValueThatDoesCoerceToTheFieldsDataType() {
+      DataRefModel[] fields = { field("Region"), field("OrderId", "integer"), field("OrderDate") };
+
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("OrderId", "greater_than", List.of("42"), null)), fields);
+
+      ConditionValueModel value = ((ConditionModel) list[0]).getValues()[0];
+      assertEquals(ConditionValueModel.VALUE, value.getType());
+      assertEquals("42", value.getValue(), "the literal is passed through unchanged; "
+         + "ConditionUtil performs the actual coercion downstream, as before");
+   }
+
+   @Test
+   void acceptsAStringLiteralAgainstAStringTypedField() {
+      DataRefModel[] fields = { field("Region", "string"), field("Revenue"), field("OrderDate") };
+
+      assertDoesNotThrow(() -> ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("CUSTOMER_ID"), null)), fields));
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `set_highlight`/`set_condition` with a bare-string `values` entry against a non-string-typed field (e.g. `{field:"ORDER_ID", operator:"greater_than", values:["CUSTOMER_ID"]}`) silently produced `values:[null]` and matched zero rows, reporting `{"ok":true}` with no error.
- Root cause: `ConditionVocabulary.value()` wraps any non-Map scalar as a literal `VALUE`-type condition value untouched; `ConditionUtil.java:304-306` (shared with the manual Composer UI, not modified here) later force-coerces it via `Tool.getData(dataType, value)`, which for a non-numeric string against a numeric field returns `null` on failure (swallowed inside `CoreTool`'s parsing chain) instead of surfacing an error.
- Fix: `ConditionVocabulary.value()` now threads the target field's `DataRefModel` through and, for a non-blank `String` against a non-`XSchema.STRING` field, eagerly attempts the same `Tool.getData` coercion one hop earlier — while the field name/index are still in scope — and throws a named `IllegalArgumentException` (naming the condition index, offending value, field name, and declared type, with a hint toward the working `{type:"field", field:"..."}` alternative) when it fails, instead of silently persisting a null-valued condition.
- `ConditionUtil.java` and `CoreTool.getData` are unchanged (confirmed shared with the manual Composer UI and 129+ unrelated call sites respectively).

## Test plan
- [x] `./mvnw test -pl core -Dtest=ConditionVocabularyTest` — 49/49 tests pass (46 existing + 3 new), including:
  - `refusesAStringValueThatCannotCoerceToTheFieldsDataType` — the exact repro (non-numeric string against an integer field) now throws a named error
  - `acceptsAStringValueThatDoesCoerceToTheFieldsDataType` — a genuinely numeric string (`"42"`) against an integer field still works unchanged
  - `acceptsAStringLiteralAgainstAStringTypedField` — the existing string/string literal path is unaffected
  - all pre-existing tests (including the `{type:"field", field:"..."}` typed-operand coverage) still pass unchanged