### PR TITLE
Validate CheckBox/RadioButton variable bindings (bug #76551)

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -569,10 +569,13 @@ public class VSInputService {
       setListValues(checkBoxAssemblyInfo, value, viewsheet, principal);
 
       // TODO validate column/row variable/expression type
-      String table = dataInputPaneModel.getTable();
-      checkBoxAssemblyInfo.setTableName(
-         table == null || "".equals(table.trim()) ? null : table);
-      checkBoxAssemblyInfo.setVariable(table != null && dataInputPaneModel.isVariable());
+      String table = resolveInputTableBinding(viewsheet.getViewsheet().getBaseWorksheet(),
+         viewsheet.getViewsheet(), dataInputPaneModel.getTable(),
+         dataInputPaneModel.getColumnValue());
+      checkBoxAssemblyInfo.setTableName(table == null ? "" : table);
+      checkBoxAssemblyInfo.setVariable(resolvesToVariableBinding(
+         viewsheet.getViewsheet().getBaseWorksheet(), viewsheet.getViewsheet(), table,
+         dataInputPaneModel.getColumnValue()));
 
       checkBoxAssemblyInfo.setScriptEnabled(vsAssemblyScriptPaneModel.scriptEnabled());
       checkBoxAssemblyInfo.setScript(vsAssemblyScriptPaneModel.expression());
@@ -1321,11 +1324,15 @@ public class VSInputService {
 
       setListValues(radioButtonAssemblyInfo, value, viewsheet, principal);
 
-      String table = dataInputPaneModel.getTable();
+      String table = resolveInputTableBinding(viewsheet.getViewsheet().getBaseWorksheet(),
+         viewsheet.getViewsheet(), dataInputPaneModel.getTable(),
+         dataInputPaneModel.getColumnValue());
       radioButtonAssemblyInfo.setTableName(table == null ? "" : table);
       radioButtonAssemblyInfo.setColumnValue(dataInputPaneModel.getColumnValue());
       radioButtonAssemblyInfo.setRowValue(dataInputPaneModel.getRowValue());
-      radioButtonAssemblyInfo.setVariable(dataInputPaneModel.isVariable());
+      radioButtonAssemblyInfo.setVariable(resolvesToVariableBinding(
+         viewsheet.getViewsheet().getBaseWorksheet(), viewsheet.getViewsheet(), table,
+         dataInputPaneModel.getColumnValue()));
       radioButtonAssemblyInfo.setWriteBackValue(dataInputPaneModel.isWriteBackDirectly());
 
       radioButtonAssemblyInfo.setScriptEnabled(vsAssemblyScriptPaneModel.scriptEnabled());

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -107,21 +107,23 @@ public final class PropertyAliases {
                          "sortOthersLastEnabled", "dateComparisonSupport"));
 
    /**
-    * textinput/combobox/slider/spinner's {@code dataInputPaneModel.variable} (bug #76530): has a
-    * real getter/setter, populated correctly on every read from the persisted
-    * {@code InputVSAssemblyInfo.isVariable()} -- but every one of these four types' setters
+    * textinput/combobox/slider/spinner/checkbox/radiobutton's {@code dataInputPaneModel.variable}
+    * (bug #76530, extended to checkbox/radiobutton by bug #76551): has a real getter/setter,
+    * populated correctly on every read from the persisted
+    * {@code InputVSAssemblyInfo.isVariable()} -- but every one of these six types' setters
     * derives the real, persisted flag solely from whether {@code dataInputPaneModel.table} (after
     * {@code VSInputService.resolveInputTableBinding}'s normalization) is shaped
     * {@code "$(varName)"}. The client's own boolean here is never read back on write, for any of
-    * the four. Unlike a plain {@link #DEAD_FIELDS} entry, a write here is not refused
+    * the six. Unlike a plain {@link #DEAD_FIELDS} entry, a write here is not refused
     * unconditionally -- see {@code AssemblyPropertyService.requireVariableFlagAchievable}, which
     * this set only marks as needing that check, because whether the write is actually honored
-    * depends on the resulting table binding, not on the field alone. CheckBox and RadioButton are
-    * deliberately absent: their setters read {@code dataInputPaneModel.isVariable()} directly (a
-    * different, separate defect -- tracked on its own, not this one).
+    * depends on the resulting table binding, not on the field alone. CheckBox and RadioButton used
+    * to be deliberately absent here (their setters read {@code dataInputPaneModel.isVariable()}
+    * directly), but bug #76551's fix made their {@code VSInputService} setters derive-not-trust
+    * the same way the original four already did, so they now belong in this set too.
     */
    private static final Set<String> VARIABLE_FLAG_DERIVED_TYPES =
-      Set.of("textinput", "combobox", "slider", "spinner");
+      Set.of("textinput", "combobox", "slider", "spinner", "checkbox", "radiobutton");
 
    /**
     * {@code refresh} is aliased through the shared {@link #basicGeneral} helper because it is

--- a/core/src/test/java/inetsoft/web/viewsheet/service/CheckBoxRadioButtonTableBindingSetterTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/CheckBoxRadioButtonTableBindingSetterTest.java
@@ -1,0 +1,256 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+/*
+ * Regression for bug #76551: unlike setTextInputPropertyDialogModel/setComboboxPropertyDialogModel/
+ * setSliderPropertyDialogModel/setSpinnerPropertyDialogModel (bug #76478/#76530),
+ * setCheckboxPropertyModel/setRadioButtonPropertyModel used to copy dataInputPaneModel.getTable()
+ * straight into the assembly with no resolution at all, and persisted
+ * dataInputPaneModel.isVariable() verbatim regardless of whether the table actually named a
+ * variable. This let a garbage table name (or, for RadioButton, no table at all) reach the
+ * assembly with variable:true honored unconditionally.
+ *
+ * VSInputTableBindingResolutionTest already covers resolveInputTableBinding/
+ * resolvesToVariableBinding themselves, type-agnostically. This class instead calls through the
+ * real setCheckboxPropertyModel/setRadioButtonPropertyModel methods (the interactive Composer
+ * dialog-save path, which never touches the wiz-only AssemblyPropertyService/
+ * requireVariableFlagAchievable safety net) to prove the fix actually reaches that layer, not
+ * just the shared helper.
+ */
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.DefaultVariableAssembly;
+import inetsoft.uql.asset.EmbeddedTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.CheckBoxVSAssembly;
+import inetsoft.uql.viewsheet.RadioButtonVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.CheckBoxVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.RadioButtonVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.util.MessageException;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.handler.VSColumnHandler;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.composer.model.vs.CheckboxPropertyDialogModel;
+import inetsoft.web.composer.model.vs.RadioButtonPropertyDialogModel;
+import inetsoft.web.composer.model.vs.VSAssemblyScriptPaneModel;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import inetsoft.web.composer.vs.objects.controller.VSTrapService;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@WizAgentTestSupport
+class CheckBoxRadioButtonTableBindingSetterTest {
+   // ── CheckBox ──────────────────────────────────────────────────────────────
+
+   /** The exact reported repro shape: a garbage table name paired with {@code variable:true}. */
+   @Test
+   void setCheckboxPropertyModelThrowsOnAnUnresolvableTable() {
+      Harness h = harnessForCheckbox(new Worksheet(), new CheckBoxVSAssemblyInfo());
+      CheckboxPropertyDialogModel model = checkboxModel("TotallyUnknownTable", null, true);
+
+      MessageException ex = assertThrows(MessageException.class, () ->
+         h.service().setCheckboxPropertyModel("vs1", "Check1", model, "", principal(), null));
+
+      assertTrue(ex.getMessage().contains("TotallyUnknownTable"), ex.getMessage());
+   }
+
+   /**
+    * A real, resolvable table that is not a variable must not honor a stale/mismatched
+    * {@code variable:true} request -- the setter must derive the flag from the binding, the same
+    * way the four already-fixed types do, instead of trusting the client's raw boolean.
+    */
+   @Test
+   void setCheckboxPropertyModelDerivesVariableFalseWhenTheResolvedTableIsARealNonVariableTable()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new EmbeddedTableAssembly(ws, "Query1"));
+      Harness h = harnessForCheckbox(ws, new CheckBoxVSAssemblyInfo());
+      CheckboxPropertyDialogModel model = checkboxModel("Query1", null, true);
+
+      h.service().setCheckboxPropertyModel("vs1", "Check1", model, "", principal(), null);
+
+      CheckBoxVSAssemblyInfo persisted = (CheckBoxVSAssemblyInfo) h.capturePersistedInfo();
+      assertFalse(persisted.isVariable(),
+                  "a real, non-variable table must not honor a stale variable:true request");
+      assertEquals("Query1", persisted.getTableName());
+   }
+
+   /** The mirror image: a table that genuinely resolves to a variable must still be honored. */
+   @Test
+   void setCheckboxPropertyModelPersistsVariableTrueWhenTheTableActuallyResolvesToAVariable()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "discountRate"));
+      Harness h = harnessForCheckbox(ws, new CheckBoxVSAssemblyInfo());
+      CheckboxPropertyDialogModel model = checkboxModel("$(discountRate)", null, true);
+
+      h.service().setCheckboxPropertyModel("vs1", "Check1", model, "", principal(), null);
+
+      CheckBoxVSAssemblyInfo persisted = (CheckBoxVSAssemblyInfo) h.capturePersistedInfo();
+      assertTrue(persisted.isVariable());
+      assertEquals("$(discountRate)", persisted.getTableName());
+   }
+
+   // ── RadioButton ───────────────────────────────────────────────────────────
+
+   @Test
+   void setRadioButtonPropertyModelThrowsOnAnUnresolvableTable() {
+      Harness h = harnessForRadioButton(new Worksheet(), new RadioButtonVSAssemblyInfo());
+      RadioButtonPropertyDialogModel model = radioButtonModel("TotallyUnknownTable", null, true);
+
+      MessageException ex = assertThrows(MessageException.class, () ->
+         h.service().setRadioButtonPropertyModel("vs1", "Radio1", model, "", principal(), null));
+
+      assertTrue(ex.getMessage().contains("TotallyUnknownTable"), ex.getMessage());
+   }
+
+   /**
+    * The exact reported worst case (bug #76551): RadioButton had zero gating at all, unlike
+    * CheckBox's non-blank-table check -- no table/columnValue whatsoever still honored
+    * {@code variable:true} unconditionally before this fix.
+    */
+   @Test
+   void setRadioButtonPropertyModelDerivesVariableFalseWhenNoTableIsBoundAtAll() throws Exception {
+      Harness h = harnessForRadioButton(new Worksheet(), new RadioButtonVSAssemblyInfo());
+      RadioButtonPropertyDialogModel model = radioButtonModel(null, null, true);
+
+      h.service().setRadioButtonPropertyModel("vs1", "Radio1", model, "", principal(), null);
+
+      RadioButtonVSAssemblyInfo persisted = (RadioButtonVSAssemblyInfo) h.capturePersistedInfo();
+      assertFalse(persisted.isVariable(),
+                  "no table at all cannot possibly resolve to a variable -- must not persist true");
+   }
+
+   @Test
+   void setRadioButtonPropertyModelPersistsVariableTrueWhenTheTableActuallyResolvesToAVariable()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "discountRate"));
+      Harness h = harnessForRadioButton(ws, new RadioButtonVSAssemblyInfo());
+      RadioButtonPropertyDialogModel model = radioButtonModel("$(discountRate)", null, true);
+
+      h.service().setRadioButtonPropertyModel("vs1", "Radio1", model, "", principal(), null);
+
+      RadioButtonVSAssemblyInfo persisted = (RadioButtonVSAssemblyInfo) h.capturePersistedInfo();
+      assertTrue(persisted.isVariable());
+      assertEquals("$(discountRate)", persisted.getTableName());
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(VSInputService service, VSObjectPropertyService propertyService) {
+      /** The clone of the seed info that the setter actually wrote its changes onto. */
+      VSAssemblyInfo capturePersistedInfo() throws Exception {
+         ArgumentCaptor<VSAssemblyInfo> captor = ArgumentCaptor.forClass(VSAssemblyInfo.class);
+         verify(propertyService).editObjectProperty(
+            any(), captor.capture(), any(), any(), any(), any(), any());
+         return captor.getValue();
+      }
+   }
+
+   private static CheckboxPropertyDialogModel checkboxModel(String table, String columnValue,
+                                                             boolean variable)
+   {
+      CheckboxPropertyDialogModel model = new CheckboxPropertyDialogModel();
+      model.getDataInputPaneModel().setTable(table);
+      model.getDataInputPaneModel().setColumnValue(columnValue);
+      model.getDataInputPaneModel().setVariable(variable);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().expression("").scriptEnabled(false).build());
+      return model;
+   }
+
+   private static RadioButtonPropertyDialogModel radioButtonModel(String table, String columnValue,
+                                                                   boolean variable)
+   {
+      RadioButtonPropertyDialogModel model = new RadioButtonPropertyDialogModel();
+      model.getDataInputPaneModel().setTable(table);
+      model.getDataInputPaneModel().setColumnValue(columnValue);
+      model.getDataInputPaneModel().setVariable(variable);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().expression("").scriptEnabled(false).build());
+      return model;
+   }
+
+   private static Harness harnessForCheckbox(Worksheet ws, CheckBoxVSAssemblyInfo seed) {
+      CheckBoxVSAssembly assembly = mock(CheckBoxVSAssembly.class);
+      when(assembly.getVSAssemblyInfo()).thenReturn(seed);
+      return harness(ws, assembly);
+   }
+
+   private static Harness harnessForRadioButton(Worksheet ws, RadioButtonVSAssemblyInfo seed) {
+      RadioButtonVSAssembly assembly = mock(RadioButtonVSAssembly.class);
+      when(assembly.getVSAssemblyInfo()).thenReturn(seed);
+      return harness(ws, assembly);
+   }
+
+   private static Harness harness(Worksheet ws, VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseWorksheet()).thenReturn(ws);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      // isKnownVariableName() merges this in unconditionally alongside the worksheet's own
+      // variables; an unstubbed mock array getter defaults to null, which NPEs the merge.
+      when(vs.getAllVariables()).thenReturn(new inetsoft.uql.schema.UserVariable[0]);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+
+      try {
+         when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      VSObjectPropertyService propertyService = mock(VSObjectPropertyService.class);
+
+      VSInputService service = new VSInputService(
+         mock(VSObjectService.class),
+         mock(CoreLifecycleService.class),
+         viewsheetService,
+         propertyService,
+         mock(VSDialogService.class),
+         mock(VSTrapService.class),
+         mock(DataRefModelFactoryService.class),
+         mock(VSAssemblyInfoHandler.class),
+         mock(VSColumnHandler.class));
+
+      return new Harness(service, propertyService);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -22,7 +22,9 @@ import inetsoft.test.*;
 import inetsoft.uql.asset.DefaultVariableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.web.composer.model.vs.CheckboxPropertyDialogModel;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
+import inetsoft.web.composer.model.vs.RadioButtonPropertyDialogModel;
 import inetsoft.web.composer.model.vs.TextInputPropertyDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
 import org.junit.jupiter.api.Tag;
@@ -434,6 +436,141 @@ class AssemblyPropertyServiceTest {
          Map.of("dataInputPaneModel.variable", false), ""));
    }
 
+   // ── checkbox/radiobutton (bug #76551) ────────────────────────────────────
+   //
+   // Same four cases as TextInput above, now that checkbox/radiobutton are in
+   // PropertyAliases.VARIABLE_FLAG_DERIVED_TYPES too. This only exercises the AI/wiz-layer
+   // achievability check (requireVariableFlagAchievable) -- VSInputService is mocked here, so it
+   // never runs the real setCheckboxPropertyModel/setRadioButtonPropertyModel body. The setter's
+   // own derive-not-trust behavior (the interactive Composer UI's own protection) is covered
+   // separately by CheckBoxRadioButtonTableBindingSetterTest.
+
+   @Test
+   void allowsTheExactReportedReproNowThatColumnValueAloneResolvesToAKnownVariableForCheckbox()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      CheckboxPropertyDialogModel model = new CheckboxPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithCheckbox(mock(CheckBoxVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", true);
+
+      assertDoesNotThrow(
+         () -> service.set("tok", principal(), "StartDateCheckbox", patch, ""));
+   }
+
+   @Test
+   void refusesAnExplicitVariableWriteWhenNeitherTableNorColumnValueResolveToAVariableForCheckbox() {
+      CheckboxPropertyDialogModel model = new CheckboxPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithCheckbox(mock(CheckBoxVSAssembly.class), model, new Worksheet());
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "StartDateCheckbox",
+            Map.of("dataInputPaneModel.variable", true), ""));
+
+      assertTrue(thrown.getMessage().contains("dataInputPaneModel.variable"),
+                 "must name the refused field: " + thrown.getMessage());
+   }
+
+   @Test
+   void refusesAnExplicitVariableFalseWriteWhenTheBindingStillResolvesToAVariableForCheckbox() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      CheckboxPropertyDialogModel model = new CheckboxPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithCheckbox(mock(CheckBoxVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", false);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "StartDateCheckbox", patch, ""));
+
+      assertTrue(thrown.getMessage().contains("dataInputPaneModel.variable"),
+                 "must name the refused field: " + thrown.getMessage());
+   }
+
+   @Test
+   void allowsAnExplicitVariableFalseWriteWhenTheBindingAlreadyDoesNotResolveToAVariableForCheckbox()
+      throws Exception
+   {
+      CheckboxPropertyDialogModel model = new CheckboxPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithCheckbox(mock(CheckBoxVSAssembly.class), model, new Worksheet());
+
+      assertDoesNotThrow(() -> service.set("tok", principal(), "StartDateCheckbox",
+         Map.of("dataInputPaneModel.variable", false), ""));
+   }
+
+   @Test
+   void allowsTheExactReportedReproNowThatColumnValueAloneResolvesToAKnownVariableForRadioButton()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      RadioButtonPropertyDialogModel model = new RadioButtonPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithRadioButton(mock(RadioButtonVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", true);
+
+      assertDoesNotThrow(
+         () -> service.set("tok", principal(), "StartDateRadio", patch, ""));
+   }
+
+   @Test
+   void refusesAnExplicitVariableWriteWhenNeitherTableNorColumnValueResolveToAVariableForRadioButton() {
+      RadioButtonPropertyDialogModel model = new RadioButtonPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithRadioButton(mock(RadioButtonVSAssembly.class), model, new Worksheet());
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "StartDateRadio",
+            Map.of("dataInputPaneModel.variable", true), ""));
+
+      assertTrue(thrown.getMessage().contains("dataInputPaneModel.variable"),
+                 "must name the refused field: " + thrown.getMessage());
+   }
+
+   @Test
+   void refusesAnExplicitVariableFalseWriteWhenTheBindingStillResolvesToAVariableForRadioButton() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new DefaultVariableAssembly(ws, "StartDate"));
+      RadioButtonPropertyDialogModel model = new RadioButtonPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithRadioButton(mock(RadioButtonVSAssembly.class), model, ws);
+
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("dataInputPaneModel.columnValue", "$(StartDate)");
+      patch.put("dataInputPaneModel.variable", false);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "StartDateRadio", patch, ""));
+
+      assertTrue(thrown.getMessage().contains("dataInputPaneModel.variable"),
+                 "must name the refused field: " + thrown.getMessage());
+   }
+
+   @Test
+   void allowsAnExplicitVariableFalseWriteWhenTheBindingAlreadyDoesNotResolveToAVariableForRadioButton()
+      throws Exception
+   {
+      RadioButtonPropertyDialogModel model = new RadioButtonPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithRadioButton(mock(RadioButtonVSAssembly.class), model, new Worksheet());
+
+      assertDoesNotThrow(() -> service.set("tok", principal(), "StartDateRadio",
+         Map.of("dataInputPaneModel.variable", false), ""));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {
@@ -446,8 +583,20 @@ class AssemblyPropertyServiceTest {
       return serviceWith(assembly, model, model, baseWorksheet);
    }
 
+   private static AssemblyPropertyService serviceWithCheckbox(
+      VSAssembly assembly, CheckboxPropertyDialogModel model, Worksheet baseWorksheet)
+   {
+      return serviceWith(assembly, model, model, baseWorksheet);
+   }
+
+   private static AssemblyPropertyService serviceWithRadioButton(
+      VSAssembly assembly, RadioButtonPropertyDialogModel model, Worksheet baseWorksheet)
+   {
+      return serviceWith(assembly, model, model, baseWorksheet);
+   }
+
    private static AssemblyPropertyService serviceWith(
-      VSAssembly assembly, Object model, TextInputPropertyDialogModel textInputModel,
+      VSAssembly assembly, Object model, Object inputModel,
       Worksheet baseWorksheet)
    {
       Viewsheet vs = mock(Viewsheet.class);
@@ -487,15 +636,25 @@ class AssemblyPropertyServiceTest {
       inetsoft.web.viewsheet.service.VSInputService inputService =
          mock(inetsoft.web.viewsheet.service.VSInputService.class);
 
-      if(textInputModel != null) {
-         try {
+      try {
+         if(inputModel instanceof TextInputPropertyDialogModel textInputModel) {
             when(inputService.getTextInputPropertyDialogModel(anyString(), anyString(),
                                                                any(Principal.class)))
                .thenReturn(textInputModel);
          }
-         catch(Exception e) {
-            throw new IllegalStateException(e);
+         else if(inputModel instanceof CheckboxPropertyDialogModel checkboxModel) {
+            when(inputService.getCheckBoxPropertyModel(anyString(), anyString(),
+                                                        any(Principal.class)))
+               .thenReturn(checkboxModel);
          }
+         else if(inputModel instanceof RadioButtonPropertyDialogModel radioButtonModel) {
+            when(inputService.getRadioButtonPropertyModel(anyString(), anyString(),
+                                                           any(Principal.class)))
+               .thenReturn(radioButtonModel);
+         }
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
       }
 
       return new AssemblyPropertyService(


### PR DESCRIPTION
## Root cause

`setCheckboxPropertyModel`/`setRadioButtonPropertyModel` in `VSInputService` never
validated `dataInputPaneModel.table`, and persisted `dataInputPaneModel.isVariable()`
verbatim, regardless of whether `table` actually resolved to a real worksheet
variable. This is the same class of defect bug #76478/#76530 fixed for
`textinput`/`combobox`/`slider`/`spinner`, but checkbox/radiobutton were left out
at the time (see `PropertyAliases.VARIABLE_FLAG_DERIVED_TYPES`'s prior comment).
RadioButton had zero gating at all (no table required); CheckBox at least required
a non-blank table string before honoring `variable:true`.

## Fix

Two layers, mirroring the four already-fixed types exactly:

1. **`VSInputService.java`** (`setCheckboxPropertyModel`, `setRadioButtonPropertyModel`):
   route `table` through the existing `resolveInputTableBinding()` before storing it
   (rejects a garbage/unresolvable table instead of persisting it raw), and derive the
   persisted `variable` flag from the resolved binding via `resolvesToVariableBinding()`
   instead of reading the client's raw boolean. This is the change that protects the
   **interactive Composer dialog-save path**
   (`CheckboxPropertyDialogController`/`RadioButtonPropertyDialogController`), which
   calls these setters directly and never goes through `AssemblyPropertyService`.
2. **`PropertyAliases.java`**: added `checkbox`/`radiobutton` to
   `VARIABLE_FLAG_DERIVED_TYPES`, so `AssemblyPropertyService.requireVariableFlagAchievable`
   now also gives the AI/wiz caller a loud, named refusal for these two types, matching
   the other four.

Left alone (pre-existing, unrelated to this bug's symptom): CheckBox's setter still
does not persist `columnValue`/`rowValue` at all.

## Tests

- New `CheckBoxRadioButtonTableBindingSetterTest` calls the real setters directly
  (not through `AssemblyPropertyService`) to lock in the derive-not-trust behavior at
  the layer that protects the interactive UI path: an unresolvable table now throws,
  a real-but-non-variable table now derives `variable:false` regardless of a stale
  client `true`, and a genuine `"$(var)"` binding still persists `true`.
- `AssemblyPropertyServiceTest`: 8 new cases (4 each for checkbox/radiobutton)
  mirroring the existing TextInput achievability-check coverage.

```
./mvnw -q -pl core test -Dtest=inetsoft.web.viewsheet.service.CheckBoxRadioButtonTableBindingSetterTest   # 6/6
./mvnw -q -pl core test -Dtest=inetsoft.web.wiz.viewsheet.AssemblyPropertyServiceTest                     # 30/30
./mvnw -q -pl core test -Dtest=inetsoft.web.wiz.viewsheet.PropertyAliasesTest                             # 44/44
./mvnw -q -pl core test -Dtest=inetsoft.web.viewsheet.service.VSInputTableBindingResolutionTest           # 13/13
```
Also ran the full `inetsoft.web.wiz.viewsheet` (28 classes, 729 tests) and
`inetsoft.web.viewsheet.service` (7 classes, 69 tests) packages — all green, no
regressions in the four already-fixed input types.

Closes #76551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)