### PR TITLE
Bug #76549, don't hold the crosstab info monitor across the data fetch

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -367,33 +367,60 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
             box.getVariableTable().put(XQuery.HINT_IGNORE_MAX_ROWS, "true");
          }
 
-         TableLens base = null;
-         DataRef[] rheaders = null;
-         DataRef[] cheaders = null;
-         DataRef[] aggregates = null;
+         TableLens base;
+         TableAssembly baseTable;
+         DataRef[] rheaders;
+         DataRef[] cheaders;
+         DataRef[] aggregates;
 
+         // Keep the data fetch out of the cinfo monitor. getTableLens() releases and
+         // re-acquires the sandbox lock around the asset cache fetch (76233), so holding
+         // monitor(cinfo) across it inverted the order every write path takes -- sandbox
+         // lock first, then the crosstab info -- and deadlocked the whole viewsheet against
+         // ViewsheetSandbox.updateAssembly() -> VSCrosstabInfo.update(). (76549)
+         //
+         // The monitor still covers the prepare phase, which is what rewrites the runtime
+         // refs and what the reads below must be consistent with. Prepare is not
+         // unconditionally non-blocking though, so this narrowing fixes the reported case
+         // rather than the whole deadlock class. Two prepare paths still release the sandbox
+         // lock while this monitor is held:
+         //   - a crosstab bound to another VS assembly (SourceInfo.VS_ASSEMBLY) reaches
+         //     VSAQuery.createAssemblyTable() -> box.getTableData();
+         //   - for any source type, CubeVSAQuery.createBaseTableAssembly0() calls
+         //     setSharedCondition(box.getBrushingChart(..), ..), and for a brushed chart
+         //     carrying dynamic values that runs a script which can re-enter box.getData().
+         // Both land in ViewsheetSandbox.doExecuteData(), whose lockWrite() first drops this
+         // thread's read lock and then competes for the write lock, so the counterpart can be
+         // any writer that subsequently needs this monitor -- not only a second crosstab
+         // query. Both are pre-existing and out of scope here.
+         //
+         // Narrowing does widen one race: a concurrent prepare for the same crosstab can now
+         // run while this thread's query is in flight, and prepare mutates shared state (the
+         // bound table it registers in box.getWorksheet() under a deterministic name, and the
+         // VSDimensionRefs it re-ranks). ChartVSAQuery handles the equivalent exposure by
+         // querying a private table clone; the crosstab path does not do that yet.
          synchronized(cinfo) {
-            base = getAssetBaseTableLens(postDrill);
-            DataRef[] aggrs = cinfo.getRuntimeAggregates();
+            baseTable = prepareAssetBaseTable(postDrill);
 
-            if(aggrs == null || aggrs.length == 0) {
-               DataRef[] rows = cinfo.getRuntimeRowHeaders();
-               DataRef[] cols = cinfo.getRuntimeColHeaders();
-               return (rows == null || rows.length == 0) &&
-                  (cols == null || cols.length == 0) ? null : base;
-            }
-
-            // show detail? do nothing
-            if(details != null && details.getSize() > 0) {
-               return base;
-            }
-            else if(isDetail() || base == null || cinfo == null) {
-               return null;
-            }
-
+            // read after prepare -- getTableAssembly() rewrites these
+            aggregates = cinfo.getRuntimeAggregates();
             rheaders = cinfo.getRuntimeRowHeaders();
             cheaders = cinfo.getRuntimeColHeaders();
-            aggregates = cinfo.getRuntimeAggregates();
+         }
+
+         base = executeAssetBaseTable(baseTable, cinfo);
+
+         if(aggregates == null || aggregates.length == 0) {
+            return (rheaders == null || rheaders.length == 0) &&
+               (cheaders == null || cheaders.length == 0) ? null : base;
+         }
+
+         // show detail? do nothing
+         if(details != null && details.getSize() > 0) {
+            return base;
+         }
+         else if(isDetail() || base == null) {
+            return null;
          }
 
          DataRef[] oaggs = oldInfo.getRuntimeAggregates();
@@ -1177,11 +1204,17 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
    }
 
    /**
-    * Get the asset base table lens.
+    * Prepare the base table assembly for the asset query.
+    *
+    * <p>This mutates the crosstab runtime refs -- getTableAssembly() rewrites the runtime
+    * row headers and the pushed-down aggregates -- so the caller must hold the
+    * VSCrosstabInfo monitor across it. It must not execute the crosstab's own query; that
+    * is {@link #executeAssetBaseTable(TableAssembly, VSCrosstabInfo)}. (76549)
+    *
     * @param post true if the aggregate is done in post processingj
-    * @return the asset base table lens.
+    * @return the prepared base table assembly, or null if there is nothing to execute.
     */
-   private TableLens getAssetBaseTableLens(boolean post) throws Exception {
+   private TableAssembly prepareAssetBaseTable(boolean post) throws Exception {
       CrosstabDataVSAssembly cassembly = (CrosstabDataVSAssembly) getAssembly();
       VSCrosstabInfo cinfo = cassembly.getVSCrosstabInfo();
       TableAssembly table = getTableAssembly(false, post);
@@ -1251,6 +1284,27 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
             conds = ConditionUtil.mergeConditionList(list, JunctionOperator.AND);
             table.setPreRuntimeConditionList(conds);
          }
+      }
+
+      return table;
+   }
+
+   /**
+    * Execute the prepared base table assembly and return the base lens.
+    *
+    * <p>Must NOT be called while holding the VSCrosstabInfo monitor: getTableLens()
+    * releases and restores the sandbox lock around the asset cache fetch, and blocking to
+    * re-acquire that lock while holding the monitor inverts the lock order every write path
+    * uses -- sandbox lock first, then the crosstab info. (76549)
+    *
+    * @param table the prepared base table assembly, may be null.
+    * @return the base table lens, or null if there was nothing to execute.
+    */
+   private TableLens executeAssetBaseTable(TableAssembly table, VSCrosstabInfo cinfo)
+      throws Exception
+   {
+      if(table == null) {
+         return null;
       }
 
       TableLens lens = getTableLens(table);

--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -1116,6 +1116,14 @@ public abstract class VSAQuery {
     * getTableLens()), which defeats it. Releasing here restores that invariant regardless of
     * which path reached the cache. The assembly mutations happen before this call and the
     * fetch itself does not mutate assembly state, so it is safe to release.
+    *
+    * <p><b>Callers must not hold any object monitor that a sandbox-lock holder can need.</b>
+    * restoreLocks() blocks re-acquiring the sandbox lock, so holding such a monitor across
+    * this call inverts the lock order every write path uses -- the write path takes the
+    * sandbox lock first and the assembly info monitor second -- and deadlocks the whole
+    * viewsheet. That is what AbstractCrosstabVSAQuery.getTableLens0() did with the
+    * VSCrosstabInfo monitor until 76549. The same caution applies to any nested fetch that
+    * reaches ViewsheetSandbox.doExecuteData(), which releases the locks the same way.
     */
    private TableLens getDataWithoutSandboxLock(TableAssembly table, AssetQuerySandbox wbox,
                                                Set ignored, int mode, boolean limited,


### PR DESCRIPTION
## Problem

Two concurrent Format Painter requests on the same Crosstab deadlock the viewsheet permanently. The reported thread dump carries a JVM-generated `Found Java-level deadlocks` section, so this is a real cycle rather than a slow query. Once it forms, every later action needing that `ViewsheetSandbox` lock hangs until the server restarts — the dump already shows Crosstab "Show Details" and `VSBindingService.open` queued behind it.

The reporter could not confirm exact UI steps, but they aren't needed: `FormatPainterService.getFormat()` takes no sandbox lock on entry, so any two overlapping picks on the same crosstab race for it.

## Root cause

A lock-order inversion between the sandbox `UpgradableReadWriteLock` and the `VSCrosstabInfo` monitor.

`AbstractCrosstabVSAQuery.getTableLens0()` held `monitor(cinfo)` across the entire query, and the fetch underneath it releases and re-acquires the sandbox lock:

- `AbstractCrosstabVSAQuery.java:375` — `synchronized(cinfo)`
- `:376` — `getAssetBaseTableLens(postDrill)` inside the monitor
- `:1256` — `getTableLens(table)`
- `VSAQuery.java:1125/1132` — `box.unlockAll()` … `box.restoreLocks()`

So thread A dropped the read lock while holding the monitor, then blocked in `restoreLocks()`. Thread B took the freed **write** lock at `ViewsheetSandbox.java:6121` and blocked on the same monitor via `updateAssembly` → `refreshMetaData` → `CrossBaseVSAssemblyInfo:429` → `VSCrosstabInfo.java:1337`.

Every write path takes *sandbox lock → crosstab info*; this one query path took the reverse. Worth noting the sandbox RW lock is non-fair but a *queued* writer still blocks `readLock().lock()`, so A wedges even against a writer that is merely waiting.

**Regression window:** reachable only since `1f2b17726` (#76233), which introduced the `unlockAll`/`restoreLocks` pair. Before it the read lock was never released, so no other thread could own the write lock and the inversion was unreachable. #76233 is right in intent — it exposed a pre-existing ordering violation. Not on `v1.0.x` or `v1.1.x`, so no backport.

## Fix

Split `getAssetBaseTableLens()` (single caller) into:

- `prepareAssetBaseTable()` — keeps the cinfo mutation under the monitor. `getTableAssembly` rewrites the runtime row headers and the pushed-down aggregates, and that mutation is what needs serializing between two concurrent crosstab queries.
- `executeAssetBaseTable()` — runs the fetch outside the monitor.

Verified nothing in the execute phase touches the runtime refs: `getDcMergeDateTableLens` reads only the table's `AggregateInfo`, and `fillFakeTable` reads only the design aggregates.

Two behaviour notes:
- The runtime refs are now read **before** the fetch rather than after. This is the more consistent pairing — the base lens is built from the table assembly derived from exactly those refs, and the old order could index a lens built from one ref set with another.
- The dead `cinfo == null` in the `else if` is dropped; line 356 already returned on it.

## Scope — what this does *not* fix

This fixes the reported path, where prepare holds the read lock continuously (verified: the repro asset's `sourceInfo type="7"` is `XSourceInfo.ASSET`, not `VS_ASSEMBLY`, and the viewsheet has no chart, so `setSharedCondition` exits before its `updateAssembly`).

It is **not** a fix for the whole deadlock class. Prepare can still release the sandbox lock two ways, both pre-existing and documented in the code:

1. a `SourceInfo.VS_ASSEMBLY`-bound crosstab reaches `VSAQuery.createAssemblyTable()` → `box.getTableData()`;
2. for **any** source type, `CubeVSAQuery.createBaseTableAssembly0()` calls `setSharedCondition(box.getBrushingChart(..), ..)`, and for a brushed chart carrying dynamic values that runs a script which can re-enter `box.getData()`.

Both land in `doExecuteData()`, whose `lockWrite()` drops the caller's read lock and then competes for the write lock, so the counterpart can be any writer that then needs the monitor.

One race the narrowing **widens**: a concurrent prepare for the same crosstab can now overlap an in-flight query, and prepare mutates shared state — the bound table it registers in `box.getWorksheet()` under a deterministic name (`getBoundTable:972` uses the shared worksheet for the plain case), and the `VSDimensionRef`s it re-ranks. In the reported scenario both threads build equivalent tables, so practical risk is low. `ChartVSAQuery.java:1213-1221` handles the equivalent exposure by querying a private table clone; **recommended follow-up** is to do the same here, which needs a look at how sub-tables resolve through the shared worksheet first.

## Testing

`mvn clean test -pl core` — **4840 tests, 0 failures**.

No regression test. The deterministic unit test I had covered a `VSCrosstabInfo` change that was reverted during review (removing `synchronized(this)` from the runtime-ref publish broke the atomicity of the three-field snapshot that `getTableLens0` reads under the same monitor). Covering the narrowing itself needs the integration harness plus the Examples/Orders demo datasource; happy to add that probe if reviewers want coverage before merge.

Manual verification of the deadlock itself has not been done — it needs two overlapping `getFormat` requests against a running server with the attached `cross.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
