### PR TITLE
Fix bug 76563: provider create/delete pre-mutation refusals misreported as rollback-failed

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
@@ -200,7 +200,21 @@ public class ProviderChangesetApplyService {
          builder.providerType(SecurityProviderType.FILE);
       }
 
-      authenticationProviderService.addAuthenticationProvider(builder.build(), name, user);
+      try {
+         authenticationProviderService.addAuthenticationProvider(builder.build(), name, user);
+      }
+      catch(Exception e) {
+         // A refusal here (name collision, unlicensed provider type, or a live checkParameters()
+         // validation failure such as an unresolvable LDAP host) is provably pre-mutation --
+         // addAuthenticationProvider's only mutation tail (providerList.add/chain.setProviders)
+         // cannot itself throw -- so this is a clean per-entry failure, never an unknown-state
+         // rollback-failed.
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                              messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
 
       AuthenticationProviderModel after =
          tryGet(() -> authenticationProviderService.getAuthenticationProvider(name),
@@ -229,7 +243,17 @@ public class ProviderChangesetApplyService {
          .providerType(SecurityProviderType.FILE)
          .build();
 
-      authorizationProviderService.addAuthorizationProvider(model, name, user);
+      try {
+         authorizationProviderService.addAuthorizationProvider(model, name, user);
+      }
+      catch(Exception e) {
+         // Same pre-mutation reasoning as applyCreateAuthentication's catch above.
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                              messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
 
       List<SecurityProviderStatus> afterList =
          authorizationProviderService.getProviderListModel().providers();
@@ -297,7 +321,22 @@ public class ProviderChangesetApplyService {
    {
       AuthenticationProviderModel before = authenticationProviderService.getAuthenticationProvider(name);
       String beforeProjection = ProviderProjection.projectAuthenticationProvider(before);
-      planService.requireAuthenticationDeletePreflight("apply." + key, name, user);
+
+      try {
+         planService.requireAuthenticationDeletePreflight("apply." + key, name, user);
+      }
+      catch(IllegalArgumentException e) {
+         // Preflight is a pure read-only simulate-and-check, structurally prior to the actual
+         // removeAuthenticationProvider mutation below -- a refusal here (e.g. self-lockout) is a
+         // clean per-entry failure, never an unknown-state rollback-failed.
+         results.add(new ProviderApplyOutcome(key, beforeProjection, null,
+                                              AdminChangeRecord.STATUS_FAILED, messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                   beforeProjection, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome,
+                   user);
+         return;
+      }
+
       int index = indexOfName(authenticationProviderService.getProviderListModel().providers(), name);
 
       if(index < 0) {
@@ -334,7 +373,20 @@ public class ProviderChangesetApplyService {
    {
       AuthorizationProviderModel before = authorizationProviderService.getAuthorizationProvider(name);
       String beforeProjection = ProviderProjection.projectAuthorizationProvider(before);
-      planService.requireAuthorizationDeletePreflight("apply." + key, name);
+
+      try {
+         planService.requireAuthorizationDeletePreflight("apply." + key, name);
+      }
+      catch(IllegalArgumentException e) {
+         // Same pre-mutation reasoning as applyDeleteAuthentication's catch above.
+         results.add(new ProviderApplyOutcome(key, beforeProjection, null,
+                                              AdminChangeRecord.STATUS_FAILED, messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                   beforeProjection, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome,
+                   user);
+         return;
+      }
+
       int index = indexOfName(authorizationProviderService.getProviderListModel().providers(), name);
 
       if(index < 0) {

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
@@ -157,12 +157,14 @@ class ProviderChangesetApplyServiceTest {
    @Test void throwMidApplyRollsBackEarlierChangeButReportsRollbackFailedForTheUnknownState()
       throws Exception
    {
-      // change 2's own add throws -- its state is unknown and must never be reported as rolled
-      // back, even though change 1's own rollback succeeds (section 6/2.5 of the guide).
+      // change 2's own add succeeds (mutates state) but its post-add verification read throws --
+      // this is the one call shape addCreateAuthentication's local pre-mutation catch does NOT
+      // cover, so it is still a genuine unknown state that must never be reported as rolled back,
+      // even though change 1's own rollback succeeds (section 6/2.5 of the guide). (A throw from
+      // addAuthenticationProvider itself is, post bug-76563-fix, always pre-mutation and reported
+      // as a clean per-entry failure instead -- see the guard-clause-refusal tests below.)
       doThrow(new RuntimeException("simulated race: duplicate name"))
-         .when(authenticationProviderService)
-         .addAuthenticationProvider(argThat(m -> m != null && "p2".equals(m.providerName())),
-                                    eq("p2"), eq(user));
+         .when(authenticationProviderService).getAuthenticationProvider(eq("p2"));
 
       var result = service.apply(applyRequest("create p1 then p2",
          createFile(ProviderChain.AUTHENTICATION, "p1"), createFile(ProviderChain.AUTHENTICATION, "p2")),
@@ -178,10 +180,9 @@ class ProviderChangesetApplyServiceTest {
    }
 
    @Test void undoRunsNewestFirst() throws Exception {
+      // Post-add verification throws, same genuine-unknown-state shape as the test above.
       doThrow(new RuntimeException("boom"))
-         .when(authenticationProviderService)
-         .addAuthenticationProvider(argThat(m -> m != null && "p3".equals(m.providerName())),
-                                    eq("p3"), eq(user));
+         .when(authenticationProviderService).getAuthenticationProvider(eq("p3"));
 
       service.apply(applyRequest("create p1, p2, p3",
          createFile(ProviderChain.AUTHENTICATION, "p1"), createFile(ProviderChain.AUTHENTICATION, "p2"),
@@ -195,10 +196,9 @@ class ProviderChangesetApplyServiceTest {
    }
 
    @Test void anUndoThatItselfFailsIsReportedAlongsideTheUnknownStateFailure() throws Exception {
+      // Post-add verification throws, same genuine-unknown-state shape as the tests above.
       doThrow(new RuntimeException("boom"))
-         .when(authenticationProviderService)
-         .addAuthenticationProvider(argThat(m -> m != null && "p2".equals(m.providerName())),
-                                    eq("p2"), eq(user));
+         .when(authenticationProviderService).getAuthenticationProvider(eq("p2"));
       doThrow(new RuntimeException("rollback also fails"))
          .when(authenticationProviderService)
          .removeAuthenticationProvider(anyInt(), eq("p1"), eq(user));
@@ -220,10 +220,9 @@ class ProviderChangesetApplyServiceTest {
 
    @Test void deleteRollbackDisclosesTheRestoredAtEndAdvisoryAsAFirstClassField() throws Exception {
       seedHealthyAuthentication("keep", "victim");
+      // Post-add verification throws, same genuine-unknown-state shape as the tests above.
       doThrow(new RuntimeException("boom"))
-         .when(authenticationProviderService)
-         .addAuthenticationProvider(argThat(m -> m != null && "boom".equals(m.providerName())),
-                                    eq("boom"), eq(user));
+         .when(authenticationProviderService).getAuthenticationProvider(eq("boom"));
 
       var result = service.apply(applyRequest("delete victim then create boom",
          deleteAuth("victim"), createFile(ProviderChain.AUTHENTICATION, "boom")), user);
@@ -285,6 +284,94 @@ class ProviderChangesetApplyServiceTest {
       service.apply(applyRequest("delete victim", deleteAuth("victim")), user);
 
       verify(authenticationProviderService).removeAuthenticationProvider(eq(2), eq("victim"), eq(user));
+   }
+
+   // -------------------------------------------------------------------------
+   // bug #76563 -- pre-mutation create/delete refusals are clean per-entry failures, never
+   // reported as unknown-state rollback-failed (root cause: apply()'s single generic catch could
+   // not distinguish a pre-mutation validation refusal from a genuine unknown-state exception).
+   // -------------------------------------------------------------------------
+
+   @Test void createAuthenticationGuardClauseRefusalIsReportedAsCleanFailedNotRollbackFailed()
+      throws Exception
+   {
+      doThrow(new MessageException("Authentication provider named \"p1\" already exists"))
+         .when(authenticationProviderService).addAuthenticationProvider(any(), eq("p1"), eq(user));
+
+      var result = service.apply(applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1")),
+                                 user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      assertEquals(1, result.results().size());
+      assertEquals(AdminChangeRecord.STATUS_FAILED, result.results().get(0).status());
+      assertTrue(result.results().get(0).error().contains("already exists"));
+      assertFalse(authChainNames.contains("p1"));
+   }
+
+   @Test void createAuthorizationGuardClauseRefusalIsReportedAsCleanFailedNotRollbackFailed()
+      throws Exception
+   {
+      doThrow(new MessageException("Authorization provider named \"z1\" already exists"))
+         .when(authorizationProviderService).addAuthorizationProvider(any(), eq("z1"), eq(user));
+
+      var result = service.apply(applyRequest("create z1", createFile(ProviderChain.AUTHORIZATION, "z1")),
+                                 user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      assertEquals(1, result.results().size());
+      assertEquals(AdminChangeRecord.STATUS_FAILED, result.results().get(0).status());
+      assertTrue(result.results().get(0).error().contains("already exists"));
+      assertFalse(authzChainNames.contains("z1"));
+   }
+
+   @Test void deleteAuthenticationPreflightRaceAtApplyTimeIsReportedAsCleanFailedNotRollbackFailed()
+      throws Exception
+   {
+      // Both deletes pass their own preflight independently at plan-resolve time (each, checked
+      // alone against the still-intact two-provider chain, leaves one provider behind). Only once
+      // victim1 is actually removed at apply time does victim2's own apply-time preflight
+      // re-check (ProviderChangesetApplyService.java, not the plan-time one) see an
+      // about-to-be-empty chain and refuse -- a real race between plan and apply, not a fixture
+      // artifact.
+      seedHealthyAuthentication("victim1", "victim2");
+
+      var result = service.apply(
+         applyRequest("delete both", deleteAuth("victim1"), deleteAuth("victim2")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      var victim2Outcome = result.results().stream()
+         .filter(o -> o.property().contains("victim2")).findFirst().orElseThrow();
+      assertEquals(AdminChangeRecord.STATUS_FAILED, victim2Outcome.status());
+      assertTrue(victim2Outcome.error().contains("no remaining provider"));
+      // victim2 was never removed; victim1's delete was rolled back (recreated).
+      assertTrue(authChainNames.contains("victim1"));
+      assertTrue(authChainNames.contains("victim2"));
+   }
+
+   @Test void deleteAuthorizationPreflightRaceAtApplyTimeIsReportedAsCleanFailedNotRollbackFailed()
+      throws Exception
+   {
+      authzChainNames.add("z1");
+      authzModels.put("z1", AuthorizationProviderModel.builder()
+         .providerName("z1").providerType(SecurityProviderType.FILE).build());
+      authzChainNames.add("z2");
+      authzModels.put("z2", AuthorizationProviderModel.builder()
+         .providerName("z2").providerType(SecurityProviderType.FILE).build());
+
+      var result = service.apply(
+         applyRequest("delete both", deleteAuthz("z1"), deleteAuthz("z2")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      var z2Outcome = result.results().stream()
+         .filter(o -> o.property().contains("z2")).findFirst().orElseThrow();
+      assertEquals(AdminChangeRecord.STATUS_FAILED, z2Outcome.status());
+      assertTrue(z2Outcome.error().contains("zero remaining providers"));
+      assertTrue(authzChainNames.contains("z1"));
+      assertTrue(authzChainNames.contains("z2"));
    }
 
    // -------------------------------------------------------------------------
@@ -439,6 +526,14 @@ class ProviderChangesetApplyServiceTest {
       ProviderChangeRequest change = new ProviderChangeRequest();
       change.setVerb("delete");
       change.setChain("authentication");
+      change.setName(name);
+      return change;
+   }
+
+   private static ProviderChangeRequest deleteAuthz(String name) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("delete");
+      change.setChain("authorization");
       change.setName(name);
       return change;
    }


### PR DESCRIPTION
## Root cause

`ProviderChangesetApplyService.apply()` wraps every `applyOne()` call in a single generic
`catch(Exception e)` that unconditionally treats any exception as an unknown-state
`rollback-failed`, regardless of whether the exception actually happened before any
mutation occurred.

Confirmed by a full source trace (debugger + independent refuter, both concur):
`AuthenticationProviderService.addAuthenticationProvider`/
`AuthorizationProviderService.addAuthorizationProvider` run all their guard/validation
checks (name-exists, license, and for LDAP a live `checkParameters()` host lookup) strictly
before their two-line mutation tail (`providerList.add`/`chain.setProviders`), and that
mutation tail is provably non-throwing (`SecurityChain.setProviders` never rethrows). So
every exception these two calls can throw is pre-mutation. Likewise,
`requireAuthenticationDeletePreflight`/`requireAuthorizationDeletePreflight` are pure
read-only simulate-and-check calls, structurally prior to the actual
`removeAuthenticationProvider`/`removeAuthorizationProvider` mutation in the same method.

For the reported repro (create authentication, LDAP, bad hostname), the refusal is a
`SRSecurityException` thrown from the live LDAP host lookup — before anything is added to
the chain — yet it was reported as `rollback-failed` (an unknown, possibly-partially-applied
state), when the correct, fully-determined outcome is a clean per-entry `failed` with an
overall `rolled-back` (nothing was ever mutated, so there's nothing to roll back).

## Fix

`ProviderChangesetApplyService.java` — wrap the four call sites that are provably
pre-mutation-or-nothing in local `try/catch` blocks, reporting a clean per-entry
`STATUS_FAILED` outcome instead of letting the exception reach `apply()`'s outer generic
catch:
- `applyCreateAuthentication` — `catch(Exception e)` around
  `authenticationProviderService.addAuthenticationProvider(...)`.
- `applyCreateAuthorization` — `catch(Exception e)` around
  `authorizationProviderService.addAuthorizationProvider(...)`.
- `applyDeleteAuthentication` — `catch(IllegalArgumentException e)` (the type these preflight
  checks already throw) around `planService.requireAuthenticationDeletePreflight(...)`.
- `applyDeleteAuthorization` — same, around `requireAuthorizationDeletePreflight(...)`.

`apply()`'s outer generic `catch(Exception e)` is unchanged and remains the conservative
default for any exception not covered by the four sites above.

This intentionally does **not** introduce a new typed exception or touch
`AuthenticationProviderService.java`/`AuthorizationProviderService.java` (an initial
diagnosis proposed a `PreMutationRefusalException` there) — an independent refutation pass
confirmed the mutation tail is provably non-throwing as currently written, so a plain local
catch achieves the identical, fully-correct result with strictly less code and zero risk to
the shared service classes' other callers (their own EM REST controllers).

## Regression tests

`ProviderChangesetApplyServiceTest.java`:
- Added `createAuthenticationGuardClauseRefusalIsReportedAsCleanFailedNotRollbackFailed` and
  `createAuthorizationGuardClauseRefusalIsReportedAsCleanFailedNotRollbackFailed` (name-exists
  guard-clause throw on create → per-entry `failed`, overall `rolled-back`, empty
  `rollbackFailures`).
- Added `deleteAuthenticationPreflightRaceAtApplyTimeIsReportedAsCleanFailedNotRollbackFailed`
  and `deleteAuthorizationPreflightRaceAtApplyTimeIsReportedAsCleanFailedNotRollbackFailed` (a
  2-entry delete plan where the 2nd entry's preflight only fails once the 1st entry's delete
  has actually mutated the live chain — a genuine plan-vs-apply-time race, not a fixture
  artifact) → same assertion shape, and confirm nothing was actually removed for the refused
  entry.
- Updated 4 existing tests that previously simulated a "genuine unknown state" failure by
  throwing from `addAuthenticationProvider` itself. Post-fix, that call is always pre-mutation
  and reported as a clean per-entry failure, so those tests would have started asserting the
  wrong thing. Moved the simulated throw to the post-add verification read
  (`getAuthenticationProvider`), which still runs after the real mutation and is not covered by
  the new local catch — preserving each test's original intent and assertions unchanged, and
  keeping at least one genuine unknown-state case asserting `rollback-failed`.

All 17 tests in the class pass: `./mvnw test -pl core -Dtest=ProviderChangesetApplyServiceTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)