### PR TITLE
Add read-only ai-snapshot listing for bug 76553

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminAiController.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.ai;
 
 import inetsoft.sree.security.*;
+import inetsoft.web.admin.general.AiSnapshotInfo;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -49,6 +51,22 @@ public class AdminAiController {
    {
       requireSiteAdmin(user);
       return Map.of("backupRef", backupService.backup(body.get("transactionId")));
+   }
+
+   /**
+    * Lists every ai-snapshot that currently survives for the given transaction - the read-only
+    * counterpart to {@link #backup}. Returns an empty list, not a 404, when the transaction has no
+    * surviving (or ever-taken) snapshot, matching {@code get_changeset}'s own empty-list-not-error
+    * convention for an unknown id.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT,
+      resource = "settings/properties",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/backup/{transactionId}")
+   public List<AiSnapshotInfo> listSnapshots(@PathVariable String transactionId, Principal user) {
+      requireSiteAdmin(user);
+      return backupService.listSnapshots(transactionId);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminBackupService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminBackupService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin.ai;
 
+import inetsoft.web.admin.general.AiSnapshotInfo;
 import inetsoft.web.admin.general.BackupResult;
 import inetsoft.web.admin.general.DataSpaceSettingsService;
 import inetsoft.web.admin.general.model.BackupDataModel;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.List;
 
 /*
  * The snapshot here is taken through the live-tested {@link DataSpaceSettingsService#doBackup}
@@ -77,6 +79,26 @@ public class AdminBackupService {
       }
 
       return result.path();
+   }
+
+   /**
+    * Lists every ai-snapshot that currently survives for the given transaction - the read-only
+    * counterpart to {@link #backup}, letting a caller confirm, at any later point, whether a
+    * transaction's protection actually held rather than only trusting {@link #backup}'s own
+    * call-time return value.
+    *
+    * @param transactionId the admin-chat transaction to look up.
+    *
+    * @return the surviving snapshots for this transaction, oldest first; empty (not an error) if
+    *         none survive or none were ever taken.
+    *
+    * @throws IllegalArgumentException if {@code transactionId} is null/blank or is not a safe,
+    *         single path segment (see {@link #requireSafePathSegment}).
+    */
+   public List<AiSnapshotInfo> listSnapshots(String transactionId) {
+      requireSafePathSegment(transactionId, "transactionId", "transaction id");
+
+      return dataSpaceSettingsService.listAiSnapshots(transactionId);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/general/AiSnapshotInfo.java
+++ b/core/src/main/java/inetsoft/web/admin/general/AiSnapshotInfo.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.general;
+
+/**
+ * One surviving ai-snapshot file for a given admin-chat transaction, as reported by
+ * {@link DataSpaceSettingsService#listAiSnapshots}.
+ *
+ * @param path      the full external-storage path of the snapshot, e.g.
+ *                  {@code "ai-snapshots/admin-chg-1-20260101120000.zip"}.
+ * @param timestamp the 14-digit {@code yyyyMMddHHmmss} timestamp embedded in the snapshot's
+ *                  filename at creation time, as a long.
+ */
+public record AiSnapshotInfo(String path, long timestamp) {
+}

--- a/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
@@ -262,6 +262,58 @@ public class DataSpaceSettingsService extends BackupSupport {
    }
 
    /**
+    * Lists every surviving ai-snapshot for the given admin-chat transaction, oldest first.
+    *
+    * <p>Snapshot filenames are deterministically {@code admin-<transactionId>-<timestamp>.zip}
+    * (see {@link inetsoft.web.admin.ai.AdminBackupService#backup}/{@link #getBackFile}) - but
+    * {@code transactionId} is caller-supplied for a standalone {@code backup()} call (not only
+    * the hyphen-free system-generated ids {@code apply_*_changes} itself produces), so a plain
+    * {@code startsWith("admin-" + transactionId + "-")} would incorrectly match an unrelated
+    * transaction whose own id happens to be a hyphen-delimited extension of this one - e.g. a
+    * lookup for {@code "chg-1"} would also match a snapshot actually named for
+    * {@code "chg-1-retry"}. Since the trailing timestamp segment (and any
+    * {@link ExternalStorageService#getAvailableFile} collision disambiguator) is always purely
+    * numeric and never contains a hyphen, the last hyphen in the filename is always the
+    * transactionId/timestamp boundary regardless of how many hyphens {@code transactionId} itself
+    * contains - so the match strips the leading {@code "admin-"} and everything from the LAST
+    * hyphen onward, then requires the remainder to equal {@code transactionId} exactly, not as a
+    * prefix.
+    *
+    * @param transactionId the admin-chat transaction to look up; not validated here (see
+    *                       {@link inetsoft.web.admin.ai.AdminBackupService#backup}'s own
+    *                       {@code requireSafePathSegment} check for the caller-facing validation).
+    * @return the surviving snapshots for this transaction, oldest first; empty if none survive or
+    *         none were ever taken - never an error for an unknown or never-snapshotted id.
+    */
+   public List<AiSnapshotInfo> listAiSnapshots(String transactionId) {
+      String prefix = "admin" + BACKUP_PATH_SPLIT;
+
+      return this.externalStorageService.listFiles(AI_SNAPSHOT_FOLDER).stream()
+         .filter(f -> f.endsWith(".zip") && f.startsWith(prefix))
+         .filter(f -> transactionId.equals(extractTransactionId(f, prefix)))
+         .map(f -> new AiSnapshotInfo(AI_SNAPSHOT_FOLDER + "/" + f, getTimestamp(f)))
+         .sorted(Comparator.comparingLong(AiSnapshotInfo::timestamp))
+         .toList();
+   }
+
+   /**
+    * Recovers the transactionId encoded in an ai-snapshot filename, or {@code null} if
+    * {@code fileName} does not match the {@code admin-<transactionId>-<suffix>} shape at all
+    * (e.g. it has no further hyphen after the leading {@code "admin-"}, which
+    * {@link #listAiSnapshots}'s caller then simply skips rather than throwing on).
+    */
+   private static String extractTransactionId(String fileName, String prefix) {
+      String rest = fileName.substring(prefix.length());
+      int lastDash = rest.lastIndexOf(BACKUP_PATH_SPLIT);
+
+      if(lastDash < 0) {
+         return null;
+      }
+
+      return rest.substring(0, lastDash);
+   }
+
+   /**
     * Gets the configured {@code ai.snapshot.count}. A non-numeric value logs a warning naming
     * the property and the offending value, then falls back to {@link #DEFAULT_AI_SNAPSHOT_COUNT}
     * -- the same shape as {@code ScheduleTask.getTaskTimeout}.

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminAiControllerTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.ai;
 
 import inetsoft.sree.security.OrganizationManager;
+import inetsoft.web.admin.general.AiSnapshotInfo;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
@@ -116,11 +117,32 @@ class AdminAiControllerTest {
    // site-admin gate (#5)
    // -------------------------------------------------------------------------
 
+   @Test void listSnapshotsThrowsForbiddenWithoutBearerToken() {
+      RequestContextHolder.setRequestAttributes(
+         new ServletRequestAttributes(new MockHttpServletRequest()));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.listSnapshots("chg-1", principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(backupService);
+   }
+
    @Test void backupThrowsForbiddenForNonSiteAdmin() {
       when(orgManager.isSiteAdmin(principal)).thenReturn(false);
 
       ResponseStatusException ex = assertThrows(ResponseStatusException.class,
          () -> controller.backup(Map.of("transactionId", "chg-1"), principal));
+
+      assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+      verifyNoInteractions(backupService);
+   }
+
+   @Test void listSnapshotsThrowsForbiddenForNonSiteAdmin() {
+      when(orgManager.isSiteAdmin(principal)).thenReturn(false);
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.listSnapshots("chg-1", principal));
 
       assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
       verifyNoInteractions(backupService);
@@ -158,6 +180,25 @@ class AdminAiControllerTest {
 
       assertEquals("admin-chg-1-123.zip", actual.get("backupRef"));
       verify(backupService).backup("chg-1");
+   }
+
+   @Test void listSnapshotsDelegatesToServiceAndShapesTheResponse() {
+      List<AiSnapshotInfo> expected = List.of(
+         new AiSnapshotInfo("ai-snapshots/admin-chg-1-20260101120000.zip", 20260101120000L));
+      when(backupService.listSnapshots("chg-1")).thenReturn(expected);
+
+      List<AiSnapshotInfo> actual = controller.listSnapshots("chg-1", principal);
+
+      assertEquals(expected, actual);
+      verify(backupService).listSnapshots("chg-1");
+   }
+
+   @Test void listSnapshotsReturnsEmptyListWhenNoneSurvive() {
+      when(backupService.listSnapshots("chg-1")).thenReturn(List.of());
+
+      List<AiSnapshotInfo> actual = controller.listSnapshots("chg-1", principal);
+
+      assertTrue(actual.isEmpty());
    }
 
    @Test void previewDelegatesToService() {

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminBackupServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminBackupServiceTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin.ai;
 
+import inetsoft.web.admin.general.AiSnapshotInfo;
 import inetsoft.web.admin.general.BackupResult;
 import inetsoft.web.admin.general.DataSpaceSettingsService;
 import inetsoft.web.admin.general.model.BackupDataModel;
@@ -27,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -96,6 +98,46 @@ class AdminBackupServiceTest {
    void backupRejectsNullOrBlankTransactionId() {
       assertThrows(IllegalArgumentException.class, () -> service.backup(null));
       assertThrows(IllegalArgumentException.class, () -> service.backup("   "));
+      verifyNoInteractions(dataSpaceSettingsService);
+   }
+
+   // -------------------------------------------------------------------------
+   // listSnapshots -- the read-only counterpart to backup()
+   // -------------------------------------------------------------------------
+
+   @Test
+   void listSnapshotsDelegatesToDataSpaceSettingsService() {
+      List<AiSnapshotInfo> expected = List.of(
+         new AiSnapshotInfo("ai-snapshots/admin-chg-1-20260101120000.zip", 20260101120000L));
+      when(dataSpaceSettingsService.listAiSnapshots("chg-1")).thenReturn(expected);
+
+      List<AiSnapshotInfo> actual = service.listSnapshots("chg-1");
+
+      assertEquals(expected, actual);
+      verify(dataSpaceSettingsService).listAiSnapshots("chg-1");
+   }
+
+   @Test
+   void listSnapshotsReturnsEmptyListWhenNoneSurvive() {
+      when(dataSpaceSettingsService.listAiSnapshots("chg-1")).thenReturn(List.of());
+
+      List<AiSnapshotInfo> actual = service.listSnapshots("chg-1");
+
+      assertTrue(actual.isEmpty());
+   }
+
+   @Test
+   void listSnapshotsRejectsTransactionIdWithPathTraversal() {
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                                                   () -> service.listSnapshots("../../etc/passwd"));
+      assertTrue(ex.getMessage().contains("transactionId"), ex.getMessage());
+      verifyNoInteractions(dataSpaceSettingsService);
+   }
+
+   @Test
+   void listSnapshotsRejectsNullOrBlankTransactionId() {
+      assertThrows(IllegalArgumentException.class, () -> service.listSnapshots(null));
+      assertThrows(IllegalArgumentException.class, () -> service.listSnapshots("   "));
       verifyNoInteractions(dataSpaceSettingsService);
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/general/DataSpaceSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/DataSpaceSettingsServiceTest.java
@@ -45,6 +45,11 @@ package inetsoft.web.admin.general;
  *      must not turn a successful backup into a reported failure (a null path, which
  *      AdminBackupService escalates into an IOException that aborts the whole changeset apply).
  *      The guard is scoped to pruning only - a failure in the write itself still fails.
+ * [G10] listAiSnapshots(transactionId) is the read-only counterpart to backup(): it lists every
+ *       surviving ai-snapshot for one transaction, matching by transactionId exactly (not by
+ *       startsWith), since a caller-supplied transactionId may itself contain hyphens and a naive
+ *       prefix filter would incorrectly match an unrelated transaction whose id is a
+ *       hyphen-delimited extension of the queried one (bug 76553's confirmed refutation finding).
  */
 
 import ch.qos.logback.classic.Level;
@@ -427,5 +432,69 @@ class DataSpaceSettingsServiceTest {
       finally {
          logger.detachAppender(appender);
       }
+   }
+
+   // -------------------------------------------------------------------------
+   // [G10] listAiSnapshots -- the read-only counterpart to backup()
+   // -------------------------------------------------------------------------
+
+   // The refuter's specific required regression case: querying "chg-1" must return exactly its own
+   // two files, not "chg-12"'s (no separating hyphen) or "chg-1-retry"'s (a hyphen-delimited
+   // extension of "chg-1" - the case a naive startsWith("admin-chg-1-") prefix filter would wrongly
+   // match) or an unrelated non-admin file.
+   @Test
+   void listAiSnapshots_returnsOnlyTheExactTransactionsFiles() {
+      when(externalStorageService.listFiles("ai-snapshots")).thenReturn(List.of(
+         "admin-chg-1-20260101120000.zip",
+         "admin-chg-1-20260102120000.zip",
+         "admin-chg-12-20260103120000.zip",
+         "admin-chg-1-retry-20260104120000.zip",
+         "unrelated-file-20260105120000.zip"));
+
+      List<AiSnapshotInfo> actual = service.listAiSnapshots("chg-1");
+
+      assertEquals(2, actual.size());
+      assertEquals("ai-snapshots/admin-chg-1-20260101120000.zip", actual.get(0).path());
+      assertEquals(20260101120000L, actual.get(0).timestamp());
+      assertEquals("ai-snapshots/admin-chg-1-20260102120000.zip", actual.get(1).path());
+      assertEquals(20260102120000L, actual.get(1).timestamp());
+   }
+
+   // Oldest-first ordering, independent of listFiles' own return order.
+   @Test
+   void listAiSnapshots_ordersOldestFirst() {
+      when(externalStorageService.listFiles("ai-snapshots")).thenReturn(List.of(
+         "admin-chg-2-20260103120000.zip",
+         "admin-chg-2-20260101120000.zip",
+         "admin-chg-2-20260102120000.zip"));
+
+      List<AiSnapshotInfo> actual = service.listAiSnapshots("chg-2");
+
+      assertEquals(3, actual.size());
+      assertEquals(20260101120000L, actual.get(0).timestamp());
+      assertEquals(20260102120000L, actual.get(1).timestamp());
+      assertEquals(20260103120000L, actual.get(2).timestamp());
+   }
+
+   // A transactionId with no matching files returns an empty list, not an error - the zero-row
+   // landmine this fix was chosen specifically to avoid.
+   @Test
+   void listAiSnapshots_returnsEmptyListWhenNoneMatch() {
+      when(externalStorageService.listFiles("ai-snapshots")).thenReturn(List.of(
+         "admin-chg-1-20260101120000.zip"));
+
+      List<AiSnapshotInfo> actual = service.listAiSnapshots("chg-999-never-snapshotted");
+
+      assertTrue(actual.isEmpty());
+   }
+
+   // An empty folder is also a normal, empty-list answer.
+   @Test
+   void listAiSnapshots_returnsEmptyListWhenFolderIsEmpty() {
+      when(externalStorageService.listFiles("ai-snapshots")).thenReturn(List.of());
+
+      List<AiSnapshotInfo> actual = service.listAiSnapshots("chg-1");
+
+      assertTrue(actual.isEmpty());
    }
 }


### PR DESCRIPTION
## Summary

`backup(transactionId)` promises to protect a pending admin-chat transaction from `ai.snapshot.count` eviction, but there was no way to later confirm that protection actually held: the endpoint writes no audit record at all (`AdminAiControllerTest.backupDelegatesToService` already pins this), and neither `AdminChangeRecord` (gated behind an existing changeset a standalone `backup()` call may not have) nor the generic `ActionRecord` action log (object name hardcoded to `"Storage"`, and a no-op on community deployments) can attribute a surviving snapshot to its transaction. Full root-cause writeup: `docs/teams/2026-09-10-bug-76553-backup-verification/bug-76553/01-diagnosis.md` and `02-refute.md` in the `stylebi-wiz` repo.

- Add `DataSpaceSettingsService.listAiSnapshots(transactionId)`, a thin, read-only wrapper around the already-injected `externalStorageService.listFiles(AI_SNAPSHOT_FOLDER)`.
- Add `AdminBackupService.listSnapshots(transactionId)`, reusing the existing `requireSafePathSegment` validation.
- Add `GET /api/wiz/v1/admin/backup/{transactionId}` on `AdminAiController`, gated the same way `backup()` already is, returning an empty list (not 404) when nothing matches.
- Matching algorithm: strip the leading `"admin-"`, then strip everything from the LAST `-` onward (the always-numeric timestamp/`(N)` suffix), and compare the remainder to the queried `transactionId` **exactly**, not via `startsWith` — a naive prefix match would incorrectly match a caller-supplied id like `"chg-1"` against an unrelated `"chg-1-retry"` transaction's snapshot.

Does **not** touch `AdminBackupService.backup()`, `AdminAiController.backup()`, or any `*ChangesetApplyService` class — see the close-out notes in the linked doc for why an `AdminChangeRecord`-based fix was rejected (zero-existing-row landmine for a standalone `backup()` call, no domain context to populate, and neither existing audit mechanism can carry a transaction-scoped snapshot reference on a community deployment anyway).

## Test plan

- [x] `DataSpaceSettingsServiceTest` — new `listAiSnapshots` tests, including the refuter's required regression case (`"chg-1"` query must not match `"chg-12"` or `"chg-1-retry"`'s snapshots) and the empty-result case.
- [x] `AdminBackupServiceTest` — new `listSnapshots` delegation + validation tests.
- [x] `AdminAiControllerTest` — new `listSnapshots` gating + delegation tests.
- [x] `./mvnw -pl core -am -Dtest=DataSpaceSettingsServiceTest,AdminBackupServiceTest,AdminAiControllerTest test` — 51/51 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)