### PR TITLE
fix(#76542): canonicalize showType tokens/domain in set_assembly_properties

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -20,6 +20,8 @@ package inetsoft.web.wiz.viewsheet;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.CalendarVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.SelectionVSAssemblyInfo;
 import inetsoft.web.composer.model.vs.RangePaneModel;
 import inetsoft.web.composer.model.vs.TipCustomizeDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
@@ -245,7 +247,8 @@ public class AssemblyPropertyService {
          // to absorb the rebuild — see PropertyPath's own note), the wither produces a new
          // instance and the original reference silently stops reflecting the write.
          for(Map.Entry<String, String> entry : resolved.entrySet()) {
-            model = PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
+            Object value = canonicalShowType(type, entry.getValue(), patch.get(entry.getKey()));
+            model = PropertyPath.set(model, entry.getValue(), value);
          }
 
          if(PropertyAliases.derivesVariableFlagFromTable(type)) {
@@ -410,6 +413,95 @@ public class AssemblyPropertyService {
                : "Set 'dataInputPaneModel.table' (or 'columnValue') to a non-variable binding " +
                  "instead, or leave 'dataInputPaneModel.variable' out of the patch."));
       }
+   }
+
+   /**
+    * {@code showType}'s domain, keyed by the alias-resolved <b>full path</b> rather than by the
+    * short property name both share -- {@code selectionGeneralPaneModel.showType} (SelectionList
+    * and SelectionTree) and {@code calendarAdvancedPaneModel.showType} (Calendar) are aliased
+    * under the identical short name {@code "showType"}, but their int domains are different and
+    * overlapping: {@code 1} means "dropdown" for Selection ({@link
+    * SelectionVSAssemblyInfo#DROPDOWN_SHOW_TYPE}) and "calendar" mode for Calendar ({@link
+    * CalendarVSAssemblyInfo#CALENDAR_SHOW_TYPE}), whose own dropdown is {@code 2} ({@link
+    * CalendarVSAssemblyInfo#DROPDOWN_SHOW_TYPE}). A table keyed by leaf name alone would silently
+    * misapply "dropdown" on one of the two -- so this is keyed by the resolved path, the same
+    * reason {@link #canonicalShowType} needs it rather than {@code PropertyPath}'s leaf-name-keyed
+    * {@code CONSTRAINED_STRINGS}.
+    *
+    * <p>Only {@code showType} is covered here. {@code sortType} (a bitmask, more complex),
+    * {@code mode}, {@code linkType}, {@code rangeType}, {@code refType} and {@code newObjectType}
+    * are the same class of gap (a closed int domain with no alias/validation), but out of scope
+    * for this fix.
+    */
+   private static final Map<String, Map<String, Integer>> SHOW_TYPE_DOMAINS;
+
+   static {
+      Map<String, Integer> selection = new LinkedHashMap<>();
+      selection.put("list", SelectionVSAssemblyInfo.LIST_SHOW_TYPE);
+      selection.put("dropdown", SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+
+      Map<String, Integer> calendar = new LinkedHashMap<>();
+      calendar.put("calendar", CalendarVSAssemblyInfo.CALENDAR_SHOW_TYPE);
+      calendar.put("dropdown", CalendarVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
+
+      Map<String, Map<String, Integer>> domains = new LinkedHashMap<>();
+      domains.put("selectionGeneralPaneModel.showType", selection);
+      domains.put("calendarAdvancedPaneModel.showType", calendar);
+      SHOW_TYPE_DOMAINS = Collections.unmodifiableMap(domains);
+   }
+
+   /**
+    * Canonicalizes a {@code showType} value before it reaches {@code PropertyPath.set/coerce()},
+    * the same way {@link ChartRegionPropertyService#canonicalRotation} pre-transforms
+    * {@code rotation} for its own service: {@code showType} is a plain primitive {@code int} on
+    * both models it can resolve to, so {@code PropertyPath.coerce()}'s numeric branch never
+    * consults any alias/domain table -- a token like {@code "dropdown"} falls straight to
+    * {@code Double.parseDouble} and fails with no valid values named, and an out-of-domain int
+    * (e.g. {@code 2} on a SelectionList) is silently stored as-is.
+    *
+    * <p>Additive: any path with no entry in {@link #SHOW_TYPE_DOMAINS} (i.e. every property this
+    * service writes except {@code showType}) is returned unchanged.
+    */
+   private static Object canonicalShowType(String type, String resolvedPath, Object value) {
+      Map<String, Integer> domain = SHOW_TYPE_DOMAINS.get(resolvedPath);
+
+      if(domain == null) {
+         return value;
+      }
+
+      String text = value == null ? "" : String.valueOf(value).trim();
+
+      for(Map.Entry<String, Integer> token : domain.entrySet()) {
+         if(token.getKey().equalsIgnoreCase(text)) {
+            return token.getValue();
+         }
+      }
+
+      try {
+         int parsed = (int) Double.parseDouble(text);
+
+         if(domain.containsValue(parsed)) {
+            return parsed;
+         }
+      }
+      catch(NumberFormatException ignore) {
+         // falls through to the error below
+      }
+
+      StringBuilder allowed = new StringBuilder();
+
+      for(Map.Entry<String, Integer> token : domain.entrySet()) {
+         if(allowed.length() > 0) {
+            allowed.append(", ");
+         }
+
+         allowed.append("'").append(token.getKey()).append("' (").append(token.getValue())
+            .append(")");
+      }
+
+      throw new IllegalArgumentException(
+         "'showType' on a " + type + " accepts only " + allowed + "; '" + value +
+         "' is not one of them.");
    }
 
    // ── convention dispatch ───────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -22,10 +22,12 @@ import inetsoft.test.*;
 import inetsoft.uql.asset.DefaultVariableAssembly;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.web.composer.model.vs.CalendarPropertyDialogModel;
 import inetsoft.web.composer.model.vs.CheckboxPropertyDialogModel;
 import inetsoft.web.composer.model.vs.ChartPropertyDialogModel;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
 import inetsoft.web.composer.model.vs.RadioButtonPropertyDialogModel;
+import inetsoft.web.composer.model.vs.SelectionListPropertyDialogModel;
 import inetsoft.web.composer.model.vs.TextInputPropertyDialogModel;
 import inetsoft.web.composer.model.vs.TipCustomizeDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
@@ -639,6 +641,118 @@ class AssemblyPropertyServiceTest {
                    "an explicit tooltipMode must not be overridden by the tooltip implication");
    }
 
+   // ── showType alias/domain (bug #76542) ───────────────────────────────────
+   //
+   // selectionGeneralPaneModel.showType and calendarAdvancedPaneModel.showType share the short
+   // alias "showType" but have different, overlapping int domains (Selection: list=0/dropdown=1;
+   // Calendar: calendar=1/dropdown=2) -- a leaf-name-only canonicalization would silently misapply
+   // "dropdown" on whichever collides. canonicalShowType is keyed by the resolved full path
+   // instead, so these tests exercise both paths explicitly.
+
+   @Test
+   void canonicalizesDropdownTokenOnASelectionListShowType() throws Exception {
+      SelectionListPropertyDialogModel model = new SelectionListPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithSelectionList(mock(SelectionListVSAssembly.class), model);
+
+      service.set("tok", principal(), "Selection1", Map.of("showType", "dropdown"), "");
+
+      assertEquals(1, model.getSelectionGeneralPaneModel().getShowType());
+   }
+
+   @Test
+   void canonicalizesDropdownTokenCaseInsensitivelyOnASelectionListShowType() throws Exception {
+      SelectionListPropertyDialogModel model = new SelectionListPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithSelectionList(mock(SelectionListVSAssembly.class), model);
+
+      service.set("tok", principal(), "Selection1", Map.of("showType", "Dropdown"), "");
+
+      assertEquals(1, model.getSelectionGeneralPaneModel().getShowType());
+   }
+
+   @Test
+   void canonicalizesListTokenOnASelectionListShowType() throws Exception {
+      SelectionListPropertyDialogModel model = new SelectionListPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithSelectionList(mock(SelectionListVSAssembly.class), model);
+
+      service.set("tok", principal(), "Selection1", Map.of("showType", "list"), "");
+
+      assertEquals(0, model.getSelectionGeneralPaneModel().getShowType());
+   }
+
+   /**
+    * The regression test that would catch a wrongly-leaf-name-keyed implementation: Calendar's
+    * "dropdown" is a different int (2) from Selection's (1), because Calendar's own showType
+    * domain also has a "calendar" mode value that collides with Selection's dropdown value (1).
+    */
+   @Test
+   void canonicalizesDropdownTokenOnACalendarShowTypeToItsOwnDomain() throws Exception {
+      CalendarPropertyDialogModel model = new CalendarPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithCalendar(mock(CalendarVSAssembly.class), model);
+
+      service.set("tok", principal(), "Calendar1", Map.of("showType", "dropdown"), "");
+
+      assertEquals(2, model.getCalendarAdvancedPaneModel().getShowType());
+   }
+
+   @Test
+   void canonicalizesCalendarTokenOnACalendarShowType() throws Exception {
+      CalendarPropertyDialogModel model = new CalendarPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithCalendar(mock(CalendarVSAssembly.class), model);
+
+      service.set("tok", principal(), "Calendar1", Map.of("showType", "calendar"), "");
+
+      assertEquals(1, model.getCalendarAdvancedPaneModel().getShowType());
+   }
+
+   @Test
+   void refusesAnUnrecognizedShowTypeTokenNamingTheValidValues() {
+      SelectionListPropertyDialogModel model = new SelectionListPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithSelectionList(mock(SelectionListVSAssembly.class), model);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "Selection1", Map.of("showType", "combobox"), ""));
+
+      assertTrue(thrown.getMessage().contains("combobox"));
+      assertTrue(thrown.getMessage().contains("list"), "must name the valid tokens: " +
+                 thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("dropdown"), "must name the valid tokens: " +
+                 thrown.getMessage());
+   }
+
+   /**
+    * An out-of-domain numeric value must be rejected too, not just silently stored -- {@code 2}
+    * is Calendar's dropdown, not a valid SelectionList showType (0 or 1).
+    */
+   @Test
+   void refusesAnOutOfDomainNumericShowTypeOnASelectionList() {
+      SelectionListPropertyDialogModel model = new SelectionListPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithSelectionList(mock(SelectionListVSAssembly.class), model);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "Selection1", Map.of("showType", 2), ""));
+
+      assertTrue(thrown.getMessage().contains("2"));
+   }
+
+   /** An already-numeric, in-domain value must still work exactly as before -- no regression. */
+   @Test
+   void stillAcceptsAnAlreadyNumericInDomainShowTypeOnASelectionList() throws Exception {
+      SelectionListPropertyDialogModel model = new SelectionListPropertyDialogModel();
+      AssemblyPropertyService service =
+         serviceWithSelectionList(mock(SelectionListVSAssembly.class), model);
+
+      service.set("tok", principal(), "Selection1", Map.of("showType", 1), "");
+
+      assertEquals(1, model.getSelectionGeneralPaneModel().getShowType());
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {
@@ -661,6 +775,18 @@ class AssemblyPropertyServiceTest {
       VSAssembly assembly, RadioButtonPropertyDialogModel model, Worksheet baseWorksheet)
    {
       return serviceWith(assembly, model, model, baseWorksheet);
+   }
+
+   private static AssemblyPropertyService serviceWithSelectionList(
+      VSAssembly assembly, SelectionListPropertyDialogModel model)
+   {
+      return serviceWith(assembly, model, null, null);
+   }
+
+   private static AssemblyPropertyService serviceWithCalendar(
+      VSAssembly assembly, CalendarPropertyDialogModel model)
+   {
+      return serviceWith(assembly, model, null, null);
    }
 
    private static AssemblyPropertyService serviceWith(
@@ -695,6 +821,33 @@ class AssemblyPropertyServiceTest {
             when(gauge.getGaugePropertyDialogModel(anyString(), anyString(),
                                                    any(Principal.class)))
                .thenReturn(gaugeModel);
+         }
+         catch(Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
+      SelectionListPropertyDialogService selectionList =
+         mock(SelectionListPropertyDialogService.class);
+
+      if(model instanceof SelectionListPropertyDialogModel selectionListModel) {
+         try {
+            when(selectionList.getSelectionListPropertyModel(anyString(), anyString(),
+                                                              any(Principal.class)))
+               .thenReturn(selectionListModel);
+         }
+         catch(Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
+      CalendarPropertyDialogService calendar = mock(CalendarPropertyDialogService.class);
+
+      if(model instanceof CalendarPropertyDialogModel calendarModel) {
+         try {
+            when(calendar.getCalendarPropertyModel(anyString(), anyString(),
+                                                   any(Principal.class)))
+               .thenReturn(calendarModel);
          }
          catch(Exception e) {
             throw new IllegalStateException(e);
@@ -743,11 +896,11 @@ class AssemblyPropertyServiceTest {
          mock(TextPropertyDialogService.class),
          chart, mock(TableViewPropertyDialogService.class),
          mock(CrosstabPropertyDialogService.class),
-         mock(SelectionListPropertyDialogService.class),
+         selectionList,
          mock(SelectionTreePropertyDialogService.class),
          inputService,
          mock(RangeSliderPropertyDialogService.class),
-         mock(CalendarPropertyDialogService.class), mock(TabPropertyDialogService.class),
+         calendar, mock(TabPropertyDialogService.class),
          mock(CalcTablePropertyDialogService.class),
          mock(GroupContainerPropertyDialogService.class),
          mock(LinePropertyDialogService.class), mock(OvalPropertyDialogService.class),


### PR DESCRIPTION
## Summary
- `selectionGeneralPaneModel.showType` and `calendarAdvancedPaneModel.showType` are plain ints, aliased under the identical short name `showType`, so `PropertyPath.coerce()`'s numeric branch had no domain/alias table for either -- a token like `"dropdown"` fell straight to `Double.parseDouble`, failing with no valid values named.
- Worse, the two domains overlap and disagree (Selection: `list=0`/`dropdown=1`; Calendar: `calendar=1`/`dropdown=2`), so a fix keyed by leaf name alone would silently misapply `"dropdown"` on whichever one it didn't originally target.
- Adds `canonicalShowType(type, resolvedPath, value)` to `AssemblyPropertyService`, modeled on `ChartRegionPropertyService.canonicalRotation()`: keyed by the alias-resolved full path (not leaf name), it accepts a case-insensitive token (`"dropdown"`/`"list"`/`"calendar"`) or an already-numeric in-domain value, and throws naming the valid tokens/ints for anything else -- including an out-of-domain int like `{showType: 2}` on a SelectionList, which used to be silently stored.
- Scope: `showType` only. `sortType` (bitmask), `mode`, `linkType`, `rangeType`, `refType`, `newObjectType` are the same class of gap, flagged as a follow-up, not fixed here.

## Test plan
- [x] `AssemblyPropertyServiceTest` (42/42, incl. 7 new cases covering both the Selection/Calendar domain collision and out-of-domain rejection)
- [x] Full `inetsoft.web.wiz.viewsheet` package regression (849 tests, 0 failures/errors), incl. `PropertyPathTest` and `ChartRegionPropertyServiceTest` unaffected

Fixes Redmine #76542.