### PR TITLE
fix(wiz): resolve colName to a real data cell on plain/calc tables (Redmine #76558 VSH-001)

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
@@ -25,6 +25,7 @@ import inetsoft.graph.data.BoxDataSet;
 import inetsoft.graph.data.SumDataSet;
 import inetsoft.report.TableDataPath;
 import inetsoft.report.TableLens;
+import inetsoft.report.internal.Util;
 import inetsoft.report.composition.*;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.GraphTypeUtil;
@@ -100,6 +101,14 @@ public class HighlightDialogService {
             int[] resolved = resolveStackedMeasureCell(cinfo.getRuntimeAggregates(),
                cinfo.isSummarySideBySide(), lens.getHeaderRowCount(), lens.getHeaderColCount(),
                colName);
+
+            if(resolved != null) {
+               row = resolved[0];
+               col = resolved[1];
+            }
+         }
+         else if(colName != null) {
+            int[] resolved = resolveNamedColumnCell(lens, colName);
 
             if(resolved != null) {
                row = resolved[0];
@@ -442,6 +451,34 @@ public class HighlightDialogService {
       return summarySideBySide
          ? new int[] { headerRowCount, headerColCount + index }
          : new int[] { headerRowCount + index, headerColCount };
+   }
+
+   /**
+    * Resolves {@code colName} to a genuine DATA cell -- {@code {row, col}} -- on a non-crosstab
+    * table-type assembly (plain table or calc table); the equivalent of
+    * {@link #resolveStackedMeasureCell} for the case that method's {@code instanceof
+    * CrosstabVSAssembly} guard excludes.
+    *
+    * <p>Without this, {@code colName} was never consulted outside the crosstab branch: {@code row}/
+    * {@code col} stayed whatever the caller passed (defaulting to 0/0), and
+    * {@code lens.getTableDataPath(row, col)} landed on column 0's HEADER cell -- a highlight that
+    * then never matches any rendered DATA row (bug 76558 / VSH-001).
+    *
+    * <p>{@code colName} naming no column on this lens (or absent) returns {@code null}, leaving
+    * {@code row}/{@code col} untouched, same as {@code resolveStackedMeasureCell}'s fallback.
+    */
+   static int[] resolveNamedColumnCell(TableLens lens, String colName) {
+      if(colName == null) {
+         return null;
+      }
+
+      int col = Util.findColumn(lens, colName);
+
+      if(col < 0) {
+         return null;
+      }
+
+      return new int[] { lens.getHeaderRowCount(), col };
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/HighlightDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/HighlightDialogServiceTest.java
@@ -41,6 +41,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * a pure function of {@code (row, col)} alone, so two calls naming different measures but both
  * omitting row/col always collapsed onto the SAME {@code TableDataPath}, and every measure but the
  * first lost its highlight.
+ *
+ * <p>Bug 76558 / VSH-001: a plain (non-crosstab) table's {@code colName}-only call had no
+ * resolution at all -- {@code row}/{@code col} stayed at 0/0, landing on column 0's HEADER cell,
+ * which a rendered DATA row never matches, so the highlight was inert on every column.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -180,5 +184,62 @@ class HighlightDialogServiceTest {
                    0.0001);
       assertEquals(10.0, ((Number) table.getObject(discountCell[0], discountCell[1])).doubleValue(),
                    0.0001);
+   }
+
+   // ── resolveNamedColumnCell: bug 76558 / VSH-001 ────────────────────────────
+
+   /**
+    * Bug 76558 / VSH-001: a plain (non-crosstab) table's {@code colName}-only highlight call was
+    * never resolved to a real cell -- {@code row}/{@code col} stayed at their defaulted-to-0 input,
+    * so {@code lens.getTableDataPath(row, col)} always landed on column 0's HEADER cell, and the
+    * stored highlight then matched no rendered DATA row in any column, ever.
+    */
+   @Test
+   void resolvesANamedColumnToTheFirstDataRowOnAPlainTable() {
+      Object[][] data = {
+         { "ORDER_ID", "STATE", "AMOUNT" },
+         { 1, "NY", 100 },
+         { 2, "CA", 200 },
+      };
+      DefaultTableLens table = new DefaultTableLens(data);
+
+      int[] cell = HighlightDialogService.resolveNamedColumnCell(table, "STATE");
+
+      assertArrayEquals(new int[]{ table.getHeaderRowCount(), 1 }, cell,
+                         "STATE is column 1, and the resolved row is the first DATA row, not the " +
+                         "header row");
+   }
+
+   @Test
+   void resolvedNamedColumnCellIsARealDetailPathNotTheHeaderOfColumnZero() {
+      Object[][] data = {
+         { "ORDER_ID", "STATE", "AMOUNT" },
+         { 1, "NY", 100 },
+      };
+      DefaultTableLens table = new DefaultTableLens(data);
+
+      int[] cell = HighlightDialogService.resolveNamedColumnCell(table, "STATE");
+      TableDataPath path = table.getDescriptor().getCellDataPath(cell[0], cell[1]);
+
+      assertEquals(TableDataPath.DETAIL, path.getType(),
+                   "the whole bug: unresolved colName landed on the HEADER path of column 0, " +
+                   "which a rendered DETAIL row never matches");
+      assertArrayEquals(new String[]{ "STATE" }, path.getPath());
+   }
+
+   @Test
+   void leavesTheCellUnresolvedWhenTheNamedColumnDoesNotExist() {
+      Object[][] data = { { "ORDER_ID", "STATE" }, { 1, "NY" } };
+      DefaultTableLens table = new DefaultTableLens(data);
+
+      assertNull(HighlightDialogService.resolveNamedColumnCell(table, "NOT_A_COLUMN"));
+   }
+
+   @Test
+   void leavesTheCellUnresolvedWhenColNameIsAbsentForAPlainTable() {
+      Object[][] data = { { "ORDER_ID", "STATE" }, { 1, "NY" } };
+      DefaultTableLens table = new DefaultTableLens(data);
+
+      assertNull(HighlightDialogService.resolveNamedColumnCell(table, null));
    }
 }


### PR DESCRIPTION
## Summary

- `HighlightDialogService.getHighlightDialogModel` only resolved a `colName` to a real `row`/`col`
  when `assembly instanceof CrosstabVSAssembly` (`resolveStackedMeasureCell`). For any plain
  (non-crosstab) `TableDataVSAssemblyInfo` — a plain table or a calc table — `colName` was silently
  never consulted, `row`/`col` stayed at their unresolved default (0, 0), and the resulting
  `TableDataPath` was the HEADER cell of column 0, never a real data cell for the named column.
  A cell-level highlight built this way was therefore inert on every rendered data cell in any
  column — not merely losing priority to a co-existing row-level highlight, but never attaching to
  anything at all (`TableHighlightAttr`'s own cell-vs-row priority merge logic was independently
  confirmed correct; the defect was entirely upstream, in `colName` never being resolved).
- Fix: added `resolveNamedColumnCell(TableLens, String)`, mirroring `resolveStackedMeasureCell`'s
  shape, using `Util.findColumn` for the column index and `getHeaderRowCount()` for a genuine data
  row, wired into the `else` branch of the existing crosstab check — covering every non-crosstab
  `TableDataVSAssemblyInfo` (plain table and calc table alike), not just one narrow subtype.

## Root cause & fix docs (in the sibling `stylebi-wiz` repo)

- Diagnosis: `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-001/01-diagnosis.md`
- Refute (survived unchanged, high confidence — independently re-traced the full mechanism and
  found an additional corroborating detail the diagnosis hadn't fully spelled out):
  `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-001/02-refute.md`
- Fix: `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-001/03-fix.md`
- Review (round 1, APPROVE): `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-001/04-review-r1.md`

## Test plan

- [x] New regression coverage in `HighlightDialogServiceTest`: `resolveNamedColumnCell` resolves a
      named column on a real `DefaultTableLens` to `(headerRowCount, matchedColIndex)`; the
      resolved cell's `TableDataPath` is DETAIL-typed matching the named column, not the HEADER path
      of column 0; returns `null` for an unknown column name and for a `null` colName.
- [x] `./mvnw -q -pl core -Dtest=HighlightDialogServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
      — `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0` (7 pre-existing + 4 new).

Part of Redmine #76558 (batch covering VSH-001 through VSH-006 in the sibling `stylebi-wiz` repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)