### PR TITLE
feat(wiz): add a READ-gated tabular datasource config endpoint, fix two queryParams gaps

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/TabularTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/TabularTableAssembly.java
@@ -182,6 +182,11 @@ public class TabularTableAssembly extends BoundTableAssembly implements Scripted
          }
       }
 
+      // Cleared before the attempt, not just set on failure: a query instance reused across
+      // calls (this method's own caller may retry) must not have a stale error from a PRIOR
+      // failed attempt read back as though it explains a fresh empty-columns result.
+      query.setProperty("wizLoadColumnsError", null);
+
       try {
          if(manager != null) {
             query.setProperty("queryManager", manager);
@@ -192,6 +197,16 @@ public class TabularTableAssembly extends BoundTableAssembly implements Scripted
       catch(Exception ex) {
          LOG.warn(
             "Failed to load the columns for the table", ex);
+         // Stashed on the query's own generic property bag -- the same mechanism "queryManager"
+         // above already uses -- rather than propagated, so this method's own contract (log and
+         // return, never throw) is unchanged for every other caller. A wiz caller building a
+         // user-facing "why are there no columns" message reads this back instead of collapsing
+         // every distinct failure (a 404, an auth failure, a malformed response, an unreachable
+         // host) into the same undifferentiated "no columns" text a genuinely-empty-but-successful
+         // response also produces.
+         String detail = ex.getMessage();
+         query.setProperty("wizLoadColumnsError",
+            detail == null || detail.isBlank() ? ex.getClass().getSimpleName() : detail);
       }
 
       ColumnSelection ocolumns = getColumnSelection(false);

--- a/core/src/main/java/inetsoft/uql/tabular/TabularDataSourceConfig.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularDataSourceConfig.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A read-only, redacted view of one tabular data source's own connection-level configuration --
+ * the bean state on the {@link inetsoft.uql.XDataSource} instance itself (base URL, host, tenant,
+ * whatever else the connector declares), as opposed to {@link TabularQuerySchema}, which describes
+ * the QUERY built against it (what to fetch, not what to connect to).
+ *
+ * <p>Deliberately the datasource-level counterpart of {@code TabularQuerySchema}: same
+ * {@code @Property} reflection ({@link TabularUtil#findProperties}), same label resolution
+ * ({@link PropertyMeta#getDisplayLabel()}), same {@code password} flag off the same {@link Property}
+ * annotation every connector already declares its credential fields with -- nothing connector-
+ * specific here, which is what lets one implementation cover every {@code TabularDataSource}
+ * subclass (REST, REST.XML, METADATA, FILE families alike) with no per-connector code.</p>
+ *
+ * <p>A {@link Field} marked {@link Field#isPassword()} never carries its actual value -- see
+ * {@link Field#isConfigured()} for what a caller gets instead: whether a secret is set, without
+ * seeing what it is set to. This is the deliberate difference from {@code /tabular/definition}
+ * (see {@code DataSourceDefinition}'s own javadoc), which returns secrets in clear text and is
+ * gated on WRITE for exactly that reason -- this type exists so a READ-gated caller (composer-chat's
+ * own agent session) can still learn "is this source pointed at what I expect, does it have SOME
+ * credential configured" without ever being handed the credential itself.</p>
+ */
+public class TabularDataSourceConfig {
+   public String getDataSourceType() {
+      return dataSourceType;
+   }
+
+   public void setDataSourceType(String dataSourceType) {
+      this.dataSourceType = dataSourceType;
+   }
+
+   public List<Field> getFields() {
+      return fields;
+   }
+
+   public void setFields(List<Field> fields) {
+      this.fields = fields;
+   }
+
+   private String dataSourceType;
+   private List<Field> fields = new ArrayList<>();
+
+   /**
+    * One connection-level property on the data source bean.
+    */
+   public static class Field {
+      public String getName() {
+         return name;
+      }
+
+      public void setName(String name) {
+         this.name = name;
+      }
+
+      public String getLabel() {
+         return label;
+      }
+
+      public void setLabel(String label) {
+         this.label = label;
+      }
+
+      /**
+       * The current value, as {@code String.valueOf}. {@code null} whenever {@link #isPassword()}
+       * is {@code true} -- see {@link #isConfigured()} for that case.
+       */
+      public String getValue() {
+         return value;
+      }
+
+      public void setValue(String value) {
+         this.value = value;
+      }
+
+      public boolean isPassword() {
+         return password;
+      }
+
+      public void setPassword(boolean password) {
+         this.password = password;
+      }
+
+      /**
+       * Only meaningful when {@link #isPassword()} is {@code true}: whether SOME value is set,
+       * without revealing it. {@code false} otherwise (a non-secret field's presence is already
+       * answered by {@link #getValue()} being non-null).
+       */
+      public boolean isConfigured() {
+         return configured;
+      }
+
+      public void setConfigured(boolean configured) {
+         this.configured = configured;
+      }
+
+      private String name;
+      private String label;
+      private String value;
+      private boolean password;
+      private boolean configured;
+   }
+}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
@@ -127,6 +127,67 @@ public class TabularSchemaExtractor {
    }
 
    /**
+    * Extracts the current, redacted connection-level configuration of a data source itself --
+    * the {@code TabularDataSourceConfig} counterpart of {@link #extract(TabularQuery, String)},
+    * which describes the QUERY built against it instead.
+    *
+    * <p>Same reflection {@link #extract(TabularQuery, String)} already runs
+    * ({@link TabularUtil#findProperties}), pointed at {@code dataSource}'s own class rather than
+    * a query class -- {@code TabularDataSource} subclasses declare their connection fields
+    * (URL, host, tenant, whatever else) with the identical {@code @Property} annotation a query's
+    * fields carry, so no per-connector code is needed here any more than in {@code extract}
+    * itself. A property carrying {@code @Property(password = true)} -- every credential field
+    * already declares this, since it is the same flag {@code TabularQueryContractSupport}'s own
+    * redaction relies on -- never has its value read into the response; only whether one is set.
+    *
+    * @param dataSource the data source instance to describe. {@code null} is not accepted --
+    *                    the caller resolves the path to an instance first, the same as every
+    *                    other entry point in this package.
+    *
+    * @return the redacted configuration, or an empty field list if reflection finds nothing
+    *         (a data source type with no {@code @Property}-annotated connection state).
+    */
+   public TabularDataSourceConfig extractDataSourceConfig(XDataSource dataSource) {
+      TabularDataSourceConfig config = new TabularDataSourceConfig();
+      config.setDataSourceType(dataSource.getType());
+
+      List<TabularDataSourceConfig.Field> fields = new ArrayList<>();
+
+      for(PropertyMeta prop : TabularUtil.findProperties(dataSource.getClass())) {
+         TabularDataSourceConfig.Field field = new TabularDataSourceConfig.Field();
+         field.setName(prop.getName());
+         field.setLabel(prop.getDisplayLabel());
+
+         Property property = prop.getProperty();
+         boolean password = property != null && property.password();
+         field.setPassword(password);
+
+         Object value;
+
+         try {
+            value = prop.getValue(dataSource);
+         }
+         catch(Exception ex) {
+            LOG.debug("Could not read '{}' off {}", prop.getName(), dataSource.getClass(), ex);
+            value = null;
+         }
+
+         if(password) {
+            field.setConfigured(value != null && !String.valueOf(value).isBlank());
+         }
+         else {
+            field.setValue(value == null ? null : String.valueOf(value));
+         }
+
+         fields.add(field);
+      }
+
+      config.setFields(fields);
+
+      return config;
+   }
+
+   /**
     * Of the named parameters, those that do not apply to the query as it currently stands.
     *
     * <p>The counterpart of the dependency matrix, asked of one configured query rather than of a

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -27,6 +27,7 @@ import inetsoft.uql.XRepository;
 import inetsoft.uql.tabular.BrowsableQuery;
 import inetsoft.uql.tabular.LayoutCreator;
 import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularDataSourceConfig;
 import inetsoft.uql.tabular.TabularEditor;
 import inetsoft.uql.tabular.TabularQuery;
 import inetsoft.uql.tabular.TabularQueryParamsSchemaBuilder;
@@ -324,6 +325,44 @@ public class WizTabularController {
       finally {
          endConnectorSession();
       }
+   }
+
+   /**
+    * The data source's OWN connection-level configuration -- base URL, host, tenant, whatever
+    * else the connector declares -- as opposed to {@code /tabular/query-schema}, which describes
+    * the QUERY built against it. Answers "what is this source actually pointed at" without the
+    * caller having to build a throwaway query and hope a value happens to be readable off it.
+    *
+    * <p>Gated on READ, like {@code /tabular/query-schema} and unlike {@code /tabular/definition}
+    * next to it: every credential-shaped field is redacted (see
+    * {@link TabularDataSourceConfig.Field#isPassword()}) to only "is one configured", never the
+    * value, which is what makes a READ gate correct here where it is not for
+    * {@code /tabular/definition}'s clear-text secrets.</p>
+    *
+    * @param path      the data source's full repository path.
+    * @param principal the current user.
+    *
+    * @return the redacted connection configuration.
+    */
+   @GetMapping(value = "/tabular/datasource-config", produces = MediaType.APPLICATION_JSON_VALUE)
+   @Secured({
+      @RequiredPermission(
+         resourceType = ResourceType.DATA_SOURCE, actions = ResourceAction.READ
+      )
+   })
+   public TabularDataSourceConfig getDataSourceConfig(
+      @PermissionPath @RequestParam("path") String path, Principal principal) throws Exception
+   {
+      requireTabularDataSource(path);
+
+      XDataSource dataSource = xrepository.getDataSource(path);
+
+      if(dataSource == null) {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Data source not found: " + path);
+      }
+
+      return new TabularSchemaExtractor().extractDataSourceConfig(dataSource);
    }
 
    @GetMapping(value = "/tabular/definition", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularQueryContractSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularQueryContractSupport.java
@@ -112,6 +112,45 @@ public final class TabularQueryContractSupport {
             dsName + "'. It accepts: " + String.join(", ", new TreeSet<>(pmap.keySet())) + ".");
       }
 
+      // A SCALAR param that is unconditionally required (isRequired(), never "required once some
+      // other value is chosen" -- see TabularQuerySchema.Param#isRequired's own javadoc) but
+      // simply absent from queryParams was never checked here: the loop below only ever iterates
+      // queryParams.keySet(), so a key nobody sent is a key nobody's absence is ever noticed for.
+      // Collected as one report, not one round trip per missing field, matching every other
+      // "report everything wrong before making a live call" check in this file.
+      //
+      // Composite-typed params (Kind A, e.g. "parameters") are deliberately excluded: a composite
+      // can be legitimately absent as a whole (an endpoint with no required path parameters has
+      // nothing to fill), and its OWN required elements are already checked, once supplied, by
+      // fillNamedSkeleton below -- requiring the composite KEY itself to always be present would
+      // reject callers who correctly omitted an empty/inapplicable one.
+      List<String> missingRequired = new ArrayList<>();
+
+      for(TabularQuerySchema.Param param : schema.getParams()) {
+         if(!param.isRequired()) {
+            continue;
+         }
+
+         PropertyMeta prop = pmap.get(param.getName());
+         Class<?> type = prop == null ? null : prop.getDescriptor().getPropertyType();
+
+         if(type != null && TabularSchemaExtractor.isCompositeType(type) && type != File.class) {
+            continue;
+         }
+
+         Object value = queryParams.get(param.getName());
+
+         if(value == null || (value instanceof String s && s.isBlank())) {
+            missingRequired.add(param.getName());
+         }
+      }
+
+      if(!missingRequired.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'" + dsName + "' requires " + String.join(", ", missingRequired) +
+            " -- queryParams is missing " + (missingRequired.size() == 1 ? "it" : "them") + ".");
+      }
+
       validateCustomLookupUrls(queryParams);
 
       List<String> order = topologicalSort(queryParams.keySet(), schema, dsName);

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularQueryContractSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularQueryContractSupport.java
@@ -119,11 +119,21 @@ public final class TabularQueryContractSupport {
       // Collected as one report, not one round trip per missing field, matching every other
       // "report everything wrong before making a live call" check in this file.
       //
-      // Composite-typed params (Kind A, e.g. "parameters") are deliberately excluded: a composite
-      // can be legitimately absent as a whole (an endpoint with no required path parameters has
-      // nothing to fill), and its OWN required elements are already checked, once supplied, by
-      // fillNamedSkeleton below -- requiring the composite KEY itself to always be present would
-      // reject callers who correctly omitted an empty/inapplicable one.
+      // Composite-typed params (Kind A, e.g. "parameters") are deliberately excluded, and this
+      // leaves a KNOWN, NOT-CLOSED gap: a composite marked required=true that is omitted from
+      // queryParams ENTIRELY is caught by nothing -- not this check (excluded here) and not
+      // fillNamedSkeleton below (which only ever visits keys the caller actually supplied). This
+      // is a pre-existing gap, not introduced by this change, and is left open deliberately
+      // rather than closed unconditionally: a composite's required-ness is frequently
+      // endpoint-/choice-dependent (e.g. an endpoint with no required path parameters has nothing
+      // to fill), and this static, top-level annotation has no way to distinguish "always
+      // required" from "required once some endpoint/value is chosen" the way isConditional() does
+      // for simple visibility gates. Requiring the composite KEY itself to always be present
+      // would reject callers who correctly omitted an empty/inapplicable one -- see
+      // FakeNamedConnectorQuery#getParameters and TabularQueryContractSupportTest's
+      // setsEndpointAndBuildsSuffix-family tests, which supply "endpoint" with no "parameters"
+      // key and correctly expect success. Closing this gap properly would need per-endpoint-aware
+      // validation this check doesn't have the context to do.
       List<String> missingRequired = new ArrayList<>();
 
       for(TabularQuerySchema.Param param : schema.getParams()) {
@@ -134,7 +144,7 @@ public final class TabularQueryContractSupport {
          PropertyMeta prop = pmap.get(param.getName());
          Class<?> type = prop == null ? null : prop.getDescriptor().getPropertyType();
 
-         if(type != null && TabularSchemaExtractor.isCompositeType(type) && type != File.class) {
+         if(type != null && TabularSchemaExtractor.isCompositeType(type)) {
             continue;
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1562,8 +1562,10 @@ public class WorksheetTableService {
       ColumnSelection columns = table.getColumnSelection(false);
 
       if(columns == null || columns.getAttributeCount() == 0) {
+         Object loadError = query.getProperty("wizLoadColumnsError");
          throw new IllegalArgumentException(
-            "The query on '" + dsName + "' returned no columns. Parameters sent: " + probeDesc +
+            "The query on '" + dsName + "' returned no columns" +
+            (loadError == null ? "" : " (" + loadError + ")") + ". Parameters sent: " + probeDesc +
             ". Check them against GET /api/wiz/tabular/query-schema — in particular that each " +
             "one applies to the others, since one that does not is stored and never read — and " +
             "that the data source's credentials are valid; the underlying cause is in the " +

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -788,8 +788,10 @@ public class WorksheetAgentController {
             // Mirrors WorksheetTableService.buildTabularTable's empty-column check -- without this
             // the assembly persists with zero columns and the agent is told "success" for a table
             // nothing can bind to.
+            Object loadError = query.getProperty("wizLoadColumnsError");
             throw new PairingException("The request to '" + target + "' of '" + dsName +
-               "' returned no columns. URL suffix sent: " + suffix + ". Check the parameter " +
+               "' returned no columns" + (loadError == null ? "" : " (" + loadError + ")") +
+               ". URL suffix sent: " + suffix + ". Check the parameter " +
                "values and datasource credentials -- see the server log for the cause.");
          }
 
@@ -875,9 +877,11 @@ public class WorksheetAgentController {
          ColumnSelection columns = assembly.getColumnSelection(false);
 
          if(columns == null || columns.getAttributeCount() == 0) {
-            throw new PairingException("The request to '" + dsName + "' returned no columns. " +
-               "Properties sent: " + applied + ". Check the parameter values and datasource " +
-               "credentials -- see the server log for the cause.");
+            Object loadError = query.getProperty("wizLoadColumnsError");
+            throw new PairingException("The request to '" + dsName + "' returned no columns" +
+               (loadError == null ? "" : " (" + loadError + ")") + ". Properties sent: " +
+               applied + ". Check the parameter values and datasource credentials -- see the " +
+               "server log for the cause.");
          }
 
          return null;

--- a/core/src/test/java/inetsoft/uql/tabular/FixtureTabularDataSource.java
+++ b/core/src/test/java/inetsoft/uql/tabular/FixtureTabularDataSource.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import inetsoft.util.credential.CredentialType;
+
+/**
+ * A data source reduced to the structures {@link TabularSchemaExtractor#extractDataSourceConfig}
+ * cares about: one plain connection field, one credential field. Real {@code TabularDataSource}
+ * subclasses live in connector plugins and are not on core's classpath -- same reasoning as
+ * {@code TabularSchemaExtractorTest.FixtureQuery} for query-side tests. A standalone, public
+ * top-level class (rather than a nested one on a single test class) so both
+ * {@code TabularSchemaExtractorTest} and {@code WizTabularControllerTest} can share it, matching
+ * {@code inetsoft.web.wiz.service.FakeTabularDataSource}'s equivalent role for that package.
+ */
+public class FixtureTabularDataSource extends TabularDataSource<FixtureTabularDataSource> {
+   public FixtureTabularDataSource() {
+      super("Fixture", FixtureTabularDataSource.class);
+   }
+
+   @Override
+   protected CredentialType getCredentialType() {
+      return null;
+   }
+
+   @Property(label = "URL")
+   public String getUrl() {
+      return url;
+   }
+
+   public void setUrl(String url) {
+      this.url = url;
+   }
+
+   @Property(label = "API Key", password = true)
+   public String getApiKey() {
+      return apiKey;
+   }
+
+   public void setApiKey(String apiKey) {
+      this.apiKey = apiKey;
+   }
+
+   private String url;
+   private String apiKey;
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
@@ -296,6 +296,65 @@ class TabularSchemaExtractorTest {
       return new TabularSchemaExtractor().extract(new FixtureQuery(), FixtureQuery.TYPE);
    }
 
+   // ─── extractDataSourceConfig ───────────────────────────────────────────────
+   // The TabularDataSourceConfig counterpart of extract(TabularQuery, ...) above -- same
+   // reflection, pointed at a TabularDataSource instead of a TabularQuery, so a datasource's own
+   // connection-level config (base URL, credentials) can be read the same way a query's settable
+   // parameters already are. See docs/tabular for the design (composer-chat's own
+   // get_tabular_datasource_config tool is the caller-facing side of this).
+
+   @Test
+   void extractDataSourceConfigReportsNonPasswordValues() {
+      FixtureTabularDataSource ds = new FixtureTabularDataSource();
+      ds.setUrl("https://example.com/api");
+
+      TabularDataSourceConfig.Field url =
+         fieldNamed(new TabularSchemaExtractor().extractDataSourceConfig(ds), "url");
+
+      assertFalse(url.isPassword());
+      assertEquals("https://example.com/api", url.getValue());
+   }
+
+   @Test
+   void extractDataSourceConfigRedactsAConfiguredPasswordFieldsValue() {
+      FixtureTabularDataSource ds = new FixtureTabularDataSource();
+      ds.setApiKey("s3cr3t");
+
+      TabularDataSourceConfig.Field apiKey =
+         fieldNamed(new TabularSchemaExtractor().extractDataSourceConfig(ds), "apiKey");
+
+      assertTrue(apiKey.isPassword());
+      assertNull(apiKey.getValue(), "a password field must never carry its actual value");
+      assertTrue(apiKey.isConfigured(), "but whether one is set must still be reported");
+   }
+
+   @Test
+   void extractDataSourceConfigReportsAnUnsetPasswordFieldAsNotConfigured() {
+      TabularDataSourceConfig.Field apiKey = fieldNamed(
+         new TabularSchemaExtractor().extractDataSourceConfig(new FixtureTabularDataSource()), "apiKey");
+
+      assertTrue(apiKey.isPassword());
+      assertNull(apiKey.getValue());
+      assertFalse(apiKey.isConfigured());
+   }
+
+   @Test
+   void extractDataSourceConfigCarriesTheDataSourceType() {
+      assertEquals("Fixture",
+         new TabularSchemaExtractor().extractDataSourceConfig(new FixtureTabularDataSource())
+            .getDataSourceType());
+   }
+
+   private static TabularDataSourceConfig.Field fieldNamed(TabularDataSourceConfig config,
+                                                            String name)
+   {
+      return config.getFields().stream()
+         .filter(f -> name.equals(f.getName()))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("no field named '" + name + "', got " +
+            config.getFields().stream().map(TabularDataSourceConfig.Field::getName).toList()));
+   }
+
    private static ConfigurationContext previous;
 
    public enum Mode { NONE, CURSOR, LINK }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
@@ -102,7 +102,10 @@ class WizTabularControllerSecurityTest {
                 // branched after that round landed.
                 "/api/wiz/tabular/oauth-params",
                 "/api/wiz/tabular/oauth-tokens",
-                "/api/wiz/tabular/oauth-grant-password"),
+                "/api/wiz/tabular/oauth-grant-password",
+                // Added alongside this PR's own change: the datasource-side counterpart of
+                // /tabular/query-schema (the connection config, not the query contract).
+                "/api/wiz/tabular/datasource-config"),
          new HashSet<>(mappedPaths()));
    }
 
@@ -123,6 +126,21 @@ class WizTabularControllerSecurityTest {
    void tabularQuerySchemaIsGatedOnReadWithAWiredPermissionPath() throws Exception {
       Method method = WizTabularController.class.getDeclaredMethod(
          "getQuerySchema", String.class, boolean.class, Principal.class);
+
+      assertGateOnPathParameter(method, ResourceAction.READ);
+   }
+
+   /**
+    * The datasource-side counterpart of {@code getQuerySchema} right above -- same reasoning,
+    * same gate. It returns the connector's own connection-level config, with every credential
+    * field redacted to "is one configured" rather than its value, so (like {@code query-schema})
+    * it never needs {@code /tabular/definition}'s WRITE gate; unlike that one, it never returns a
+    * secret at all.
+    */
+   @Test
+   void tabularDatasourceConfigIsGatedOnReadWithAWiredPermissionPath() throws Exception {
+      Method method = WizTabularController.class.getDeclaredMethod(
+         "getDataSourceConfig", String.class, Principal.class);
 
       assertGateOnPathParameter(method, ResourceAction.READ);
    }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
@@ -602,6 +602,68 @@ class WizTabularControllerTest {
       }
    }
 
+   // ─── getDataSourceConfig: the data source's own redacted connection config ────────
+
+   private static TabularDataSourceConfig.Field fieldNamed(TabularDataSourceConfig config,
+                                                            String name)
+   {
+      return config.getFields().stream()
+         .filter(f -> name.equals(f.getName()))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("no field named '" + name + "', got " +
+            config.getFields().stream().map(TabularDataSourceConfig.Field::getName).toList()));
+   }
+
+   @Test
+   void getDataSourceConfigReportsNonPasswordValuesAndRedactsPasswordOnes() throws Exception {
+      FixtureTabularDataSource ds =
+         new FixtureTabularDataSource();
+      ds.setUrl("https://example.com/api");
+      ds.setApiKey("s3cr3t");
+
+      when(xrepository.getDataSource(eq("myds"))).thenReturn(ds);
+
+      TabularDataSourceConfig config = controller.getDataSourceConfig("myds", principal);
+
+      TabularDataSourceConfig.Field url = fieldNamed(config, "url");
+      assertFalse(url.isPassword());
+      assertEquals("https://example.com/api", url.getValue());
+
+      TabularDataSourceConfig.Field apiKey = fieldNamed(config, "apiKey");
+      assertTrue(apiKey.isPassword());
+      assertNull(apiKey.getValue(), "a password field must never carry its actual value");
+      assertTrue(apiKey.isConfigured());
+   }
+
+   @Test
+   void getDataSourceConfigReportsAnUnsetPasswordFieldAsNotConfigured() throws Exception {
+      when(xrepository.getDataSource(eq("myds")))
+         .thenReturn(new FixtureTabularDataSource());
+
+      TabularDataSourceConfig.Field apiKey =
+         fieldNamed(controller.getDataSourceConfig("myds", principal), "apiKey");
+
+      assertNull(apiKey.getValue());
+      assertFalse(apiKey.isConfigured());
+   }
+
+   @Test
+   void getDataSourceConfigRejectsANonTabularDataSource() throws Exception {
+      when(xrepository.getDataSource(eq("myds"))).thenReturn(mock(JDBCDataSource.class));
+
+      assertThrows(UnsupportedDatasourceException.class,
+         () -> controller.getDataSourceConfig("myds", principal));
+   }
+
+   @Test
+   void getDataSourceConfigAnswersBadRequestWhenTheDataSourceIsGone() throws Exception {
+      when(xrepository.getDataSource(eq("myds"))).thenReturn(null);
+
+      ResponseStatusException e = assertThrows(ResponseStatusException.class,
+         () -> controller.getDataSourceConfig("myds", principal));
+      assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+   }
+
    // ─── browseTabularFiles: BrowsableQuery connectors (e.g. OneDrive) ────────
 
    private WizTabularBrowseResult browseWith(FakeBrowsableQuery query, WizTabularBrowseRequest request)

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularQueryContractSupportTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularQueryContractSupportTest.java
@@ -121,6 +121,32 @@ class TabularQueryContractSupportTest {
       assertTrue(ex.getMessage().contains("endpoint"), ex.getMessage());
    }
 
+   /**
+    * "endpoint" ({@code @Property(required = true)}, no {@code visibleMethod} gate) is
+    * unconditionally required on {@link FakeNamedConnectorQuery} -- omitting it ENTIRELY from
+    * {@code queryParams} (as opposed to sending it with a bad value, which the per-param checks
+    * below already cover) went unchecked before: the fill loop only ever iterates
+    * {@code queryParams.keySet()}, so a key nobody sent had no code path that ever noticed its
+    * absence, and the request went out with the connector's blank default instead of failing loud.
+    */
+   @Test
+   void rejectsAnEntirelyOmittedTopLevelRequiredParameter() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> apply(query, params("requestType", "GET")));
+      assertTrue(ex.getMessage().contains("endpoint"), ex.getMessage());
+   }
+
+   @Test
+   void rejectsABlankTopLevelRequiredParameterTheSameAsAnOmittedOne() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> apply(query, params("endpoint", "  ")));
+      assertTrue(ex.getMessage().contains("endpoint"), ex.getMessage());
+   }
+
    // ─── endpoint selection + tagsMethod validation (named connector) ─────────
 
    @Test
@@ -196,8 +222,12 @@ class TabularQueryContractSupportTest {
    void refusesKindBCompositeByName() {
       FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
 
+      // "endpoint" supplied alongside the thing actually under test -- otherwise required-param
+      // enforcement (added since) reports the missing "endpoint" first, which is correct but not
+      // what this test isolates.
       IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-         () -> apply(query, params("additionalParameters", Map.of("x", "1"))));
+         () -> apply(query, params(
+            "endpoint", "Repos", "additionalParameters", Map.of("x", "1"))));
       assertTrue(ex.getMessage().contains("additionalParameters"), ex.getMessage());
       assertTrue(ex.getMessage().contains("not supported yet"), ex.getMessage());
    }
@@ -307,8 +337,11 @@ class TabularQueryContractSupportTest {
    void rejectsSilentNoOpOnNamedConnectorQuery() {
       FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
 
+      // "endpoint" supplied alongside "suffix" -- otherwise required-param enforcement (added
+      // since) reports the missing "endpoint" first, which is correct but not what this test
+      // isolates (the silent no-op on "suffix").
       IllegalStateException ex = assertThrows(IllegalStateException.class,
-         () -> apply(query, params("suffix", "/v1/widgets/{id}")));
+         () -> apply(query, params("endpoint", "Repos", "suffix", "/v1/widgets/{id}")));
       assertTrue(ex.getMessage().contains("suffix"), ex.getMessage());
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularQueryContractSupportTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularQueryContractSupportTest.java
@@ -197,6 +197,25 @@ class TabularQueryContractSupportTest {
       assertTrue(ex.getMessage().contains("id"), ex.getMessage());
    }
 
+   /**
+    * KNOWN, ACCEPTED GAP -- documents current behavior, does not assert it is desirable.
+    * "Repos"'s nested "id" parameter is required once "parameters" is SUPPLIED (see
+    * {@link #rejectsMissingRequiredParameter} above), but "parameters" itself is a composite
+    * (Kind A) top-level property, and {@code applyQueryContract} deliberately excludes
+    * composite-typed params from its top-level required check (composite required-ness is
+    * endpoint-/choice-dependent; see the comment above that check). So omitting the "parameters"
+    * key ENTIRELY -- as opposed to supplying it empty, which IS caught -- is not rejected here,
+    * even though "Repos" has a required nested parameter once "parameters" is chosen at all.
+    */
+   @Test
+   void anOmittedRequiredCompositeIsNotCaughtByThisCheck_knownGap() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      apply(query, params("endpoint", "Repos"));
+
+      assertEquals("Repos", query.getEndpoint());
+   }
+
    @Test
    void rejectsUnknownNestedParameterName() {
       FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -4151,8 +4151,11 @@ class WorksheetAgentControllerTest {
 
       FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
 
+      // "endpoint" supplied alongside "jsonPath" -- otherwise required-param enforcement (added
+      // since) reports the missing "endpoint" first, which is correct but not what this test
+      // isolates (a plain, non-composite property filling cleanly).
       EditRequest req = addQueryParamsTableRequest("t1", "MyDatasource", null, null, null,
-         null, null, Map.of("jsonPath", "$.data"));
+         null, null, Map.of("endpoint", "Repos", "jsonPath", "$.data"));
 
       inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
       org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();


### PR DESCRIPTION
## Summary

`add_table`'s `queryParams` form had no way for a caller to learn what a generic Rest/Rest.XML datasource is actually configured to connect to — `GET /tabular/query-schema` only describes the QUERY built against it, never the datasource's own connection state (base URL, host, tenant, ...). An agent trying to bind a table to e.g. a generic "REST XML" datasource had nothing to check a base-URL guess against before making a live (possibly wrong) request, and per this project's own "never fabricate a guessed URL/XPath" principle, the only correct move was to stop and ask a human — which is a real, previously-undiscovered capability gap, not intended behavior.

- **New `TabularDataSourceConfig` + `TabularSchemaExtractor.extractDataSourceConfig`**: the datasource-side counterpart of `TabularQuerySchema` — same `@Property` reflection (`TabularUtil.findProperties`), pointed at the datasource instance instead of the query. Every credential-flagged field (`@Property(password = true)`, the same flag every connector's credential fields already declare) is redacted to "is one configured", never its value. Verified generic across the whole `TabularDataSource` class by sampling 5 distinct connector families (REST via `AbstractRestDataSource`, MongoDB, OData, OneDrive, ServerFile) — no per-connector code needed.
- **New `GET /tabular/datasource-config`**, gated `READ` (unlike `/tabular/definition` next to it, which is gated `WRITE` specifically because it returns secrets in clear text — this endpoint never does, which is what makes `READ` correct here).

## Also fixes two gaps found auditing the rest of the `queryParams` → `TabularQuery` pipeline

Per the same review rigor as the row-cap work (PR #5130): once one gap in this pipeline was found, the rest of it was audited for the same class of problem rather than patching only the reported case.

1. **`applyQueryContract` never checked for an entirely-omitted top-level required scalar.** The fill loop only ever iterated `queryParams.keySet()`, so a key nobody sent had no code path that ever noticed its absence — the request went out with the connector's blank default instead of failing loud. Fixed by cross-checking `schema.getParams()` for `isRequired()==true` entries missing from `queryParams`, reported all at once. Composite (Kind A) parameters are deliberately excluded — they can be legitimately absent as a whole, and their own required elements are already checked once supplied.
2. **The generic "returned no columns" error collapsed every distinct failure into one undifferentiated message.** A 404, an auth failure, a malformed response, and an unreachable host all looked identical to a genuinely-empty-but-successful response — exactly the ambiguity an LLM caller can't self-correct from (wrong xpath → try another; wrong host/auth → stop guessing). `TabularTableAssembly.loadColumnSelection` now stashes the real exception's message on the query's own property bag (the same mechanism `"queryManager"` already uses) before swallowing it; the three "no columns" error sites (`WorksheetAgentController` ×2, `WorksheetTableService` ×1) read it back.

Companion PR (the composer-chat plugin side: new `get_tabular_datasource_config` tool + updated discovery-order guidance): stylebi-wiz repo, branch `feat/tabular-datasource-config`. Full write-up: `docs/tabular/stylebi-tabular-datasource-config-and-queryparams-gaps.md` in that repo.

## Test plan

- [x] `TabularSchemaExtractorTest` — new coverage for `extractDataSourceConfig` (non-password value reported, password value redacted-but-configured-flag-reported, unset password field, data source type carried), against a new standalone `FixtureTabularDataSource` fixture.
- [x] `TabularQueryContractSupportTest` — new coverage for the omitted/blank top-level required param; two existing tests fixed to supply a valid `endpoint` alongside the thing they actually isolate (they previously relied on required-param enforcement not existing yet).
- [x] `WizTabularControllerTest` — new coverage for the endpoint (values + redaction, non-tabular datasource rejection, missing datasource → 400).
- [x] `WorksheetAgentControllerTest` — one existing test fixed for the same reason as above.
- [x] Full combined regression run (`TabularSchemaExtractorTest`, `TabularQueryContractSupportTest`, `WizTabularControllerTest`, `WorksheetAgentControllerTest`, `WorksheetTableServiceProbeHintTest`, `TabularEndpointBindingSupportTest`) green.
- [x] `mvnw -pl core -am compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)