### PR TITLE
fix(wiz): resolve a sharing date comparison's real config on read (bug 76522, DCG-003)

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java
@@ -109,7 +109,7 @@ public class DateComparisonDialogService {
       Viewsheet vs = rvs.getViewsheet();
       VSAssembly vsAssembly = vs.getAssembly(objectId);
       VSAssemblyInfo info = vsAssembly == null ? null : vsAssembly.getVSAssemblyInfo();
-      return DateComparisonUtil.isDateComparisonDefined(info, false);
+      return DateComparisonUtil.isDateComparisonDefined(info, true);
    }
 
    @ClusterWriteMethod

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -26,8 +26,11 @@ import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.DateCompareAbleAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
+import inetsoft.uql.viewsheet.internal.DateComparisonUtil;
 import inetsoft.uql.viewsheet.internal.StandardPeriods;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -96,7 +99,8 @@ public class DateComparisonService {
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
       throws Exception
    {
-      String runtimeId = sessions.resolve(sessionToken, user).getID();
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      String runtimeId = rvs.getID();
       DateComparisonPaneModel model =
          comparisonService.getDateComparison(runtimeId, assemblyName, user);
 
@@ -124,6 +128,29 @@ public class DateComparisonService {
          }
 
          return out;
+      }
+
+      // model fetched above is this assembly's OWN DateComparisonPaneModel — a default,
+      // unset one whenever comparisonShareFrom is set, since a sharing assembly never carries
+      // its own DateComparisonInfo (see setDateComparison()). "enabled:true" alone would then
+      // report Chart2's own defaults (comparisonOption=VALUE, useFacet=false, ...) as if they
+      // were real settings. When sharing, resolve the populated fields through to the share
+      // source's actual config instead — DateComparisonUtil.getDateComparison() already
+      // performs this resolution (including one level of nested sharing) for every
+      // rendering-facing caller.
+      if(hasShareFrom) {
+         Viewsheet vs = rvs.getViewsheet();
+         VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+         VSAssemblyInfo info = assembly == null ? null : assembly.getVSAssemblyInfo();
+
+         if(info instanceof DateCompareAbleAssemblyInfo) {
+            DateComparisonInfo resolved =
+               DateComparisonUtil.getDateComparison((DateCompareAbleAssemblyInfo) info, vs);
+
+            if(resolved != null) {
+               model = new DateComparisonPaneModel(resolved);
+            }
+         }
       }
 
       out.put("enabled", true);

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonUtilTest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bug #76522 (DCG-003): {@code isDateComparisonDefined(info, checkShareFrom)} returns the
+ * {@code checkShareFrom} argument verbatim, with no further lookup, whenever the assembly's own
+ * {@code comparisonShareFrom} is set — it never asks whether the share source's comparison is
+ * actually live. Every render-facing caller uses the no-arg overload (hardcoded
+ * {@code checkShareFrom=true}); {@code DateComparisonDialogService.isDateComparisonEnabled()} was
+ * the sole caller passing {@code false} (copy-pasted from {@code getShare()}'s own, different-
+ * purpose usage), which made {@code get_date_comparison} always report a sharing assembly as
+ * disabled, regardless of whether the share is genuinely live. This test exercises the real,
+ * unmocked predicate directly, so a future caller cannot silently reintroduce the wrong argument
+ * value without this test documenting the asymmetry is intentional.
+ */
+@WizAgentTestSupport
+class DateComparisonUtilTest {
+   @Test
+   void checkShareFromArgumentAloneDecidesASharingAssemblysDefinedness() {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setComparisonShareFrom("Chart1");
+
+      assertTrue(DateComparisonUtil.isDateComparisonDefined(info, true),
+                 "checkShareFrom=true (every rendering-facing caller's convention) must treat " +
+                 "a configured shareAssembly as a defined comparison");
+      assertFalse(DateComparisonUtil.isDateComparisonDefined(info, false),
+                  "checkShareFrom=false must still report a sharing assembly as not-defined -- " +
+                  "this is getShare()'s own, deliberately different, 'exclude an already-" +
+                  "sharing assembly from the share-from candidate list' semantics, and is not " +
+                  "the argument value get_date_comparison's enabled check should use");
+   }
+
+   /** The no-arg overload is what every rendering-facing caller actually uses. */
+   @Test
+   void noArgOverloadDefaultsToCheckingShareFrom() {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setComparisonShareFrom("Chart1");
+
+      assertTrue(DateComparisonUtil.isDateComparisonDefined(info));
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.dialog;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.DateCompareAbleAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.binding.service.graph.aesthetic.VisualFrameModelFactoryService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug #76522 (DCG-003): {@code isDateComparisonEnabled()} called
+ * {@code DateComparisonUtil.isDateComparisonDefined(info, false)} -- {@code checkShareFrom=false}
+ * -- copy-pasted (commit 9ea28277e8) from {@code getShare()}'s own, different-purpose usage
+ * ("exclude an already-sharing assembly from the share-from candidate list"). That made
+ * {@code get_date_comparison} always report a {@code shareAssembly}-configured assembly as
+ * disabled, regardless of whether the share is genuinely live. Every render-facing caller of the
+ * same predicate uses the no-arg overload ({@code checkShareFrom=true}); this test pins
+ * {@code isDateComparisonEnabled()} to that same convention, calling the real (unmocked) method
+ * end to end -- only {@code ViewsheetService} and the assembly chain underneath it are mocked.
+ */
+@Tag("core")
+class DateComparisonDialogServiceTest {
+   @Test
+   void reportsAShareFromAssemblyAsEnabled() throws Exception {
+      VSAssemblyInfo info = mock(VSAssemblyInfo.class,
+         withSettings().extraInterfaces(DateCompareAbleAssemblyInfo.class));
+      when(((DateCompareAbleAssemblyInfo) info).getComparisonShareFrom()).thenReturn("Chart1");
+
+      VSAssembly assembly = mock(VSAssembly.class);
+      when(assembly.getVSAssemblyInfo()).thenReturn(info);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Chart2")).thenReturn(assembly);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      when(viewsheetService.getViewsheet(anyString(), any(Principal.class))).thenReturn(rvs);
+
+      DateComparisonDialogService service = new DateComparisonDialogService(
+         viewsheetService, mock(VSAssemblyInfoHandler.class),
+         mock(VisualFrameModelFactoryService.class));
+
+      Boolean enabled = service.isDateComparisonEnabled("rt1", "Chart2", () -> "admin");
+
+      assertTrue(enabled,
+                 "a shareAssembly-configured assembly must report enabled, matching every " +
+                 "rendering-facing caller of isDateComparisonDefined's own checkShareFrom=true " +
+                 "convention");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -28,9 +28,11 @@ import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.DateCompareAbleAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonInterval;
 import inetsoft.uql.viewsheet.internal.StandardPeriods;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
 import org.junit.jupiter.api.Tag;
@@ -331,6 +333,85 @@ class DateComparisonServiceTest {
       Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
 
       assertFalse(read.containsKey("shareFrom"));
+   }
+
+   /**
+    * Bug #76522 (DCG-003), second half. {@code model} fetched at the top of {@code read()} is
+    * always the TARGET assembly's own {@code DateComparisonPaneModel} -- a default-constructed,
+    * unset one whenever {@code comparisonShareFrom} is set, since a sharing assembly never
+    * carries its own {@code DateComparisonInfo}. Reporting {@code enabled:true} with THAT model's
+    * fields would surface Chart2's un-set defaults (comparisonOption=VALUE, useFacet=false) as if
+    * they were Chart1's real, live configuration -- a plausible-but-wrong result. The fields must
+    * resolve through {@code comparisonShareFrom} to the share source's actual
+    * {@code DateComparisonInfo} instead.
+    */
+   @Test
+   void resolvesSharedFieldsThroughToTheShareSourcesRealConfigOnRead() throws Exception {
+      VSAssemblyInfo targetInfo = mock(VSAssemblyInfo.class,
+         withSettings().extraInterfaces(DateCompareAbleAssemblyInfo.class));
+      when(((DateCompareAbleAssemblyInfo) targetInfo).getComparisonShareFrom())
+         .thenReturn("Chart1");
+      VSAssembly targetAssembly = mock(VSAssembly.class);
+      when(targetAssembly.getVSAssemblyInfo()).thenReturn(targetInfo);
+
+      DateComparisonInfo sourceDcInfo = new DateComparisonInfo();
+      sourceDcInfo.setComparisonOption(Calculator.CHANGE);
+      sourceDcInfo.setUseFacet(true);
+      VSAssemblyInfo sourceInfo = mock(VSAssemblyInfo.class,
+         withSettings().extraInterfaces(DateCompareAbleAssemblyInfo.class));
+      when(((DateCompareAbleAssemblyInfo) sourceInfo).getDateComparisonInfo())
+         .thenReturn(sourceDcInfo);
+      VSAssembly sourceAssembly = mock(VSAssembly.class);
+      when(sourceAssembly.getVSAssemblyInfo()).thenReturn(sourceInfo);
+
+      Harness h = harness(model(), targetAssembly);
+      when(h.vs().getAssembly("Chart1")).thenReturn(sourceAssembly);
+
+      DateComparisonDialogModel shareModel = new DateComparisonDialogModel();
+      shareModel.setShareFromAssembly("Chart1");
+      when(h.comparisons().getShare(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(shareModel);
+
+      Map<String, Object> read = h.service.read("tok", principal(), "Chart2");
+
+      assertEquals(true, read.get("enabled"));
+      assertEquals("change", read.get("comparisonOption"),
+                  "must reflect Chart1's (the share source's) real comparisonOption, not " +
+                  "Chart2's own unset default");
+      assertEquals(true, read.get("useFacet"),
+                  "must reflect Chart1's real useFacet, not Chart2's own unset default");
+   }
+
+   /**
+    * When the share chain does not resolve to a real config (e.g. a stale/broken
+    * {@code comparisonShareFrom}), {@code DateComparisonUtil.getDateComparison} returns
+    * {@code null} -- {@code read()} must fall back to the target's own (default) model rather
+    * than throwing.
+    */
+   @Test
+   void fallsBackToTheOwnModelWhenTheShareSourceDoesNotResolve() throws Exception {
+      VSAssemblyInfo targetInfo = mock(VSAssemblyInfo.class,
+         withSettings().extraInterfaces(DateCompareAbleAssemblyInfo.class));
+      when(((DateCompareAbleAssemblyInfo) targetInfo).getComparisonShareFrom())
+         .thenReturn("Chart1");
+      VSAssembly targetAssembly = mock(VSAssembly.class);
+      when(targetAssembly.getVSAssemblyInfo()).thenReturn(targetInfo);
+
+      Harness h = harness(model(), targetAssembly);
+      // Overrides harness()'s own default "every name resolves to the target assembly" stub --
+      // here "Chart1" must resolve to nothing, simulating a share source that cannot be found,
+      // so DateComparisonUtil.getDateComparison() returns null.
+      when(h.vs().getAssembly("Chart1")).thenReturn(null);
+
+      DateComparisonDialogModel shareModel = new DateComparisonDialogModel();
+      shareModel.setShareFromAssembly("Chart1");
+      when(h.comparisons().getShare(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(shareModel);
+
+      Map<String, Object> read = h.service.read("tok", principal(), "Chart2");
+
+      assertEquals(true, read.get("enabled"));
+      assertEquals("Chart1", read.get("shareFrom"));
    }
 
    // ── toDate / inclusive (period level) ────────────────────────────────────
@@ -1197,7 +1278,7 @@ class DateComparisonServiceTest {
    // ── harness ───────────────────────────────────────────────────────────────
 
    private record Harness(DateComparisonService service, ViewsheetSessionService sessions,
-                          DateComparisonDialogService comparisons) {}
+                          DateComparisonDialogService comparisons, Viewsheet vs) {}
 
    private static Harness harness(DateComparisonPaneModel model) {
       return harness(model, null);
@@ -1234,7 +1315,8 @@ class DateComparisonServiceTest {
          throw new IllegalStateException(e);
       }
 
-      return new Harness(new DateComparisonService(sessions, comparisons), sessions, comparisons);
+      return new Harness(new DateComparisonService(sessions, comparisons), sessions, comparisons,
+                         vs);
    }
 
    private static Principal principal() {


### PR DESCRIPTION
## Summary
- `get_date_comparison` always reported a `shareAssembly`-configured assembly as `enabled:false`, even when the share was genuinely live — `DateComparisonDialogService.isDateComparisonEnabled()` called `DateComparisonUtil.isDateComparisonDefined(info, false)` (`checkShareFrom=false`), copy-pasted from `getShare()`'s own, different-purpose usage (commit `9ea28277e8`). Every rendering-facing caller of the same predicate uses `checkShareFrom=true`, which is why the share rendered correctly while the read-back lied about it.
- Flipping that boolean alone is not a safe standalone step: `DateComparisonService.read()`'s populated fields (`comparisonOption`/`useFacet`/`period`/`interval`) come from the target assembly's own `DateComparisonPaneModel`, which is always a default-constructed, unset one while `comparisonShareFrom` is set. Landing just the flip would flip `enabled` to `true` while still reporting the target's own unset defaults as if they were the share source's real config — a plausible-but-wrong result. So `read()` now also resolves those fields through `DateComparisonUtil.getDateComparison()` (the existing render-time resolver, which already handles nested shares) whenever `comparisonShareFrom` is set.
- Both halves land together in this PR, per review guidance from this bug's debug-workflow batch.

## Test plan
- [x] `DateComparisonUtilTest` (new) — documents the intentional `checkShareFrom` asymmetry directly on `isDateComparisonDefined(info, checkShareFrom)`.
- [x] `DateComparisonDialogServiceTest` (new) — a real, unmocked call to `isDateComparisonEnabled()` proving it now agrees with every rendering-facing caller's `checkShareFrom=true` convention. Confirmed failing pre-fix (`expected <true> but was <false>`), passing post-fix.
- [x] `DateComparisonServiceTest` — two new cases: resolving `read()`'s fields through to the share source's real config, and falling back to the target's own model when the share source cannot be resolved. Confirmed the first fails pre-fix (`expected <change> but was <null>`), passes post-fix.
- [x] `mvn -pl core test -Dtest=DateComparisonServiceTest,DateComparisonUtilTest,DateComparisonDialogServiceTest,DateComparisonFormatOrphanedFacetTest,DateComparisonIntervalConditionTest,DateComparisonUtilApplyDateRangeTest,DateComparisonUtilValidPartsTest` — all green (94 tests across the DateComparison test family, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)