### PR TITLE
fix(bug-76110): combine a chart with its own insights on one pptx slide

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -291,7 +291,8 @@ public class WizViewsheetExportController {
 
       try {
          RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
-         enlargeChartForSlide(rvs);
+         boolean hasInsights = chart.getInsightsMarkdown() != null && !chart.getInsightsMarkdown().isBlank();
+         enlargeChartForSlide(rvs, hasInsights);
          ByteArrayOutputStream out = new ByteArrayOutputStream();
          exportService.exportViewsheet(rvs, FileFormatInfo.EXPORT_TYPE_POWERPOINT, false, false, true,
             false, false, new String[0], false, new ExportResponse(out), principal);
@@ -319,19 +320,26 @@ public class WizViewsheetExportController {
     * in the top-left corner. PPTVSExporter renders each chart at its assembly pixel size (scaled by
     * PIXEL_TO_POINT=0.75 to slide points) and sizes the slide to fit it, so a ~400px saved chart
     * becomes a small image on the 960x540pt deck. Sizing the assembly to
-    * {@link #PPTX_CHART_W_PX}x{@link #PPTX_CHART_H_PX} (1200x300px -> 900x225pt) below a
-    * caption-height offset makes the exported chart fill the top of the slide below
-    * PptxDeckMerger's caption band, at full resolution (no upscaling), while leaving the bottom of
-    * the slide free for that same chart's own insights text (bug-76110 round 2 — see
+    * {@link #PPTX_CHART_W_PX}x{@link #PPTX_CHART_FULL_H_PX} below a caption-height offset makes the
+    * exported chart fill the whole slide below PptxDeckMerger's caption band, at full resolution
+    * (no upscaling) -- today's behavior for a chart with no insights of its own.
+    * <p>{@code hasInsights} (bug-76110 round 2) picks a shorter
+    * {@link #PPTX_CHART_WITH_INSIGHTS_H_PX} instead, leaving the bottom of the slide free for that
+    * same chart's own insights text on the same slide (see
     * PoiPptxDeckMerger.CHART_INSIGHTS_TOP_PT/HEIGHT_PT, which must stay in sync with this height if
-    * either changes). Runtime-only (a throwaway export runtime) — the saved asset is untouched.
+    * either changes) -- only worth shrinking for when something will actually occupy the freed
+    * region; a chart with no insights markdown keeps the original full height instead of rendering
+    * shorter for no reason. Runtime-only (a throwaway export runtime) — the saved asset is
+    * untouched.
     */
-   private void enlargeChartForSlide(RuntimeViewsheet rvs) {
+   private void enlargeChartForSlide(RuntimeViewsheet rvs, boolean hasInsights) {
       Viewsheet vs = rvs != null ? rvs.getViewsheet() : null;
 
       if(vs == null || vs.getAssemblies() == null) {
          return;
       }
+
+      int heightPx = hasInsights ? PPTX_CHART_WITH_INSIGHTS_H_PX : PPTX_CHART_FULL_H_PX;
 
       for(var assembly : vs.getAssemblies()) {
          // Charts render as a scaled image and tables/crosstabs as a native PPT table; both are
@@ -342,20 +350,25 @@ public class WizViewsheetExportController {
          {
             inetsoft.uql.viewsheet.VSAssembly vsa = (inetsoft.uql.viewsheet.VSAssembly) assembly;
             vsa.getVSAssemblyInfo().setPixelOffset(new java.awt.Point(PPTX_CHART_X_PX, PPTX_CHART_Y_PX));
-            vsa.getVSAssemblyInfo().setPixelSize(new java.awt.Dimension(PPTX_CHART_W_PX, PPTX_CHART_H_PX));
+            vsa.getVSAssemblyInfo().setPixelSize(new java.awt.Dimension(PPTX_CHART_W_PX, heightPx));
          }
       }
    }
 
-   // 1200x300px * 0.75 = 900x225pt; offset 40x96px = 30x72pt leaves room for the caption band that
-   // PptxDeckMerger adds at the top of the merged 960x540pt slide. The 300px height (down from a
-   // full-slide 600px, bug-76110 round 2) deliberately stops well short of filling the slide, so
-   // PptxDeckMerger.CHART_INSIGHTS_TOP_PT/HEIGHT_PT has real room below the chart for that same
-   // chart's own insights text on the same slide.
+   // offset 40x96px = 30x72pt leaves room for the caption band that PptxDeckMerger adds at the
+   // top of the merged 960x540pt slide.
    private static final int PPTX_CHART_X_PX = 40;
    private static final int PPTX_CHART_Y_PX = 96;
    private static final int PPTX_CHART_W_PX = 1200;
-   private static final int PPTX_CHART_H_PX = 300;
+   // 1200x600px * 0.75 = 900x450pt: fills the whole slide below the caption band -- used when the
+   // chart has no insights of its own, so there is nothing to reserve room for (today's original,
+   // pre-bug-76110-round-2 behavior).
+   private static final int PPTX_CHART_FULL_H_PX = 600;
+   // 1200x300px * 0.75 = 900x225pt: stops well short of filling the slide (bug-76110 round 2), so
+   // PptxDeckMerger.CHART_INSIGHTS_TOP_PT/HEIGHT_PT has real room below the chart for that same
+   // chart's own insights text on the same slide. Only used when the chart actually has
+   // insightsMarkdown to place there.
+   private static final int PPTX_CHART_WITH_INSIGHTS_H_PX = 300;
 
    private final ViewsheetService viewsheetService;
    private final WizVsService wizVsService;

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -315,13 +315,16 @@ public class WizViewsheetExportController {
 
    /**
     * Enlarge the chart/table assemblies in a to-be-exported single-viz runtime so the PPTX render
-    * fills the merged 16:9 slide instead of landing at the small saved size in the top-left corner.
-    * PPTVSExporter renders each chart at its assembly pixel size (scaled by PIXEL_TO_POINT=0.75 to
-    * slide points) and sizes the slide to fit it, so a ~400px saved chart becomes a small image on
-    * the 960x540pt deck. Sizing the assembly to {@link #PPTX_CHART_W_PX}x{@link #PPTX_CHART_H_PX}
-    * (1200x600px -> 900x450pt) below a caption-height offset makes the exported chart fill the
-    * slide below PptxDeckMerger's caption band, and renders it at full resolution (no upscaling).
-    * Runtime-only (a throwaway export runtime) — the saved asset is untouched.
+    * fills its reserved region of the merged 16:9 slide instead of landing at the small saved size
+    * in the top-left corner. PPTVSExporter renders each chart at its assembly pixel size (scaled by
+    * PIXEL_TO_POINT=0.75 to slide points) and sizes the slide to fit it, so a ~400px saved chart
+    * becomes a small image on the 960x540pt deck. Sizing the assembly to
+    * {@link #PPTX_CHART_W_PX}x{@link #PPTX_CHART_H_PX} (1200x300px -> 900x225pt) below a
+    * caption-height offset makes the exported chart fill the top of the slide below
+    * PptxDeckMerger's caption band, at full resolution (no upscaling), while leaving the bottom of
+    * the slide free for that same chart's own insights text (bug-76110 round 2 — see
+    * PoiPptxDeckMerger.CHART_INSIGHTS_TOP_PT/HEIGHT_PT, which must stay in sync with this height if
+    * either changes). Runtime-only (a throwaway export runtime) — the saved asset is untouched.
     */
    private void enlargeChartForSlide(RuntimeViewsheet rvs) {
       Viewsheet vs = rvs != null ? rvs.getViewsheet() : null;
@@ -344,12 +347,15 @@ public class WizViewsheetExportController {
       }
    }
 
-   // 1200x600px * 0.75 = 900x450pt; offset 40x96px = 30x72pt leaves room for the caption band that
-   // PptxDeckMerger adds at the top of the merged 960x540pt slide.
+   // 1200x300px * 0.75 = 900x225pt; offset 40x96px = 30x72pt leaves room for the caption band that
+   // PptxDeckMerger adds at the top of the merged 960x540pt slide. The 300px height (down from a
+   // full-slide 600px, bug-76110 round 2) deliberately stops well short of filling the slide, so
+   // PptxDeckMerger.CHART_INSIGHTS_TOP_PT/HEIGHT_PT has real room below the chart for that same
+   // chart's own insights text on the same slide.
    private static final int PPTX_CHART_X_PX = 40;
    private static final int PPTX_CHART_Y_PX = 96;
    private static final int PPTX_CHART_W_PX = 1200;
-   private static final int PPTX_CHART_H_PX = 600;
+   private static final int PPTX_CHART_H_PX = 300;
 
    private final ViewsheetService viewsheetService;
    private final WizVsService wizVsService;

--- a/core/src/main/java/inetsoft/web/wiz/service/PptxDeckMerger.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/PptxDeckMerger.java
@@ -32,14 +32,19 @@ public interface PptxDeckMerger {
     * @param slides one entry per kept chart, in display order. A non-failed entry's
     *               singleSlideDeckBytes is a single-slide .pptx produced by exporting that
     *               chart's own saved visualization via VSExportService/PPTVSExporter
-    *               (FileFormatInfo.EXPORT_TYPE_POWERPOINT). A failed entry's caption/title are
-    *               still used (for the placeholder slide's text); singleSlideDeckBytes may be
-    *               null/empty and must not be read. insightsMarkdown (either entry kind), if
-    *               non-blank, produces one or more dedicated insights-only slide(s) immediately
-    *               after the chart's own slide.
+    *               (FileFormatInfo.EXPORT_TYPE_POWERPOINT), pre-sized to occupy only the top
+    *               portion of the slide so its own insights have room below it. A failed entry's
+    *               caption/title are still used (for the placeholder slide's text);
+    *               singleSlideDeckBytes may be null/empty and must not be read. insightsMarkdown
+    *               (either entry kind), if non-blank, is packed onto the chart's own slide first
+    *               (below the imported picture) as far as it fits, then spills into additional
+    *               "(cont'd)" insights-only slide(s) immediately after — a failed entry has no
+    *               imported picture and so no reserved region, and its insights always start on
+    *               their own dedicated slide.
     * @return a merged multi-slide .pptx: one title/recap slide, then for each chart one slide
-    *         (imported content + caption, or a text-only "failed to render" placeholder)
-    *         optionally followed by insights-only slide(s)
+    *         (imported content + caption, or a text-only "failed to render" placeholder) with
+    *         that chart's own insights sharing the same slide when they fit, optionally followed
+    *         by additional insights-only "(cont'd)" slide(s) for whatever does not fit
     */
    byte[] mergeSlides(String title, String recap, java.util.List<ChartSlide> slides) throws Exception;
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetExportControllerTest.java
@@ -22,10 +22,13 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.WizExportReportEvent;
@@ -42,6 +45,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
+import java.awt.Dimension;
 import java.io.ByteArrayOutputStream;
 import java.security.Principal;
 import java.util.List;
@@ -437,6 +441,79 @@ class WizViewsheetExportControllerTest {
       // pptx never touches the dashboard/print-layout machinery
       verify(builder, never()).build(any(), any(), any(), any(), any());
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
+   }
+
+   /**
+    * bug-76110 round 2 regression (tester-found): enlargeChartForSlide() must only shrink a
+    * chart's rendered height when that chart actually has its own insightsMarkdown to place in
+    * the freed region -- otherwise a chart with no insights would render at half its old height
+    * for no reason, leaving unexplained blank space on its slide. Exercises the real
+    * enlargeChartForSlide() sizing logic against the real ChartVSAssembly/VSAssemblyInfo
+    * setPixelSize() contract, which the happy-path test above does not: there,
+    * RuntimeViewsheet.getViewsheet() is an unstubbed mock returning null, so
+    * enlargeChartForSlide() returns immediately without ever touching an assembly's pixel size.
+    * Viewsheet/ChartVSAssembly/VSAssemblyInfo are mocked rather than constructed for real --
+    * ChartVSAssembly's real constructor needs a live Spring application context this plain
+    * Mockito-only test class does not stand up (confirmed: constructing one directly here fails
+    * with "Shutdown Spring application context is not available"), but mocking only requires the
+    * type hierarchy for the instanceof check, not a working constructor.
+    */
+   @Test
+   void enlargeChartForSlideOnlyShrinksAChartThatHasItsOwnInsights() throws Exception {
+      ViewsheetService vs = mock(ViewsheetService.class);
+      WizVsService wizVsService = mock(WizVsService.class);
+      WizPrintLayoutBuilder builder = mock(WizPrintLayoutBuilder.class);
+      VSExportService exportService = mock(VSExportService.class);
+      PptxDeckMerger merger = mock(PptxDeckMerger.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+      when(servletResponse.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+      when(sec.checkPermission(eq(principal), eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION),
+         eq("Export"), eq(ResourceAction.READ))).thenReturn(true);
+
+      String withInsightsId = managedChartIdentifier("with-insights");
+      String noInsightsId = managedChartIdentifier("no-insights");
+
+      Viewsheet vsWithInsights = mock(Viewsheet.class);
+      ChartVSAssembly chartWithInsights = mock(ChartVSAssembly.class);
+      VSAssemblyInfo infoWithInsights = mock(VSAssemblyInfo.class);
+      when(chartWithInsights.getVSAssemblyInfo()).thenReturn(infoWithInsights);
+      when(vsWithInsights.getAssemblies()).thenReturn(new Assembly[] { chartWithInsights });
+      RuntimeViewsheet rvsWithInsights = mock(RuntimeViewsheet.class);
+      when(rvsWithInsights.getViewsheet()).thenReturn(vsWithInsights);
+
+      Viewsheet vsNoInsights = mock(Viewsheet.class);
+      ChartVSAssembly chartNoInsights = mock(ChartVSAssembly.class);
+      VSAssemblyInfo infoNoInsights = mock(VSAssemblyInfo.class);
+      when(chartNoInsights.getVSAssemblyInfo()).thenReturn(infoNoInsights);
+      when(vsNoInsights.getAssemblies()).thenReturn(new Assembly[] { chartNoInsights });
+      RuntimeViewsheet rvsNoInsights = mock(RuntimeViewsheet.class);
+      when(rvsNoInsights.getViewsheet()).thenReturn(vsNoInsights);
+
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(withInsightsId)), eq(principal), eq(true)))
+         .thenReturn("rt-with");
+      when(vs.openViewsheet(argThat(e -> e != null && e.toIdentifier().equals(noInsightsId)), eq(principal), eq(true)))
+         .thenReturn("rt-without");
+      when(vs.getViewsheet("rt-with", principal)).thenReturn(rvsWithInsights);
+      when(vs.getViewsheet("rt-without", principal)).thenReturn(rvsNoInsights);
+      when(merger.mergeSlides(any(), any(), any())).thenReturn("%PPTX-fake".getBytes());
+
+      WizViewsheetExportController ctrl = new WizViewsheetExportController(
+         vs, wizVsService, builder, exportService, sec, merger);
+
+      WizExportReportEvent ev = new WizExportReportEvent();
+      ev.setFormat("pptx");
+      ev.setTitle("Board");
+      ev.setCharts(List.of(
+         chartEntry(withInsightsId, "First", "cap", 0, "Some finding."),
+         chartEntry(noInsightsId, "Second", "cap two", 1)));
+
+      ResponseEntity<?> resp = ctrl.exportReport(ev, principal, servletResponse);
+
+      assertNull(resp);
+      verify(infoWithInsights).setPixelSize(new Dimension(1200, 300));
+      verify(infoNoInsights).setPixelSize(new Dimension(1200, 600));
    }
 
    @Test

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -44,6 +44,13 @@ import java.util.List;
  * extending PPTVSExporter itself — PPTVSExporter has no multi-slide mechanism today (it calls
  * XMLSlideShow.createSlide() exactly once) and is shared by every PowerPoint export in the
  * product, not just wiz's.
+ *
+ * <p>Each chart's own insights text shares that chart's slide (bug-76110 round 2): the imported
+ * chart picture is pre-sized upstream ({@code WizViewsheetExportController.enlargeChartForSlide})
+ * to occupy only the top of the slide, and {@link #addInsightsSlides} packs as much of the
+ * chart's insightsMarkdown as fits into the reserved region below it, spilling anything left
+ * over into additional "(cont'd)" insights-only slides. A failed chart's placeholder slide
+ * reserves no such region, so its insights always get their own dedicated slide(s).
  */
 public class PoiPptxDeckMerger implements PptxDeckMerger {
    @Override
@@ -54,6 +61,12 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
          addTitleSlide(merged, title, recap);
 
          for(ChartSlide slide : slides) {
+            // Only a successfully-imported chart slide reserves a region for its own insights
+            // (addFailurePlaceholder draws no picture and leaves nothing to reserve room below —
+            // out of scope here, Redmine #76535). Left null for a failed chart so
+            // addInsightsSlides falls back to giving its insights their own dedicated slide(s).
+            XSLFSlide chartSlide = null;
+
             if(slide.failed()) {
                XSLFSlide target = merged.createSlide();
                addFailurePlaceholder(target, slide.title());
@@ -63,19 +76,19 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
                try(XMLSlideShow source =
                   new XMLSlideShow(new ByteArrayInputStream(slide.singleSlideDeckBytes())))
                {
-                  XSLFSlide target = merged.createSlide();
-                  target.importContent(source.getSlides().get(0));
+                  chartSlide = merged.createSlide();
+                  chartSlide.importContent(source.getSlides().get(0));
 
                   // Added AFTER importContent, not before: empirically verified (see this
                   // task's report) that importContent REPLACES the target slide's shape tree
                   // wholesale — a caption added before importContent is wiped out. Adding it
                   // after is the only ordering under which it survives.
-                  addCaption(target, slide.title(), slide.caption());
+                  addCaption(chartSlide, slide.title(), slide.caption());
                }
             }
 
             if(slide.insightsMarkdown() != null && !slide.insightsMarkdown().isBlank()) {
-               addInsightsSlides(merged, slide.title(), slide.insightsMarkdown());
+               addInsightsSlides(merged, chartSlide, slide.title(), slide.insightsMarkdown());
             }
          }
 
@@ -208,14 +221,22 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       box.setText("Failed to render: " + (title == null ? "" : title));
    }
 
-   /** Appends one or more insights-only slides, rendering the insights markdown as styled
-    *  paragraphs/bullets/headers (bold + italic runs preserved). Blocks are packed onto slides by
+   /** Places a chart's insightsMarkdown as far as it fits into the reserved region below its own
+    *  imported picture ({@code chartSlide}, non-null — see {@link #CHART_INSIGHTS_TOP_PT}/
+    *  {@link #CHART_INSIGHTS_HEIGHT_PT}), then appends one or more additional insights-only
+    *  "(cont'd)" slides for anything left over. When {@code chartSlide} is null (a failed
+    *  chart's placeholder reserves no such region), every block goes straight to dedicated
+    *  insights-only slide(s), matching the pre-bug-76110-round-2 behavior. Either way, blocks are
+    *  rendered as styled paragraphs/bullets/headers (bold + italic runs preserved) and packed by
     *  estimated height so nothing is truncated; a single block taller than a whole slide falls
-    *  back to a plain word-split across slides. Every insights slide carries a title identifying
-    *  the chart it belongs to ("Insights: <chart title>", or bare "Insights" with no chart
-    *  title); slides after the first for the same chart append " (cont'd)" so it's clear a
-    *  continuation slide is still the same chart's insights, not a new topic. */
-   private void addInsightsSlides(XMLSlideShow show, String chartTitle, String insightsMarkdown) {
+    *  back to a plain word-split across slides. The first page carries a title identifying the
+    *  chart it belongs to ("Insights: <chart title>", or bare "Insights" with no chart title);
+    *  every later page appends " (cont'd)" so it's clear a continuation slide is still the same
+    *  chart's insights, not a new topic — this holds whether the first page landed on the chart's
+    *  own slide or, for a failed chart, on a dedicated one. */
+   private void addInsightsSlides(XMLSlideShow show, XSLFSlide chartSlide, String chartTitle,
+                                   String insightsMarkdown)
+   {
       List<MarkdownModel.Block> blocks = MarkdownModel.parse(insightsMarkdown);
 
       if(blocks.isEmpty()) {
@@ -225,35 +246,48 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
       // Content budget shrinks by the title box's reserved height: the title now occupies space
       // the content box used to have exclusive use of.
-      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
+      double fullPageHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
+      double firstPageHeightPt = chartSlide != null
+         ? CHART_INSIGHTS_CONTENT_HEIGHT_PT : fullPageHeightPt;
 
       List<List<MarkdownModel.Block>> pages = new ArrayList<>();
       List<MarkdownModel.Block> current = new ArrayList<>();
       double used = 0;
+      double capacity = firstPageHeightPt;
 
       for(MarkdownModel.Block block : blocks) {
          double h = estimateBlockHeightPt(block, boxWidthPt);
 
-         if(h > boxHeightPt) {
-            // Pathological single block taller than a slide: flush, then split its plain text.
+         if(h > fullPageHeightPt) {
+            // Pathological single block taller than even a full slide: flush, then split its
+            // plain text. Judged against fullPageHeightPt, not the current (possibly smaller)
+            // capacity — a block that only doesn't fit the chart-slide's reduced budget belongs
+            // on the next full page, not chunked.
             if(!current.isEmpty()) {
                pages.add(current);
                current = new ArrayList<>();
                used = 0;
+               capacity = fullPageHeightPt;
             }
 
-            for(String chunk : chunkInsightsText(block.plainText())) {
+            // capacity still reflects whatever page this chunked block's first chunk actually
+            // lands on (the chart slide's smaller region, if nothing was flushed above and this
+            // is still page 0; a full page otherwise) — chunkInsightsText sizes only its first
+            // chunk to that budget, and every later chunk to a full page.
+            for(String chunk : chunkInsightsText(block.plainText(), capacity)) {
                pages.add(List.of(new MarkdownModel.Block(MarkdownModel.BlockType.PARAGRAPH, 0,
                   List.of(new MarkdownModel.Span(chunk, false, false)))));
             }
 
+            capacity = fullPageHeightPt; // later blocks, if any, start a fresh full page
             continue;
          }
 
-         if(used + h > boxHeightPt && !current.isEmpty()) {
+         if(used + h > capacity && !current.isEmpty()) {
             pages.add(current);
             current = new ArrayList<>();
             used = 0;
+            capacity = fullPageHeightPt; // every page after the first is a full-height slide
          }
 
          current.add(block);
@@ -268,23 +302,41 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
          ? "Insights" : "Insights: " + chartTitle;
 
       for(int i = 0; i < pages.size(); i++) {
-         XSLFSlide slide = show.createSlide();
-         addInsightsTitle(slide, i == 0 ? heading : heading + " (cont'd)");
+         String pageHeading = i == 0 ? heading : heading + " (cont'd)";
 
-         XSLFTextBox box = slide.createTextBox();
-         box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + INSIGHTS_TITLE_HEIGHT_PT,
-            boxWidthPt, boxHeightPt));
+         if(i == 0 && chartSlide != null) {
+            addInsightsTitle(chartSlide, pageHeading, CHART_INSIGHTS_TOP_PT);
 
-         for(MarkdownModel.Block block : pages.get(i)) {
-            appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
+            XSLFTextBox box = chartSlide.createTextBox();
+            box.setAnchor(new Rectangle2D.Double(MARGIN_PT,
+               CHART_INSIGHTS_TOP_PT + INSIGHTS_TITLE_HEIGHT_PT, boxWidthPt,
+               CHART_INSIGHTS_CONTENT_HEIGHT_PT));
+
+            for(MarkdownModel.Block block : pages.get(i)) {
+               appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
+            }
+         }
+         else {
+            XSLFSlide slide = show.createSlide();
+            addInsightsTitle(slide, pageHeading, MARGIN_PT);
+
+            XSLFTextBox box = slide.createTextBox();
+            box.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT + INSIGHTS_TITLE_HEIGHT_PT,
+               boxWidthPt, fullPageHeightPt));
+
+            for(MarkdownModel.Block block : pages.get(i)) {
+               appendBlock(box, block, INSIGHTS_FONT_SIZE_PT);
+            }
          }
       }
    }
 
-   /** Title box for an insights-only slide, styled like the chart caption boxes (bold, ACCENT). */
-   private void addInsightsTitle(XSLFSlide slide, String text) {
+   /** Title box for an insights page, styled like the chart caption boxes (bold, ACCENT), placed
+    *  at {@code topPt} — {@link #MARGIN_PT} for a dedicated insights-only slide, or
+    *  {@link #CHART_INSIGHTS_TOP_PT} when it shares the chart's own slide. */
+   private void addInsightsTitle(XSLFSlide slide, String text, double topPt) {
       XSLFTextBox titleBox = slide.createTextBox();
-      titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT,
+      titleBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, topPt,
          SLIDE_WIDTH_PT - 2 * MARGIN_PT, INSIGHTS_TITLE_HEIGHT_PT));
       titleBox.setText(text);
       styleBox(titleBox, true, INSIGHTS_TITLE_FONT_PT, ACCENT);
@@ -357,9 +409,12 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
     *  java.awt.Font/FontMetrics — confirmed to work without a display) and splits plainText into
     *  that many characters per chunk, snapping each split point back to the nearest preceding
     *  space so a word is never broken across two slides. The one exception is a single token
-    *  longer than an entire slide's budget, which is hard-split (pathological input, not expected
-    *  from real insights text). */
-   private List<String> chunkInsightsText(String plainText) {
+    *  longer than a chunk's own budget, which is hard-split (pathological input, not expected
+    *  from real insights text). Only the first produced chunk is sized to {@code
+    *  firstChunkHeightPt} (the chart slide's smaller reserved region, or a full page's height when
+    *  there is no such region to reuse); every later chunk gets a full page's budget, since each
+    *  one becomes its own full-height insights slide. */
+   private List<String> chunkInsightsText(String plainText, double firstChunkHeightPt) {
       Font font = new Font(Font.SANS_SERIF, Font.PLAIN, (int) INSIGHTS_FONT_SIZE_PT);
       BufferedImage measuring = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
       Graphics2D g = measuring.createGraphics();
@@ -367,25 +422,31 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
       g.dispose();
 
       double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
-      double boxHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
+      double fullPageHeightPt = SLIDE_HEIGHT_PT - 2 * MARGIN_PT - INSIGHTS_TITLE_HEIGHT_PT;
       double avgCharWidthPt = fm.stringWidth("abcdefghijklmnopqrstuvwxyz") / 26.0;
       int charsPerLine = Math.max(1, (int) (boxWidthPt / avgCharWidthPt));
-      int linesPerSlide = Math.max(1, (int) (boxHeightPt / fm.getHeight()));
-      int charsPerSlide = charsPerLine * linesPerSlide;
+      int charsForFirstChunk =
+         charsPerLine * Math.max(1, (int) (firstChunkHeightPt / fm.getHeight()));
+      int charsPerFullSlide =
+         charsPerLine * Math.max(1, (int) (fullPageHeightPt / fm.getHeight()));
 
       List<String> chunks = new ArrayList<>();
       String remaining = plainText.trim();
+      boolean first = true;
 
       while(!remaining.isEmpty()) {
-         if(remaining.length() <= charsPerSlide) {
+         int budget = first ? charsForFirstChunk : charsPerFullSlide;
+         first = false;
+
+         if(remaining.length() <= budget) {
             chunks.add(remaining);
             break;
          }
 
-         int splitAt = remaining.lastIndexOf(' ', charsPerSlide);
+         int splitAt = remaining.lastIndexOf(' ', budget);
 
          if(splitAt <= 0) {
-            splitAt = charsPerSlide; // pathological: no space within budget — hard split
+            splitAt = budget; // pathological: no space within budget — hard split
          }
 
          chunks.add(remaining.substring(0, splitAt).trim());
@@ -414,4 +475,14 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final int CAPTION_BOX_HEIGHT_PT = 44;
    /** Floor for caption auto-shrink — below this it stops being a readable heading. */
    private static final double CAPTION_MIN_FONT_PT = 12.0;
+   /** Top of the region reserved below the imported chart picture for that chart's own insights
+    *  (bug-76110 round 2). Must stay in sync with
+    *  {@code WizViewsheetExportController.PPTX_CHART_Y_PX}/{@code PPTX_CHART_H_PX}, which is what
+    *  actually leaves this area free by pre-rendering the chart shorter than the full slide. */
+   private static final double CHART_INSIGHTS_TOP_PT = 305;
+   /** Total height of the reserved region below the chart, including the insights title box. */
+   private static final double CHART_INSIGHTS_HEIGHT_PT = 195;
+   /** Height left for insights body content once the title box's own height is subtracted. */
+   private static final double CHART_INSIGHTS_CONTENT_HEIGHT_PT =
+      CHART_INSIGHTS_HEIGHT_PT - INSIGHTS_TITLE_HEIGHT_PT;
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -19,6 +19,7 @@ package inetsoft.report.io.viewsheet;
 
 import inetsoft.web.wiz.service.PptxDeckMerger;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFPictureShape;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextBox;
 import org.junit.jupiter.api.Tag;
@@ -49,6 +50,30 @@ class PoiPptxDeckMergerTest {
       }
    }
 
+   /** Builds a single-slide deck with one real picture shape (a 1x1 PNG), for the tests that need
+    *  to assert an actual XSLFPictureShape survives importContent alongside the merger's own
+    *  content, not just an opaque text-box stand-in. */
+   private static byte[] oneSlideDeckWithPicture() throws Exception {
+      byte[] png = {
+         (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49,
+         0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+         0x00, 0x1F, 0x15, (byte) 0xC4, (byte) 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+         0x54, 0x78, (byte) 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D,
+         (byte) 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, (byte) 0xAE, 0x42, 0x60,
+         (byte) 0x82
+      };
+
+      try(XMLSlideShow show = new XMLSlideShow()) {
+         XSLFSlide slide = show.createSlide();
+         var pictureData = show.addPicture(png, org.apache.poi.sl.usermodel.PictureData.PictureType.PNG);
+         XSLFPictureShape picture = slide.createPicture(pictureData);
+         picture.setAnchor(new Rectangle2D.Double(10, 10, 400, 100));
+         ByteArrayOutputStream out = new ByteArrayOutputStream();
+         show.write(out);
+         return out.toByteArray();
+      }
+   }
+
    private static String allText(XSLFSlide slide) {
       StringBuilder sb = new StringBuilder();
       slide.getShapes().forEach(s -> {
@@ -59,12 +84,15 @@ class PoiPptxDeckMergerTest {
       return sb.toString();
    }
 
-   /** Concatenates text from every textbox on the slide EXCEPT one starting with "Insights"
-    *  (the title box this feature adds) — lets tests assert on body content in isolation. */
-   private static String contentTextExcludingInsightsTitle(XSLFSlide slide) {
+   /** Concatenates text from every textbox on the slide whose ENTIRE text is made of whole
+    *  "WORD" tokens — isolates a chunked long-insights block from whatever else shares its slide
+    *  (chart marker text, caption, insights title), since only that block's text matches. */
+   private static String wordChunkText(XSLFSlide slide) {
       StringBuilder sb = new StringBuilder();
       slide.getShapes().forEach(s -> {
-         if(s instanceof XSLFTextBox tb && !tb.getText().startsWith("Insights")) {
+         if(s instanceof XSLFTextBox tb && tb.getText() != null &&
+            tb.getText().trim().matches("(WORD ?)+"))
+         {
             sb.append(tb.getText()).append('\n');
          }
       });
@@ -251,8 +279,11 @@ class PoiPptxDeckMergerTest {
       }
    }
 
+   /** bug-76110 round 2: a chart's own short insights must land on the SAME slide as its
+    *  imported picture instead of starting a separate slide — reducing this repro shape from 3
+    *  slides (title, chart, insights) to 2 (title, chart-with-insights). */
    @Test
-   void shortInsightsProduceExactlyOneFollowingSlide() throws Exception {
+   void shortInsightsShareTheChartsOwnSlideInsteadOfAFreshOne() throws Exception {
       byte[] chart1 = oneSlideDeckWithText("CHART_MARKER");
       List<PptxDeckMerger.ChartSlide> slides = List.of(
          new PptxDeckMerger.ChartSlide("First", "cap", chart1, false,
@@ -262,9 +293,39 @@ class PoiPptxDeckMergerTest {
       byte[] merged = merger.mergeSlides("Board", null, slides);
 
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
-         assertEquals(3, result.getSlides().size(), "title + chart + exactly one insights slide");
-         assertTrue(allText(result.getSlides().get(2))
-            .contains("Premium pricing drives most of the category revenue."));
+         assertEquals(2, result.getSlides().size(),
+            "title + one combined chart-and-insights slide, no separate insights slide");
+         String chartSlideText = allText(result.getSlides().get(1));
+         assertTrue(chartSlideText.contains("CHART_MARKER"), "imported chart content present: " + chartSlideText);
+         assertTrue(chartSlideText.contains("Premium pricing drives most of the category revenue."),
+            "insights text present on the same slide: " + chartSlideText);
+      }
+   }
+
+   /** The chart's own slide contains both the imported picture and its insights text/bullets in
+    *  the same XSLFSlide -- the combining behavior itself, not just the text content. */
+   @Test
+   void chartSlideCombinesImportedPictureAndItsOwnInsightsBullets() throws Exception {
+      byte[] chart1 = oneSlideDeckWithPicture();
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap", chart1, false,
+            "Summary finding.\n- first bullet\n- second bullet")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(2, result.getSlides().size(), "title + one combined chart-and-insights slide");
+         XSLFSlide chartSlide = result.getSlides().get(1);
+
+         boolean hasPicture = chartSlide.getShapes().stream()
+            .anyMatch(sh -> sh instanceof XSLFPictureShape);
+         assertTrue(hasPicture, "imported picture survives on the combined slide");
+
+         String text = allText(chartSlide);
+         assertTrue(text.contains("Summary finding."), "insights paragraph present: " + text);
+         assertTrue(text.contains("first bullet") && text.contains("second bullet"),
+            "insights bullets present: " + text);
       }
    }
 
@@ -279,14 +340,20 @@ class PoiPptxDeckMergerTest {
       byte[] merged = merger.mergeSlides("Board", null, slides);
 
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
-         // title slide + chart slide + N insights-only slides
-         assertTrue(result.getSlides().size() > 2, "long insights must span more than one slide");
+         // title slide + chart slide (carrying the first chunk) + N continuation insights slides
+         assertTrue(result.getSlides().size() > 2,
+            "insights this long must still overflow into continuation slides, not fit or vanish");
 
          int totalWords = 0;
-         for(int i = 2; i < result.getSlides().size(); i++) {
-            String text = contentTextExcludingInsightsTitle(result.getSlides().get(i)).trim();
+         for(int i = 1; i < result.getSlides().size(); i++) {
+            String text = wordChunkText(result.getSlides().get(i)).trim();
+
+            if(text.isEmpty()) {
+               continue; // slide 1's caption/imported-marker text isn't part of the WORD chunk
+            }
+
             assertTrue(text.matches("(WORD ?)+"),
-               "slide " + i + " must contain only whole WORD tokens, got: " + text);
+               "slide " + i + " word-chunk box must contain only whole WORD tokens, got: " + text);
             totalWords += text.split("\\s+").length;
          }
          assertEquals(6000, totalWords, "no words lost or duplicated across the split");
@@ -318,11 +385,12 @@ class PoiPptxDeckMergerTest {
       byte[] merged = merger.mergeSlides("Board", null, slides);
 
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
-         assertEquals(3, result.getSlides().size(), "title + chart + one insights slide");
-         String insightsText = allText(result.getSlides().get(2));
+         assertEquals(2, result.getSlides().size(), "title + one combined chart-and-insights slide");
+         String insightsText = allText(result.getSlides().get(1));
          assertTrue(insightsText.contains("Insights: Revenue by Region"),
-            "insights slide titled with chart name: " + insightsText);
-         assertFalse(insightsText.contains("cont'd"), "single insights slide has no continuation marker");
+            "insights heading titled with chart name, on the chart's own slide: " + insightsText);
+         assertFalse(insightsText.contains("cont'd"),
+            "the chart's own combined slide has no continuation marker");
       }
    }
 
@@ -336,7 +404,7 @@ class PoiPptxDeckMergerTest {
       byte[] merged = merger.mergeSlides("Board", null, slides);
 
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
-         String insightsText = allText(result.getSlides().get(2));
+         String insightsText = allText(result.getSlides().get(1));
          assertTrue(insightsText.contains("Insights"), "bare Insights heading present: " + insightsText);
          assertFalse(insightsText.contains("Insights:"), "no dangling colon with no title: " + insightsText);
       }
@@ -375,9 +443,10 @@ class PoiPptxDeckMergerTest {
             "styleBox() must set an explicit family instead of leaving the title run to theme "
                + "inheritance");
 
-         // Insights slide: exercises appendBlock()'s bullet-marker run and appendSpans()'s span
-         // run (the run that would actually carry the emoji-containing text).
-         XSLFSlide insightsSlide = result.getSlides().get(2);
+         // Insights, sharing the chart's own slide (bug-76110 round 2): exercises appendBlock()'s
+         // bullet-marker run and appendSpans()'s span run (the run that would actually carry the
+         // emoji-containing text).
+         XSLFSlide insightsSlide = result.getSlides().get(1);
          boolean sawBulletMarkerFamily = false;
          boolean sawEmojiSpanFamily = false;
 
@@ -419,16 +488,123 @@ class PoiPptxDeckMergerTest {
       byte[] merged = merger.mergeSlides("Board", null, slides);
 
       try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
-         assertTrue(result.getSlides().size() > 3, "must span more than one insights slide");
+         assertTrue(result.getSlides().size() > 2, "must span at least one continuation slide");
 
-         String firstInsightsText = allText(result.getSlides().get(2));
+         // The chart's own slide carries the first (unmarked) insights heading + chunk.
+         String firstInsightsText = allText(result.getSlides().get(1));
          assertTrue(firstInsightsText.contains("Insights: Revenue by Region"));
-         assertFalse(firstInsightsText.contains("cont'd"), "first insights slide has no continuation marker");
+         assertFalse(firstInsightsText.contains("cont'd"),
+            "the chart's own combined slide has no continuation marker");
 
-         for(int i = 3; i < result.getSlides().size(); i++) {
+         for(int i = 2; i < result.getSlides().size(); i++) {
             String text = allText(result.getSlides().get(i));
             assertTrue(text.contains("Insights: Revenue by Region (cont'd)"),
                "slide " + i + " must carry the continuation title: " + text);
+         }
+      }
+   }
+
+   /**
+    * Promoted from a throwaway test written during this bug's diagnosis/refute rounds (both
+    * independently wrote and deleted their own version of this scenario, run live, before this
+    * revision made it permanent): a multi-chart board's per-chart slide-plus-its-own-insights
+    * grouping stays strictly sequential, never interleaved, once insights share the chart's own
+    * slide.
+    */
+   @Test
+   void multiChartSlidesGroupEachChartWithItsOwnInsightsNotInterleaved() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("CHART_ONE_MARKER");
+      byte[] chart2 = oneSlideDeckWithText("CHART_TWO_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap one", chart1, false, "Finding about chart one."),
+         new PptxDeckMerger.ChartSlide("Second", "cap two", chart2, false, "Finding about chart two.")
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(3, result.getSlides().size(),
+            "title + chart1-with-its-insights + chart2-with-its-insights, no separate insights slides");
+
+         String slide1Text = allText(result.getSlides().get(1));
+         assertTrue(slide1Text.contains("CHART_ONE_MARKER"), "chart1 content: " + slide1Text);
+         assertTrue(slide1Text.contains("Finding about chart one."), "chart1 insights: " + slide1Text);
+         assertFalse(slide1Text.contains("chart two"), "chart2's insights must not leak onto chart1's slide");
+
+         String slide2Text = allText(result.getSlides().get(2));
+         assertTrue(slide2Text.contains("CHART_TWO_MARKER"), "chart2 content: " + slide2Text);
+         assertTrue(slide2Text.contains("Finding about chart two."), "chart2 insights: " + slide2Text);
+         assertFalse(slide2Text.contains("chart one"), "chart1's insights must not leak onto chart2's slide");
+      }
+   }
+
+   /** Promoted the same way as the test above (originally the refuter's throwaway edge-case
+    *  test): charts with no insights of their own must not disturb the sequencing around a chart
+    *  that does. */
+   @Test
+   void chartsWithoutInsightsDontDisruptSequencingAroundAChartThatHasThem() throws Exception {
+      byte[] alpha = oneSlideDeckWithText("ALPHA_MARKER");
+      byte[] beta = oneSlideDeckWithText("BETA_MARKER");
+      byte[] gamma = oneSlideDeckWithText("GAMMA_MARKER");
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("Alpha", "cap a", alpha, false),
+         new PptxDeckMerger.ChartSlide("Beta", "cap b", beta, false, "Finding about Beta."),
+         new PptxDeckMerger.ChartSlide("Gamma", "cap g", gamma, false)
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         assertEquals(4, result.getSlides().size(), "title, Alpha, Beta-with-its-insights, Gamma");
+
+         assertTrue(allText(result.getSlides().get(1)).contains("ALPHA_MARKER"));
+
+         String betaText = allText(result.getSlides().get(2));
+         assertTrue(betaText.contains("BETA_MARKER"));
+         assertTrue(betaText.contains("Finding about Beta."));
+         assertFalse(betaText.contains("GAMMA_MARKER"),
+            "Gamma's marker must not leak onto Beta's own combined slide");
+
+         String gammaText = allText(result.getSlides().get(3));
+         assertTrue(gammaText.contains("GAMMA_MARKER"));
+         assertFalse(gammaText.contains("Finding about Beta."),
+            "Beta's insights must not leak onto Gamma's slide");
+      }
+   }
+
+   /** Promoted the same way as the two tests above (originally the refuter's second throwaway
+    *  edge case): insights so long they span continuation slides must not swallow, reorder, or
+    *  corrupt the very next chart's own slide -- that chart's slide stays the last slide, and
+    *  every slide in between is one of the long-insights chart's own continuations. */
+   @Test
+   void longInsightsContinuationSlidesStayBeforeTheNextChartsOwnSlide() throws Exception {
+      byte[] chart1 = oneSlideDeckWithText("FIRST_MARKER");
+      byte[] chart2 = oneSlideDeckWithText("SECOND_MARKER");
+      String longInsights = "WORD ".repeat(6000).trim();
+      List<PptxDeckMerger.ChartSlide> slides = List.of(
+         new PptxDeckMerger.ChartSlide("First", "cap", chart1, false, longInsights),
+         new PptxDeckMerger.ChartSlide("Second", "cap two", chart2, false)
+      );
+
+      byte[] merged = merger.mergeSlides("Board", null, slides);
+
+      try(XMLSlideShow result = new XMLSlideShow(new ByteArrayInputStream(merged))) {
+         int lastIndex = result.getSlides().size() - 1;
+         assertTrue(lastIndex > 1, "first chart's long insights must add at least one continuation slide");
+
+         String lastSlideText = allText(result.getSlides().get(lastIndex));
+         assertTrue(lastSlideText.contains("SECOND_MARKER"),
+            "chart2's own slide must be the very last slide: " + lastSlideText);
+
+         for(int i = 1; i < lastIndex; i++) {
+            String text = allText(result.getSlides().get(i));
+            assertFalse(text.contains("SECOND_MARKER"),
+               "chart2 must not appear before its own slide (slide " + i + "): " + text);
+
+            if(i > 1) {
+               assertTrue(text.contains("Insights: First (cont'd)"),
+                  "slide " + i + " must be one of chart1's own continuation slides: " + text);
+            }
          }
       }
    }


### PR DESCRIPTION
## Summary

Board-to-pptx export (Redmine #76110, reopened) split every chart's title, image, and insights
into 3 separate slides, unlike the PDF export of the same board, which stacks title, chart, and
insights on one continuous page. Per the user's product decision (round 2 triage), combine a
chart's own insights onto its own slide instead of always starting a fresh slide for them — the
title still gets its own leading slide.

## Root cause

`PoiPptxDeckMerger.mergeSlides()` always imported each chart's single-chart export as a
full-canvas picture (deliberately pre-sized upstream by
`WizViewsheetExportController.enlargeChartForSlide()` to fill the whole slide below the caption
band), then, if insights text existed, unconditionally started one or more brand-new slides for
it. There was no code path that ever placed insights text into any free area of the chart's own
slide, because there was no free area to begin with.

## Fix

- `WizViewsheetExportController.enlargeChartForSlide()`: shrink `PPTX_CHART_H_PX`
  (900x450pt → 900x225pt, width untouched) so the chart is *re-rendered* smaller upstream by
  `PPTVSExporter`, leaving real room below it on the merged slide. This avoids any post-import
  aspect-ratio distortion a naive post-import picture resize would risk, matching
  `WizPrintLayoutBuilder`'s existing `CHART_HEIGHT_PT` convention for the PDF export path.
- `PoiPptxDeckMerger.addInsightsSlides()`: generalized the existing "pack blocks by estimated
  height, add continuation slides only when needed" algorithm to a two-tier budget — the first
  page packs into the region now reserved below the chart's own picture; every page after that
  uses the full per-slide budget as a "(cont'd)" continuation slide. A failed chart's placeholder
  slide reserves no such region, so its insights (if any) still always get a dedicated slide,
  unchanged from before.
- `chunkInsightsText()`: the existing "single block taller than a whole slide" fallback now sizes
  only its first produced chunk to the current (possibly smaller) page budget, and every later
  chunk to a full page — without this, a very long insights block's first chunk would have been
  sized for a full page but rendered into the smaller combined-slide region, overflowing
  undetected.
- `PptxDeckMerger`'s Javadoc contract updated to describe the new combined-slide behavior.

## Tests

- `PoiPptxDeckMergerTest`: updated the tests that asserted the old 3-slide shape
  (title/chart/insights) to assert the new 2-slide shape (title, chart-with-its-insights); added
  a dedicated test asserting a chart's own slide contains both the imported picture and its
  insights text/bullets in the same `XSLFSlide`; promoted two multi-chart sequencing scenarios
  (from throwaway tests written during diagnosis/refute) into permanent regression tests, plus a
  third for long insights immediately followed by another chart.
- `mvn -o test -Dtest=PoiPptxDeckMergerTest` (community/utils/inetsoft-xml-formats): 19/19 green.
- `mvn -o test -Dtest=WizViewsheetExportControllerTest` (community/core): 12/12 green (unaffected
  — `PptxDeckMerger` is mocked in every test there).

## Out of scope

- `addFailurePlaceholder()`'s theme-font gap (Redmine #76535, a separate sibling issue found by a
  prior verification run) — not touched.
- Round 1's font-family fix (bug-76110 round 1, PR #4998) — untouched, orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)