### PR TITLE
fix(wiz): make GraphGenerator's whole-chart highlight fallback reachable (Redmine #76558 VSH-003 / #76522 DCG-001)

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -5887,11 +5887,6 @@ public abstract class GraphGenerator {
             ((HighlightRef) refs[i]).getHighlightGroup() != null)
          {
             list.add(0, (HighlightRef) refs[i]);
-            continue;
-         }
-
-         if(refs[i] instanceof ChartAggregateRef && refs[i].isMeasure()) {
-            list.add(0, (ChartAggregateRef) refs[i]);
          }
       }
 

--- a/core/src/test/java/inetsoft/report/composition/graph/GraphGeneratorWholeChartHighlightFallbackTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/GraphGeneratorWholeChartHighlightFallbackTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.graph;
+
+import inetsoft.graph.aesthetic.ColorFrame;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.report.filter.HighlightGroup;
+import inetsoft.report.filter.TextHighlight;
+import inetsoft.test.*;
+import inetsoft.uql.*;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.graph.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Color;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug 76558 / VSH-003 (the same underlying defect as bug 76522 / DCG-001): a colName-less chart
+ * mark highlight is written by {@code HighlightDialogService.updateHighlights} to the whole-chart
+ * level ({@code ChartInfo.setHighlightGroup()}), not to any individual measure ref. Before this
+ * fix, {@code GraphGenerator.getHighlightRefs(ChartRef...)} unconditionally counted every
+ * axis-bound measure as "already covered" even when that measure carried no highlight of its own,
+ * so {@code applyHighlight}'s whole-chart fallback (only reachable when its ref array is empty)
+ * was never taken whenever any measure was bound -- the common case.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class GraphGeneratorWholeChartHighlightFallbackTest {
+   @Test
+   void wholeChartForegroundHighlightRecolorsAMarkWhenNoMeasureCarriesItsOwnHighlight() {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(GraphTypes.CHART_BAR);
+
+      VSChartDimensionRef region = new VSChartDimensionRef(new AttributeRef("REGION"));
+      VSChartAggregateRef revenue = new VSChartAggregateRef();
+      revenue.setDataRef(new AttributeRef("REVENUE"));
+      revenue.setFormula(AggregateFormula.SUM);
+
+      info.setRTXFields(new ChartRef[]{ region });
+      info.setRTYFields(new ChartRef[]{ revenue });
+
+      // the exact repro shape: the measure bound on the chart carries no highlight of its own.
+      assertNull(revenue.getHighlightGroup());
+
+      // mirrors the write side (HighlightDialogService.java, ~line 633): a colName-less,
+      // non-text chart highlight lands at the whole-chart level, keyed by no particular column.
+      Condition cond = new Condition();
+      cond.addValue("USA East");
+      cond.setOperation(XCondition.EQUAL_TO);
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef("REGION"), cond, 0));
+
+      TextHighlight rule = new TextHighlight();
+      rule.setName("TopRegionBarForeground");
+      rule.setConditionGroup(conds);
+      rule.setForeground(Color.RED);
+      rule.setBackground(Color.BLUE);
+
+      HighlightGroup wholeChartGroup = new HighlightGroup();
+      wholeChartGroup.addHighlight("TopRegionBarForeground", rule);
+      info.setHighlightGroup(wholeChartGroup);
+
+      GraphGenerator gen = mock(GraphGenerator.class, CALLS_REAL_METHODS);
+      gen.info = info;
+
+      DefaultDataSet data = new DefaultDataSet(new Object[][] {
+         { "REGION", "SUM(REVENUE)" },
+         { "USA East", 100.0 },
+         { "USA West", 50.0 },
+      });
+
+      ColorFrame frame = gen.applyHighlight(null, data);
+
+      assertNotNull(frame, "the whole-chart highlight fallback must now be reachable and " +
+                    "produce a color frame -- before the fix this was null and the bar never " +
+                    "recolored");
+      assertEquals(Color.RED, frame.getColor(data, "SUM(REVENUE)", 0),
+                   "foreground must recolor the matching row's mark");
+      assertNotEquals(Color.BLUE, frame.getColor(data, "SUM(REVENUE)", 0),
+                       "background must never affect a chart mark's color -- HLColorFrame.getColor" +
+                       " only ever reads getForeground(), by design, independent of this fix");
+      assertNull(frame.getColor(data, "SUM(REVENUE)", 1),
+                 "USA West does not match the rule's condition and must stay uncolored");
+   }
+}


### PR DESCRIPTION
## Summary

- Two cooperating defects made a colName-less chart-mark `set_highlight` silently no-op: (1)
  `HighlightDialogService`'s write path stores such a highlight at the whole-chart level
  (`chartInfo.setHighlightGroup()`) instead of any per-measure ref, and (2)
  `GraphGenerator.getHighlightRefs(ChartRef...)` unconditionally counted any axis-bound measure
  ref as "already covered," regardless of whether it individually carried a highlight — keeping
  `applyHighlight()`'s whole-chart fallback permanently unreachable for any chart with >=1
  axis-bound measure (the ordinary case).
- Fix: deleted the unconditional inclusion branch in `getHighlightRefs()`. Since
  `ChartAggregateRef` already `extends HighlightRef`, the remaining branch (`instanceof
  HighlightRef && getHighlightGroup() != null`) already covers every case the deleted branch could
  legitimately have covered — it only ever mattered for a ref with a null group, exactly this bug's
  repro shape. Confirmed no regression risk for the other four chart families dispatched from the
  same method (Gantt/Relation/Candle/Radar all implement `MergedChartInfo`, so the whole-chart
  fallback condition is already unconditionally true for them regardless of this change; Treemap's
  group fields are dimension-typed in normal use, never `ChartAggregateRef`).
- Only `foreground` is fixed — `background` never affects a chart mark's rendered color under any
  configuration; `HLColorFrame.getColor()` structurally only ever reads `getForeground()`. This is
  independent of this fix, confirmed correct-by-design, and explicitly asserted as still-broken in
  the new regression test.
- Same underlying defect as existing bug **76522/DCG-001** (whose `stylebi-wiz`-side mitigation —
  a client-side refusal that stops the malformed call before it reaches the server — already
  landed). This PR is the actual server-side rendering fix; a human should reconcile Redmine
  bookkeeping between #76558 and 76522/DCG-001 at close-out.

## Root cause & fix docs (in the sibling `stylebi-wiz` repo)

- Diagnosis: `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-003/01-diagnosis.md`
- Refute (survived on its core claim; upgraded the duplicate-of-76522/DCG-001 claim from "likely"
  to confirmed; corrected an overstated claim about `background`):
  `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-003/02-refute.md`
- Fix (includes a self-verification: temporarily reverted the fix with the new test left in place,
  confirmed it fails exactly as predicted, then restored the fix and confirmed it passes again):
  `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-003/03-fix.md`
- Review (round 1, APPROVE — independently re-verified the class hierarchy claim and the
  regression-safety of every other call site): `docs/teams/2026-09-10-bugs-76558-vs-highlight/bug-VSH-003/04-review-r1.md`

## Test plan

- [x] New test `GraphGeneratorWholeChartHighlightFallbackTest`: asserts the whole-chart fallback is
      now reachable, `foreground` recolors the matching mark, `background` explicitly does NOT
      (asserted `!= BLUE`), and a non-matching row stays uncolored.
- [x] `./mvnw -pl core -Dtest=GraphGeneratorWholeChartHighlightFallbackTest -Dsurefire.failIfNoSpecifiedTests=false test`
      — `Tests run: 1, Failures: 0, Errors: 0` (re-verified after rebasing onto VSH-001's now-merged
      fix, #5131).

Part of Redmine #76558 (batch covering VSH-001 through VSH-006 in the sibling `stylebi-wiz` repo).
Depends on / builds on #5131 (VSH-001), already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)