### PR TITLE
fix(wiz): disclose a chart's retargeted date dimension (Redmine #76522 DCG-008)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -204,6 +204,21 @@ public class DateComparisonService {
     * produces {@code getDateComparisonRef()}, so it is a definitive answer, not a guess. Trying
     * row first and falling back to column would misreport an unrelated, untouched dimension's
     * level if a crosstab happened to bind a same-named date dimension on both shelves.
+    *
+    * <p>A chart needs the opposite before/after pairing. {@code CrosstabDcProcessor} stashes the
+    * pre-retarget clone on {@code getDateComparisonRef()} <i>before</i> mutating the live ref
+    * (stash-then-mutate), but {@code ChartDcProcessor.process()} mutates the dimension it found
+    * in place first and only clones it into {@code VSChartInfo.getDateComparisonRef()}
+    * afterward (mutate-then-stash — see {@code ChartDcProcessor.java} lines 186 then 203..204).
+    * So for a chart, {@code getDateComparisonRef()} already holds the <i>after</i> level, not a
+    * "before" snapshot; reusing it as "before" the way the crosstab branch does would compare an
+    * already-retargeted value against itself and always report nothing. Instead, "before" comes
+    * from the untouched design binding — {@code VSChartInfo.getXFields()}/{@code getYFields()},
+    * which {@code ChartInfoModelBuilder} never RT-substitutes for a dimension (only for
+    * {@code VSChartAggregateRef} measures) — matched by name against the axis
+    * {@code VSChartInfo.isDcBaseDateOnX()} says the date dimension actually came from (the same
+    * flag {@code ChartDcProcessor.process()} sets before it starts mutating, so — like the
+    * crosstab's row/column flag — it is a definitive answer, not a guess).
     */
    private static Map<String, Object> describeRetargetedDimension(RuntimeViewsheet rvs,
                                                                    String assemblyName)
@@ -212,29 +227,51 @@ public class DateComparisonService {
       Viewsheet vs = rvs.getViewsheet();
       VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
 
-      if(!(assembly instanceof CrosstabVSAssembly)) {
+      if(assembly instanceof CrosstabVSAssembly) {
+         VSCrosstabInfo crosstabInfo = ((CrosstabVSAssembly) assembly).getVSCrosstabInfo();
+         VSDataRef before = crosstabInfo == null ? null : crosstabInfo.getDateComparisonRef();
+
+         if(!(before instanceof VSDimensionRef)) {
+            return out;
+         }
+
+         VSDimensionRef beforeDim = (VSDimensionRef) before;
+         DataRef[] shelf = crosstabInfo.isDateComparisonOnRow() ?
+            crosstabInfo.getRuntimeRowHeaders() : crosstabInfo.getRuntimeColHeaders();
+         VSDimensionRef afterDim = findDimensionByName(shelf, beforeDim.getName());
+
+         if(afterDim == null || afterDim.getDateLevel() == beforeDim.getDateLevel()) {
+            return out;
+         }
+
+         out.put("retargetedDimension", beforeDim.getName());
+         out.put("retargetedFromLevel", levelWord(beforeDim.getDateLevel()));
+         out.put("retargetedToLevel", levelWord(afterDim.getDateLevel()));
          return out;
       }
 
-      VSCrosstabInfo crosstabInfo = ((CrosstabVSAssembly) assembly).getVSCrosstabInfo();
-      VSDataRef before = crosstabInfo == null ? null : crosstabInfo.getDateComparisonRef();
+      if(assembly instanceof ChartVSAssembly) {
+         VSChartInfo cinfo = ((ChartVSAssembly) assembly).getVSChartInfo();
+         VSDataRef after = cinfo == null ? null : cinfo.getDateComparisonRef();
 
-      if(!(before instanceof VSDimensionRef)) {
+         if(!(after instanceof VSDimensionRef)) {
+            return out;
+         }
+
+         VSDimensionRef afterDim = (VSDimensionRef) after;
+         DataRef[] designShelf = cinfo.isDcBaseDateOnX() ? cinfo.getXFields() : cinfo.getYFields();
+         VSDimensionRef beforeDim = findDimensionByName(designShelf, afterDim.getName());
+
+         if(beforeDim == null || beforeDim.getDateLevel() == afterDim.getDateLevel()) {
+            return out;
+         }
+
+         out.put("retargetedDimension", afterDim.getName());
+         out.put("retargetedFromLevel", levelWord(beforeDim.getDateLevel()));
+         out.put("retargetedToLevel", levelWord(afterDim.getDateLevel()));
          return out;
       }
 
-      VSDimensionRef beforeDim = (VSDimensionRef) before;
-      DataRef[] shelf = crosstabInfo.isDateComparisonOnRow() ?
-         crosstabInfo.getRuntimeRowHeaders() : crosstabInfo.getRuntimeColHeaders();
-      VSDimensionRef afterDim = findDimensionByName(shelf, beforeDim.getName());
-
-      if(afterDim == null || afterDim.getDateLevel() == beforeDim.getDateLevel()) {
-         return out;
-      }
-
-      out.put("retargetedDimension", beforeDim.getName());
-      out.put("retargetedFromLevel", levelWord(beforeDim.getDateLevel()));
-      out.put("retargetedToLevel", levelWord(afterDim.getDateLevel()));
       return out;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -23,7 +23,9 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonInfo;
 import inetsoft.web.composer.model.vs.*;
@@ -576,6 +578,119 @@ class DateComparisonServiceTest {
       CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
       when(assembly.getVSCrosstabInfo()).thenReturn(crosstabInfo);
       return assembly;
+   }
+
+   // ── reporting a retargeted dimension (chart) ────────────────────────────────
+
+   /**
+    * DCG-008: unlike the crosstab branch above, {@code ChartDcProcessor} mutates the dimension
+    * it found in place first and only clones the already-mutated result onto
+    * {@code VSChartInfo.getDateComparisonRef()} afterward (mutate-then-stash — see
+    * {@code ChartDcProcessor.java} lines 186 then 203-204) — the reverse of the crosstab's
+    * stash-then-mutate order. So the "before" snapshot for a chart cannot come from
+    * {@code getDateComparisonRef()} the way it does for a crosstab (that would compare an
+    * already-retargeted value against itself and always report nothing); it must come from the
+    * untouched design binding ({@code getXFields()}/{@code getYFields()}, which
+    * {@code ChartInfoModelBuilder} never RT-substitutes for a dimension), matched by name
+    * against whichever axis {@code isDcBaseDateOnX()} says the date dimension came from.
+    */
+   @Test
+   void reportsARetargetedDimensionForAChart() throws Exception {
+      VSChartDimensionRef before = mock(VSChartDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
+
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getDateComparisonRef()).thenReturn(after);
+      when(cinfo.isDcBaseDateOnX()).thenReturn(true);
+      when(cinfo.getXFields()).thenReturn(new ChartRef[] {before});
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertEquals("Order Date", result.get("retargetedDimension"));
+      assertEquals("month", result.get("retargetedFromLevel"));
+      assertEquals("year", result.get("retargetedToLevel"));
+   }
+
+   /** The retargeted dimension can be on y instead of x, per {@code isDcBaseDateOnX()}. */
+   @Test
+   void findsTheRetargetedChartDimensionOnYWhenNotOnX() throws Exception {
+      VSChartDimensionRef before = mock(VSChartDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.YEAR_DATE_GROUP);
+
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getDateComparisonRef()).thenReturn(after);
+      when(cinfo.isDcBaseDateOnX()).thenReturn(false);
+      when(cinfo.getYFields()).thenReturn(new ChartRef[] {before});
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertEquals("Order Date", result.get("retargetedDimension"));
+      assertEquals("year", result.get("retargetedToLevel"));
+   }
+
+   @Test
+   void returnsAnEmptyMapWhenTheChartLevelDidNotActuallyChange() throws Exception {
+      VSChartDimensionRef before = mock(VSChartDimensionRef.class);
+      when(before.getName()).thenReturn("Order Date");
+      when(before.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSDimensionRef after = mock(VSDimensionRef.class);
+      when(after.getName()).thenReturn("Order Date");
+      when(after.getDateLevel()).thenReturn(XConstants.MONTH_DATE_GROUP);
+
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getDateComparisonRef()).thenReturn(after);
+      when(cinfo.isDcBaseDateOnX()).thenReturn(true);
+      when(cinfo.getXFields()).thenReturn(new ChartRef[] {before});
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertFalse(result.containsKey("retargetedDimension"));
+   }
+
+   /** No date comparison actually applied to the chart at all (see describeDateComparisonInactive). */
+   @Test
+   void returnsAnEmptyMapForAChartWhoseDateComparisonRefIsNull() throws Exception {
+      VSChartInfo cinfo = mock(VSChartInfo.class);
+      when(cinfo.getDateComparisonRef()).thenReturn(null);
+      when(cinfo.getRTChartType()).thenReturn(GraphTypes.CHART_BAR);
+
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(cinfo);
+      Harness h = harness(model(), assembly);
+
+      Map<String, Object> result =
+         h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      assertFalse(result.containsKey("retargetedDimension"));
    }
 
    // ── reporting a chart-type override ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `DateComparisonService.describeRetargetedDimension()` only handled `CrosstabVSAssembly`; a `ChartVSAssembly` whose bound date dimension was genuinely retargeted (e.g. day -> quarter, by `ChartDcProcessor.process()`) had that retargeting silently dropped from `set_date_comparison`'s response because of the `!(assembly instanceof CrosstabVSAssembly)` guard.
- Adds a chart branch to the same method. It is **not** a mechanical port of the crosstab branch: `CrosstabDcProcessor` stashes the pre-retarget clone onto `getDateComparisonRef()` *before* mutating (stash-then-mutate), but `ChartDcProcessor` mutates the dimension in place *first* and only clones the already-mutated result onto `VSChartInfo.getDateComparisonRef()` afterward (mutate-then-stash, `ChartDcProcessor.java:186` then `203-204`). So for a chart, `getDateComparisonRef()` already holds the "after" value — reusing it as "before" the way the crosstab branch does would always compare an already-retargeted value against itself and silently report nothing.
- The chart branch instead pairs "before" = the matching dimension in the untouched design binding (`VSChartInfo.getXFields()`/`getYFields()`, confirmed never RT-substituted for a dimension by `ChartInfoModelBuilder` — only for `VSChartAggregateRef` measures) against "after" = `VSChartInfo.getDateComparisonRef()` (confirmed to hold the final, retargeted level), matched by name on whichever axis `isDcBaseDateOnX()` says the date dimension came from (set by `ChartDcProcessor.process()` before it starts mutating, so it's a definitive answer, not a guess — the chart's counterpart to the crosstab's `isDateComparisonOnRow()`).

## Scope note

`get_binding`'s own stale `dateLevel` read-back for a chart dimension is left out of scope for this PR. It is structural, not just a disclosure gap: `ChartInfoModelBuilder.createChartBinding()` only ever RT-substitutes `VSChartAggregateRef` (measures) with their runtime counterpart, never `VSDimensionRef` — so a date dimension's `dateLevel` in `get_binding`'s response always reflects the design-time binding. Fixing that would mean extending RT-substitution to dimensions in `ChartInfoModelBuilder`, which is shared by every other binding-read path in Composer, not just the wiz agent route — a materially wider blast radius than this bug's disclosure gap, and better done as its own change if wanted.

## Test plan

- [x] `./mvnw test -pl core -Dtest=DateComparisonServiceTest` — 89 tests, 0 failures (85 pre-existing + 4 new), including all pre-existing crosstab cases unchanged.
- New tests: a chart whose date dimension is retargeted on X, the same on Y (`isDcBaseDateOnX()==false`), a chart where the level did not actually change (no disclosure), and a chart with no date comparison ref at all (no disclosure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)