### PR TITLE
fix(wiz): let add_table/ws-table satisfy the row-cap gate on a paginated REST target

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/TabularEndpointBindingSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularEndpointBindingSupport.java
@@ -347,9 +347,16 @@ public final class TabularEndpointBindingSupport {
     *
     * <p>Not only endpoints. Pagination is an ordinary property -- {@code setPaginationType} writes
     * the spec that {@code isPaged()} reads, with nothing in between -- so a target kind addressed
-    * by its parameters rather than by an endpoint name can paginate just as readily. Which kinds
-    * are asked is {@code WorksheetTableService.rowCapRequiredFor}; what this needs to know is that
-    * {@code target} may be absent, since such a kind has no endpoint to name.</p>
+    * by its parameters rather than by an endpoint name can paginate just as readily; {@code target}
+    * may be absent for that reason, since such a kind has no endpoint to name.</p>
+    *
+    * <p>The cap itself is {@link TabularQuery#getMaxRows()} -- the same {@code XQuery} row limit
+    * every render already enforces ({@code AbstractQueryRunner.getTable()} feeds it straight into
+    * both REST runners' {@code hasNext()}, and {@code BoundQuery.getDefinedMaxRows()} folds it into
+    * the effective render-time limit), not a second, parallel concept. The caller is responsible
+    * for calling {@code query.setMaxRows(...)} from whatever field the request carries (e.g.
+    * {@code EditRequest.maxRows()}/{@code WorksheetTable.TabularSource.getMaxRows()}) BEFORE this
+    * check runs -- this method only reads it back.</p>
     */
    public static void requireRowCapWhenPaged(TabularQuery query, String target, String dsName) {
       // Built first so the message reads correctly for a kind that has no target: there is no
@@ -366,11 +373,29 @@ public final class TabularEndpointBindingSupport {
          return;
       }
 
-      if(paged) {
+      if(!paged) {
+         return;
+      }
+
+      int maxRows;
+
+      try {
+         // XQuery.getMaxRows() reads the org-wide row-limit policy via SreeEnv, which needs a live
+         // Spring context -- unavailable the same "we cannot tell" way isPaged() above can be, e.g.
+         // a lightweight unit test with no application context. Same fallback: left alone, not
+         // blocked, rather than a check that cannot run turning into a hard failure.
+         maxRows = query.getMaxRows();
+      }
+      catch(Exception ex) {
+         LOG.debug("Could not read the row cap already applied to {}; not requiring one", subject, ex);
+         return;
+      }
+
+      if(maxRows <= 0) {
          throw new IllegalArgumentException(
             subject + " is paginated, so a row cap is required: without it every render of this " +
-            "table requests pages until the service runs out of data. Choose a row cap for the " +
-            "question being asked.");
+            "table requests pages until the service runs out of data. Set maxRows to a positive " +
+            "value for the question being asked.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1523,12 +1523,6 @@ public class WorksheetTableService {
          query.setMaxRows(src.getMaxRows());
       }
 
-      // Same guard the Composer's own add_table takes (WorksheetAgentController.addTabularTable /
-      // addQueryParamsTable) -- this write path shares TabularEndpointBindingSupport with those but,
-      // until now, never called this check, so a paginated tabular table could be built here with no
-      // cap and no warning at all.
-      TabularEndpointBindingSupport.requireRowCapWhenPaged(query, null, dsName);
-
       // How many rows to report back, carried ON THE QUERY because the runner is the only place that
       // sees a response and it is the only thing that can sample one. Zero when the caller did not
       // ask, which is the default: sampling is opt-in, so a table built without this field runs

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1523,6 +1523,12 @@ public class WorksheetTableService {
          query.setMaxRows(src.getMaxRows());
       }
 
+      // Same guard the Composer's own add_table takes (WorksheetAgentController.addTabularTable /
+      // addQueryParamsTable) -- this write path shares TabularEndpointBindingSupport with those but,
+      // until now, never called this check, so a paginated tabular table could be built here with no
+      // cap and no warning at all.
+      TabularEndpointBindingSupport.requireRowCapWhenPaged(query, null, dsName);
+
       // How many rows to report back, carried ON THE QUERY because the runner is the only place that
       // sees a response and it is the only thing that can sample one. Zero when the caller did not
       // ask, which is the default: sampling is opt-in, so a table built without this field runs

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -50,7 +50,7 @@ import java.util.Map;
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields. For three or more tables joined in a single call, supply {@code joinPaths} instead (each a {leftTable, leftKey, rightTable, rightKey, joinType} edge) — {@code leftTable}/{@code leftKey}/{@code rightTable}/{@code rightKey}/{@code joinType}/{@code leftKeys}/{@code rightKeys} are ignored when {@code joinPaths} is present</li>
  *   <li>{@code remove_join} — {@code name}</li>
- *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code parameters}/{@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code parameters}/{@code lookup}; or optional {@code queryParams} (a flat connector-property map) for a METADATA/FILE/Rest.XML datasource with no predefined endpoint catalogue and no simple URL-suffix shape — mutually exclusive with all of the above</li>
+ *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code parameters}/{@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code parameters}/{@code lookup}; or optional {@code queryParams} (a flat connector-property map) for a METADATA/FILE/Rest.XML datasource with no predefined endpoint catalogue and no simple URL-suffix shape — mutually exclusive with all of the above. {@code maxRows} (see its own doc below) also applies to all three forms above: when the resolved query paginates ({@code TabularEndpointBindingSupport.requireRowCapWhenPaged}), a positive {@code maxRows} is effectively required, since the call otherwise refuses to create the table.</li>
  *   <li>{@code edit_condition} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code edit_expression} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code edit_join} — {@code name}, {@code leftKey}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys}</li>
@@ -226,7 +226,12 @@ public record EditRequest(
    String alias,
    /** Table description for set_table_properties. */
    String description,
-   /** Max rows for set_table_properties. */
+   /**
+    * Max rows for set_table_properties, and (0 or absent = unlimited, but see the {@code add_table}
+    * bullet above) the row cap applied to the query built by add_table's endpoint/suffix/queryParams
+    * forms. The same {@code XQuery} row limit either way -- {@code TabularQuery.setMaxRows} -- not
+    * two different settings that happen to share a name.
+    */
    Integer maxRows,
    /** Distinct flag for set_table_properties. */
    Boolean distinct,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -723,6 +723,11 @@ public class WorksheetAgentController {
 
          suffix = TabularEndpointBindingSupport.applyEndpointContract(query, pmap, req.endpoint(),
             req.parameters(), null, null, null, dsName);
+
+         if(req.maxRows() != null) {
+            query.setMaxRows(req.maxRows());
+         }
+
          TabularEndpointBindingSupport.requireRowCapWhenPaged(query, req.endpoint(), dsName);
 
          if(req.lookup() != null && !req.lookup().isEmpty()) {
@@ -738,6 +743,11 @@ public class WorksheetAgentController {
 
          suffix = TabularEndpointBindingSupport.applyCustomSuffix(query, pmap, req.suffix(), null,
             dsName);
+
+         if(req.maxRows() != null) {
+            query.setMaxRows(req.maxRows());
+         }
+
          TabularEndpointBindingSupport.requireRowCapWhenPaged(query, req.suffix(), dsName);
 
          if(req.customLookups() != null && !req.customLookups().isEmpty()) {
@@ -831,6 +841,12 @@ public class WorksheetAgentController {
       TabularQuerySchema schema = new TabularSchemaExtractor().extract(query, dataSource.getType());
       String applied = TabularQueryContractSupport.applyQueryContract(
          query, pmap, schema, req.queryParams(), dsName);
+
+      if(req.maxRows() != null) {
+         query.setMaxRows(req.maxRows());
+      }
+
+      TabularEndpointBindingSupport.requireRowCapWhenPaged(query, null, dsName);
 
       String tableName = req.table();
 

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeCustomRestQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeCustomRestQuery.java
@@ -70,6 +70,17 @@ public class FakeCustomRestQuery extends TabularQuery {
       this.suffix = suffix;
    }
 
+   /**
+    * Non-{@code @Property} reflection surface, mirroring {@link FakeLegacyEndpointQuery#isPaged()}'s
+    * pattern for the generic/custom (no {@code endpoint} property) shape: a custom REST-JSON
+    * connector's pagination is driven by its own connector-specific properties, not a name lookup,
+    * so this fixture ties it to the one property the suffix form actually sets -- {@code suffix}
+    * itself -- rather than adding an unrelated property no caller sets.
+    */
+   public boolean isPaged() {
+      return "/paged".equals(suffix);
+   }
+
    @Property(label = "Json Path")
    public String getJsonPath() {
       return jsonPath;

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularEndpointBindingSupportTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularEndpointBindingSupportTest.java
@@ -20,8 +20,8 @@ package inetsoft.web.wiz.service;
 import inetsoft.uql.tabular.PropertyMeta;
 import inetsoft.uql.tabular.RestParameter;
 import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.worksheet.WorksheetMutationSupport;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -36,8 +36,13 @@ import static org.junit.jupiter.api.Assertions.*;
  * {@link FakeLegacyEndpointQuery}/{@link FakeCustomRestQuery} -- real (non-mock) {@code TabularQuery}
  * instances, since the class under test works entirely through {@code TabularUtil}'s bean-property
  * reflection, which a mock cannot stand in for.
+ *
+ * <p>{@code @WizAgentTestSupport} (rather than a bare {@code @Tag("core")}) is required as of the
+ * {@code requireRowCapWhenPaged} coverage below: that method reads {@code TabularQuery.getMaxRows()},
+ * which goes through {@code SreeEnv}/{@code ConfigurationContext} to apply the org-wide row-limit
+ * policy -- unavailable without the minimal Spring context this annotation boots.</p>
  */
-@Tag("core")
+@WizAgentTestSupport
 class TabularEndpointBindingSupportTest {
 
    // ─── applyEndpointContract (named connector) ──────────────────────────────
@@ -140,6 +145,39 @@ class TabularEndpointBindingSupportTest {
 
       assertDoesNotThrow(
          () -> TabularEndpointBindingSupport.requireRowCapWhenPaged(query, "Repos", "myds"));
+   }
+
+   /**
+    * The cap itself is the ordinary {@code XQuery} row limit ({@link
+    * inetsoft.uql.tabular.TabularQuery#getMaxRows()}/{@code setMaxRows}), not a second, parallel
+    * concept -- setting a positive value is what should let a paged endpoint through.
+    */
+   @Test
+   void requireRowCapWhenPagedAllowsAPagedEndpointOnceMaxRowsIsSet() throws Exception {
+      FakeLegacyEndpointQuery query = new FakeLegacyEndpointQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Paged", null, null, null, null, "myds");
+      query.setMaxRows(500);
+
+      assertDoesNotThrow(
+         () -> TabularEndpointBindingSupport.requireRowCapWhenPaged(query, "Paged", "myds"));
+   }
+
+   /**
+    * {@code 0} must not be read as "a cap was chosen" -- it is {@code XQuery}'s own "unlimited"
+    * sentinel, so treating it as a valid cap would silently defeat the whole check.
+    */
+   @Test
+   void requireRowCapWhenPagedTreatsZeroMaxRowsAsStillUnset() throws Exception {
+      FakeLegacyEndpointQuery query = new FakeLegacyEndpointQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Paged", null, null, null, null, "myds");
+      query.setMaxRows(0);
+
+      assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.requireRowCapWhenPaged(query, "Paged", "myds"));
    }
 
    // ─── applyLookupChain (named connector) ───────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -68,6 +68,7 @@ import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.service.FakeCustomRestQuery;
 import inetsoft.web.wiz.service.FakeNamedConnectorQuery;
 import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.service.RenderNotReadyException;
@@ -372,6 +373,45 @@ class WorksheetAgentControllerTest {
       if(endpoint != null) body.put("endpoint", endpoint);
       if(suffix != null) body.put("suffix", suffix);
       if(queryParams != null) body.put("queryParams", queryParams);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
+   /**
+    * Same {@code add_table} endpoint/suffix shape as {@link #addTabularTableRequest}, but also
+    * carrying {@code maxRows} -- built through the real app {@link ObjectMapper}, the same
+    * technique {@link #addQueryParamsTableRequest} uses, since hand-counting nulls to a new
+    * position in the 70+ field positional record risks the exact silent off-by-one that technique
+    * exists to avoid.
+    */
+   private static EditRequest addTabularTableRequestWithMaxRows(
+      String table, String datasource, String endpoint, String suffix, Integer maxRows)
+      throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(endpoint != null) body.put("endpoint", endpoint);
+      if(suffix != null) body.put("suffix", suffix);
+      if(maxRows != null) body.put("maxRows", maxRows);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
+   /** Same as {@link #addQueryParamsTableRequest}, but also carrying {@code maxRows}. */
+   private static EditRequest addQueryParamsTableRequestWithMaxRows(
+      String table, String datasource, Map<String, Object> queryParams, Integer maxRows)
+      throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(queryParams != null) body.put("queryParams", queryParams);
+      if(maxRows != null) body.put("maxRows", maxRows);
 
       ObjectMapper mapper = new WebConfig().objectMapper();
       return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
@@ -3796,6 +3836,150 @@ class WorksheetAgentControllerTest {
       }
    }
 
+   /**
+    * Regression for round-1 review finding 2 on the row-cap PR: proves
+    * {@code TabularEndpointBindingSupport.requireRowCapWhenPaged} is actually WIRED into
+    * {@code addTabularTable}'s endpoint branch, not just exercised in isolation by
+    * {@code TabularEndpointBindingSupportTest}. {@code FakeNamedConnectorQuery}'s "Paged" endpoint
+    * (see its own doc) reports {@code isPaged() == true} with no {@code maxRows} supplied.
+    */
+   @Test
+   void addTabularTableRejectsPagedEndpointWithoutMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addTabularTableRequestWithMaxRows(
+         "t1", "MyDatasource", "Paged", null, null);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ctrl.edit("TOK-TT9", req, agent));
+         assertTrue(ex.getMessage().contains("paginated"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+   }
+
+   /** Same wiring as {@link #addTabularTableRejectsPagedEndpointWithoutMaxRows}, but a positive
+    *  {@code maxRows} must satisfy the check and let execution reach {@code editService}. */
+   @Test
+   void addTabularTableAllowsPagedEndpointWithMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addTabularTableRequestWithMaxRows(
+         "t1", "MyDatasource", "Paged", null, 500);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-TT10", req, agent),
+            "a positive maxRows must satisfy the row-cap check on a paginated endpoint");
+         verify(editSvc).applyOnRuntime(eq("TOK-TT10"), eq(agent), any());
+      }
+   }
+
+   /**
+    * Same regression as {@link #addTabularTableRejectsPagedEndpointWithoutMaxRows}, for the
+    * generic/custom (suffix) branch instead of the named-connector (endpoint) one.
+    * {@code FakeCustomRestQuery} has no {@code endpoint} property (so {@code addTabularTable}
+    * dispatches to the suffix branch) and reports {@code isPaged() == true} only for
+    * {@code suffix == "/paged"} -- see its own doc.
+    */
+   @Test
+   void addTabularTableRejectsPagedSuffixWithoutMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithMaxRows(
+         "t1", "MyDatasource", null, "/paged", null);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ctrl.edit("TOK-TT11", req, agent));
+         assertTrue(ex.getMessage().contains("paginated"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+   }
+
+   /** Same wiring as {@link #addTabularTableRejectsPagedSuffixWithoutMaxRows}, but a positive
+    *  {@code maxRows} must satisfy the check and let execution reach {@code editService}. */
+   @Test
+   void addTabularTableAllowsPagedSuffixWithMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithMaxRows(
+         "t1", "MyDatasource", null, "/paged", 500);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-TT12", req, agent),
+            "a positive maxRows must satisfy the row-cap check on a paginated suffix");
+         verify(editSvc).applyOnRuntime(eq("TOK-TT12"), eq(agent), any());
+      }
+   }
+
    // ---------------------------------------------------------------------------
    // add_table with queryParams — naming for addQueryParamsTable()
    // ---------------------------------------------------------------------------
@@ -3989,6 +4173,108 @@ class WorksheetAgentControllerTest {
          // editService.applyOnRuntime is only reached AFTER applyQueryContract succeeds -- if
          // jsonPath had not been threaded through at all, this mock would never be touched.
          verify(editSvc).applyOnRuntime(eq("TOK-QP7"), eq(agent), any());
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
+   /**
+    * Regression for round-1 review finding 2 on the row-cap PR: proves
+    * {@code TabularEndpointBindingSupport.requireRowCapWhenPaged} is actually wired into
+    * {@code addQueryParamsTable} too, not just {@code addTabularTable}'s two branches.
+    * {@code queryParams.endpoint = "Paged"} drives {@code FakeNamedConnectorQuery.isPaged()} to
+    * {@code true} the same way the endpoint-form test above does; the connector-agnostic
+    * queryParams form has no {@code endpoint} concept of its own, but reuses the same fixture
+    * property here purely as a paged/unpaged toggle.
+    */
+   @Test
+   void addQueryParamsTableRejectsPagedConnectorWithoutMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeNamedConnector");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addQueryParamsTableRequestWithMaxRows(
+         "t1", "MyDatasource", Map.of("endpoint", "Paged"), null);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ctrl.edit("TOK-QP8", req, agent));
+         assertTrue(ex.getMessage().contains("paginated"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
+   /** Same wiring as {@link #addQueryParamsTableRejectsPagedConnectorWithoutMaxRows}, but a
+    *  positive {@code maxRows} must satisfy the check and let execution reach {@code editService}. */
+   @Test
+   void addQueryParamsTableAllowsPagedConnectorWithMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeNamedConnector");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addQueryParamsTableRequestWithMaxRows(
+         "t1", "MyDatasource", Map.of("endpoint", "Paged"), 500);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-QP9", req, agent),
+            "a positive maxRows must satisfy the row-cap check on a paginated connector");
+         verify(editSvc).applyOnRuntime(eq("TOK-QP9"), eq(agent), any());
       }
       finally {
          configContext.setApplicationContext(realAppContext);


### PR DESCRIPTION
## Summary

`TabularEndpointBindingSupport.requireRowCapWhenPaged` throws unconditionally for any paginated tabular query — there was no field anywhere in the wiz-agent request chain that could ever satisfy it (the validation shipped without its other half). This wires it to the row limit that already gates REST pagination end to end (`RestJsonQueryRunner`/`RestXMLQueryRunner`'s `hasNext()`, via `AbstractQueryRunner.getTable()` → `TabularQuery.getMaxRows()`):

- `requireRowCapWhenPaged` now only throws when `isPaged()` is true **and** `query.getMaxRows() <= 0`.
- `WorksheetAgentController.addTabularTable` (both the `endpoint` and `suffix` forms) and `addQueryParamsTable` now apply `req.maxRows()` via `query.setMaxRows(...)` before the check runs. `addQueryParamsTable` previously never called this guard at all — a paginated queryParams-based table could be created with no protection.
- `WorksheetTableService.buildTabularTable` (the wiz-services `/ws/table` write path) already wired `TabularSource.maxRows` onto the query, but never called `requireRowCapWhenPaged` either — an independent, pre-existing gap closed here alongside the Composer-side fix.
- `EditRequest.java`'s `maxRows` field already existed (used by `set_table_properties`); only its javadoc changed to document the new use — no new field, no new compatibility constructor needed.

Full root-cause writeup: `stylebi-wiz` repo, `docs/tabular/stylebi-tabular-rest-row-cap-gap.md` (companion PR in that repo wires the new `maxRows` parameter through the composer-chat MCP tool).

## Test plan

- [x] `TabularEndpointBindingSupportTest` — new coverage: paged endpoint throws when `maxRows` unset or `0`, passes once a positive `maxRows` is set; existing unpaged-endpoint case unchanged. Required adding `@WizAgentTestSupport` (was a bare `@Tag("core")`) since `getMaxRows()` now touches `SreeEnv`/`ConfigurationContext`.
- [x] `WorksheetAgentControllerTest` — full suite (184 tests) green, no regressions from the `maxRows` wiring in `addTabularTable`/`addQueryParamsTable`.
- [x] `mvnw -pl core -am compile` and `-am test -Dtest=TabularEndpointBindingSupportTest,WorksheetAgentControllerTest` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)