### PR TITLE
fix(wiz): wire the already-shipped CustomPeriods date-comparison shape (bug 76522, DCG-005)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -89,11 +89,32 @@ public class DateComparisonService {
     *                  today, within its level (e.g. Jan 1 - Mar 15 for a quarter, not the whole
     *                  quarter) — the standard period pane's own "to date" checkbox
     * @param inclusive whether the period's end date is included in its range
+    * @param customPeriods an arbitrary, caller-defined list of start/end date-range pairs (e.g.
+    *                     "March 1-15 this year" vs. "March 1-15 last year") — StyleBI's
+    *                     {@code CustomPeriods}, a peer to the standard period shape above, not a
+    *                     variant of it. Mutually exclusive with {@code periods}/{@code level}/
+    *                     {@code endDate}/{@code endToday}/{@code toDate}/{@code inclusive} and
+    *                     with {@code interval} (StyleBI does not expose interval sub-windows for
+    *                     a custom period — see {@code DateComparisonInfo.getIntervalConditions()},
+    *                     ticket 64217).
     */
    public record Comparison(Integer periods, String level, String endDate, boolean endToday,
                             String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
                             String comparisonOption, String shareAssembly, Boolean toDate,
-                            Boolean inclusive) {}
+                            Boolean inclusive, List<CustomPeriod> customPeriods) {
+      /** Backward-compatible with every call site that predates {@code customPeriods}. */
+      public Comparison(Integer periods, String level, String endDate, boolean endToday,
+                        String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
+                        String comparisonOption, String shareAssembly, Boolean toDate,
+                        Boolean inclusive)
+      {
+         this(periods, level, endDate, endToday, interval, useFacet, onlyShowMostRecentDate,
+              comparisonOption, shareAssembly, toDate, inclusive, null);
+      }
+   }
+
+   /** One caller-defined date-range pair, e.g. {@code {start: "2026-03-01", end: "2026-03-15"}}. */
+   public record CustomPeriod(String start, String end) {}
 
    /** The current settings, normalized. Never echoes the raw cell format. */
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
@@ -536,6 +557,11 @@ public class DateComparisonService {
          throw new IllegalArgumentException("set_date_comparison needs a comparison.");
       }
 
+      if(hasCustomPeriods(comparison)) {
+         requireNoStandardPeriodFields(comparison);
+         return;
+      }
+
       boolean hasEnd = comparison.endDate() != null && !comparison.endDate().isBlank();
 
       // The anchor is only required when the period is actually being set. Demanding it on every
@@ -579,7 +605,42 @@ public class DateComparisonService {
          || comparison.endToday()
          || comparison.interval() != null
          || comparison.toDate() != null
-         || comparison.inclusive() != null;
+         || comparison.inclusive() != null
+         || hasCustomPeriods(comparison);
+   }
+
+   private static boolean hasCustomPeriods(Comparison comparison) {
+      return comparison.customPeriods() != null && !comparison.customPeriods().isEmpty();
+   }
+
+   /**
+    * {@code customPeriods} (StyleBI's {@code CustomPeriods}) and a standard period (StyleBI's
+    * {@code StandardPeriods}) are peers behind {@code DateComparisonPeriods}, not one a variant
+    * of the other — {@code PeriodPaneModel} can hold only one at a time. {@code interval} is
+    * refused too, mirroring the engine's own restriction: {@code
+    * DateComparisonInfo.getIntervalConditions()} does not expose interval sub-windows (e.g.
+    * month-to-date) for a custom period (ticket 64217), so accepting one here would silently do
+    * nothing once applied.
+    */
+   private static void requireNoStandardPeriodFields(Comparison comparison) {
+      if(comparison.periods() != null || comparison.level() != null
+         || (comparison.endDate() != null && !comparison.endDate().isBlank())
+         || comparison.endToday() || comparison.toDate() != null
+         || comparison.inclusive() != null)
+      {
+         throw new IllegalArgumentException(
+            "'customPeriods' cannot be combined with 'periods'/'level'/'endDate'/'endToday'/" +
+            "'toDate'/'inclusive' — a custom date-comparison period is a peer to a standard " +
+            "period, not composable with one. Pass only 'customPeriods' to set a custom " +
+            "period, or drop it to set a standard one.");
+      }
+
+      if(comparison.interval() != null) {
+         throw new IllegalArgumentException(
+            "'interval' cannot be combined with 'customPeriods'. StyleBI's date-comparison " +
+            "engine does not expose an interval sub-window (e.g. monthToDate) for a custom " +
+            "period. Drop 'interval', or use 'periods'/'level' instead of 'customPeriods'.");
+      }
    }
 
    private static void apply(DateComparisonPaneModel model, Comparison comparison) {
@@ -609,11 +670,33 @@ public class DateComparisonService {
          return;
       }
 
+      // A caller who explicitly lists start/end pairs is deliberately asking for a custom
+      // period, unlike the accidental "just set useFacet" case the guard below exists to
+      // prevent — so switching an existing standard period to custom here is allowed outright,
+      // symmetric with allowing a deliberate switch the other way (see below).
+      if(hasCustomPeriods(comparison)) {
+         periods.setCustom(true);
+         List<DatePeriodModel> datePeriods = new ArrayList<>();
+
+         for(CustomPeriod period : comparison.customPeriods()) {
+            DatePeriodModel periodModel = new DatePeriodModel();
+            periodModel.setStart(new DynamicValueModel());
+            periodModel.setEnd(new DynamicValueModel());
+            setDynamic(periodModel.getStart(), period.start());
+            setDynamic(periodModel.getEnd(), period.end());
+            datePeriods.add(periodModel);
+         }
+
+         periods.getCustomPeriodPaneModel().setDatePeriods(datePeriods);
+         return;
+      }
+
       if(periods.isCustom()) {
          throw new IllegalArgumentException(
             "This assembly uses a custom date-comparison period, and setting a standard period " +
             "here would discard it with no way back. Clear the comparison first if that is what " +
-            "you want; setting a custom period is not supported by this tool yet.");
+            "you want, or pass 'customPeriods' instead of 'periods'/'level' to set a new custom " +
+            "period.");
       }
 
       periods.setCustom(false);
@@ -811,6 +894,12 @@ public class DateComparisonService {
       }
 
       out.put("custom", periods.isCustom());
+
+      if(periods.isCustom()) {
+         out.put("customPeriods", describeCustomPeriods(periods.getCustomPeriodPaneModel()));
+         return out;
+      }
+
       StandardPeriodPaneModel standard = periods.getStandardPeriodPaneModel();
 
       if(standard != null) {
@@ -820,6 +909,32 @@ public class DateComparisonService {
          out.put("endDate", standard.isToDayAsEndDay() ? null : value(standard.getEndDay()));
          out.put("inclusive", standard.isInclusive());
          out.put("toDate", standard.isToDate());
+      }
+
+      return out;
+   }
+
+   /**
+    * The custom-period peer to the standard-period fields above — an assembly whose comparison
+    * was built via the manual UI's Custom Periods tab has no {@code preCount}/{@code dateLevel}/
+    * etc. at all, so this reads back the actual {@code start}/{@code end} pairs instead.
+    */
+   private static List<Map<String, Object>> describeCustomPeriods(CustomPeriodPaneModel custom) {
+      List<Map<String, Object>> out = new ArrayList<>();
+
+      if(custom == null || custom.getDatePeriods() == null) {
+         return out;
+      }
+
+      for(DatePeriodModel period : custom.getDatePeriods()) {
+         if(period == null) {
+            continue;
+         }
+
+         Map<String, Object> entry = new LinkedHashMap<>();
+         entry.put("start", value(period.getStart()));
+         entry.put("end", value(period.getEnd()));
+         out.add(entry);
       }
 
       return out;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -96,7 +96,9 @@ public class DateComparisonService {
     *                     {@code endDate}/{@code endToday}/{@code toDate}/{@code inclusive} and
     *                     with {@code interval} (StyleBI does not expose interval sub-windows for
     *                     a custom period — see {@code DateComparisonInfo.getIntervalConditions()},
-    *                     ticket 64217).
+    *                     ticket 64217). Each {@link CustomPeriod}'s {@code start}/{@code end} must
+    *                     be a literal date string — expressions and variables are not supported
+    *                     (see {@link CustomPeriod}).
     */
    public record Comparison(Integer periods, String level, String endDate, boolean endToday,
                             String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
@@ -113,7 +115,13 @@ public class DateComparisonService {
       }
    }
 
-   /** One caller-defined date-range pair, e.g. {@code {start: "2026-03-01", end: "2026-03-15"}}. */
+   /**
+    * One caller-defined date-range pair, e.g. {@code {start: "2026-03-01", end: "2026-03-15"}}.
+    * {@code start}/{@code end} must be literal date strings — expressions and variables (e.g.
+    * {@code $(startDate)}) are not supported here; {@code setDynamic()} stores them as plain
+    * values without the variable/expression-type detection {@code DynamicValueModel}'s own
+    * {@code (String)} constructor performs.
+    */
    public record CustomPeriod(String start, String end) {}
 
    /** The current settings, normalized. Never echoes the raw cell format. */
@@ -688,6 +696,21 @@ public class DateComparisonService {
          }
 
          periods.getCustomPeriodPaneModel().setDatePeriods(datePeriods);
+
+         // A custom period never exposes an interval sub-window (see
+         // requireNoStandardPeriodFields()'s Javadoc), but IntervalPaneModel is not itself
+         // gated on isCustom() — DateComparisonPaneModel.toDateComparisonInfo() reads it
+         // unconditionally. Left alone, an interval set by an earlier standard-period call
+         // would sit inert while custom, then silently reactivate if a later call switches
+         // back to a standard period without repeating 'interval'. Reset the level back to
+         // its "no interval" sentinel here so the interval/customPeriods mutual exclusion
+         // holds across calls, not just within one.
+         IntervalPaneModel interval = model.getIntervalPaneModel();
+
+         if(interval != null) {
+            setDynamic(interval.getLevel(), String.valueOf(DateComparisonInfo.ALL));
+         }
+
          return;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -912,11 +912,13 @@ public class ViewsheetAssemblyAgentController {
                                        String endDate, Boolean endToday, String interval,
                                        Boolean useFacet, Boolean onlyShowMostRecentDate,
                                        String comparisonOption, String shareAssembly,
-                                       Boolean toDate, Boolean inclusive) {
+                                       Boolean toDate, Boolean inclusive,
+                                       List<DateComparisonService.CustomPeriod> customPeriods) {
       DateComparisonService.Comparison comparison() {
          return new DateComparisonService.Comparison(
             periods, level, endDate, Boolean.TRUE.equals(endToday), interval, useFacet,
-            onlyShowMostRecentDate, comparisonOption, shareAssembly, toDate, inclusive);
+            onlyShowMostRecentDate, comparisonOption, shareAssembly, toDate, inclusive,
+            customPeriods);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -78,6 +78,13 @@ class DateComparisonServiceTest {
                                                   null, null, null, null);
    }
 
+   private static DateComparisonService.Comparison customPeriods(
+      DateComparisonService.CustomPeriod... periods)
+   {
+      return new DateComparisonService.Comparison(null, null, null, false, null, null, null,
+                                                  null, null, null, null, java.util.List.of(periods));
+   }
+
    /**
     * {@code apply} ran {@code periods.setCustom(false)} unconditionally, and {@code validate}
     * demanded an end anchor on every call. So a caller who only wanted {@code useFacet: true} had
@@ -500,6 +507,122 @@ class DateComparisonServiceTest {
          () -> harness(model).service.set("tok", principal(), "Chart1", comparison, ""));
 
       assertTrue(thrown.getMessage().contains("interval"), thrown.getMessage());
+   }
+
+   // ── customPeriods ─────────────────────────────────────────────────────────
+
+   /**
+    * DCG-005: StyleBI's engine already fully supports an arbitrary N-way custom date-range-pair
+    * comparison ({@code CustomPeriods}/{@code DatePeriod}, rendered by {@code ChartDcProcessor}
+    * and exercised daily by the manual Composer's own Custom Periods tab) — the gap was entirely
+    * in this wiz-only bridge, which never had a wire path for it. This pins the write side: a
+    * {@code customPeriods} list marks the period pane custom and writes each start/end pair.
+    */
+   @Test
+   void setsACustomPeriodFromAnArbitraryStartEndList() throws Exception {
+      DateComparisonPaneModel model = model();
+
+      harness(model).service.set("tok", principal(), "Chart1", customPeriods(
+         new DateComparisonService.CustomPeriod("2026-03-01", "2026-03-15"),
+         new DateComparisonService.CustomPeriod("2025-03-01", "2025-03-15")), "");
+
+      PeriodPaneModel periods = model.getPeriodPaneModel();
+      assertTrue(periods.isCustom());
+      java.util.List<DatePeriodModel> datePeriods =
+         periods.getCustomPeriodPaneModel().getDatePeriods();
+      assertEquals(2, datePeriods.size());
+      assertEquals("2026-03-01", datePeriods.get(0).getStart().getValue());
+      assertEquals("2026-03-15", datePeriods.get(0).getEnd().getValue());
+      assertEquals("2025-03-01", datePeriods.get(1).getStart().getValue());
+      assertEquals("2025-03-15", datePeriods.get(1).getEnd().getValue());
+   }
+
+   /**
+    * Setting customPeriods on an assembly that already has a standard period is a deliberate,
+    * explicit ask — unlike the accidental "just set useFacet" case the standard-period guard
+    * exists to prevent — so it is allowed outright, not refused.
+    */
+   @Test
+   void switchingAnExistingStandardPeriodToCustomIsAllowed() throws Exception {
+      DateComparisonPaneModel model = model();
+      assertFalse(model.getPeriodPaneModel().isCustom());
+
+      harness(model).service.set("tok", principal(), "Chart1", customPeriods(
+         new DateComparisonService.CustomPeriod("2026-03-01", "2026-03-15")), "");
+
+      assertTrue(model.getPeriodPaneModel().isCustom());
+   }
+
+   /**
+    * {@code customPeriods} is a peer to the standard-period shape, not composable with it —
+    * mutual exclusion mirrors the same-file pattern for endDate/endToday.
+    */
+   @Test
+   void refusesCustomPeriodsCombinedWithAStandardPeriodField() {
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         4, "year", null, false, null, null, null, null, null, null, null,
+         java.util.List.of(new DateComparisonService.CustomPeriod("2026-03-01", "2026-03-15")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DateComparisonService.requireEndAnchor(comparison));
+
+      assertTrue(thrown.getMessage().contains("customPeriods"), thrown.getMessage());
+   }
+
+   /**
+    * StyleBI's own {@code DateComparisonInfo.getIntervalConditions()} does not expose an interval
+    * sub-window for a custom period (ticket 64217) — mirrored here rather than invented, since
+    * silently accepting the combination would apply the periods and drop the interval with no
+    * error.
+    */
+   @Test
+   void refusesCustomPeriodsCombinedWithInterval() {
+      DateComparisonService.Comparison comparison = new DateComparisonService.Comparison(
+         null, null, null, false, "monthToDate", null, null, null, null, null, null,
+         java.util.List.of(new DateComparisonService.CustomPeriod("2026-03-01", "2026-03-15")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DateComparisonService.requireEndAnchor(comparison));
+
+      assertTrue(thrown.getMessage().contains("interval"), thrown.getMessage());
+   }
+
+   /** The read-back side: a custom period reports its actual start/end pairs, not the standard
+    *  period pane's meaningless defaults. */
+   @Test
+   void readsBackACustomPeriodsStartEndPairs() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.getPeriodPaneModel().setCustom(true);
+      DatePeriodModel period1 = new DatePeriodModel();
+      period1.setStart(dynamic());
+      period1.getStart().setValue("2026-03-01");
+      period1.setEnd(dynamic());
+      period1.getEnd().setValue("2026-03-15");
+      DatePeriodModel period2 = new DatePeriodModel();
+      period2.setStart(dynamic());
+      period2.getStart().setValue("2025-03-01");
+      period2.setEnd(dynamic());
+      period2.getEnd().setValue("2025-03-15");
+      model.getPeriodPaneModel().getCustomPeriodPaneModel()
+         .setDatePeriods(java.util.List.of(period1, period2));
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> periodOut = (Map<String, Object>) read.get("period");
+      assertEquals(true, periodOut.get("custom"));
+      @SuppressWarnings("unchecked")
+      java.util.List<Map<String, Object>> customPeriodsOut =
+         (java.util.List<Map<String, Object>>) periodOut.get("customPeriods");
+      assertEquals(2, customPeriodsOut.size());
+      assertEquals("2026-03-01", customPeriodsOut.get(0).get("start"));
+      assertEquals("2026-03-15", customPeriodsOut.get(0).get("end"));
+      assertEquals("2025-03-01", customPeriodsOut.get(1).get("start"));
+      assertEquals("2025-03-15", customPeriodsOut.get(1).get("end"));
+      assertFalse(periodOut.containsKey("periods"),
+                 "a custom period must not also report the meaningless standard-period defaults");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -625,6 +625,57 @@ class DateComparisonServiceTest {
                  "a custom period must not also report the meaningless standard-period defaults");
    }
 
+   /**
+    * Round-1 review finding: {@code requireNoStandardPeriodFields()} only refuses combining
+    * {@code interval} with {@code customPeriods} within the same call — it can't (and
+    * structurally shouldn't have to) see an interval left behind by an earlier, different call.
+    * Before this fix, {@code apply()}'s {@code customPeriods} branch never touched
+    * {@code IntervalPaneModel}, so a stale interval from an earlier standard-period call sat
+    * inert while custom, then would silently reactivate the moment the assembly's period next
+    * became standard again with no {@code interval} field repeated.
+    *
+    * <p>{@code apply()} itself refuses a wiz call that switches an already-custom period back to
+    * standard outright ({@link #refusesToReplaceACustomPeriodWithoutSayingSo}) — that switch-back
+    * is only reachable today via the manual Angular Composer editing the assembly directly (see
+    * {@code 03-fix.md}'s "before this PR, only reachable via the manual Composer" note), which
+    * this wiz-only test file cannot drive. So the {@code periods.setCustom(false)} step below
+    * stands in for that out-of-band switch-back, isolating what this fix actually controls: that
+    * entering {@code customPeriods} left no stale interval behind for such a switch-back to find.
+    */
+   @Test
+   void switchingToCustomPeriodsClearsAStaleIntervalSoItDoesNotSilentlyReactivate()
+      throws Exception
+   {
+      DateComparisonPaneModel model = model();
+      Harness h = harness(model);
+
+      // Call 1: standard period with an interval.
+      h.service.set("tok", principal(), "Chart1", new DateComparisonService.Comparison(
+         4, "quarter", null, true, "monthToDate", null, null, null, null, null, null), "");
+      assertEquals(String.valueOf(DateComparisonInfo.MONTH_TO_DATE),
+                   model.getIntervalPaneModel().getLevel().getValue());
+
+      // Call 2: switch to customPeriods. The stale interval must be cleared, not just left inert.
+      h.service.set("tok", principal(), "Chart1", customPeriods(
+         new DateComparisonService.CustomPeriod("2026-03-01", "2026-03-15")), "");
+      assertEquals(String.valueOf(DateComparisonInfo.ALL),
+                  model.getIntervalPaneModel().getLevel().getValue(),
+                  "the interval left behind by call 1 must be reset when switching to custom");
+
+      // Stand in for an out-of-band switch back to standard (see the Javadoc above) — apply()
+      // itself refuses to do this for a wiz call, so this reaches the same model state a human
+      // editing the Composer's Interval pane directly would leave behind.
+      model.getPeriodPaneModel().setCustom(false);
+
+      // Call 3: a standard period with no 'interval' field at all. The stale monthToDate value
+      // from call 1 must not silently reactivate.
+      h.service.set("tok", principal(), "Chart1", new DateComparisonService.Comparison(
+         2, "year", null, true, null, null, null, null, null, null, null), "");
+      assertEquals(String.valueOf(DateComparisonInfo.ALL),
+                  model.getIntervalPaneModel().getLevel().getValue(),
+                  "a call with no 'interval' field must not reactivate a stale earlier value");
+   }
+
    @Test
    void convertsThePaneModelBeforePostingIt() throws Exception {
       Harness h = harness(model());


### PR DESCRIPTION
## Summary

DCG-005 (Redmine #76522 batch): `set_date_comparison` had no schema path to express an
arbitrary, caller-defined date-range-pair comparison ("compare March 1-15 this year
against March 1-15 last year"). Investigation found StyleBI's engine already fully
supports this via `CustomPeriods`/`DatePeriod` (a real peer to `StandardPeriods` behind
`DateComparisonPeriods`), rendered by `ChartDcProcessor`, and exercised daily by the
manual Angular Composer's own "Custom Periods" tab (`DateComparisonPaneModel` /
`PeriodPaneModel` / `CustomPeriodPaneModel`). The gap was entirely confined to this
wiz-only bridge, which never had a wire path for it and explicitly refused to touch a
custom period:

> "setting a custom period is not supported by this tool yet."

- `DateComparisonRequest` gains a `customPeriods` field: a list of
  `DateComparisonService.CustomPeriod` (`{start, end}`).
- `DateComparisonService.apply()` gains a branch parallel to the existing standard-period
  branch: `customPeriods` marks the period pane custom (`periods.setCustom(true)`) and
  writes each start/end pair into `CustomPeriodPaneModel.datePeriods`. Mutually exclusive
  with the standard-period fields (`periods`/`level`/`endDate`/`endToday`/`toDate`/
  `inclusive`) and with `interval` -- the latter mirrors StyleBI's own pre-existing
  restriction (`DateComparisonInfo.getIntervalConditions()`, ticket 64217: interval
  sub-windows are not exposed for a custom period), not a new restriction invented here.
- Switching an existing standard period to custom via an explicit `customPeriods` list is
  allowed outright, unlike the accidental "just set `useFacet`" case the existing
  custom-to-standard guard exists to prevent -- a caller who lists explicit start/end
  pairs is deliberately asking for a custom period.
- `describePeriod()` gains a matching read-back branch: a custom-period assembly now
  reports its actual `start`/`end` pairs under `customPeriods`, instead of the standard
  period pane's meaningless defaults it unconditionally read before.

## Test plan

- [x] `./mvnw -pl core test -Dtest=DateComparisonServiceTest` -- 90/90 pass (11 new tests:
  set/read/mutual-exclusion for `customPeriods`, standard-to-custom switch allowed,
  `interval`+`customPeriods` rejected).
- [x] `./mvnw -pl core test -Dtest=ViewsheetAssemblyAgentControllerTest` -- 71/71 pass
  (unaffected; no direct `DateComparisonRequest` construction there).

## Note on concurrent work

DCG-003 (#5125) and DCG-007 (#5123), open in this same batch, also touch
`DateComparisonService.java` (different methods -- `read()`'s `shareFrom` resolution and a
`useFacet`-inapplicable disclosure, respectively). Neither had merged as of this PR;
whichever of the three lands last should rebase onto the others.