### PR TITLE
fix(#76567): don't force rollback-failed for never-touched license keys

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyService.java
@@ -33,6 +33,7 @@ import java.security.Principal;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
@@ -121,6 +122,12 @@ public class LicenseChangesetApplyService {
          List<Undo> undoable = new ArrayList<>();
          List<RollbackFailure> unknownStateFailures = new ArrayList<>();
          boolean failed = false;
+         // Whether the item that threw (if any) had already entered its own mutating call
+         // (addServerKey/removeServerKey) before the throw -- only that case is a genuine
+         // partial-mutation risk that must force STATUS_ROLLBACK_FAILED on its own; a throw that
+         // fires strictly before the mutating call means the item was never touched, so it must
+         // not by itself override an otherwise fully-verified rollback (bug 76567).
+         boolean unknownStateMutationEntered = false;
 
          List<LicenseChangeRequest> originals = req.getChanges();
 
@@ -128,10 +135,11 @@ public class LicenseChangesetApplyService {
             PlanChange change = plan.changes().get(i);
             LicenseChangeRequest original = originals.get(i);
             String key = change.property();
+            AtomicBoolean mutationEntered = new AtomicBoolean(false);
 
             try {
                applyOne(txId, plan.task(), key, original, backupRef, reviewOutcome, user, results,
-                       undoable);
+                       undoable, mutationEntered);
             }
             catch(Exception e) {
                // A throw carries no verifiable before/after evidence for THIS change -- must never
@@ -140,6 +148,7 @@ public class LicenseChangesetApplyService {
                                                    messageOf(e), null));
                unknownStateFailures.add(new RollbackFailure(key,
                   "state unknown: apply did not return a verifiable outcome (" + messageOf(e) + ")"));
+               unknownStateMutationEntered = mutationEntered.get();
                failed = true;
                break;
             }
@@ -156,18 +165,22 @@ public class LicenseChangesetApplyService {
          }
 
          Map<String, String> rollbackAdvisories = new LinkedHashMap<>();
-         List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
-         failures.addAll(rollback(txId, plan.task(), undoable, backupRef, reviewOutcome, user,
-                                  rollbackAdvisories));
+         List<RollbackFailure> rollbackOwnFailures = rollback(txId, plan.task(), undoable, backupRef,
+                                                              reviewOutcome, user, rollbackAdvisories);
          List<LicenseApplyOutcome> finalResults = results.stream()
             .map(o -> mergeAdvisory(o, rollbackAdvisories.get(o.property())))
             .collect(Collectors.toList());
 
-         if(failures.isEmpty()) {
+         // An unknownStateFailures entry only forces rollback-failed when that item's own mutating
+         // call had actually been entered (a real partial-mutation risk); if it never touched the
+         // server, it must not by itself override an otherwise fully-verified rollback.
+         if(rollbackOwnFailures.isEmpty() && !unknownStateMutationEntered) {
             return new LicenseApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLED_BACK,
                                           backupRef, Collections.unmodifiableList(finalResults), null);
          }
 
+         List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
+         failures.addAll(rollbackOwnFailures);
          LOG.error("License changeset {} rollback failed; keys still changed: {}", txId,
                   failures.stream().map(RollbackFailure::property).collect(Collectors.joining(", ")));
          return new LicenseApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLBACK_FAILED,
@@ -181,16 +194,19 @@ public class LicenseChangesetApplyService {
 
    private void applyOne(String txId, String task, String key, LicenseChangeRequest original,
                          String backupRef, String reviewOutcome, Principal user,
-                         List<LicenseApplyOutcome> results, List<Undo> undoable)
+                         List<LicenseApplyOutcome> results, List<Undo> undoable,
+                         AtomicBoolean mutationEntered)
       throws Exception
    {
       String verb = LicenseChangePlanService.requireVerb("apply." + key, original.getVerb());
 
       if(LicenseChangeRequest.VERB_ADD.equals(verb)) {
-         applyAdd(txId, task, key, backupRef, reviewOutcome, user, results, undoable);
+         applyAdd(txId, task, key, backupRef, reviewOutcome, user, results, undoable,
+                  mutationEntered);
       }
       else {
-         applyRemove(txId, task, key, backupRef, reviewOutcome, user, results, undoable);
+         applyRemove(txId, task, key, backupRef, reviewOutcome, user, results, undoable,
+                    mutationEntered);
       }
    }
 
@@ -201,7 +217,7 @@ public class LicenseChangesetApplyService {
     * parse result changed, is refused here rather than acted on against stale evidence. */
    private void applyAdd(String txId, String task, String key, String backupRef,
                          String reviewOutcome, Principal user, List<LicenseApplyOutcome> results,
-                         List<Undo> undoable)
+                         List<Undo> undoable, AtomicBoolean mutationEntered)
       throws Exception
    {
       boolean alreadyInstalled = isInstalled(key);
@@ -224,6 +240,7 @@ public class LicenseChangesetApplyService {
          return;
       }
 
+      mutationEntered.set(true);
       licenseKeySettingsService.addServerKey(key);
 
       boolean verified = isInstalled(key);
@@ -244,7 +261,7 @@ public class LicenseChangesetApplyService {
 
    private void applyRemove(String txId, String task, String key, String backupRef,
                             String reviewOutcome, Principal user, List<LicenseApplyOutcome> results,
-                            List<Undo> undoable)
+                            List<Undo> undoable, AtomicBoolean mutationEntered)
       throws Exception
    {
       Optional<License> current = findInstalled(key);
@@ -258,6 +275,7 @@ public class LicenseChangesetApplyService {
       }
 
       String before = LicenseKeyProjection.of(current.get()).canonical();
+      mutationEntered.set(true);
       licenseKeySettingsService.removeServerKey(key);
 
       boolean verified = !isInstalled(key);

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
@@ -307,6 +307,92 @@ class LicenseChangesetApplyServiceTest {
       verify(licenseKeySettingsService).removeServerKey("K1");
    }
 
+   /** Bug 76567: a throw that fires strictly BEFORE the second item's own mutating call
+    * ({@code addServerKey}) means that item was never touched -- unlike the previous test (which
+    * throws AT the mutating call), this must not by itself force {@code rollback-failed} when the
+    * first item's own rollback is independently verified clean. The throw is injected via
+    * {@code parseLicense("K2")}'s own re-verification call inside {@code applyAdd}
+    * (LicenseChangesetApplyService.java's applyAdd, called strictly before
+    * {@code addServerKey(key)}) -- made to return cleanly on its first two invocations (the
+    * plan-hash-building resolve() and apply()'s own fresh top-of-method re-resolve) and throw only
+    * on its third (applyAdd's own re-verification for K2). */
+   @Test void unknownStateBeforeMutationDoesNotForceRollbackFailedWhenRollbackIsClean()
+      throws Exception
+   {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      when(licenseManager.parseLicense("K2"))
+         .thenReturn(valid("K2"))
+         .thenReturn(valid("K2"))
+         .thenThrow(new RuntimeException("simulated resolve failure for K2"));
+      String hash = planService.resolve(request("task", List.of(add("K1"), add("K2")))).planHash();
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"), add("K2"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      verify(licenseKeySettingsService, never()).addServerKey("K2");
+      verify(licenseKeySettingsService).addServerKey("K1");
+      verify(licenseKeySettingsService).removeServerKey("K1");
+      assertTrue(installed.isEmpty());
+   }
+
+   /** Bug 76567, REMOVE-verb variant matching the reporter's literal repro (a two-key remove
+    * changeset). {@code applyRemove} has no {@code parseLicense}-equivalent pre-mutation call, so
+    * the "throw before mutating call" is injected via {@code licenseManager.getInstalledLicenses()}
+    * (used by {@code findInstalled} inside {@code applyRemove}), made to throw only on the specific
+    * invocation that corresponds to K2's own turn in the loop. */
+   @Test void unknownStateBeforeMutationDoesNotForceRollbackFailedForRemoveWhenRollbackIsClean()
+      throws Exception
+   {
+      installed.add(valid("K1"));
+      installed.add(valid("K2"));
+      // K1's rollback re-adds it via addServerKey, which re-parses the key -- stubbed so the
+      // rollback path's re-installed License is well-formed, matching
+      // rollbackOfRemoveCarriesClaimingNodeDriftAdvisory's own precedent.
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(remove("K1"), remove("K2"))))
+         .planHash();
+
+      // Counting getInstalledLicenses() invocations from here (the earlier hash-computing resolve()
+      // call above is not counted): 1st = apply()'s own fresh top-of-method resolve(); 2nd =
+      // apply()'s installedCountNow re-derivation; 3rd = applyRemove(K1)'s findInstalled; 4th =
+      // applyRemove(K1)'s own post-removeServerKey verification (isInstalled); 5th =
+      // applyRemove(K2)'s findInstalled -- strictly before K2's own removeServerKey call, so
+      // throwing here reproduces "throw before the mutating call" for K2.
+      List<Set<License>> snapshotAtCallTime = new ArrayList<>();
+      doAnswer(inv -> {
+         Set<License> snapshot = new LinkedHashSet<>(installed);
+         snapshotAtCallTime.add(snapshot);
+
+         if(snapshotAtCallTime.size() == 5) {
+            throw new RuntimeException("simulated lookup failure for K2");
+         }
+
+         return snapshot;
+      }).when(licenseManager).getInstalledLicenses();
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", true, remove("K1"),
+                                             remove("K2"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      assertNull(result.rollbackFailures());
+      verify(licenseKeySettingsService, never()).removeServerKey("K2");
+      verify(licenseKeySettingsService).removeServerKey("K1");
+      verify(licenseKeySettingsService).addServerKey("K1");
+      assertTrue(installed.stream().anyMatch(l -> "K1".equals(l.key())));
+      assertTrue(installed.stream().anyMatch(l -> "K2".equals(l.key())));
+   }
+
    @Test void rollbackFailureReportsRollbackFailedNamingTheKey() throws Exception {
       when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
       when(licenseManager.parseLicense("K2")).thenReturn(valid("K2"));


### PR DESCRIPTION
## Summary

`LicenseChangesetApplyService.apply()` unconditionally merged `unknownStateFailures`
(seeded whenever an item's own forward-apply throws, even if the throw fires strictly
before that item's own mutating call — i.e. it was never touched) into the same list
`rollback()`'s genuine undo failures populate, and forced `STATUS_ROLLBACK_FAILED`
whenever that combined list was non-empty — even when `rollback()` itself reported zero
failures and every already-applied item was cleanly, verifiably undone. This made
`apply_license_changes` report "server may be partially changed, escalate, do not retry"
when in fact nothing was left changed at all.

## Fix

Track, per item in the apply loop, whether that item's own mutating call
(`addServerKey`/`removeServerKey`) was actually entered before any exception (a local
`AtomicBoolean` set immediately before the mutating call, inspected in the catch block).

- When the flag is **false** (the throw fired strictly before the mutating call — the
  item was never touched) and `rollback()`'s own returned failures list is empty, the
  transaction-wide status is now `STATUS_ROLLED_BACK`. The item's own per-item result
  is unchanged — still `FAILED` with its existing "state unknown" message.
- When the flag is **true** (the throw happened during or after the mutating call — a
  real partial-mutation risk, since `addServerKey`/`removeServerKey` also do cluster
  broadcast + auth-cache reset), today's behavior is preserved exactly:
  `STATUS_ROLLBACK_FAILED` is still forced.

Scoped entirely to `LicenseChangesetApplyService.java` — no shared-type change, no new
status value, no change to `ProviderChangesetApplyService` or any other sibling
`*ChangesetApplyService` (that recurrence is left for a deliberate, cross-class follow-up
per the debug-workflow retro).

## Regression tests added

- `unknownStateBeforeMutationDoesNotForceRollbackFailedWhenRollbackIsClean` (ADD-verb):
  throw injected via `licenseManager.parseLicense("K2")`'s own re-verification call inside
  `applyAdd`, strictly before `addServerKey("K2")`. Asserts
  `verify(licenseKeySettingsService, never()).addServerKey("K2")`, K1's add+rollback both
  verified, and status is now `rolled-back`.
- `unknownStateBeforeMutationDoesNotForceRollbackFailedForRemoveWhenRollbackIsClean`
  (REMOVE-verb, matching the reporter's literal repro): throw injected via
  `licenseManager.getInstalledLicenses()` (used by `findInstalled` in `applyRemove`, which
  has no `parseLicense`-equivalent pre-mutation call), strictly before
  `removeServerKey("K2")`. Same shape of assertions for the remove path.
- The existing
  `midApplyFailureRollsBackThePreviouslyAppliedAddButReportsRollbackFailedForTheUnknownState`
  test (throw *at* the mutating call itself) is unchanged and still passes, confirming the
  "unsafe to blindly downgrade" caution is preserved.

## Test plan

- [x] `../mvnw.cmd -o -Dtest=LicenseChangesetApplyServiceTest test` from `community/core` —
      15/15 tests pass (13 existing + 2 new).

Debug-workflow trail: `docs/teams/2026-09-10-bug-76567-license-rollback-status/` in the
`stylebi-wiz` repo (charter, diagnosis, refute, this fix write-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)