### PR TITLE
Bug #76518, only skip the DC orphaned-cell heuristic when part is truly the faceted dimension

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -21,6 +21,8 @@ import inetsoft.util.*;
 import inetsoft.util.data.CommonKVModel;
 import inetsoft.graph.*;
 import inetsoft.graph.aesthetic.VisualFrame;
+import inetsoft.graph.coord.Coordinate;
+import inetsoft.graph.coord.FacetCoord;
 import inetsoft.graph.data.CalcColumn;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.element.GraphElement;
@@ -642,22 +644,35 @@ public class DateComparisonUtil {
 
          // Compute which part cells have data from the most recent (current) year.
          // Orphaned cells — those with only comparison-year data — should be excluded
-         // from the x-axis scale so they don't produce spurious labels. Skip this in facet
-         // mode: there, "part" identifies the facet itself (e.g. DayOfWeek), and the
-         // heuristic's sort-order-based "hasn't chronologically reached this part yet" test
-         // is meaningless for a facet dimension — a facet with no row in the most recent
-         // period isn't a future bucket, it's a facet whose most recent period happens to be
-         // absent (see Bug #76388: DayOfWeek facets 5-7 have real data for every period
-         // except the last, and excluding them entirely from every period is wrong; the
-         // per-facet sub-chart already correctly shows only the periods that actually have
-         // data for it once this exclusion doesn't run first). Also skip this for
-         // "Compare Data Of: All" (isCompareAll()) -- that mode intentionally shows every
-         // part of each comparison period unclipped, so a part the in-progress current
-         // period hasn't reached yet (e.g. December while the current year is only a few
-         // months in) is not an orphan -- it's real historical data for the prior periods
-         // and must still render. Applying the heuristic there silently dropped whole
-         // weeks/months of valid comparison-year data. (Bug #76389)
-         final Set<Object> validParts = info.isFacet() || dcInfo.isCompareAll() ?
+         // from the x-axis scale so they don't produce spurious labels. Skip this when the
+         // part column is itself one of the dimensions the graph is faceted on: there,
+         // "part" identifies the facet rather than a position on a chronologically
+         // progressing axis, and the heuristic's sort-order-based "hasn't chronologically
+         // reached this part yet" test is meaningless — a facet with no row in the most
+         // recent period isn't a future bucket, it's a facet whose most recent period
+         // happens to be absent (see Bug #76388: DayOfWeek facets 5-7 have real data for
+         // every period except the last, and excluding them entirely from every period is
+         // wrong; the per-facet sub-chart already correctly shows only the periods that
+         // actually have data for it once this exclusion doesn't run first).
+         //
+         // The test is deliberately narrower than info.isFacet(). That flag is a single
+         // chart-wide boolean (GraphGenerator.createCoord() sets it from
+         // "coordinate instanceof FacetCoord"), so it is true whenever *any* axis carries
+         // two or more dimensions — including when an unrelated dimension (e.g. Region)
+         // shares the axis while the part column is still a plain chronological one. In
+         // that case the heuristic is still meaningful and must run, otherwise a genuinely
+         // unreached future part (e.g. December while the current year has only reached
+         // April) renders for the prior comparison periods. (Bug #76518)
+         //
+         // Also skip this for "Compare Data Of: All" (isCompareAll()) -- that mode
+         // intentionally shows every part of each comparison period unclipped, so a part
+         // the in-progress current period hasn't reached yet is not an orphan -- it's real
+         // historical data for the prior periods and must still render. Applying the
+         // heuristic there silently dropped whole weeks/months of valid comparison-year
+         // data. (Bug #76389)
+         final boolean partIsFacetDim =
+            info.isFacet() && isFacetedField(egraph.getCoordinate(), partCol);
+         final Set<Object> validParts = partIsFacetDim || dcInfo.isCompareAll() ?
             Collections.emptySet() :
             computeValidParts(data, periodCol, partCol, startDate);
 
@@ -707,6 +722,53 @@ public class DateComparisonUtil {
             }
          }
       }
+   }
+
+   /**
+    * Check whether a field is one of the dimensions the graph is actually faceted on, i.e. it
+    * supplies a scale of a {@link FacetCoord}'s outer coordinate rather than of the innermost
+    * plot coordinate.
+    *
+    * <p>{@link VSChartInfo#isFacet()} cannot answer this: it is a single chart-wide boolean set
+    * from "coordinate instanceof FacetCoord", true whenever any axis carries two or more
+    * dimensions, regardless of which of them ended up as the facet levels.
+    * GraphGenerator.createCoord() consumes the innermost dimension of each axis as the plot axis
+    * and wraps every remaining outer dimension in a FacetCoord, so the coordinate tree built
+    * there is the authoritative record of what was faceted on. (Bug #76518)</p>
+    */
+   private static boolean isFacetedField(Coordinate coord, String field) {
+      if(field == null || !(coord instanceof FacetCoord)) {
+         return false;
+      }
+
+      FacetCoord facet = (FacetCoord) coord;
+      Coordinate outer = facet.getOuterCoordinate();
+
+      if(outer != null) {
+         for(Scale scale : outer.getScales()) {
+            String[] fields = scale == null ? null : scale.getFields();
+
+            // match on fields[0] exactly as applyDateRange()'s part-scale lookup does, so the
+            // two always agree on which scale is the part column's.
+            if(fields != null && fields.length > 0 && Tool.equals(field, fields[0])) {
+               return true;
+            }
+         }
+      }
+
+      // multi-level facets are nested: createCoord() wraps the previous FacetCoord as the inner
+      // coordinate of the next one, so keep walking inward.
+      Coordinate[] inners = facet.getInnerCoordinates();
+
+      if(inners != null) {
+         for(Coordinate inner : inners) {
+            if(isFacetedField(inner, field)) {
+               return true;
+            }
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilApplyDateRangeTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilApplyDateRangeTest.java
@@ -18,10 +18,13 @@
 package inetsoft.uql.viewsheet.internal;
 
 import inetsoft.graph.EGraph;
+import inetsoft.graph.coord.Coordinate;
+import inetsoft.graph.coord.FacetCoord;
 import inetsoft.graph.coord.RectCoord;
 import inetsoft.graph.data.DataSet;
 import inetsoft.graph.data.DefaultDataSet;
 import inetsoft.graph.element.GraphtDataSelector;
+import inetsoft.graph.internal.GTool;
 import inetsoft.graph.scale.CategoricalScale;
 import inetsoft.graph.scale.LinearScale;
 import inetsoft.graph.scale.Scale;
@@ -33,7 +36,6 @@ import inetsoft.uql.viewsheet.graph.DefaultVSChartInfo;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,17 +72,18 @@ import static inetsoft.test.XTableUtil.date;
  * "isFacet()|isCompareAll()" core/src/test returned no hits against DateComparisonUtil before
  * this file was added) -- both fixes had previously been verified live only.
  *
- * <p>{@link #facetCausedByUnrelatedDimensionStillOrphansUnreachedChronologicalPart()} covers a
- * narrower, still-open question the two bugs above don't: {@code applyDateRange()}'s skip
- * condition only ever consults the single {@link VSChartInfo#isFacet()} flag, which is true
- * whenever the chart ends up with a {@code FacetCoord} for *any* reason (see
- * {@code GraphGenerator.createCoord()} -- any axis carrying 2+ dimensions produces one,
- * regardless of whether the DC part column is among them). It cannot distinguish "part IS the
- * faceted dimension" (Bug #76388's case, where skipping is correct) from "some unrelated
- * dimension is faceted and part is still a plain chronologically-ordered axis" (where skipping
- * means a genuinely-unreached future part -- e.g. December while the current year has only
- * reached April -- renders anyway). This test currently fails against the production code,
- * documenting that gap rather than asserting it is fixed.</p>
+ * <p>Bug #76518 narrowed the first of those two conditions. {@link VSChartInfo#isFacet()} is a
+ * single chart-wide boolean that {@code GraphGenerator.createCoord()} sets from
+ * "coordinate instanceof FacetCoord", so it is true whenever *any* axis carries 2+ dimensions,
+ * regardless of whether the DC part column is one of them. On its own it cannot distinguish
+ * "part IS the faceted dimension" (Bug #76388's case, where skipping is correct) from "some
+ * unrelated dimension is faceted and part is still a plain chronologically-ordered axis" (where
+ * skipping means a genuinely-unreached future part -- e.g. December while the current year has
+ * only reached April -- renders anyway). {@code applyDateRange()} now also checks the actual
+ * coordinate tree, so these tests pin down all three shapes via {@code CoordShape}:
+ * {@code NO_FACET}, {@code PART_IS_FACET} (part scale in the FacetCoord's outer coordinate) and
+ * {@code UNRELATED_FACET} (part scale in the inner coordinate, an unrelated dimension faceted
+ * around it).</p>
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -99,7 +102,7 @@ class DateComparisonUtilApplyDateRangeTest {
       DataSet data = buildRows();
       DateComparisonInfo dcInfo = dcInfo(true);
 
-      Scale partScale = applyAndGetPartScale(dcInfo, data, false);
+      Scale partScale = applyAndGetPartScale(dcInfo, data, CoordShape.NO_FACET);
 
       // 2019/2020's December weeks (51-52) are past what 2021 (the most recent period) has
       // reached (only up to week 17) -- Compare-All must keep them anyway.
@@ -118,7 +121,7 @@ class DateComparisonUtilApplyDateRangeTest {
       DataSet data = buildRows();
       DateComparisonInfo dcInfo = dcInfo(false);
 
-      Scale partScale = applyAndGetPartScale(dcInfo, data, false);
+      Scale partScale = applyAndGetPartScale(dcInfo, data, CoordShape.NO_FACET);
 
       // Same rows as the Compare-All test above, but now Compare-All is off, so the heuristic
       // must run and exclude them as unreached-future parts (2021, the most recent period,
@@ -140,7 +143,7 @@ class DateComparisonUtilApplyDateRangeTest {
       DataSet data = buildRows();
       DateComparisonInfo dcInfo = dcInfo(false);
 
-      Scale partScale = applyAndGetPartScale(dcInfo, data, true);
+      Scale partScale = applyAndGetPartScale(dcInfo, data, CoordShape.PART_IS_FACET);
 
       // facet group 5-7 (encoded here as parts 51/52) never appears in 2021 (the most recent
       // period) at all -- facet mode must still keep 2019/2020's real rows for them.
@@ -150,28 +153,23 @@ class DateComparisonUtilApplyDateRangeTest {
    }
 
    /**
-    * Same rows/DC config as {@link #nonCompareAllNonFacetModeStillOrphansUnreachedParts()} --
-    * part is a plain chronologically-ordered week number, not itself a facet dimension -- except
-    * {@code info.isFacet()} is true, simulating a chart where some *other*, DC-unrelated
-    * dimension (e.g. Region) shares the axis and happens to trigger a {@code FacetCoord}. Unlike
+    * Bug #76518: same rows/DC config as
+    * {@link #nonCompareAllNonFacetModeStillOrphansUnreachedParts()} -- part is a plain
+    * chronologically-ordered week number, not itself a facet dimension -- except the chart is a
+    * {@code FacetCoord} because some *other*, DC-unrelated dimension (e.g. Region) shares the
+    * axis, so {@code info.isFacet()} is true. Unlike
     * {@link #facetModeDoesNotOrphanFacetsTheMostRecentPeriodLacks()} (where part genuinely is the
     * faceted dimension), the most-recent period's own chronological reach is still meaningful
-    * here, so parts 51/52 (December) should still be orphaned -- the current implementation
-    * cannot tell these two facet causes apart and skips the heuristic either way, so this
-    * currently fails.
+    * here, so parts 51/52 (December) must still be orphaned.
     */
    @Test
-   @Disabled("Bug #76518 -- fails against current production code (applyDateRange() cannot yet "
-      + "distinguish 'part is the faceted dimension' from 'an unrelated dimension is faceted'); "
-      + "re-enable once #76518 is fixed.")
    void facetCausedByUnrelatedDimensionStillOrphansUnreachedChronologicalPart() {
       DataSet data = buildRows();
       DateComparisonInfo dcInfo = dcInfo(false);
 
-      // facet=true here stands in for "an unrelated dimension made the chart a FacetCoord",
-      // not "the DC part column is the faceted dimension" -- applyDateRange() has no way to
-      // tell the two apart from info.isFacet() alone.
-      Scale partScale = applyAndGetPartScale(dcInfo, data, true);
+      // the part scale sits in the FacetCoord's *inner* coordinate here -- the facet levels are
+      // the unrelated dimension's, so the orphan heuristic must still run.
+      Scale partScale = applyAndGetPartScale(dcInfo, data, CoordShape.UNRELATED_FACET);
 
       assertPartRowAccepted(partScale, data, false, "2019-01-01", 51);
       assertPartRowAccepted(partScale, data, false, "2019-01-01", 52);
@@ -237,15 +235,35 @@ class DateComparisonUtilApplyDateRangeTest {
    }
 
    /**
+    * The three coordinate shapes applyDateRange()'s facet handling has to tell apart. Mirrors
+    * what GraphGenerator.createCoord() produces: the innermost dimension of an axis becomes the
+    * plot axis of the inner coordinate, and every remaining outer dimension is wrapped in a
+    * FacetCoord.
+    */
+   private enum CoordShape {
+      /** Plain single-coordinate chart; {@code info.isFacet()} false. */
+      NO_FACET,
+      /** Bug #76388: the DC part column is the faceted dimension (part scale in the outer coord). */
+      PART_IS_FACET,
+      /** Bug #76518: an unrelated dimension is faceted; part stays a plain inner axis. */
+      UNRELATED_FACET
+   }
+
+   private static final String OTHER_DIM_COL = "region";
+   private static final String INNER_DIM_COL = "innerPeriod";
+
+   /**
     * Builds a minimal VSChartInfo bound to PERIOD_COL/PART_COL, a matching hand-built EGraph
     * (bypassing the full chart-generation pipeline, the same "construct only what the seam under
     * test needs" approach {@link DateComparisonFormatOrphanedFacetTest} uses), calls the real
     * DateComparisonUtil.applyDateRange() entry point, and returns the part-column Scale so the
     * test can inspect the GraphtDataSelector it ends up with.
     */
-   private static Scale applyAndGetPartScale(DateComparisonInfo dcInfo, DataSet data, boolean facet) {
+   private static Scale applyAndGetPartScale(DateComparisonInfo dcInfo, DataSet data,
+                                             CoordShape shape)
+   {
       VSChartInfo info = new DefaultVSChartInfo();
-      info.setFacet(facet);
+      info.setFacet(shape != CoordShape.NO_FACET);
       info.setDcBaseDateOnX(true);
       info.setDateComparisonRef(new VSDimensionRef(new AttributeRef(PERIOD_COL)));
 
@@ -260,11 +278,37 @@ class DateComparisonUtilApplyDateRangeTest {
       valueScale.setFields(VALUE_COL);
 
       EGraph egraph = new EGraph();
-      egraph.setCoordinate(new RectCoord(partScale, valueScale));
+      egraph.setCoordinate(buildCoord(shape, partScale, valueScale));
 
       DateComparisonUtil.applyDateRange(dcInfo, egraph, info, data);
 
       return partScale;
+   }
+
+   private static Coordinate buildCoord(CoordShape shape, Scale partScale, Scale valueScale) {
+      switch(shape) {
+      case PART_IS_FACET: {
+         // X = [part, innerPeriod]: createCoord() consumes the innermost dim (innerPeriod) as
+         // the plot axis and wraps part as the facet level -- Bug #76388's Month_SameWeek
+         // DayOfWeek-facet shape, where ChartDcProcessor appends the period ref after the part.
+         Scale innerScale = new CategoricalScale();
+         innerScale.setFields(INNER_DIM_COL);
+         RectCoord outer = new RectCoord(partScale, GTool.createFakeScale(null));
+
+         return new FacetCoord(outer, new RectCoord(innerScale, valueScale));
+      }
+      case UNRELATED_FACET: {
+         // X = [region, part]: part is still the innermost (plain chronological) axis; the facet
+         // level is an unrelated dimension.
+         Scale otherScale = new CategoricalScale();
+         otherScale.setFields(OTHER_DIM_COL);
+         RectCoord outer = new RectCoord(otherScale, GTool.createFakeScale(null));
+
+         return new FacetCoord(outer, new RectCoord(partScale, valueScale));
+      }
+      default:
+         return new RectCoord(partScale, valueScale);
+      }
    }
 
    private static void assertPartRowAccepted(Scale partScale, DataSet data, boolean expectAccepted,


### PR DESCRIPTION
## Problem

`DateComparisonUtil.applyDateRange()` skipped its orphaned-cell heuristic (`computeValidParts()` / `ValidPartsSelector`) whenever `info.isFacet() || dcInfo.isCompareAll()`.

`VSChartInfo.isFacet()` is a **single chart-wide boolean**: `GraphGenerator.createCoord()` sets it from `coordinate instanceof FacetCoord`, and a `FacetCoord` is produced whenever *any* axis carries 2+ dimensions — regardless of whether the DC part column is one of them.

So the skip added for Bug #76388 (where the part column genuinely *is* the faceted dimension, e.g. a DayOfWeek facet, and "has the most recent period chronologically reached this part yet?" is meaningless) also fired when an unrelated dimension such as Region shared the DC axis. There the part column is still a plain, chronologically ordered axis, the heuristic is still meaningful, and skipping it let a genuinely unreached future part — December while the current year has only reached April — render for the prior comparison periods.

## Fix

Decide from the **actual coordinate tree** instead of the chart-wide flag.

`createCoord()` consumes the innermost dimension of each axis as the plot axis and wraps every remaining outer dimension in a `FacetCoord`, so a field found in a `FacetCoord`'s *outer* coordinate is one the graph is genuinely faceted on. The new `isFacetedField()` walks that structure (recursing through nested facets) and matches on `fields[0]` exactly as `applyDateRange()`'s own part-scale lookup does, so the two always agree on which scale is the part column's.

`info.isFacet()` is kept as a cheap short-circuit so non-facet charts don't walk the coordinate at all.

### Why not `DateComparisonInfo.isUseFacet()`

Considered and rejected: it was `false` in #76388's own scenario. The facet there comes from `ChartDcProcessor` **appending** `periodRef` to the base axis for non-`ALL` granularity (giving X = `[part, period]`, so `period` becomes the inner plot axis and `part` the facet level), not from the DC dialog's facet setting. Keying on `isUseFacet()` would regress that fix.

## Tests

`DateComparisonUtilApplyDateRangeTest`'s fixture could no longer express the distinction with a bare `isFacet()` boolean, so it now builds the three real coordinate shapes:

| Shape | Coordinate | Heuristic |
|---|---|---|
| `NO_FACET` | plain `RectCoord` | runs |
| `PART_IS_FACET` | part scale in the `FacetCoord`'s **outer** coord (#76388) | skipped |
| `UNRELATED_FACET` | part scale in the **inner** coord, unrelated dim faceted (#76518) | runs |

That re-enables the previously `@Disabled` `facetCausedByUnrelatedDimensionStillOrphansUnreachedChronologicalPart()` and keeps `facetModeDoesNotOrphanFacetsTheMostRecentPeriodLacks()` as the #76388 guard.

**Verified both directions:**
- Reverting the condition to bare `info.isFacet()` fails the #76518 test with the exact reported message: `row for period=2019-01-01, part=51 expected accepted=false but was true`
- Stubbing `isFacetedField()` to return `false` fails the #76388 test

Still passing: `DateComparisonUtilValidPartsTest`, `DateComparisonFormatOrphanedFacetTest`, `DateComparisonIntervalConditionTest`, `DcFormatTableLensTest`, `DCMergeDateFilterTest`, `DCMergeDatePartFilterTest`, `VSChartShowDataServiceTest`.

No live UI verification: as the reporter already noted, the available dataset's older comparison periods don't contain data past the current period's reach, so there is nothing for the bug to incorrectly reveal. The defect reproduces directly at the `applyDateRange()` level, independent of dataset shape.

Related: #76388, #76389, #76390, #76391 — same `applyDateRange()`/`computeValidParts()` area.

A companion docs-only PR in the enterprise repo adds the missing `claude/chart-date-comparison.md` coverage of this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)