### PR TITLE
Fix bug 76556 (VFO-018): set_conditions silently over-filters expression-typed valueSpecs

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1779,7 +1779,7 @@ public final class WorksheetMutationSupport {
                cl.append(new ConditionItem(ref, resolved, node.level()));
             }
             else {
-               Condition c = new Condition(dtype);
+               AssetCondition c = new AssetCondition(dtype);
                c.setOperation(op);
 
                if(isEqualInclusive(spec.operation())) {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -5547,6 +5547,39 @@ class WorksheetEditServiceMutatorsTest {
       ExpressionValue expr = (ExpressionValue) c.getValue(0);
       assertEquals("field['b']*2", expr.getExpression());
       assertEquals(ExpressionValue.JAVASCRIPT, expr.getType());
+
+      // Bug #76556 (VFO-018): the condition must be built as an AssetCondition, not the plain
+      // Condition superclass -- ExpressionValue pre-execution (AssetConditionGroup ->
+      // execExpressionValues) is gated on instanceof AssetCondition, so a plain Condition
+      // silently never evaluates the expression and rejects every row.
+      assertTrue(c instanceof AssetCondition,
+         "a condition holding an ExpressionValue must be an AssetCondition so its expression " +
+         "gets pre-execution-evaluated, got: " + c.getClass());
+   }
+
+   @Test
+   void setConditionsSqlExpressionValueSpecBuildsAssetCondition() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a", "b");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setConditions("T", List.of(
+         new WorksheetMutationSupport.ConditionNode(
+            new WorksheetMutationSupport.ConditionSpec("a", ">", null, false, null,
+               List.of(new WorksheetMutationSupport.ConditionValueSpec(
+                  "expression", null, "b * 2", "sql"))),
+            null, 0))));
+
+      Condition c = firstCondition(t);
+      assertTrue(c.getValue(0) instanceof ExpressionValue,
+         "an 'expression' valueSpec must build an ExpressionValue, got: " + c.getValue(0));
+      ExpressionValue expr = (ExpressionValue) c.getValue(0);
+      assertEquals(ExpressionValue.SQL, expr.getType());
+      assertTrue(c instanceof AssetCondition,
+         "an SQL-typed expression valueSpec must also build an AssetCondition, got: " +
+         c.getClass());
    }
 
    @Test


### PR DESCRIPTION
## Summary

`WorksheetMutationSupport.setConditions` (`core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java:1782`) built a plain `inetsoft.uql.Condition` for every non-`DATE_IN` condition, instead of `inetsoft.uql.asset.AssetCondition` like the native Composer condition dialog's equivalent conversion (`ConditionUtil.java:312`).

`ExpressionValue`-typed condition values (built for `valueSpecs:[{valueType:"expression", ...}]`) only get pre-execution-evaluated — the JS/SQL body run and the value replaced with a real scalar — when the enclosing condition is an `AssetCondition` (`AssetConditionGroup` gates `execExpressionValues` on `instanceof AssetCondition`). With a plain `Condition`, the raw `ExpressionValue` object sits unevaluated in the value list. `Condition.evaluate`'s comparator (`DefaultComparer`/`CoreTool.compare`) class-ranks `Double` against `ExpressionValue` and returns a constant mismatch regardless of row value, so every row is rejected — silently, no exception — whenever the table's conditions are evaluated via StyleBI's in-memory (non-SQL-merged) filtering path (`AssetQuery.getConditionTableLens` → `AssetConditionGroup`).

Reported behavior: `set_conditions` with an expression-typed `valueSpec` (e.g. `REVENUE > 100+50`) returns `{"ok":true}` and echoes back correctly, but `preview_worksheet_data` then returns `[]` even though matching rows exist. A `valueType:"field"` workaround (comparing to another column instead) works reliably, because `DataRef` values need no pre-execution step in either the SQL-merge or in-memory path.

## Fix

Construct `AssetCondition` instead of `Condition` at the one call site. This is safe because:
- `AssetCondition` is already the norm for ordinary conditions built by the native dialog (the plain-`Condition` construction here was the outlier, not the reverse).
- `AssetCondition(String)` shares the same constructor signature, and all methods called afterward (`setOperation`, `setEqual`, `setNegated`, `addValue`) are inherited unchanged.
- Condition XML serialization is per-instance class-name-based, so `Condition` and `AssetCondition` already coexist in saved worksheets today — no new shape to handle.
- Verified this doesn't change SQL-merge-path mergeability for these conditions: `PreAssetQuery.isConditionItemMergeable` only applies extra `AssetCondition`-specific checks when a sub-query value is present, which `setConditions` never sets (`sub == null` → `return true`, same as the plain-`Condition` early-return path).

Covers `set_post_conditions` (HAVING) too, since both share this function via the `post` flag.

## Test plan

- [x] Added `setConditionsSqlExpressionValueSpecBuildsAssetCondition` and extended `setConditionsExpressionValueSpecBuildsExpressionValue` in `WorksheetEditServiceMutatorsTest` to assert the built condition is an `AssetCondition` — confirmed both fail against the pre-fix code (`class inetsoft.uql.Condition`) and pass after the fix.
- [x] `./mvnw -pl core -Dtest=WorksheetEditServiceMutatorsTest test` — 246/246 pass.
- [x] `./mvnw -pl core -Dtest=WorksheetAgentControllerTest,WorksheetScriptServiceTest,WorksheetPreviewServiceTest,WorksheetReadServiceTest test` — all pass, no collateral breakage in related worksheet-mutation/preview test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)