### PR TITLE
Bug #76538, resolve dynamic column binding for form input write-back

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4032,8 +4032,19 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             EmbeddedTableAssembly eassembly = (EmbeddedTableAssembly) ass;
             // resolve the column from the current column selection instead of relying on
             // iassembly.getColumn(), which is only refreshed on a full sandbox reset and
-            // may be stale if the binding was changed without reopening the viewsheet
-            DataRef column = eassembly.getColumnSelection(false).getAttribute(iassembly.getColumnValue());
+            // may be stale if the binding was changed without reopening the viewsheet.
+            // use the runtime column value so a variable or expression binding resolves
+            // to the column it evaluates to instead of the literal $(var)/=expr text.
+            String cname = iassembly.getRuntimeColumnValue();
+            DataRef column = cname == null
+               ? null : eassembly.getColumnSelection(false).getAttribute(cname);
+
+            // a dynamic value that has not been executed yet resolves to null, fall back
+            // to the column resolved by InputVSAssemblyInfo.update()
+            if(column == null) {
+               column = iassembly.getColumn();
+            }
+
             int row = iassembly.getRow();
 
             if(column != null && row > 0) {

--- a/core/src/main/java/inetsoft/uql/viewsheet/InputVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/InputVSAssembly.java
@@ -147,6 +147,15 @@ public abstract class InputVSAssembly extends AbstractVSAssembly implements Bind
    }
 
    /**
+    * Get the runtime target column name, resolving a variable or expression binding.
+    * @return the runtime target column name, or <tt>null</tt> if a dynamic value has
+    * not been executed yet.
+    */
+   public String getRuntimeColumnValue() {
+      return getInputVSAssemblyInfo().getRuntimeColumnValue();
+   }
+
+   /**
     * Get the target data type.
     * @return the target data type of this assembly info.
     */

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/InputVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/InputVSAssemblyInfo.java
@@ -92,6 +92,18 @@ public abstract class InputVSAssemblyInfo extends VSAssemblyInfo {
    }
 
    /**
+    * Get the runtime target column name. Unlike getColumnValue(), which returns the
+    * design time text, this resolves a variable or expression binding to the value it
+    * was executed to.
+    * @return the runtime target column name, or <tt>null</tt> if a dynamic value has
+    * not been executed yet.
+    */
+   public String getRuntimeColumnValue() {
+      Object obj = columnValue.getRuntimeValue(true);
+      return obj == null ? null : obj.toString();
+   }
+
+   /**
     * Get the target data type.
     * @return the target data type of this assembly info.
     */

--- a/core/src/test/java/inetsoft/report/composition/execution/RefreshVariableTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/RefreshVariableTest.java
@@ -1,0 +1,209 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.report.composition.ChangedAssemblyList;
+import inetsoft.sree.security.OrganizationManager;
+import inetsoft.test.*;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.InputVSAssemblyInfo;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for ViewsheetSandbox.refreshVariable(), specifically the write-back of an
+ * input assembly's selected value into the cell of its bound embedded table.
+ *
+ * The target cell is addressed by the assembly's columnValue/rowValue, both of which may
+ * be bound to a variable or an expression. The method is private, so it is exercised via
+ * reflection, and a minimal AssetQuerySandbox is injected into the sandbox to avoid the
+ * full viewsheet init cycle -- the same approach as ApplyParameterToInputTest.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, RefreshVariableTest.TestConfig.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class RefreshVariableTest {
+   /**
+    * refreshVariable() invalidates the cache for the table it just wrote to. Only the
+    * write itself is under test here, so a stub is enough and it keeps the context from
+    * pulling in the whole data source registry.
+    */
+   @Configuration
+   static class TestConfig {
+      @Bean
+      public AssetDataCache assetDataCache() {
+         return mock(AssetDataCache.class);
+      }
+   }
+
+   /** Name of the bound embedded table in the base worksheet. */
+   private static final String TABLE = "Query1_O";
+   /** Column index of "state" / "product_name" in the embedded data. */
+   private static final int STATE_COL = 0;
+   private static final int PRODUCT_COL = 1;
+
+   private Viewsheet vs;
+   private EmbeddedTableAssembly embedded;
+   private ViewsheetSandbox sandbox;
+   private Method refreshVariable;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      Worksheet ws = new Worksheet();
+      embedded = new EmbeddedTableAssembly(ws, TABLE);
+      // row 0 is the header row, so the addressable data rows are 1 and 2
+      embedded.setEmbeddedData(new XEmbeddedTable(
+         new String[]{ XSchema.STRING, XSchema.STRING },
+         new Object[][] {
+            { "state", "product_name" },
+            { "NY", "InsideView" },
+            { "CA", "Fast Mail" }
+         }));
+      ws.addAssembly(embedded);
+
+      vs = new Viewsheet();
+
+      // Viewsheet.setBaseWorksheet() is private and only reachable through a full
+      // update() against an asset repository, so wire the base worksheet directly.
+      Field wsField = Viewsheet.class.getDeclaredField("ws");
+      wsField.setAccessible(true);
+      wsField.set(vs, ws);
+
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "test/RefreshVariableTest",
+         null, OrganizationManager.getInstance().getCurrentOrgID());
+      sandbox = new ViewsheetSandbox(vs, AbstractSheet.SHEET_RUNTIME_MODE, null, false, entry);
+
+      Field wboxField = ViewsheetSandbox.class.getDeclaredField("wbox");
+      wboxField.setAccessible(true);
+      wboxField.set(sandbox, new AssetQuerySandbox(ws, null, new VariableTable()));
+
+      refreshVariable = ViewsheetSandbox.class.getDeclaredMethod(
+         "refreshVariable", InputVSAssembly.class, boolean.class, ChangedAssemblyList.class);
+      refreshVariable.setAccessible(true);
+   }
+
+   /**
+    * Create an input assembly bound to a cell of the embedded table.
+    *
+    * @param columnValue the design time column binding, literal or dynamic.
+    * @param rowValue    the design time row binding, literal or dynamic.
+    */
+   private TextInputVSAssembly createInput(String columnValue, String rowValue) {
+      TextInputVSAssembly input = new TextInputVSAssembly(vs, "TextInput1");
+      input.setTableName(TABLE);
+      input.setColumnValue(columnValue);
+      input.setRowValue(rowValue);
+      input.setSelectedObject("written");
+      vs.addAssembly(input);
+
+      return input;
+   }
+
+   /**
+    * Stand in for ViewsheetSandbox.executeDynamicValues(), which resolves a variable or
+    * expression and stores the result on the DynamicValue. updateAssembly() always runs
+    * that immediately before refreshVariable().
+    */
+   private void execute(InputVSAssembly input, String dvalue, Object rvalue) {
+      ((InputVSAssemblyInfo) input.getVSAssemblyInfo()).getDynamicValues().stream()
+         .filter(dval -> Tool.equals(dvalue, dval.getDValue()))
+         .forEach(dval -> dval.setRValue(rvalue));
+   }
+
+   private Object cell(int row, int col) {
+      return embedded.getEmbeddedData().getObject(row, col);
+   }
+
+   private void invoke(InputVSAssembly input) throws Exception {
+      refreshVariable.invoke(sandbox, input, false, null);
+   }
+
+   @Test
+   void literalColumnValueWritesCell() throws Exception {
+      invoke(createInput("state", "1"));
+
+      assertEquals("written", cell(1, STATE_COL));
+   }
+
+   @Test
+   void expressionColumnValueWritesCell() throws Exception {
+      TextInputVSAssembly input = createInput("='state'", "1");
+      execute(input, "='state'", "state");
+
+      invoke(input);
+
+      assertEquals("written", cell(1, STATE_COL));
+   }
+
+   @Test
+   void variableColumnValueWritesCell() throws Exception {
+      TextInputVSAssembly input = createInput("$(PField)", "=2");
+      execute(input, "$(PField)", "product_name");
+      execute(input, "=2", 2);
+
+      invoke(input);
+
+      assertEquals("written", cell(2, PRODUCT_COL));
+   }
+
+   @Test
+   void unresolvableColumnLeavesTableUnchanged() throws Exception {
+      TextInputVSAssembly input = createInput("='nosuchcolumn'", "1");
+      execute(input, "='nosuchcolumn'", "nosuchcolumn");
+
+      assertDoesNotThrow(() -> invoke(input));
+      assertEquals("NY", cell(1, STATE_COL));
+   }
+
+   @Test
+   void literalColumnValueWinsOverStaleCachedColumn() throws Exception {
+      // Bug #75929: the DataRef cached on the assembly info is only refreshed on a full
+      // sandbox reset, so a binding changed since then must not be written to the old
+      // column.
+      TextInputVSAssembly input = createInput("state", "1");
+      DataRef stale = embedded.getColumnSelection(false).getAttribute("product_name");
+      input.setColumn(stale);
+
+      invoke(input);
+
+      assertEquals("written", cell(1, STATE_COL));
+      assertEquals("InsideView", cell(1, PRODUCT_COL));
+   }
+}


### PR DESCRIPTION
## Problem

A form input (Slider, Spinner, TextInput, RadioButton, ComboBox) whose **Data** tab column is bound to *A Variable* or *An Expression* does not write its selected value into the target embedded table cell, so the bound table keeps its original data.

Reported as "expression and variable to set all options of form component can't work". The reporter's `Form_Options` asset binds `columnValue` to `='state'` / `='product_name'` / `$(PField)` across five inputs, none of which write back. The min/max/increment and minDate/maxDate expressions in the same asset *do* evaluate — only the write-back is broken. The slider's rendered maximum also differs (1042 vs the expected 1454) purely because `=sum(Query1['customer_id'])` is summing the un-written column.

## Root cause

`ViewsheetSandbox.refreshVariable()` looked the column up by the **design time** text:

```java
DataRef column = eassembly.getColumnSelection(false).getAttribute(iassembly.getColumnValue());
```

`getColumnValue()` returns `columnValue.getDValue()` — the literal `='state'` / `$(PField)` string, which never matches a column name. `column` resolves to `null` and the `edata.setObject(row, col, cdata)` write is skipped entirely. The row binding directly beside it already reads the runtime value via `getRow()`.

This regressed in #4541 (Bug #75929), which replaced `iassembly.getColumn()` with the `getColumnValue()` lookup to avoid a stale cached `DataRef`. `getColumn()` is resolved *from the runtime value* by `InputVSAssemblyInfo.update()`, so the original code handled dynamic bindings; the replacement does not. Static column bindings were unaffected, which is why #75929's own scenario passed.

Ordering is not a factor: `outputDataChanged()` runs `updateAssembly()` (→ `executeDynamicValues`) immediately before `refreshVariable()`, so the runtime value is available by then.

## Fix

Add `InputVSAssemblyInfo.getRuntimeColumnValue()`, which reads the executed value of the `columnValue` `DynamicValue`, and use it for the lookup. `DynamicValue.getRValue()` already falls back to the design value for non-dynamic text, so static bindings still resolve against the live `ColumnSelection` and keep the freshness property #75929 added. The cached `DataRef` remains as a fallback for any path that reaches `refreshVariable()` without a prior `updateAssembly()`.

Only this one call site resolved an input's target column from `getColumnValue()`; the other runtime consumers (`InputVSAQuery`, `CoreLifecycleService`) already use the runtime-resolved `getColumn()`.

## Tests

New `RefreshVariableTest`, following the reflection pattern of `ApplyParameterToInputTest` in the same package. Five cases: literal binding, `='state'` expression, `$(PField)` variable, an unresolvable column, and the #75929 stale-cached-column case.

Verified the tests catch the defect — with the fix reverted, the expression and variable cases fail while the other three still pass. `mvn test -pl core` for `inetsoft.report.composition.execution.*` and `inetsoft.web.viewsheet.service.*`: 89 tests, all green.

## Notes for the reporter

Two things noticed while tracing that are **not** addressed here:

1. The expected screenshot shows the calendar combo box as `2023-06-13` while the current build renders `2023-6-13` — a date-format difference independent of the write-back defect. Needs its own ticket if it is in scope.
2. Several `DynamicValue` fields on input assemblies are never added to `getDynamicValues()`/`getViewDynamicValues()` and so could never resolve an expression (slider tick/label visibility flags, `ListInputVSAssemblyInfo.sortTypeValue`/`selectFirstItem`, `TextInputVSAssemblyInfo.defaultText`, `submitOnChange`/`writeBackValue`, and the range-slider `TimeInfo` fields). None are reachable from the property dialogs today — they render as plain checkboxes and selects, not `dynamic-combo-box` — so no user can currently enter a `$(var)`/`=expr` for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
