### PR TITLE
Fix #76556 (VFO-016): refuse dead basicGeneralPaneModel.enabled write

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -149,6 +149,21 @@ public final class PropertyAliases {
     */
    private static final Set<String> LOCKED_LIVE_TYPES = Set.of("image", "line", "oval", "rectangle");
 
+   /**
+    * {@code basicGeneralPaneModel.enabled} is aliased through the shared {@link #basicGeneral}
+    * helper's own comment as dead everywhere -- "the Editable flag wearing the wrong name" -- but
+    * only the six input assemblies routed through {@code VSInputService} are confirmed here: their
+    * read methods (checkbox/textinput/slider/radiobutton/combobox/spinner, one apply method each)
+    * populate {@code basicGeneralPaneModel}'s name/primary/visible/refresh (and combobox's
+    * editable) from the real assembly, but never {@code enabled}; their write methods read
+    * {@code isPrimary()}/{@code getVisible()}/{@code isRefresh()} (and combobox's
+    * {@code isEditable()}) back, but never {@code isEnabled()}. A raw dotted-path write there
+    * reports success and changes nothing -- the live switch is the {@code enabled} alias, one
+    * level up at {@code generalPropPaneModel.enabled}.
+    */
+   private static final Set<String> BASIC_GENERAL_ENABLED_DEAD_TYPES =
+      Set.of("checkbox", "textinput", "slider", "radiobutton", "combobox", "spinner");
+
    private static final Map<String, TypeAliases> REGISTRY = registry();
 
    private PropertyAliases() {
@@ -267,6 +282,16 @@ public final class PropertyAliases {
             "populated on every read, but this type's apply method never reads it back -- a " +
             "write would report success and change nothing. Use edit(op:\"set_lock\") to " +
             "lock/unlock this assembly instead.";
+      }
+
+      if("enabled".equals(leaf) && pathOrKey.contains("basicGeneralPaneModel") &&
+         BASIC_GENERAL_ENABLED_DEAD_TYPES.contains(normalizedType))
+      {
+         return "'basicGeneralPaneModel.enabled' is read-only on " + normalizedType + ". It has " +
+            "a getter/setter pair on the dialog model, populated on every read, but this type's " +
+            "apply method never reads it back -- a write would report success and change " +
+            "nothing. Use the 'enabled' alias instead, which resolves to the live " +
+            "generalPropPaneModel.enabled.";
       }
 
       return null;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -672,4 +672,42 @@ class PropertyAliasesTest {
                             "'locked' must stay writable for " + type);
       }
    }
+
+   /**
+    * Bug #76556 (VFO-016): {@code basicGeneralPaneModel.enabled} has a getter/setter pair on the
+    * six input assemblies' dialog models -- populated on every read, one level below the live
+    * {@code enabled} alias -- but {@code VSInputService}'s apply methods for all six never read
+    * it back. Before this fix, a raw dotted-path write there returned {@code ok:true} and always
+    * read back {@code false}. The {@code enabled} alias itself must keep resolving to, and stay
+    * writable at, the live {@code generalPropPaneModel.enabled} one level up.
+    */
+   @Test
+   void refusesBasicGeneralEnabledOnTheSixInputTypesWhereItIsDead() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("spinner",
+                      "spinnerGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel." +
+                      "enabled"));
+
+      java.util.Map<String, String> prefixes = java.util.Map.of(
+         "checkbox", "checkboxGeneralPaneModel",
+         "textinput", "textInputGeneralPaneModel",
+         "slider", "sliderGeneralPaneModel",
+         "radiobutton", "radioButtonGeneralPaneModel",
+         "combobox", "comboboxGeneralPaneModel",
+         "spinner", "spinnerGeneralPaneModel");
+
+      for(var entry : prefixes.entrySet()) {
+         String path = entry.getValue() +
+            ".generalPropPaneModel.basicGeneralPaneModel.enabled";
+         assertThrows(IllegalArgumentException.class,
+                      () -> PropertyAliases.resolveForWrite(entry.getKey(), path),
+                      "basicGeneralPaneModel.enabled has no effect on write for " +
+                      entry.getKey());
+
+         assertEquals(entry.getValue() + ".generalPropPaneModel.enabled",
+                      PropertyAliases.resolveForWrite(entry.getKey(), "enabled"),
+                      "the 'enabled' alias must still resolve to, and stay writable at, the " +
+                      "live field for " + entry.getKey());
+      }
+   }
 }


### PR DESCRIPTION
## Summary

- `spinnerGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.enabled` (and the equivalent
  path for checkbox/textinput/slider/radiobutton/combobox) is populated on every dialog-model read
  but never read back by `VSInputService`'s apply methods for any of these six input types — a raw
  dotted-path write there via `set_assembly_properties` returned `ok:true` and silently changed
  nothing.
- Extends `PropertyAliases`' existing `DEAD_FIELDS`/`deadFieldWriteRefusal` mechanism (already used
  for `shadow`/`editable`/`container`/`refresh`/`locked` on other types) to refuse this write on the
  six confirmed-dead types, with a message pointing the caller at the live `enabled` alias
  (`generalPropPaneModel.enabled`).
- No change needed in `plugin/composer` — `set_assembly_properties` is a thin pass-through that
  already surfaces whatever `resolveForWrite` throws as a tool error.

Verified independently (not just from the diagnosis/refutation): re-grepped
`VSInputService.java`'s read/write methods for all six types (checkbox, textinput, slider,
radiobutton, combobox, spinner) and confirmed none of them ever call
`basicGeneralPaneModel.setEnabled(...)`/`.isEnabled()` — each only touches
`name`/`primary`/`visible`/`refresh`/`objectNames` (combobox additionally `editable`).

## Test plan

- [x] Added `refusesBasicGeneralEnabledOnTheSixInputTypesWhereItIsDead` to
      `PropertyAliasesTest.java`, asserting the raw path throws `IllegalArgumentException` for all
      six types, and that the `enabled` alias itself still resolves to and stays writable at
      `generalPropPaneModel.enabled`.
- [x] `./mvnw -pl core test -Dtest=PropertyAliasesTest -o` — 45/45 pass (44 pre-existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)