### PR TITLE
feat(wiz): add a queryParams add_table form to WorksheetAgentController

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -50,7 +50,7 @@ import java.util.Map;
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields. For three or more tables joined in a single call, supply {@code joinPaths} instead (each a {leftTable, leftKey, rightTable, rightKey, joinType} edge) — {@code leftTable}/{@code leftKey}/{@code rightTable}/{@code rightKey}/{@code joinType}/{@code leftKeys}/{@code rightKeys} are ignored when {@code joinPaths} is present</li>
  *   <li>{@code remove_join} — {@code name}</li>
- *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code parameters}/{@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code parameters}/{@code lookup}</li>
+ *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code parameters}/{@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code parameters}/{@code lookup}; or optional {@code queryParams} (a flat connector-property map) for a METADATA/FILE/Rest.XML datasource with no predefined endpoint catalogue and no simple URL-suffix shape — mutually exclusive with all of the above</li>
  *   <li>{@code edit_condition} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code edit_expression} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code edit_join} — {@code name}, {@code leftKey}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys}</li>
@@ -409,8 +409,61 @@ public record EditRequest(
     * established in a single call instead of the second overwriting the first. {@code null} or
     * absent is equivalent to an empty list (clears all ranking).
     */
-   List<WorksheetMutationSupport.RankingSpec> rankings
+   List<WorksheetMutationSupport.RankingSpec> rankings,
+   /**
+    * Connector-specific property values for add_table, keyed by the connector's OWN property
+    * names (not a Composer-invented shape) — e.g. an OData entity set name, a Cassandra table
+    * name, a file's {@code fileFolder}/{@code excelSheet}, or a Rest.XML endpoint's
+    * {@code suffix}/{@code xpath}/{@code schema}. Fill it against
+    * {@code GET .../tabular/query-schema}'s response for the datasource. Mutually exclusive
+    * with {@code endpoint}/{@code suffix}/{@code parameters}/{@code lookup}/
+    * {@code customLookups} — this is the fourth, independent add_table form, for a datasource
+    * whose target space is not enumerable through {@code list_endpoint_lookups} (METADATA,
+    * FILE, Rest.XML, and plain Rest when it needs more than a bare suffix). There is no
+    * separate "target id" field: the remote target's own identity (an entity set name, a table
+    * name, a file path) is itself one entry in this map, exactly like wiz-services' own
+    * {@code tabularSource.queryParams} shape — not a second addressing scheme.
+    */
+   Map<String, Object> queryParams
 ) {
+   /**
+    * Compatibility constructor for callers built before {@code queryParams} was added, but after
+    * {@code rankings} — defaults {@code queryParams} to {@code null}.
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups, Boolean crosstab,
+      List<String> labels, WorksheetMutationSupport.VariableChoicesSpec choices,
+      List<WorksheetMutationSupport.JoinPathSpec> joinPaths, Boolean mergeable,
+      Boolean visibleInViewsheet, Boolean confirmed, Integer rowCount, Boolean concatDistinct,
+      List<WorksheetMutationSupport.RankingSpec> rankings)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, choices, joinPaths,
+           mergeable, visibleInViewsheet, confirmed, rowCount, concatDistinct, rankings, null);
+   }
+
    /**
     * Compatibility constructor for callers built before {@code rankings} was added, but after
     * {@code confirmed}/{@code rowCount}/{@code concatDistinct} — defaults {@code rankings} to

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -51,6 +51,8 @@ import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.tabular.PropertyMeta;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.uql.tabular.TabularQuerySchema;
+import inetsoft.uql.tabular.TabularSchemaExtractor;
 import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.uql.text.TextOutput;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -79,6 +81,7 @@ import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.service.RenderWaitSupport;
 import inetsoft.web.wiz.service.TabularEndpointBindingSupport;
+import inetsoft.web.wiz.service.TabularQueryContractSupport;
 import inetsoft.web.wiz.script.PaneScopeService;
 import inetsoft.web.wiz.viewsheet.SheetOpenService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
@@ -283,6 +286,40 @@ public class WorksheetAgentController {
       throws Exception
    {
       requireEnabled();
+
+      // add_table with queryParams binds a TabularTableAssembly via the SAME generic,
+      // connector-agnostic path WorksheetTableService.buildTabularTable uses for wiz-services'
+      // /ws/table -- see addQueryParamsTable's own doc comment for why this is a fourth,
+      // independent add_table form rather than a variant of the endpoint/suffix block below.
+      // Checked FIRST, before the endpoint/suffix block, so a request carrying queryParams
+      // together with either of those gets ITS OWN contradiction error rather than being
+      // silently treated as the endpoint/suffix form.
+      if("add_table".equals(req.op()) && req.queryParams() != null && !req.queryParams().isEmpty()) {
+         if((req.endpoint() != null && !req.endpoint().isBlank()) ||
+            (req.suffix() != null && !req.suffix().isBlank()))
+         {
+            throw new PairingException("add_table cannot carry queryParams together with " +
+               "endpoint or suffix -- choose exactly one add_table form.");
+         }
+
+         if(req.datasource() == null || req.datasource().isBlank()) {
+            throw new PairingException("datasource is required when queryParams is specified.");
+         }
+
+         if(req.logicalModel() != null && !req.logicalModel().isBlank()) {
+            throw new PairingException(
+               "add_table cannot carry both queryParams and logicalModel -- choose one.");
+         }
+
+         if(req.schema() != null || req.catalog() != null) {
+            throw new PairingException("add_table cannot carry schema/catalog together with " +
+               "queryParams -- those name a physical table; queryParams targets a connector " +
+               "property map instead.");
+         }
+
+         addQueryParamsTable(sessionToken, req, user);
+         return;
+      }
 
       // add_table with endpoint (named connector) or suffix (generic/custom REST-JSON) binds a
       // TabularTableAssembly instead of a physical table or logical-model entity. Checked before
@@ -744,6 +781,87 @@ public class WorksheetAgentController {
             throw new PairingException("The request to '" + target + "' of '" + dsName +
                "' returned no columns. URL suffix sent: " + suffix + ". Check the parameter " +
                "values and datasource credentials -- see the server log for the cause.");
+         }
+
+         return null;
+      });
+   }
+
+   /**
+    * Create a {@link TabularTableAssembly} bound to an arbitrary connector's OWN properties,
+    * filled via {@link TabularQueryContractSupport#applyQueryContract} -- the SAME
+    * connector-agnostic reflection path {@link WorksheetTableService#buildTabularTable}
+    * (wiz-services' {@code /api/wiz/ws/table} write path) already uses. Unlike
+    * {@link #addTabularTable}, which only knows the two REST-JSON shapes
+    * ({@code endpoint}/{@code suffix}), this method makes no assumption about which connector
+    * it is talking to -- it is the Composer-side entry point for METADATA (OData, Cassandra,
+    * ...), FILE (OneDrive, ServerFile), and Rest.XML, none of which have an
+    * {@code endpoint}/{@code suffix} property on their query class.
+    */
+   private void addQueryParamsTable(String sessionToken, EditRequest req, Principal user)
+      throws Exception
+   {
+      String dsName = req.datasource();
+
+      if(!dataSourceService.checkPermission(dsName, ResourceAction.READ, user)) {
+         throw new PairingException("Access denied: no READ permission on datasource " + dsName);
+      }
+
+      XDataSource dataSource = xrepository.getDataSource(dsName);
+
+      if(dataSource == null) {
+         throw new PairingException("Data source not found: " + dsName);
+      }
+
+      if(!(dataSource instanceof TabularDataSource)) {
+         throw new PairingException("'" + dsName + "' is a " + dataSource.getType() +
+            " data source, not a tabular one, so it has no connector properties. Use " +
+            "datasource+schema+table for a physical table, or datasource+logicalModel for a " +
+            "logical model entity.");
+      }
+
+      TabularQuery query = TabularUtil.createQuery(dsName);
+
+      if(query == null) {
+         throw new PairingException("Could not create a query for data source '" + dsName +
+            "' -- its connector plugin may not be loaded.");
+      }
+
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularQuerySchema schema = new TabularSchemaExtractor().extract(query, dataSource.getType());
+      String applied = TabularQueryContractSupport.applyQueryContract(
+         query, pmap, schema, req.queryParams(), dsName);
+
+      String tableName = req.table();
+
+      if(tableName == null || tableName.isBlank()) {
+         throw new PairingException(
+            "table (the desired worksheet table name) is required for add_table with queryParams.");
+      }
+
+      editService.applyOnRuntime(sessionToken, user, rws -> {
+         Worksheet ws = rws.getWorksheet();
+         String normalizedTableName = AssetUtil.normalizeTable(tableName);
+         String assemblyName = AssetUtil.getNextName(ws, normalizedTableName, normalizedTableName);
+         TabularTableAssembly assembly = new TabularTableAssembly(ws, assemblyName);
+         TabularTableAssemblyInfo info = (TabularTableAssemblyInfo) assembly.getTableInfo();
+         info.setQuery(query);
+         info.setSourceInfo(new SourceInfo(SourceInfo.DATASOURCE, dsName, dsName));
+
+         positionBelowExisting(ws, assembly);
+         ws.addAssembly(assembly);
+
+         // The live call -- same one WorksheetTableService.buildTabularTable and
+         // addTabularTable above both make; a tabular query has no columns until one response
+         // has been parsed.
+         assembly.loadColumnSelection(new VariableTable(), true, null);
+
+         ColumnSelection columns = assembly.getColumnSelection(false);
+
+         if(columns == null || columns.getAttributeCount() == 0) {
+            throw new PairingException("The request to '" + dsName + "' returned no columns. " +
+               "Properties sent: " + applied + ". Check the parameter values and datasource " +
+               "credentials -- see the server log for the cause.");
          }
 
          return null;

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
@@ -95,7 +95,14 @@ class WizTabularControllerSecurityTest {
                 "/api/wiz/tabular/probe/open",
                 "/api/wiz/tabular/probe/table",
                 "/api/wiz/tabular/probe/close",
-                "/api/wiz/tabular/query-schema"),
+                "/api/wiz/tabular/query-schema",
+                // Added by the bearer-token OAuth endpoints round (stylebi#5096) -- this frozen
+                // list was not updated at the time, which is a pre-existing gap unrelated to
+                // this PR's own change, caught here only because it makes CI red for any PR
+                // branched after that round landed.
+                "/api/wiz/tabular/oauth-params",
+                "/api/wiz/tabular/oauth-tokens",
+                "/api/wiz/tabular/oauth-grant-password"),
          new HashSet<>(mappedPaths()));
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
@@ -76,6 +76,30 @@ class EditRequestParametersDeserializationTest {
    }
 
    /**
+    * queryParams is appended as the LAST field of the canonical record (after {@code rankings}),
+    * matching this file's own established every-new-field-goes-at-the-end convention, so this
+    * confirms it round-trips through the real app ObjectMapper the same way {@code parameters}
+    * does above -- a real caller's add_table request supplying it must not 400 at deserialization.
+    */
+   @Test
+   void deserializesAddTableWithQueryParams() throws Exception {
+      EditRequest req = mapper.readValue("""
+         {
+           "op": "add_table",
+           "table": "Orders",
+           "datasource": "OData/Northwind",
+           "queryParams": {"entitySet": "Orders", "top": 100, "includeAnnotations": true}
+         }
+         """, EditRequest.class);
+
+      assertNotNull(req.queryParams());
+      assertEquals(3, req.queryParams().size());
+      assertEquals("Orders", req.queryParams().get("entitySet"));
+      assertEquals(100, req.queryParams().get("top"));
+      assertEquals(true, req.queryParams().get("includeAnnotations"));
+   }
+
+   /**
     * WBS-029 (bug 76502): {@code variableValues} is now {@code Map<String, Object>} so a JSON
     * array can bind to a genuine multi-value assignment. Confirms the real app
     * {@code ObjectMapper}'s default binding for an untyped {@code Object} map value -- a plain

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.worksheet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.web.WebConfig;
 import inetsoft.report.composition.RuntimeSheet;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.RuntimeWorksheet;
@@ -345,6 +347,34 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, endpoint, parameters, lookup, lookupExpandArrays,
          lookupTopLevelOnly, suffix, customLookups
       );
+   }
+
+   /**
+    * Builds an {@code add_table} EditRequest carrying {@code queryParams} -- the fourth,
+    * connector-agnostic form routed to {@code addQueryParamsTable()}. Built through the real app
+    * {@link ObjectMapper} rather than the canonical record constructor: {@code queryParams} is
+    * appended as the LAST field of a 70+ parameter positional record, and hand-counting nulls out
+    * to that position is exactly the kind of silent off-by-one this sidesteps entirely -- see
+    * {@link EditRequestParametersDeserializationTest} for the same technique used to prove the
+    * field deserializes at all.
+    */
+   private static EditRequest addQueryParamsTableRequest(
+      String table, String datasource, String logicalModel, String schema, String catalog,
+      String endpoint, String suffix, Map<String, Object> queryParams) throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(logicalModel != null) body.put("logicalModel", logicalModel);
+      if(schema != null) body.put("schema", schema);
+      if(catalog != null) body.put("catalog", catalog);
+      if(endpoint != null) body.put("endpoint", endpoint);
+      if(suffix != null) body.put("suffix", suffix);
+      if(queryParams != null) body.put("queryParams", queryParams);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
    }
 
    /**
@@ -3763,6 +3793,205 @@ class WorksheetAgentControllerTest {
          // if 'id' had not been threaded through, a PairingException would have fired first and
          // this mock would never have been touched.
          verify(editSvc).applyOnRuntime(eq("TOK-TT8"), eq(agent), any());
+      }
+   }
+
+   // ---------------------------------------------------------------------------
+   // add_table with queryParams — naming for addQueryParamsTable()
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void addQueryParamsTableRejectsQueryParamsTogetherWithEndpoint() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", null, null, null,
+         "Charges", null, Map.of("entitySet", "Orders"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP1", req, agent));
+      assertTrue(ex.getMessage().contains("queryParams together with endpoint or suffix"),
+         ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsQueryParamsTogetherWithSuffix() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", null, null, null,
+         null, "/v1/widgets", Map.of("entitySet", "Orders"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP2", req, agent));
+      assertTrue(ex.getMessage().contains("queryParams together with endpoint or suffix"),
+         ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRequiresDatasource() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequest("t1", null, null, null, null,
+         null, null, Map.of("entitySet", "Orders"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP3", req, agent));
+      assertTrue(ex.getMessage().contains("datasource is required"), ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsLogicalModelTogether() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", "Order Model", null,
+         null, null, null, Map.of("entitySet", "Orders"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP4", req, agent));
+      assertTrue(ex.getMessage().contains("queryParams and logicalModel"), ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsSchemaCatalogTogether() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", null, "dbo", null,
+         null, null, Map.of("entitySet", "Orders"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP5", req, agent));
+      assertTrue(ex.getMessage().contains("schema/catalog"), ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsNonTabularDatasource() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      JDBCDataSource jdbcDs = mock(JDBCDataSource.class);
+      when(jdbcDs.getType()).thenReturn("JDBC");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(jdbcDs);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", null, null, null,
+         null, null, Map.of("entitySet", "Orders"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP6", req, agent));
+      assertTrue(ex.getMessage().contains("not a tabular"), ex.getMessage());
+      verifyNoInteractions(editSvc);
+   }
+
+   /**
+    * Proves {@code req.queryParams()} actually reaches
+    * {@code TabularQueryContractSupport.applyQueryContract} through {@code addQueryParamsTable}
+    * -- the same connector-agnostic reflection path
+    * {@code WorksheetTableService.buildTabularTable} (wiz-services' write path) uses. Fills
+    * {@code FakeNamedConnectorQuery}'s plain, non-composite {@code jsonPath} property (no
+    * {@code dependsOn}, no {@code tagsMethod}) rather than {@code endpoint}, since queryParams'
+    * whole point is addressing a connector that has no {@code endpoint}/{@code suffix} property
+    * at all -- reaching {@code editService.applyOnRuntime} is what proves the fill succeeded.
+    *
+    * <p>{@code TabularSchemaExtractor.extract} resolves connector labels through a Spring-bean
+    * {@code Config.getConfig()}, which this class's real (but minimal) {@code @WizAgentTestSupport}
+    * context does not register -- unlike {@code TabularQueryContractSupportTest}, which owns its
+    * whole context and can install a mock one for the class's entire lifetime, this test wraps
+    * the REAL installed {@link ApplicationContext} with a delegating spy for its own duration
+    * only, restoring the original context in every case (including failure) so the ~160 other
+    * tests in this class keep the real Spring context they depend on.</p>
+    */
+   @Test
+   void addQueryParamsTableThreadsQueryParamsIntoTheSharedHelper() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeNamedConnector");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", null, null, null,
+         null, null, Map.of("jsonPath", "$.data"));
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-QP7", req, agent),
+            "a plain, non-composite property with no dependsOn/tagsMethod must fill cleanly");
+         assertEquals("$.data", query.getJsonPath());
+         // editService.applyOnRuntime is only reached AFTER applyQueryContract succeeds -- if
+         // jsonPath had not been threaded through at all, this mock would never be touched.
+         verify(editSvc).applyOnRuntime(eq("TOK-QP7"), eq(agent), any());
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
       }
    }
 


### PR DESCRIPTION
## Summary
- Adds a fourth, mutually-exclusive `add_table` form to `WorksheetAgentController`:
  `queryParams`, a flat connector-property map keyed by the connector's own property names
  (not a Composer-invented shape). Routes through the exact same
  `TabularQueryContractSupport.applyQueryContract` path `WorksheetTableService.buildTabularTable`
  (wiz-services' `/api/wiz/ws/table` write path) already uses -- no new connector logic, just a
  new caller of an existing, shared, connector-agnostic mechanism.
- Unlocks Composer-side table building for METADATA (OData, Cassandra, Hive, Salesforce, GA4,
  Google Sheets, Facebook Ad Insights, Elasticsearch, MongoDB, SharePoint Online, Aerospike,
  OrientDB), FILE (OneDrive, ServerFile), and Rest.XML -- none of which have an
  `endpoint`/`suffix` property on their query class, so the existing `addTabularTable` REST-JSON
  forms could never reach them.
- `queryParams` is appended as the LAST field of `EditRequest`'s canonical record (after
  `rankings`), with a new compatibility constructor covering every field up to `rankings` --
  matching this file's own established convention of adding every new field at the end rather
  than mid-list. (An earlier attempt inserted it between `customLookups` and `crosstab`; caught
  before merge because that shift silently breaks every existing compatibility constructor's
  delegating call, several of which pass `Boolean`/`List` values into what would then be the
  `Map<String, Object> queryParams` slot -- a real compile error, not a silent corruption, but a
  needless one avoided by following the established append-only pattern instead.)

## Design
Full design + implementation plan: `stylebi-wiz` repo,
`docs/superpowers/specs/2026-09-09-composer-plugin-tabular-datasource-support-design.md` and
`docs/superpowers/plans/2026-09-09-composer-plugin-tabular-datasource-support.md`.

Paired with `stylebi-wiz`'s companion PR, which carries the Composer plugin's TS-side
`add_table` extension plus two new discovery tools (`list_tabular_targets`,
`get_tabular_query_contract`) and a skill reference doc. That PR's unit tests mock the HTTP
layer, so it does not need this PR merged first to be tested -- but the two together are what
close the capability gap end to end.

## Testing
- `./mvnw -pl core test -Dtest=WorksheetAgentControllerTest,EditRequestParametersDeserializationTest` -- all green (7 new WorksheetAgentControllerTest cases, 1 new deserialization test)
- `./mvnw -pl core,connectors/inetsoft-rest test -Dtest=TabularSchemaExtractorTest,TabularQueryContractSupportTest,EditRequestParametersDeserializationTest,WorksheetAgentControllerTest,TabularQueryContractSupportRestJsonQueryReadBackTest` -- all green (broader regression check across every directly related test class in both modules)
- `./mvnw -pl core -am compile` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)