### PR TITLE
fix(wiz): report a useFacet that can't take effect (bug 76522, DCG-007)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -27,6 +27,7 @@ import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
+import inetsoft.uql.viewsheet.internal.StandardPeriods;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,7 +153,11 @@ public class DateComparisonService {
     * effect at all — its date field isn't on x/y, or its chart type doesn't support date
     * comparison to begin with — reports {@code dateComparisonInactive:true} and a {@code reason}
     * (see {@link #describeDateComparisonInactive}) instead of silently returning as if it
-    * applied.
+    * applied. For a chart where the comparison did apply but a requested {@code useFacet:true}
+    * has no rendering effect on it (the comparison's period level already matches its interval
+    * granularity, with no value-plus rendering to fall back on either), reports
+    * {@code useFacetInapplicable:true} and a {@code reason}
+    * (see {@link #describeUseFacetInapplicable}).
     */
    public Map<String, Object> set(String sessionToken, Principal user, String assemblyName,
                                   Comparison comparison, String linkUri) throws Exception
@@ -180,6 +185,7 @@ public class DateComparisonService {
          result.putAll(describeRetargetedDimension(rvs, assemblyName));
          result.putAll(describeChartTypeOverride(rvs, assemblyName, beforeChartType));
          result.putAll(describeDateComparisonInactive(rvs, assemblyName));
+         result.putAll(describeUseFacetInapplicable(rvs, assemblyName, comparison));
       });
 
       return result;
@@ -374,6 +380,73 @@ public class DateComparisonService {
             "group, color, shape, or text.");
       }
 
+      return out;
+   }
+
+   /**
+    * {@code useFacet} is genuinely read by {@code ChartDcProcessor} (unlike a dead flag), but its
+    * one axis-placement consumer (the {@code periodRef != null} block, {@code ChartDcProcessor
+    * .process():110-165}) only ever creates a {@code periodRef} for a {@code StandardPeriods}
+    * comparison when {@code DateComparisonInfo.periodLevelSameAsGranularityLevel()} is false — the
+    * common case of a plain N-over-N comparison with no distinct interval breakdown (e.g. a
+    * year-over-year comparison with no quarterly/monthly granularity override) makes that method
+    * return true, so {@code periodRef} stays null and this whole block — every line that reads
+    * {@code useFacet} — never runs. The flag's only other consumer ({@code
+    * ChartDcProcessor.updateDateComparisonChartType():806}, choosing Line vs. Point for the
+    * secondary "change" series) is gated behind {@code DateComparisonInfo.isValuePlus()}
+    * separately, so {@code useFacet} still has an effect there even when the axis-placement
+    * consumer is dead — this only reports {@code useFacetInapplicable} when both are inactive.
+    *
+    * <p>Only meaningful for a chart ({@code useFacet} has no crosstab consumer at all), and only
+    * when the comparison itself actually applied to it — {@link #describeDateComparisonInactive}
+    * already reports the case where it didn't (wrong chart type, or no date field on x/y), and
+    * that message already covers {@code useFacet} having no effect too, for an unrelated reason;
+    * reporting both here would be redundant and would misname the cause.
+    *
+    * <p>Not a chart, {@code useFacet:true} was not requested, or the comparison had (or would
+    * still have, via the value-plus consumer) some rendering effect: returns an empty map.
+    */
+   private static Map<String, Object> describeUseFacetInapplicable(RuntimeViewsheet rvs,
+                                                                    String assemblyName,
+                                                                    Comparison comparison)
+   {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(comparison.useFacet() == null || !comparison.useFacet()) {
+         return out;
+      }
+
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(!(assembly instanceof ChartVSAssembly)) {
+         return out;
+      }
+
+      VSChartInfo cinfo = ((ChartVSAssembly) assembly).getVSChartInfo();
+
+      if(cinfo == null || cinfo.getDateComparisonRef() == null) {
+         return out;
+      }
+
+      DateComparisonInfo dcInfo = ((ChartVSAssembly) assembly).getChartInfo().getDateComparisonInfo();
+
+      if(dcInfo == null) {
+         return out;
+      }
+
+      boolean periodAxisPlacementDead = dcInfo.getPeriods() instanceof StandardPeriods &&
+         dcInfo.periodLevelSameAsGranularityLevel();
+
+      if(!periodAxisPlacementDead || dcInfo.isValuePlus()) {
+         return out;
+      }
+
+      out.put("useFacetInapplicable", true);
+      out.put("reason", "faceting has no effect when the comparison's period level already " +
+         "matches its interval granularity — there is no separate breakdown left to place on " +
+         "the opposite axis. A finer interval granularity than the period level (e.g. a " +
+         "quarterly breakdown within a yearly comparison) is needed for useFacet to take effect.");
       return out;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -25,7 +25,10 @@ import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
+import inetsoft.uql.viewsheet.internal.DateComparisonInterval;
+import inetsoft.uql.viewsheet.internal.StandardPeriods;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.junit.jupiter.api.Tag;
@@ -719,6 +722,137 @@ class DateComparisonServiceTest {
          h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
 
       assertFalse(result.containsKey("dateComparisonInactive"));
+   }
+
+   // ── reporting useFacet as inapplicable ──────────────────────────────────────
+
+   /**
+    * A {@code DateComparisonInfo} with the given period level and interval granularity.
+    *
+    * <p>{@code StandardPeriods}/{@code DateComparisonInterval}'s real {@code getDateLevel()}/
+    * {@code getGranularity()} route through {@code DynamicValue}, which touches {@code VSUtil}'s
+    * static init (a full Spring context) — unavailable here, so both are mocked to hand back a
+    * plain int directly, the same way {@link #model()} already mocks the pane models it builds.
+    */
+   private static DateComparisonInfo dcInfo(int periodLevel, int granularity, int comparisonOption) {
+      StandardPeriods periods = mock(StandardPeriods.class);
+      when(periods.getDateLevel()).thenReturn(periodLevel);
+
+      DateComparisonInterval interval = mock(DateComparisonInterval.class);
+      when(interval.getGranularity()).thenReturn(granularity);
+
+      DateComparisonInfo dcInfo = mock(DateComparisonInfo.class, CALLS_REAL_METHODS);
+      dcInfo.setDateComparisonPeriods(periods);
+      dcInfo.setDateComparisonInterval(interval);
+      dcInfo.setComparisonOption(comparisonOption);
+      return dcInfo;
+   }
+
+   private static ChartVSAssembly chartWithDcInfo(DateComparisonInfo dcInfo) {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+      when(cinfo.getDateComparisonRef()).thenReturn(mock(VSDataRef.class));
+
+      ChartVSAssemblyInfo assemblyInfo = mock(ChartVSAssemblyInfo.class);
+      when(assemblyInfo.getDateComparisonInfo()).thenReturn(dcInfo);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      when(assembly.getChartInfo()).thenReturn(assemblyInfo);
+      return assembly;
+   }
+
+   /**
+    * DCG-007: a plain year-over-year comparison (period level == interval granularity, both
+    * year) with a value-only comparisonOption — {@code ChartDcProcessor.process()}'s {@code
+    * periodRef} never gets created (its {@code StandardPeriods} branch is gated behind {@code
+    * !periodLevelSameAsGranularityLevel()}), so the entire {@code useFacet}-branching block that
+    * would place the period dimension on an axis never runs, and the value-plus consumer
+    * ({@code isValuePlus()}) is also inapplicable for a value-only comparison. {@code useFacet}
+    * genuinely has zero rendering effect here.
+    */
+   @Test
+   void reportsUseFacetInapplicableForAPlainYearOverYearComparison() throws Exception {
+      DateComparisonInfo dcInfo = dcInfo(XConstants.YEAR_DATE_GROUP, DateComparisonInfo.YEAR,
+                                         Calculator.VALUE);
+      ChartVSAssembly assembly = chartWithDcInfo(dcInfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result = h.service.set("tok", principal(), "Chart1", facetOnly(), "");
+
+      assertEquals(true, result.get("useFacetInapplicable"));
+      String reason = (String) result.get("reason");
+      assertTrue(reason.contains("granularity"), reason);
+   }
+
+   /**
+    * The period level differs from the interval granularity (a quarterly breakdown within a
+    * yearly comparison) — {@code periodLevelSameAsGranularityLevel()} is false, {@code periodRef}
+    * gets created, and {@code useFacet} has its usual axis-placement effect. Must not be flagged.
+    */
+   @Test
+   void doesNotReportUseFacetInapplicableWhenPeriodLevelDiffersFromGranularity() throws Exception {
+      DateComparisonInfo dcInfo = dcInfo(XConstants.YEAR_DATE_GROUP,
+                                         DateComparisonInfo.QUARTER, Calculator.VALUE);
+      ChartVSAssembly assembly = chartWithDcInfo(dcInfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result = h.service.set("tok", principal(), "Chart1", facetOnly(), "");
+
+      assertFalse(result.containsKey("useFacetInapplicable"));
+   }
+
+   /**
+    * Same dead {@code periodRef} gate as the first test, but {@code comparisonOption} is
+    * {@code changeAndValue} — {@code isValuePlus()} is true, so {@code useFacet} still affects
+    * {@code ChartDcProcessor.updateDateComparisonChartType()}'s Line-vs-Point choice even though
+    * the axis-placement consumer is dead. Must not be flagged as wholly inapplicable.
+    */
+   @Test
+   void doesNotReportUseFacetInapplicableWhenTheValuePlusConsumerIsStillActive() throws Exception {
+      DateComparisonInfo dcInfo = dcInfo(XConstants.YEAR_DATE_GROUP, DateComparisonInfo.YEAR,
+                                         DateComparisonInfo.CHANGE_VALUE);
+      ChartVSAssembly assembly = chartWithDcInfo(dcInfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result = h.service.set("tok", principal(), "Chart1", facetOnly(), "");
+
+      assertFalse(result.containsKey("useFacetInapplicable"));
+   }
+
+   /** {@code useFacet} was not requested at all — nothing to report, regardless of the gates. */
+   @Test
+   void doesNotReportUseFacetInapplicableWhenUseFacetWasNotRequested() throws Exception {
+      DateComparisonInfo dcInfo = dcInfo(XConstants.YEAR_DATE_GROUP, DateComparisonInfo.YEAR,
+                                         Calculator.VALUE);
+      ChartVSAssembly assembly = chartWithDcInfo(dcInfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertFalse(result.containsKey("useFacetInapplicable"));
+   }
+
+   /**
+    * The comparison never took effect on this chart at all ({@code getDateComparisonRef()} is
+    * null) — {@code describeDateComparisonInactive} already reports that; this must not also
+    * report {@code useFacetInapplicable} for an unrelated, misattributed reason.
+    */
+   @Test
+   void doesNotReportUseFacetInapplicableWhenTheWholeComparisonIsInactive() throws Exception {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+      when(cinfo.getDateComparisonRef()).thenReturn(null);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result = h.service.set("tok", principal(), "Chart1", facetOnly(), "");
+
+      assertEquals(true, result.get("dateComparisonInactive"));
+      assertFalse(result.containsKey("useFacetInapplicable"));
    }
 
    // ── comparisonOption ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `useFacet` is genuinely read by `ChartDcProcessor`, but its only axis-placement consumer (`process():110-165`) never creates a `periodRef` for a `StandardPeriods` comparison whose period level already matches its interval granularity — the common case of a plain N-over-N comparison (e.g. year-over-year) with no distinct interval breakdown. `get_date_comparison` correctly reads `useFacet:true` back regardless, since the flag itself is stored/applied fine — only its rendering effect for this config shape is inert. No error, no disclosure, `set()` returned `{ok:true}` as if it had applied.
- `DateComparisonService.set()` now reports `useFacetInapplicable:true` plus a `reason` in that case, following the same post-mutation-inspection pattern already established for `retargetedDimension`/`chartTypeOverridden`/`dateComparisonInactive` (bug 76522, DCG-004, #5109).
- Additive-only: does not touch `ChartDcProcessor`/`DateComparisonInfo` (shared engine code, also used by the interactive Angular Composer's own Date Comparison dialog) — mirrors `periodLevelSameAsGranularityLevel()`/`isValuePlus()`'s existing gate logic rather than changing it.

## Test plan
- [x] `./mvnw test -pl core -Dtest=DateComparisonServiceTest -DfailIfNoTests=false` — 90 tests, 0 failures (85 pre-existing + 5 new)

Part of the Redmine #76522 date-comparison guard batch; depends on #5109 (DCG-004, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)