### PR TITLE
Bug #76529, base the week start on week.start alone and fix the Sunday-hardcoded rewind

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/DCMergeDatePartFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/DCMergeDatePartFilter.java
@@ -23,6 +23,7 @@ import inetsoft.report.lens.AbstractTableLens;
 import inetsoft.uql.asset.DateRangeRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.XDimensionRef;
+import inetsoft.uql.viewsheet.internal.DateComparisonUtil;
 import inetsoft.util.Tool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -302,7 +303,8 @@ public class DCMergeDatePartFilter extends AbstractTableLens implements TableFil
                // to a different actual week in another period's year (e.g. the previous year's
                // bar shares the current year's bucket). Recompute the part value from this
                // cell's own date using the same logic as JavaScriptEngine.datePart("wy") for the
-               // non-to-date case -- move to the first day of the week, then month*10 +
+               // non-to-date case -- move to the first day of the week (honoring the
+               // configured week start, in lockstep with that method), then month*10 +
                // weekOfMonth -- so the equivalence cell matches the data/label for the cell's
                // actual week regardless of the configured first day of week. Deriving from the
                // stored part value instead (the previous approach) failed when the first day of
@@ -311,7 +313,7 @@ public class DCMergeDatePartFilter extends AbstractTableLens implements TableFil
                cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
                cal.setMinimalDaysInFirstWeek(7);
                cal.setTime((Date) getDateGroupValue());
-               cal.add(Calendar.DATE, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+               DateComparisonUtil.moveToWeekStart(cal);
                int equivalenceValue =
                   (cal.get(Calendar.MONTH) + 1) * 10 + cal.get(Calendar.WEEK_OF_MONTH);
 

--- a/core/src/main/java/inetsoft/uql/asset/DateTimeProcessor.java
+++ b/core/src/main/java/inetsoft/uql/asset/DateTimeProcessor.java
@@ -166,6 +166,10 @@ class DateTimeProcessor {
          int weekOfMonth = getWeekOfMonth();
 
          if(weekOfMonth < 1) {
+            // NOTE: -7 lands in the week *before* this date's own week, so the weekOfMonth
+            // read below is one short of what datePart('wy') computes for the same date. It
+            // only feeds the forceDcToDateWeekOfMonth comparison, which a forced value of 1-5
+            // can never reach from here, so the returned month is unaffected either way.
             jcalendar.add(Calendar.DATE, -7);
          }
 
@@ -248,6 +252,11 @@ class DateTimeProcessor {
     */
    public final Timestamp getYearOfFullWeek(int forceDcToDateWeekOfMonth) {
       GregorianCalendar calendar = new GregorianCalendar();
+      // a bare GregorianCalendar starts the week wherever the JVM default locale says, which
+      // is unrelated to the week.start this processor (and every sibling method) uses. The
+      // set(DAY_OF_WEEK, getFirstDayOfWeek()) rewind below then landed in the wrong week and
+      // the year could come out off by one.
+      calendar.setFirstDayOfWeek(firstDay);
       calendar.setMinimalDaysInFirstWeek(7);
       calendar.setTime(new Date(time));
       calendar.set(Calendar.DAY_OF_WEEK, calendar.getFirstDayOfWeek());

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
@@ -1926,7 +1926,7 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
          int dayOfWeek = intervalToDateCal.get(Calendar.DAY_OF_WEEK);
          // use same week-of-month and month-of-year instead of week-of-year. this is
          // same as google analytics and is more comprehensible to human. (63990)
-         intervalToDateCal.add(Calendar.DATE, -(intervalToDateCal.get(Calendar.DAY_OF_WEEK) - Tool.getFirstDayOfWeek()));
+         DateComparisonUtil.moveToWeekStart(intervalToDateCal);
 
          int weekOfMonth = intervalToDateCal.get(Calendar.WEEK_OF_MONTH);
 
@@ -2376,7 +2376,7 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
       if(isWeekToDate) {
          Calendar intervalToDateCal = DateComparisonInfo.getCalendar();
          intervalToDateCal.setTime(getRangeToDate());
-         intervalToDateCal.add(Calendar.DATE, -(intervalToDateCal.get(Calendar.DAY_OF_WEEK) - 1));
+         DateComparisonUtil.moveToWeekStart(intervalToDateCal);
 
          return intervalToDateCal.get(Calendar.WEEK_OF_MONTH);
       }

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonUtil.java
@@ -2005,6 +2005,26 @@ public class DateComparisonUtil {
       return dim.getFullName();
    }
 
+   /**
+    * Move the calendar back to the first day of its own week, honoring the calendar's
+    * configured {@link Calendar#getFirstDayOfWeek()}.
+    *
+    * <p>The obvious <code>-(DAY_OF_WEEK - 1)</code> rewind is only correct when the week
+    * starts on Sunday: <code>DAY_OF_WEEK</code> is always Sunday-anchored and is unaffected
+    * by {@link Calendar#setFirstDayOfWeek(int)}. With any other week start it lands on a day
+    * in the wrong week, so the <code>WEEK_OF_MONTH</code>/<code>WEEK_OF_YEAR</code> read that
+    * normally follows disagrees with the week start the same calendar is configured for --
+    * including producing week 0, which is outside the domain the callers encode.
+    *
+    * @return the same calendar, for chaining.
+    */
+   public static Calendar moveToWeekStart(Calendar calendar) {
+      int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
+      calendar.add(Calendar.DATE, -((dayOfWeek - calendar.getFirstDayOfWeek() + 7) % 7));
+
+      return calendar;
+   }
+
    public static boolean adjustCalendarByForceWM(Calendar calendar, int forceWM) {
       Date date = calendar.getTime();
       int weekOfMonth = calendar.get(Calendar.WEEK_OF_MONTH);

--- a/core/src/main/java/inetsoft/util/Tool.java
+++ b/core/src/main/java/inetsoft/util/Tool.java
@@ -4533,10 +4533,19 @@ public final class Tool extends CoreTool {
       return sb.toString();
    }
 
+   /**
+    * Get the first day of the week, as a {@link Calendar} day-of-week constant.
+    *
+    * <p>This is determined solely by the <code>week.start</code> property. When the property
+    * is missing or is not a valid day name, {@link Calendar#SUNDAY} is used. The value is
+    * deliberately <em>not</em> derived from the locale: the locale of the calling thread is
+    * the viewing user's, so a locale-derived week start made the same dashboard bucket
+    * weeks differently for different users, and disagreed with the Sunday-based week
+    * expressions that {@link inetsoft.uql.asset.DateRangeRef} pushes down to SQL.
+    */
    public static int getFirstDayOfWeek() {
       String firstDayProperty = Tool.firstDayProperty.get();
-      Locale locale = ThreadContext.getLocale();
-      String key = firstDayProperty + locale;
+      String key = String.valueOf(firstDayProperty);
 
       return firstDayOfWeeks.computeIfAbsent(key, k -> {
          Integer firstDay = null;
@@ -4568,12 +4577,27 @@ public final class Tool extends CoreTool {
          }
 
          if(firstDay == null) {
-            Calendar c = GregorianCalendar.getInstance(locale);
-            firstDay = c.getFirstDayOfWeek();
+            if(firstDayProperty != null && !firstDayProperty.trim().isEmpty()) {
+               LOG.info("Ignoring invalid week.start value \"" + firstDayProperty +
+                           "\", using Sunday. Valid values are Sunday through Saturday.");
+            }
+
+            firstDay = Calendar.SUNDAY;
          }
 
          return firstDay;
       });
+   }
+
+   /**
+    * Discard the cached week start so that a <code>week.start</code> change made through the
+    * Enterprise Manager takes effect immediately, rather than after the property cache
+    * timeout. Without this, {@link #getFirstDayOfWeek()} and {@link #getWeekStart()} (which
+    * reads the property directly) can disagree for the length of that timeout.
+    */
+   public static void clearWeekStartCache() {
+      firstDayProperty.updateValue();
+      firstDayOfWeeks.clear();
    }
 
    public static String getWeekStart() {

--- a/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
+++ b/core/src/main/java/inetsoft/util/script/JavaScriptEngine.java
@@ -418,14 +418,17 @@ public class JavaScriptEngine {
 
       if(dateVal != null) {
          Calendar cal = CoreTool.calendar.get();
-         int oldStart = applyWeekStart ? cal.getFirstDayOfWeek() : 0;
+         int oldStart = cal.getFirstDayOfWeek();
          int minFirstWeek = cal.getMinimalDaysInFirstWeek();
 
          try {
-            if(applyWeekStart) {
-               cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
-            }
-
+            // CoreTool.calendar is a shared ThreadLocal that other callers leave mutated
+            // (CalcDateTime.date() sets its first day and never restores it), so pin the
+            // week start explicitly in both branches rather than inheriting whatever ran
+            // earlier on this pooled thread. Without applyWeekStart the week parts here
+            // have always been Sunday-based; that is now true of the WEEK_OF_MONTH reads
+            // as well as the rewind, instead of half of each.
+            cal.setFirstDayOfWeek(applyWeekStart ? Tool.getFirstDayOfWeek() : Calendar.SUNDAY);
             cal.setMinimalDaysInFirstWeek(7);
             cal.setTime(dateVal);
 
@@ -436,7 +439,7 @@ public class JavaScriptEngine {
                return cal.get(Calendar.MONTH) % 3 + 1;
             // month of quarter of full week
             case "wmq":
-               cal.add(Calendar.DATE, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+               DateComparisonUtil.moveToWeekStart(cal);
                DateComparisonUtil.adjustCalendarByForceWM(cal, forceDcToDateWeekOfMonth);
 
                return cal.get(Calendar.MONTH) % 3 + 1;
@@ -445,8 +448,7 @@ public class JavaScriptEngine {
                return DateComparisonUtil.getWeekOfQuarter(cal, cal.getFirstDayOfWeek());
                // week of year
             case "wy":
-               int dayOfWeek = cal.get(Calendar.DAY_OF_WEEK);
-               cal.add(Calendar.DATE, -(dayOfWeek - 1));
+               DateComparisonUtil.moveToWeekStart(cal);
                int weekOfMonth = cal.get(Calendar.WEEK_OF_MONTH);
 
                if(DateComparisonUtil.adjustCalendarByForceWM(cal, forceDcToDateWeekOfMonth)) {
@@ -476,7 +478,7 @@ public class JavaScriptEngine {
 
                // if week-of-month is before the 1st week, it's the last week of previous month.
                if(val < 1 && "wm".equals(interval)) {
-                  cal.add(Calendar.DATE, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+                  DateComparisonUtil.moveToWeekStart(cal);
                   val = cal.get(field);
                }
 
@@ -484,10 +486,7 @@ public class JavaScriptEngine {
             }
          }
          finally {
-            if(applyWeekStart) {
-               cal.setFirstDayOfWeek(oldStart);
-            }
-
+            cal.setFirstDayOfWeek(oldStart);
             cal.setMinimalDaysInFirstWeek(minFirstWeek);
          }
       }

--- a/core/src/main/java/inetsoft/web/admin/presentation/PresentationTimeSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PresentationTimeSettingsService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.presentation;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.admin.presentation.model.PresentationTimeSettingsModel;
 import inetsoft.web.viewsheet.Audited;
@@ -44,6 +45,7 @@ public class PresentationTimeSettingsService {
       SreeEnv.setProperty("week.start", model.weekStart(), !globalSettings);
       SreeEnv.setProperty("schedule.time.12hours", model.scheduleTime12Hours()+"", !globalSettings);
       SreeEnv.save();
+      Tool.clearWeekStartCache();
    }
 
    @Audited(
@@ -55,5 +57,6 @@ public class PresentationTimeSettingsService {
       SreeEnv.resetProperty("week.start", !globalSettings);
       SreeEnv.resetProperty("schedule.time.12hours", !globalSettings);
       SreeEnv.save();
+      Tool.clearWeekStartCache();
    }
 }

--- a/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/DCMergeDatePartFilterTest.java
@@ -29,7 +29,7 @@ import inetsoft.uql.viewsheet.VSDataRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
 import inetsoft.uql.viewsheet.XDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSFieldValue;
-import inetsoft.util.ThreadContext;
+import inetsoft.uql.viewsheet.internal.DateComparisonUtil;
 import inetsoft.util.Tool;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Locale;
 
 import static inetsoft.test.XTableUtil.date;
 
@@ -166,19 +165,16 @@ public class DCMergeDatePartFilterTest {
    // failed when the first day of week was not Sunday, leaving drill-to-detail one week off.
    @Test
    public void testWeekOfYearEquivalenceUsesCellDateNonSundayWeekStart() {
-      Locale oldLocale = ThreadContext.getLocale();
-
-      try {
-         // Locale.UK uses Monday as the first day of week (no week.start property set), which
-         // is the configuration under which the previous fix failed.
-         ThreadContext.setLocale(Locale.UK);
+      WeekStartUtil.withWeekStart("monday", () -> {
          Assertions.assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek(),
                                  "test requires a non-Sunday first day of week");
 
-         Date cellDate = date("2020-02-06");
+         // 2020-01-02 (Thu) belongs to the Dec 30 - Jan 5 week, i.e. December 2019's 5th
+         // week, while the 2021 bar sharing its axis position falls in January's 1st week.
+         Date cellDate = date("2020-01-02");
          // The bucket carries the comparison (other-year) period's week part value; here the
          // 2021 bar's week is shared with the 2020 bar at the same axis position.
-         int storedPartValue = weekOfYearPart(date("2021-02-04"));
+         int storedPartValue = weekOfYearPart(date("2021-01-07"));
          int actualWeekPart = weekOfYearPart(cellDate);
 
          Assertions.assertNotEquals(actualWeekPart, storedPartValue,
@@ -214,10 +210,7 @@ public class DCMergeDatePartFilterTest {
             "equivalence cell expected when the stored week differs from the cell's actual week");
          Assertions.assertEquals(actualWeekPart, ((Number) equivalenceCell.getValue(0)).intValue(),
             "equivalence week must match the cell's actual date, not the stored part value");
-      }
-      finally {
-         ThreadContext.setLocale(oldLocale);
-      }
+      });
    }
 
    // Bug #75351: Same-Day comparison groups by the sequential week-of-year ('ww'), which already
@@ -226,10 +219,7 @@ public class DCMergeDatePartFilterTest {
    // even in the same non-Sunday boundary scenario where the legacy 'wy' encoding diverges.
    @Test
    public void testSequentialWeekSkipsEquivalence() {
-      Locale oldLocale = ThreadContext.getLocale();
-
-      try {
-         ThreadContext.setLocale(Locale.UK);
+      WeekStartUtil.withWeekStart("monday", () -> {
          Assertions.assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek(),
                                  "test requires a non-Sunday first day of week");
 
@@ -258,10 +248,7 @@ public class DCMergeDatePartFilterTest {
          DCMergeDatePartFilter.MergePartCell mpc = (DCMergeDatePartFilter.MergePartCell) cell;
          Assertions.assertNull(mpc.getEquivalenceCell(),
             "sequential-week part must skip the equivalence remap (it is already aligned)");
-      }
-      finally {
-         ThreadContext.setLocale(oldLocale);
-      }
+      });
    }
 
    // Mirrors JavaScriptEngine.datePart("ww", date, true): the sequential week-of-year value
@@ -280,7 +267,7 @@ public class DCMergeDatePartFilterTest {
       cal.setFirstDayOfWeek(Tool.getFirstDayOfWeek());
       cal.setMinimalDaysInFirstWeek(7);
       cal.setTime(dt);
-      cal.add(Calendar.DATE, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+      DateComparisonUtil.moveToWeekStart(cal);
       return (cal.get(Calendar.MONTH) + 1) * 10 + cal.get(Calendar.WEEK_OF_MONTH);
    }
 }

--- a/core/src/test/java/inetsoft/test/WeekStartUtil.java
+++ b/core/src/test/java/inetsoft/test/WeekStartUtil.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.test;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
+
+import java.util.function.Supplier;
+
+/**
+ * Drives the <code>week.start</code> property from a test. This is the only supported way to
+ * vary the first day of week: {@link Tool#getFirstDayOfWeek()} is a pure function of that
+ * property and deliberately ignores the thread locale.
+ */
+public final class WeekStartUtil {
+   private WeekStartUtil() {
+   }
+
+   /**
+    * Run an action with <code>week.start</code> set to the given day name (or an empty
+    * string / null for the default), restoring the previous value afterwards.
+    */
+   public static void withWeekStart(String day, Runnable action) {
+      withWeekStart(day, () -> {
+         action.run();
+         return null;
+      });
+   }
+
+   /**
+    * Evaluate a supplier with <code>week.start</code> set to the given day name.
+    */
+   public static <T> T withWeekStart(String day, Supplier<T> action) {
+      String old = SreeEnv.getProperty("week.start");
+      setWeekStart(day);
+
+      try {
+         return action.get();
+      }
+      finally {
+         setWeekStart(old);
+      }
+   }
+
+   private static void setWeekStart(String day) {
+      SreeEnv.setProperty("week.start", day == null ? "" : day);
+      Tool.clearWeekStartCache();
+   }
+}

--- a/core/src/test/java/inetsoft/uql/asset/DateRangeRefWeekPushdownTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/DateRangeRefWeekPushdownTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.test.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.util.ThreadContext;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Week grouping is either pushed down to SQL (which computes Sunday-based weeks) or done in
+ * memory from a script. The choice must agree with the first day of week actually in effect,
+ * or the database and the engine bucket the same rows differently.
+ *
+ * <p>The gate used to also require {@code Tool.getWeekStart() != null}, i.e. an explicitly
+ * configured property. With a blank {@code week.start} and a Monday locale the first day of
+ * week was Monday but pushdown still happened -- the SQL/Java split this pins shut.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class DateRangeRefWeekPushdownTest {
+   @Test
+   void weekPushdownSuppressedForNonSundayWeekStart() {
+      WeekStartUtil.withWeekStart("monday", () -> {
+         assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek());
+         assertEquals("", weekExpression(),
+                      "a non-Sunday week start must fall back to in-memory grouping");
+      });
+   }
+
+   @Test
+   void weekPushdownUsedForSundayWeekStart() {
+      WeekStartUtil.withWeekStart("sunday", () ->
+         assertNotEquals("", weekExpression(),
+                         "a Sunday week start can be computed by the database"));
+   }
+
+   /**
+    * The invariant behind both cases: pushdown happens only when the effective week start is
+    * Sunday. This failed with a blank {@code week.start} under a Monday locale.
+    */
+   @Test
+   void pushdownAgreesWithEffectiveWeekStartUnderAnyLocale() {
+      Locale old = ThreadContext.getLocale();
+
+      try {
+         for(String tag : new String[]{ "en-US", "en-GB", "zh-CN", "de-DE" }) {
+            ThreadContext.setLocale(Locale.forLanguageTag(tag));
+
+            for(String weekStart : new String[]{ "", "sunday", "monday", "saturday" }) {
+               WeekStartUtil.withWeekStart(weekStart, () ->
+                  assertTrue(weekExpression().isEmpty() ||
+                                Tool.getFirstDayOfWeek() == Calendar.SUNDAY,
+                             "week grouping pushed down to SQL while the engine starts " +
+                                "weeks on day " + Tool.getFirstDayOfWeek() +
+                                " (locale " + tag + ", week.start \"" + weekStart + "\")"));
+            }
+         }
+      }
+      finally {
+         ThreadContext.setLocale(old);
+      }
+   }
+
+   private static String weekExpression() {
+      return DateRangeRef.getExpression("mysql", new AttributeRef("orderDate"),
+                                        DateRangeRef.WEEK_INTERVAL);
+   }
+}

--- a/core/src/test/java/inetsoft/uql/asset/DateTimeProcessorTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/DateTimeProcessorTest.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.test.*;
+import inetsoft.util.Tool;
+import inetsoft.util.script.JavaScriptEngine;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.sql.Timestamp;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The full-week date levels must agree with each other and with the {@code datePart('wy')}
+ * expression that feeds them, for any configured week start.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class DateTimeProcessorTest {
+   /**
+    * {@code getMonthPartOfFullWeek} is the week-start-correct sibling, so it is the oracle
+    * for the month half of the {@code (month + 1) * 10 + weekOfMonth} encoding that
+    * {@code datePart('wy')} produces.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = { "sunday", "monday", "wednesday" })
+   void monthPartOfFullWeekMatchesWeekOfYearDatePart(String weekStart) {
+      WeekStartUtil.withWeekStart(weekStart, () -> {
+         for(Date day : everyDayOf(2021)) {
+            DateTimeProcessor processor = DateTimeProcessor.at(day.getTime());
+            int expected = (int) (JavaScriptEngine.datePart("wy", day, true) / 10);
+
+            assertEquals(expected, processor.getMonthPartOfFullWeek(-1),
+                         "month of full week disagrees with datePart('wy') for " + day +
+                            " (" + weekStart + " week start)");
+         }
+      });
+   }
+
+   /**
+    * {@code getMonthOfFullWeek} rewinds differently from its sibling above; the two must
+    * still land on the same month for every date and every forced week-of-month.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = { "sunday", "monday", "wednesday" })
+   void monthOfFullWeekAgreesWithMonthPartOfFullWeek(String weekStart) {
+      WeekStartUtil.withWeekStart(weekStart, () -> {
+         Calendar cal = new GregorianCalendar();
+
+         for(Date day : everyDayOf(2021)) {
+            for(int forceWM = -1; forceWM <= 5; forceWM++) {
+               DateTimeProcessor processor = DateTimeProcessor.at(day.getTime());
+               Timestamp month = processor.getMonthOfFullWeek(forceWM);
+               cal.setTime(month);
+
+               assertEquals(DateTimeProcessor.at(day.getTime()).getMonthPartOfFullWeek(forceWM),
+                            cal.get(Calendar.MONTH) + 1,
+                            "getMonthOfFullWeek and getMonthPartOfFullWeek disagree for " +
+                               day + " forceWM=" + forceWM + " (" + weekStart + ")");
+            }
+         }
+      });
+   }
+
+   /**
+    * {@code getYearOfFullWeek} built a bare {@code GregorianCalendar}, so it started weeks
+    * wherever the JVM default locale said rather than at the configured week start.
+    */
+   @Test
+   void yearOfFullWeekIgnoresTheDefaultLocale() {
+      Locale old = Locale.getDefault();
+
+      try {
+         WeekStartUtil.withWeekStart("monday", () -> {
+            // one setDefault per pass rather than one per assertion, to keep the window in
+            // which this test perturbs JVM-global state as short as possible.
+            List<Timestamp> underSunday = yearsOfFullWeek(Locale.US);
+            List<Timestamp> underMonday = yearsOfFullWeek(Locale.UK);
+            List<String> labels = labels();
+
+            for(int i = 0; i < labels.size(); i++) {
+               assertEquals(underSunday.get(i), underMonday.get(i),
+                            "year of full week changed with the JVM default locale for " +
+                               labels.get(i));
+            }
+         });
+      }
+      finally {
+         Locale.setDefault(old);
+      }
+   }
+
+   private static List<Timestamp> yearsOfFullWeek(Locale defaultLocale) {
+      Locale.setDefault(defaultLocale);
+      List<Timestamp> results = new ArrayList<>();
+
+      for(Date day : everyDayOf(2021)) {
+         for(int forceWM = -1; forceWM <= 5; forceWM++) {
+            results.add(DateTimeProcessor.at(day.getTime()).getYearOfFullWeek(forceWM));
+         }
+      }
+
+      return results;
+   }
+
+   /** One label per (date, forceWM) pair, in the same order as {@link #yearsOfFullWeek}. */
+   private static List<String> labels() {
+      List<String> labels = new ArrayList<>();
+
+      for(Date day : everyDayOf(2021)) {
+         for(int forceWM = -1; forceWM <= 5; forceWM++) {
+            labels.add(day + " forceWM=" + forceWM);
+         }
+      }
+
+      return labels;
+   }
+
+   private static List<Date> everyDayOf(int year) {
+      List<Date> days = new ArrayList<>();
+      Calendar cal = new GregorianCalendar();
+      cal.clear();
+      cal.set(year, Calendar.JANUARY, 1, 12, 0, 0);
+
+      while(cal.get(Calendar.YEAR) == year) {
+         days.add(cal.getTime());
+         cal.add(Calendar.DATE, 1);
+      }
+
+      return days;
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonInfoWeekStartTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonInfoWeekStartTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.test.*;
+import inetsoft.util.script.JavaScriptEngine;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@code getToDateWeekOfMonth()} produces the {@code forceDcToDateWeekOfMonth} argument of
+ * the {@code datePartForceWeekOfMonth('wy'|'wm'|'wmq', ...)} expressions this class emits.
+ * Producer and consumer must compute the week the same way, or the month-boundary folding
+ * they implement together silently stops matching.
+ *
+ * <p>The producer rewound to the preceding Sunday regardless of the configured week start,
+ * so under a Monday start it could return week-of-month 0 -- and every consumer guards on
+ * {@code forceWM > 0}, disabling the folding outright.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class DateComparisonInfoWeekStartTest {
+   @ParameterizedTest
+   @ValueSource(strings = { "sunday", "monday", "saturday" })
+   void toDateWeekOfMonthMatchesTheWeekOfYearDatePart(String weekStart) {
+      WeekStartUtil.withWeekStart(weekStart, () -> {
+         for(Date day : everyDayOf(2021)) {
+            int actual = weekToDateInfo(day).getToDateWeekOfMonth();
+            int expected = (int) JavaScriptEngine.datePart("wy", day, true) % 10;
+
+            assertEquals(expected, actual,
+                         "getToDateWeekOfMonth disagrees with the datePart('wy') week it " +
+                            "is compared against, for " + day + " (" + weekStart + ")");
+         }
+      });
+   }
+
+   /**
+    * A forced week-of-month of 0 reads as "not forced" to every consumer, so the value must
+    * always be a real week number.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = { "sunday", "monday", "saturday" })
+   void toDateWeekOfMonthIsAlwaysARealWeek(String weekStart) {
+      WeekStartUtil.withWeekStart(weekStart, () -> {
+         for(Date day : everyDayOf(2021)) {
+            int weekOfMonth = weekToDateInfo(day).getToDateWeekOfMonth();
+
+            assertTrue(weekOfMonth >= 1 && weekOfMonth <= 5,
+                       "forced week-of-month out of range for " + day + " (" + weekStart +
+                          "): " + weekOfMonth);
+         }
+      });
+   }
+
+   /** Week-to-date over a year context, ending on the given day. */
+   private static DateComparisonInfo weekToDateInfo(Date toDate) {
+      DateComparisonInterval interval = new DateComparisonInterval();
+      interval.setLevelValue("week to date");
+      interval.setContextLevelValue("year");
+      interval.setEndDayAsToDate(false);
+      interval.setIntervalEndDate(toDate);
+      interval.setInclusive(true);
+
+      DateComparisonInfo info = new DateComparisonInfo();
+      info.setDateComparisonInterval(interval);
+
+      return info;
+   }
+
+   private static List<Date> everyDayOf(int year) {
+      List<Date> days = new ArrayList<>();
+      Calendar cal = new GregorianCalendar();
+      cal.clear();
+      cal.set(year, Calendar.JANUARY, 1, 12, 0, 0);
+
+      while(cal.get(Calendar.YEAR) == year) {
+         days.add(cal.getTime());
+         cal.add(Calendar.DATE, 1);
+      }
+
+      return days;
+   }
+}

--- a/core/src/test/java/inetsoft/util/ToolWeekStartTest.java
+++ b/core/src/test/java/inetsoft/util/ToolWeekStartTest.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The first day of week must be a pure function of the {@code week.start} property.
+ *
+ * <p>It used to fall back to {@code GregorianCalendar.getInstance(locale)} whenever the
+ * property was unset -- and the shipped default is blank, so that was the normal path. The
+ * locale is {@link ThreadContext#getLocale()}, i.e. the viewing user's, so the same dashboard
+ * bucketed weeks differently for different users, and disagreed with the Sunday-based week
+ * expression {@code DateRangeRef} pushes down to SQL.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ToolWeekStartTest {
+   private static final List<String> DAY_NAMES =
+      List.of("sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday");
+
+   @ParameterizedTest
+   @ValueSource(strings = { "en-US", "en-GB", "zh-CN", "de-DE", "ja-JP" })
+   void blankWeekStartIsSundayRegardlessOfLocale(String languageTag) {
+      Locale old = ThreadContext.getLocale();
+
+      try {
+         ThreadContext.setLocale(Locale.forLanguageTag(languageTag));
+         WeekStartUtil.withWeekStart("", () ->
+            assertEquals(Calendar.SUNDAY, Tool.getFirstDayOfWeek(),
+                         "blank week.start must not follow the " + languageTag + " locale"));
+      }
+      finally {
+         ThreadContext.setLocale(old);
+      }
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "foo", " ", "2", "MON" })
+   void invalidWeekStartIsSunday(String value) {
+      WeekStartUtil.withWeekStart(value, () ->
+         assertEquals(Calendar.SUNDAY, Tool.getFirstDayOfWeek(),
+                      "invalid week.start \"" + value + "\" must fall back to Sunday"));
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "monday", "Monday", "MONDAY" })
+   void dayNameIsMatchedCaseInsensitively(String value) {
+      WeekStartUtil.withWeekStart(value, () ->
+         assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek()));
+   }
+
+   @Test
+   void everyDayNameResolves() {
+      for(int i = 0; i < DAY_NAMES.size(); i++) {
+         final int expected = Calendar.SUNDAY + i;
+         WeekStartUtil.withWeekStart(DAY_NAMES.get(i), () ->
+            assertEquals(expected, Tool.getFirstDayOfWeek()));
+      }
+   }
+
+   /**
+    * {@code getWeekStart()} reads the property directly while {@code getFirstDayOfWeek()}
+    * reads it through a timed cache. {@code DateRangeRef.getExpression()} consults both to
+    * decide whether to push week grouping down to SQL, so they must never disagree.
+    */
+   @Test
+   void weekStartAndFirstDayOfWeekAgree() {
+      for(String day : new String[]{ "sunday", "monday", "saturday", "", "bogus" }) {
+         WeekStartUtil.withWeekStart(day, () -> {
+            String weekStart = Tool.getWeekStart();
+            int firstDay = Tool.getFirstDayOfWeek();
+
+            if(weekStart == null) {
+               assertEquals(Calendar.SUNDAY, firstDay,
+                            "no configured week start must mean Sunday");
+            }
+            else {
+               assertEquals(DAY_NAMES.indexOf(weekStart) + Calendar.SUNDAY, firstDay,
+                            "\"" + weekStart + "\" resolves to a different day than " +
+                               "getWeekStart() reports");
+            }
+         });
+      }
+   }
+
+   /**
+    * A change made through the EM must be visible at once, not after the property cache
+    * timeout -- otherwise the two accessors above disagree for the length of it.
+    */
+   @Test
+   void cacheClearMakesAChangeVisibleImmediately() {
+      WeekStartUtil.withWeekStart("monday", () -> {
+         assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek());
+         WeekStartUtil.withWeekStart("thursday", () ->
+            assertEquals(Calendar.THURSDAY, Tool.getFirstDayOfWeek()));
+         assertEquals(Calendar.MONDAY, Tool.getFirstDayOfWeek());
+      });
+   }
+}

--- a/core/src/test/java/inetsoft/util/script/JavaScriptEngineTest.java
+++ b/core/src/test/java/inetsoft/util/script/JavaScriptEngineTest.java
@@ -461,6 +461,115 @@ class JavaScriptEngineTest {
       assertEquals(0, JavaScriptEngine.datePartForceWeekOfMonth("d", null, false, -1));
    }
 
+   // The "wy"/"wm"/"wmq" date parts rewound to the preceding *Sunday*
+   // (-(DAY_OF_WEEK - 1)) even when the calendar was configured for another week start,
+   // so a date landed in the wrong week bucket and could produce week-of-month 0 -- an
+   // encoding the (month + 1) * 10 + weekOfMonth scheme has no room for. These pin the
+   // rewind to the configured week start.
+   @Test
+   void testWeekDatePartsMondayWeekStart() {
+      WeekStartUtil.withWeekStart("monday", () -> {
+         // 2021-01-04 (Mon) starts the first full week of January; 2021-01-01 (Fri) through
+         // 2021-01-03 (Sun) belong to the Dec 28 - Jan 3 week, i.e. December's 4th week.
+         assertEquals(11, JavaScriptEngine.datePart("wy", toDate("2021-01-04T00:00"), true));
+         assertEquals(11, JavaScriptEngine.datePart("wy", toDate("2021-01-05T00:00"), true));
+         assertEquals(124, JavaScriptEngine.datePart("wy", toDate("2021-01-01T00:00"), true));
+         // a Sunday: the day the old Sunday-anchored rewind got most wrong, because it is
+         // the *last* day of a Monday-start week.
+         assertEquals(124, JavaScriptEngine.datePart("wy", toDate("2021-01-03T00:00"), true));
+
+         assertEquals(3, JavaScriptEngine.datePart("wmq", toDate("2021-01-01T00:00"), true));
+         assertEquals(4, JavaScriptEngine.datePart("wm", toDate("2021-01-01T00:00"), true));
+      });
+   }
+
+   // Regression guard: the fix must be a strict no-op when the week starts on Sunday, since
+   // (dow - 1 + 7) % 7 == dow - 1 for firstDayOfWeek == SUNDAY. These are the values the
+   // Sunday-anchored code produced.
+   @Test
+   void testWeekDatePartsSundayWeekStartUnchanged() {
+      WeekStartUtil.withWeekStart("sunday", () -> {
+         assertEquals(11, JavaScriptEngine.datePart("wy", toDate("2021-01-03T00:00"), true));
+         assertEquals(11, JavaScriptEngine.datePart("wy", toDate("2021-01-05T00:00"), true));
+         assertEquals(124, JavaScriptEngine.datePart("wy", toDate("2021-01-01T00:00"), true));
+         assertEquals(3, JavaScriptEngine.datePart("wmq", toDate("2021-01-01T00:00"), true));
+         assertEquals(4, JavaScriptEngine.datePart("wm", toDate("2021-01-01T00:00"), true));
+         assertEquals(2, JavaScriptEngine.datePart("wq", toDate("2025-04-15T00:00"), true));
+      });
+   }
+
+   // CoreTool.calendar is a shared ThreadLocal and CalcDateTime.date() leaves its first day
+   // of week set, so the applyWeekStart=false form of datePart -- which is the documented
+   // 2-arg script signature -- used to depend on what had run earlier on the same pooled
+   // thread. It must be Sunday-based no matter what.
+   @Test
+   void testDatePartWithoutWeekStartIsUnaffectedByTheSharedCalendar() {
+      Calendar shared = inetsoft.util.CoreTool.calendar.get();
+      int old = shared.getFirstDayOfWeek();
+
+      try {
+         // 2021-01-03 is a Sunday: it is week 1 of January under a Sunday start but the
+         // last day of December's 4th week under a Monday start, so the two disagree.
+         java.util.Date date = toDate("2021-01-03T00:00");
+
+         shared.setFirstDayOfWeek(Calendar.MONDAY);
+
+         // week.start is Monday too, to prove applyWeekStart=false ignores both of them.
+         WeekStartUtil.withWeekStart("monday", () ->
+            assertEquals(11, JavaScriptEngine.datePart("wy", date, false),
+                         "datePart without applyWeekStart must stay Sunday-based, not " +
+                            "inherit the shared calendar's first day of week"));
+
+         assertEquals(Calendar.MONDAY, shared.getFirstDayOfWeek(),
+                      "datePart must restore the shared calendar's first day of week");
+      }
+      finally {
+         shared.setFirstDayOfWeek(old);
+      }
+   }
+
+   // Every day of the same week must land in the same "wy" bucket. When the rewind and the
+   // WEEK_OF_MONTH read disagreed about where the week starts, a single week split into two
+   // buckets -- the phantom leading bar in the reported Year_WeekToDate chart.
+   @ParameterizedTest
+   @org.junit.jupiter.params.provider.ValueSource(strings = { "sunday", "monday", "wednesday" })
+   void testWeekOfYearIsConstantWithinAWeek(String weekStart) {
+      WeekStartUtil.withWeekStart(weekStart, () -> {
+         Calendar cal = new GregorianCalendar();
+         cal.setFirstDayOfWeek(inetsoft.util.Tool.getFirstDayOfWeek());
+         cal.setMinimalDaysInFirstWeek(7);
+         cal.clear();
+         cal.set(2020, Calendar.JANUARY, 1, 12, 0, 0);
+
+         double weekValue = -1;
+         int dayInWeek = -1;
+
+         for(int i = 0; i < 731; i++) {
+            java.util.Date day = cal.getTime();
+            double value = JavaScriptEngine.datePart("wy", day, true);
+
+            assertTrue(value >= 11 && value <= 125,
+                       "wy out of the (month+1)*10+weekOfMonth domain for " + day +
+                          " (" + weekStart + " week start): " + value);
+            assertTrue(value % 10 >= 1,
+                       "wy encodes week-of-month 0 for " + day +
+                          " (" + weekStart + " week start): " + value);
+
+            if(cal.get(Calendar.DAY_OF_WEEK) == cal.getFirstDayOfWeek()) {
+               weekValue = value;
+               dayInWeek = 0;
+            }
+            else if(dayInWeek >= 0) {
+               assertEquals(weekValue, value,
+                            "wy changed mid-week at " + day + " (" + weekStart +
+                               " week start)");
+            }
+
+            cal.add(Calendar.DATE, 1);
+         }
+      });
+   }
+
    @Test
    @Disabled("Task 5.3: scope-chain name enumeration (getNames/getDisplayNames/getIds) was " +
       "a Rhino-era instance method operating on Rhino Scriptable scopes; under GraalJS this " +

--- a/web/projects/em/src/app/settings/presentation/presentation-time-settings-view/presentation-time-settings-view.component.html
+++ b/web/projects/em/src/app/settings/presentation/presentation-time-settings-view/presentation-time-settings-view.component.html
@@ -22,7 +22,11 @@
       <section class="flex-row">
         <mat-form-field appearance="outline" color="accent">
           <mat-label>_#(Week Start Day)</mat-label>
-          <input matInput [(ngModel)]="model.weekStart" (input)="emitModel()">
+          <mat-select [(ngModel)]="model.weekStart" (selectionChange)="emitModel()">
+            @for (day of weekStartOptions; track day.value) {
+              <mat-option [value]="day.value">{{ day.label }}</mat-option>
+            }
+          </mat-select>
         </mat-form-field>
       </section>
       <section>

--- a/web/projects/em/src/app/settings/presentation/presentation-time-settings-view/presentation-time-settings-view.component.spec.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-time-settings-view/presentation-time-settings-view.component.spec.ts
@@ -22,7 +22,7 @@ import { PresentationTimeSettingsViewComponent } from "./presentation-time-setti
 import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MatFormFieldModule } from "@angular/material/form-field";
-import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
 import { MatCardModule } from "@angular/material/card";
 
 describe("PresentationTimeSettingsViewComponent", () => {
@@ -35,7 +35,7 @@ describe("PresentationTimeSettingsViewComponent", () => {
         ReactiveFormsModule,
         NoopAnimationsModule,
         MatFormFieldModule,
-        MatInputModule,
+        MatSelectModule,
         MatCardModule,
             PresentationTimeSettingsViewComponent]
          })
@@ -50,5 +50,24 @@ describe("PresentationTimeSettingsViewComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  // week.start only accepts the seven day names; anything else silently falls back to
+  // Sunday on the server, so the control must not accept free text.
+  it("should offer only the valid week start values", () => {
+    expect(component.weekStartOptions.map(o => o.value))
+      .toEqual(["", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+                "Saturday"]);
+  });
+
+  // an existing lower-case value must still select its option rather than reading as
+  // "default" and being cleared on the next save.
+  it("should normalize an existing week start onto the option list", () => {
+    component.model = {weekStart: "monday", scheduleTime12Hours: false};
+    expect(component.model.weekStart).toBe("Monday");
+
+    // a value matching nothing is preserved, not silently blanked on the next save
+    component.model = {weekStart: "bogus", scheduleTime12Hours: false};
+    expect(component.model.weekStart).toBe("bogus");
   });
 });

--- a/web/projects/em/src/app/settings/presentation/presentation-time-settings-view/presentation-time-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-time-settings-view/presentation-time-settings-view.component.ts
@@ -22,7 +22,8 @@ import { PresentationTimeSettingsModel } from "./presentation-time-settings-mode
 import { PresentationSettingsType } from "../presentation-settings-view/presentation-settings-type.enum";
 import { ContextHelp } from "../../../context-help";
 import { MatCheckbox } from "@angular/material/checkbox";
-import { MatInput } from "@angular/material/input";
+import { MatOption } from "@angular/material/core";
+import { MatSelect } from "@angular/material/select";
 import { MatFormField, MatLabel } from "@angular/material/form-field";
 import { MatCard, MatCardTitle, MatCardContent } from "@angular/material/card";
 
@@ -35,12 +36,38 @@ import { MatCard, MatCardTitle, MatCardContent } from "@angular/material/card";
     selector: "em-presentation-time-settings-view",
     templateUrl: "./presentation-time-settings-view.component.html",
     styleUrls: ["./presentation-time-settings-view.component.scss"],
-    imports: [MatCard, MatCardTitle, MatCardContent, MatFormField, MatLabel, MatInput, FormsModule, MatCheckbox]
+    imports: [MatCard, MatCardTitle, MatCardContent, MatFormField, MatLabel, MatSelect, MatOption, FormsModule, MatCheckbox]
 })
 export class PresentationTimeSettingsViewComponent {
+   // week.start only accepts these day names; anything else falls back to Sunday on the
+   // server, so the field is a fixed list rather than free text.
+   readonly weekStartOptions = [
+      {label: "_#(js:Default)", value: ""},
+      {label: "_#(js:Sunday)", value: "Sunday"},
+      {label: "_#(js:Monday)", value: "Monday"},
+      {label: "_#(js:Tuesday)", value: "Tuesday"},
+      {label: "_#(js:Wednesday)", value: "Wednesday"},
+      {label: "_#(js:Thursday)", value: "Thursday"},
+      {label: "_#(js:Friday)", value: "Friday"},
+      {label: "_#(js:Saturday)", value: "Saturday"}
+   ];
+
    @Input() isSysAdmin: boolean;
    @Input() set model(model: PresentationTimeSettingsModel) {
       this._model = model;
+
+      if(model && model.weekStart) {
+         // the property is matched case-insensitively on the server, so map an existing
+         // value onto the option list rather than showing an empty select. A value that
+         // matches nothing is left alone: it already means Sunday on the server, and
+         // rewriting it here would blank the property on the next unrelated save.
+         const match = this.weekStartOptions
+            .find(o => !!o.value && o.value.toLowerCase() === model.weekStart.toLowerCase());
+
+         if(match) {
+            model.weekStart = match.value;
+         }
+      }
 
     if(this.model) {
       this.form.setValue(this.model, {emitEvent: false});


### PR DESCRIPTION
## The reported symptom

Importing `Year_WeekToDate.vso` on a Chinese-locale server produced a phantom leading week bucket in the chart (the duplicated `2021-01-04` label), while every other Date Comparison case on the same box computed Sunday-based weeks.

Both defects in the report are confirmed. Investigating turned up three related problems alongside them.

## 1. `week.start` silently followed the thread locale

`Tool.getFirstDayOfWeek()` fell back to `GregorianCalendar.getInstance(locale).getFirstDayOfWeek()` whenever `week.start` was unset — and `defaults.properties:236` ships it blank, so that was the normal path.

The locale is `ThreadContext.getLocale()`, which resolves to the **viewing user's** `SRPrincipal` locale on a `GroupedThread` and only degrades to the JVM default elsewhere. So the week start varied per user and per thread, with nothing in the product saying so — two users could see different week bucketing on the same dashboard.

It also already caused a **SQL/Java split**. `DateRangeRef.getExpression()` suppresses SQL week pushdown only when the first day of week is not Sunday **and** `Tool.getWeekStart() != null`, and `getWeekStart()` returns null unless the property is explicitly a valid day name. Blank `week.start` + a Monday locale meant pushdown still happened: the database grouped weeks one way while every in-memory path grouped them another. `VSCalendar.java:863,875` encode the same "no explicit `week.start` means Sunday" assumption.

**Fix:** blank or invalid `week.start` now means Sunday on every thread. This makes the first day of week a pure function of one visible property, and makes an assumption three existing call sites already rely on actually true. An invalid value is logged instead of silently absorbed.

## 2. The `wy`/`wm`/`wmq` rewind was hardcoded to Sunday

These date parts set the calendar's first day of week from `week.start`, then read `WEEK_OF_MONTH` from it — but the rewind in between was `-(DAY_OF_WEEK - 1)`. `DAY_OF_WEEK` is always Sunday-anchored and is unaffected by `setFirstDayOfWeek()`.

Under a Monday start that puts a Sunday — the *last* day of its week — at offset 0, so it reads the leading partial week's `WEEK_OF_MONTH` of 0 and encodes `(month+1)*10 + 0`, outside the `[11,125]` domain the scheme allows:

| date | old rewind to | wom | bucket | fixed |
|---|---|---|---|---|
| Jan 1 2021 (Fri) | -5 -> Dec 27 | 3 | 123 | 124 |
| Jan 3 (Sun) | -0 -> Jan 3 | **0** | **10** | 124 |
| Jan 4 (Mon) | -1 -> Jan 3 | **0** | **10** | 11 |
| Jan 10 (Sun) | -0 -> Jan 10 | 1 | 11 | 11 |

Two real weeks become three buckets, the extra one carrying the invalid encoding `10`. That is the phantom bar.

Three correlated sites had to move together:

- `DateComparisonInfo.getToDateWeekOfMonth()` produces the `forceDcToDateWeekOfMonth` argument those same expressions are compared against. It had the same Sunday rewind on a calendar whose week start *was* set correctly, and returned **0** for early-January to-dates — which every consumer reads as "not forced" (`forceWM > 0`), disabling the month-boundary folding that would have absorbed the leading week into December.
- `DateComparisonInfo:1929` was a fourth variant, `-(dow - getFirstDayOfWeek())` with no `% 7`, which moves the calendar **forward** a week when `dow < firstDayOfWeek`. It decides the DC period start.
- `DCMergeDatePartFilter:314` deliberately mirrors `datePart('wy')` (Bug #75351). Fixing one without the other would make them disagree on *every* row rather than only at month boundaries — strictly worse than the status quo.

All now go through `DateComparisonUtil.moveToWeekStart()`, which is a **strict no-op under a Sunday week start**: `(dow - 1 + 7) % 7 == dow - 1`. Nothing changes on a Sunday-start system, which is the regression argument for this change.

## 3. Three problems found alongside

- **`datePart` inherited a week start from a shared mutable `ThreadLocal`.** `CoreTool.calendar` is shared per thread and `CalcDateTime.date():766` sets its first day and never restores it. The documented two-argument script form `datePart(interval, date)` coerces `applyWeekStart` to `false` and so depended on what had run earlier on the same pooled thread. It is now deterministically Sunday-based in that branch (the old code was already half-broken here: Sunday rewind, but a locale-dependent `WEEK_OF_MONTH` read).
- **`DateTimeProcessor.getYearOfFullWeek()`** built a bare `GregorianCalendar`, so it started weeks wherever the JVM default locale said rather than at the configured week start — putting the returned year **off by one** at the Dec/Jan boundary. Covered by a test that runs the same input under `Locale.US` and `Locale.UK`.
- **The EM "Week Start Day" field was free text**, so a typo fell through to the locale default with no feedback. It is now a dropdown reusing the list already defined for the same property on the EM Properties page. An existing value is only case-normalized, never rewritten, so an unrecognized value cannot be blanked by an unrelated save.

## Not changed

`DateTimeProcessor.getMonthOfFullWeek()`'s flat `-7` rewind is off by one week under every week start, but an exhaustive sweep (365 days x forceWM -1..5 x 3 week starts, against the week-start-correct sibling `getMonthPartOfFullWeek`) shows the returned month is unaffected — the `forceWM` branch it feeds cannot be reached by a real forced value of 1-5. Left in place with a comment rather than making an untestable behavior change.

## Testing

New coverage, all driving the week start through `week.start` via the new `inetsoft.test.WeekStartUtil` helper (the previous `ThreadContext.setLocale` idiom stops working by design):

- `ToolWeekStartTest` — blank/invalid `week.start` gives Sunday under `en_US`/`en_GB`/`zh_CN`/`de_DE`/`ja_JP`; `getWeekStart()` and `getFirstDayOfWeek()` never disagree; a change is visible immediately.
- `DateRangeRefWeekPushdownTest` — pushdown happens only when the effective week start is Sunday, phrased as an invariant across locales.
- `DateComparisonInfoWeekStartTest` — `getToDateWeekOfMonth()` matches the `datePart('wy')` week it is compared against, for every date of 2021 under three week starts, and is never 0.
- `DateTimeProcessorTest` — full-week levels agree with the `datePart('wy')` oracle; `getYearOfFullWeek` is independent of the JVM default locale.
- `JavaScriptEngineTest` — Monday-start values for `wy`/`wm`/`wmq`; a two-year sweep asserting every day of a week lands in one bucket and no bucket encodes week 0; a Sunday-start snapshot proving the change is a no-op there; and the shared-`ThreadLocal` determinism case.

Each was confirmed to fail without its corresponding fix. `DCMergeDatePartFilterTest`'s Bug #75351 case needed a new date pair — its old dates now agree under the corrected encoding.

Full `core` suite: 4882 tests, only the two `RefreshVariableTest` failures that also fail on `main`. EM: 378 tests pass, lint clean. Verified live on a locally-run server.

## Upgrade note

Deployments that never set `week.start` and run a Monday-start locale will see week buckets shift. They were already bucketing inconsistently between users and against their own SQL; setting `week.start` explicitly preserves the previous behavior. Worth a release note.

Also worth confirming with the reporter: `zh_CN` gives Monday under the JDK's default CLDR data, but **not** on the stock Docker image, which pins `-Djava.locale.providers=COMPAT,SPI` where `zh_CN` is Sunday. If they are on a stock container, the Monday came from the per-user locale path rather than the server locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
