### PR TITLE
Check permission and dependencies on every nested data source before deleting a folder

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/DeletedDataSource.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/DeletedDataSource.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+/**
+ * One data source actually removed as part of a folder deletion.
+ *
+ * @param path       full repository path of the removed data source.
+ * @param sourceType {@code XDataSource.getType()}, or {@code null} if the type could not be
+ *                   read (the data source object failed to load) -- deletion is not blocked on
+ *                   this, since the type is only needed by callers doing cleanup keyed on it.
+ */
+public record DeletedDataSource(String path, String sourceType) {}

--- a/core/src/main/java/inetsoft/web/admin/content/repository/FolderDeleteResult.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/FolderDeleteResult.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.content.repository;
+
+import inetsoft.web.admin.security.ConnectionStatus;
+
+import java.util.List;
+
+/**
+ * The outcome of {@link RepositoryObjectService#removeDataSourceFolder}.
+ *
+ * Exactly one of the two is meaningful: a non-null {@code status} means the deletion did not
+ * happen at all (permission denied, or a dependency conflict without {@code force}) and
+ * {@code deletedDataSources} is always empty; a null {@code status} means every check passed and
+ * the folder plus everything in {@code deletedDataSources} was actually removed.
+ */
+public record FolderDeleteResult(ConnectionStatus status, List<DeletedDataSource> deletedDataSources) {
+   public static FolderDeleteResult failure(ConnectionStatus status) {
+      return new FolderDeleteResult(status, List.of());
+   }
+
+   public static FolderDeleteResult success(List<DeletedDataSource> deletedDataSources) {
+      return new FolderDeleteResult(null, deletedDataSources);
+   }
+}

--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectService.java
@@ -225,11 +225,10 @@ public class RepositoryObjectService {
 
                break;
             case RepositoryEntry.DATA_SOURCE_FOLDER:
-               ConnectionStatus dataSourceFolder =
-                  removeDataSourceFolder(node.path(), force, principal);
+               FolderDeleteResult folderResult = removeDataSourceFolder(node.path(), force, principal);
 
-               if(dataSourceFolder != null) {
-                  return dataSourceFolder;
+               if(folderResult.status() != null) {
+                  return folderResult.status();
                }
 
                break;
@@ -521,24 +520,86 @@ public class RepositoryObjectService {
       return null;
    }
 
-   public synchronized ConnectionStatus removeDataSourceFolder(String dxname,
-                                                               boolean force,
-                                                               Principal principal)
+   public synchronized FolderDeleteResult removeDataSourceFolder(String dxname, boolean force,
+                                                                  Principal principal)
    {
-      List<String> sources = dataSourceRegistry.getSubDataSourceNames(dxname);
+      // Phase 1: check everything, delete nothing yet. allNestedDataSourceNames() reaches every
+      // nested data source at any depth, not just this folder's immediate children -- that is the
+      // fix for the bug where a data source several sub-folders deep skipped both checks entirely.
+      List<String> allSources = allNestedDataSourceNames(dxname);
+      List<DeletedDataSource> toDelete = new ArrayList<>();
 
-      for(String source : sources) {
+      for(String source : allSources) {
+         ConnectionStatus status = checkAssetEntryDependencies(source, AssetEntry.Type.DATA_SOURCE, force);
+
+         if(status != null) {
+            return FolderDeleteResult.failure(status);
+         }
+
+         if(!securityProvider.checkPermission(principal, ResourceType.DATA_SOURCE, source,
+                                              ResourceAction.DELETE))
+         {
+            return FolderDeleteResult.failure(new ConnectionStatus(Catalog.getCatalog(principal)
+               .getString("Permission denied to delete datasource")));
+         }
+
+         toDelete.add(new DeletedDataSource(source, readSourceType(source)));
+      }
+
+      // Phase 2: every check passed, so it is now safe to actually delete. Reuses the exact
+      // mechanism this method already used for its (previously incomplete) immediate-children loop.
+      for(String source : allSources) {
          ConnectionStatus status = deleteDataSource(source, force, principal);
 
          if(status != null) {
-            return status;
+            // Extremely unlikely after the phase-1 checks above (something changed between the two
+            // loops), but must not be swallowed: some sources in this loop may already be deleted at
+            // this point, so failing loudly here is strictly better than silently continuing to the
+            // folder-level delete below on top of partial state.
+            return FolderDeleteResult.failure(status);
          }
       }
 
+      // Still recurses internally and still deletes the data sources above a second time from its
+      // own point of view -- harmless and NOT a change from today's behavior: by the time this runs
+      // every one of them is already gone from the registry, so its own getEntries() lookup no
+      // longer lists them and there is nothing left for it to touch a second time. Left as-is
+      // because it is also the only thing that removes the FOLDER entry itself.
       dataSourceRegistry.removeDataSourceFolder(dxname);
       securityProvider.removePermission(ResourceType.DATA_SOURCE_FOLDER, dxname);
 
-      return null;
+      return FolderDeleteResult.success(toDelete);
+   }
+
+   /**
+    * Every data source nested under this folder, at any depth -- not just the immediate children
+    * {@code getSubDataSourceNames(dxname)} (without {@code allChild=true}) would return.
+    */
+   private List<String> allNestedDataSourceNames(String dxname) {
+      AssetEntry[] entries = dataSourceRegistry.getEntries(dxname + "/", AssetEntry.Type.DATA_SOURCE);
+      List<String> names = new ArrayList<>(entries.length);
+
+      for(AssetEntry entry : entries) {
+         names.add(entry.getPath());
+      }
+
+      return names;
+   }
+
+   /**
+    * {@code XDataSource.getType()} for a data source about to be deleted, or null if it could not
+    * be read -- mirrors DataSourceBrowserService.getDataSources()'s own tolerance for a data source
+    * that fails to load. The type is only used by callers doing cleanup keyed on it; a data source
+    * that cannot even be loaded is still deletable.
+    */
+   private String readSourceType(String dxname) {
+      try {
+         XDataSource dataSource = dataSourceRegistry.getDataSource(dxname);
+         return dataSource == null ? null : dataSource.getType();
+      }
+      catch(Throwable ex) {
+         return null;
+      }
    }
 
    private ConnectionStatus checkAssetEntryDependencies(String path, AssetEntry.Type type,

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceBrowserService.java
@@ -35,6 +35,7 @@ import inetsoft.uql.xmla.XMLADataSource;
 import inetsoft.util.*;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.Audit;
+import inetsoft.web.admin.content.repository.FolderDeleteResult;
 import inetsoft.web.admin.content.repository.RepositoryObjectService;
 import inetsoft.web.admin.model.NameLabelTuple;
 import inetsoft.web.admin.security.ConnectionStatus;
@@ -504,7 +505,7 @@ public class DataSourceBrowserService {
          actionName = ActionRecord.ACTION_NAME_DELETE,
          objectType = ActionRecord.OBJECT_TYPE_FOLDER
    )
-   public ConnectionStatus deleteDataSourceFolder(
+   public FolderDeleteResult deleteDataSourceFolder(
       String path, @SuppressWarnings("unused") @AuditObjectName String auditPath, boolean force,
       Principal principal)
    {

--- a/core/src/main/java/inetsoft/web/portal/data/DataSourceController.java
+++ b/core/src/main/java/inetsoft/web/portal/data/DataSourceController.java
@@ -107,7 +107,8 @@ public class DataSourceController {
                                                   Principal principal)
    {
       String fullPath = Util.getObjectFullPath(RepositoryEntry.DATA_SOURCE_FOLDER, path, principal);
-      return dataSourceBrowserService.deleteDataSourceFolder(path, fullPath, force, principal);
+      return dataSourceBrowserService.deleteDataSourceFolder(path, fullPath, force, principal)
+         .status();
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -39,6 +39,7 @@ import inetsoft.web.admin.content.database.*;
 import inetsoft.web.admin.content.database.types.*;
 import inetsoft.web.admin.content.repository.DataSourceSettingsModel;
 import inetsoft.web.admin.content.repository.DatabaseDatasourcesService;
+import inetsoft.web.admin.content.repository.FolderDeleteResult;
 import inetsoft.web.admin.model.NameLabelTuple;
 import inetsoft.web.admin.security.ConnectionStatus;
 import inetsoft.web.portal.data.CheckDuplicateResponse;
@@ -827,35 +828,46 @@ public class WizDatabaseController {
 
             if(!securityEngine.checkPermission(principal, type, item.path(), ResourceAction.DELETE)) {
                results.add(new WizDatasourceDeleteItemResult(
-                  item.path(), false, WizDatasourceDeleteItemResult.PERMISSION_DENIED, null));
+                  item.path(), false, WizDatasourceDeleteItemResult.PERMISSION_DENIED, null, null));
                continue;
             }
 
-            ConnectionStatus status = item.folder()
-               ? dataSourceBrowserService.deleteDataSourceFolder(item.path(),
-                    Util.getObjectFullPath(RepositoryEntry.DATA_SOURCE_FOLDER, item.path(), principal),
-                    force, principal)
-               : datasourcesService.deleteDataSource(item.path(),
-                    databaseDatasourcesService.getDataSourceAuditPath(
-                       item.path(), nameOnlyDefinition(item.name()), principal),
-                    force);
+            if(item.folder()) {
+               FolderDeleteResult folderResult = dataSourceBrowserService.deleteDataSourceFolder(
+                  item.path(),
+                  Util.getObjectFullPath(RepositoryEntry.DATA_SOURCE_FOLDER, item.path(), principal),
+                  force, principal);
 
-            if(status != null) {
-               // A message when force=false hit a dependency conflict (or, for a folder, when a
-               // child datasource lacked DELETE). Both surface the same way here; the portal
-               // cannot and need not distinguish them further than "show me the message".
-               results.add(new WizDatasourceDeleteItemResult(
-                  item.path(), false, WizDatasourceDeleteItemResult.HAS_DEPENDENCIES,
-                  status.getStatus()));
+               if(folderResult.status() != null) {
+                  results.add(new WizDatasourceDeleteItemResult(
+                     item.path(), false, WizDatasourceDeleteItemResult.HAS_DEPENDENCIES,
+                     folderResult.status().getStatus(), null));
+               }
+               else {
+                  results.add(new WizDatasourceDeleteItemResult(
+                     item.path(), true, null, null, folderResult.deletedDataSources()));
+               }
             }
             else {
-               results.add(new WizDatasourceDeleteItemResult(item.path(), true, null, null));
+               ConnectionStatus status = datasourcesService.deleteDataSource(item.path(),
+                  databaseDatasourcesService.getDataSourceAuditPath(
+                     item.path(), nameOnlyDefinition(item.name()), principal),
+                  force);
+
+               if(status != null) {
+                  results.add(new WizDatasourceDeleteItemResult(
+                     item.path(), false, WizDatasourceDeleteItemResult.HAS_DEPENDENCIES,
+                     status.getStatus(), null));
+               }
+               else {
+                  results.add(new WizDatasourceDeleteItemResult(item.path(), true, null, null, null));
+               }
             }
          }
          catch(Exception ex) {
             LOG.warn("Failed to delete {}: {}", item.path(), ex.getMessage());
             results.add(new WizDatasourceDeleteItemResult(
-               item.path(), false, WizDatasourceDeleteItemResult.UNKNOWN, null));
+               item.path(), false, WizDatasourceDeleteItemResult.UNKNOWN, null, null));
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceDeleteItemResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceDeleteItemResult.java
@@ -18,19 +18,27 @@
 
 package inetsoft.web.wiz.model;
 
+import inetsoft.web.admin.content.repository.DeletedDataSource;
+
+import java.util.List;
+
 /**
  * One item's outcome from a {@code /datasources/delete} call.
  *
- * @param path              the item's path, echoed back so the caller can pair a result with the
- *                          request it made.
- * @param ok                whether the item was deleted.
- * @param reason            null when {@code ok}. Otherwise one of {@code PERMISSION_DENIED},
- *                          {@code HAS_DEPENDENCIES}, {@code UNKNOWN}.
- * @param dependencyMessage present only when {@code reason} is {@code HAS_DEPENDENCIES} — the
- *                          server-locale message describing what depends on this item.
+ * @param path               the item's path, echoed back so the caller can pair a result with the
+ *                           request it made.
+ * @param ok                 whether the item was deleted.
+ * @param reason             null when {@code ok}. Otherwise one of {@code PERMISSION_DENIED},
+ *                           {@code HAS_DEPENDENCIES}, {@code UNKNOWN}.
+ * @param dependencyMessage  present only when {@code reason} is {@code HAS_DEPENDENCIES} — the
+ *                           server-locale message describing what depends on this item.
+ * @param deletedDataSources present only when this item is a successfully deleted FOLDER: every
+ *                           data source actually removed as part of the cascade, with its type.
+ *                           Null (not just empty) for a non-folder item or a failed delete.
  */
 public record WizDatasourceDeleteItemResult(
-   String path, boolean ok, String reason, String dependencyMessage)
+   String path, boolean ok, String reason, String dependencyMessage,
+   List<DeletedDataSource> deletedDataSources)
 {
    public static final String PERMISSION_DENIED = "PERMISSION_DENIED";
    public static final String HAS_DEPENDENCIES = "HAS_DEPENDENCIES";

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectServiceTest.java
@@ -30,6 +30,7 @@ import inetsoft.sree.RepositoryEntry;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.OrganizationContextHolder;
 import inetsoft.sree.security.Resource;
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SRPrincipal;
 import inetsoft.sree.security.SecurityProvider;
@@ -37,6 +38,7 @@ import inetsoft.sree.web.dashboard.DashboardRegistryManager;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetObject;
@@ -70,10 +72,14 @@ import java.security.Principal;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -109,6 +115,10 @@ class RepositoryObjectServiceTest {
       resourcePermissionService = mock(ResourcePermissionService.class);
       dependencyHandler = mock(DependencyHandler.class);
       dataModel = mock(XDataModel.class);
+      securityProvider = mock(SecurityProvider.class);
+      // most scenarios only care about a specific source's permission outcome -- default to
+      // allowed so a test only has to stub the source(s) it wants to deny.
+      when(securityProvider.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
 
       when(dataModel.getDataSource()).thenReturn(DATA_SOURCE);
       when(dataSourceRegistry.getDataModel(DATA_SOURCE)).thenReturn(dataModel);
@@ -118,7 +128,7 @@ class RepositoryObjectServiceTest {
 
       service = new RepositoryObjectService(
          mock(RepletRegistryService.class), mock(ContentRepositoryTreeService.class),
-         mock(SecurityProvider.class), resourcePermissionService, mock(XRepository.class),
+         securityProvider, resourcePermissionService, mock(XRepository.class),
          mock(RepositoryDashboardService.class), mock(DataModelFolderManagerService.class),
          dataSourceRegistry, mock(LibManagerProvider.class), mock(RecycleBin.class),
          dependencyHandler, mock(RenameTransformHandler.class), mock(RepletRegistryManager.class),
@@ -312,6 +322,173 @@ class RepositoryObjectServiceTest {
       assertEquals(expected, capturedDeletedDependencyKey());
    }
 
+   // ---- removeDataSourceFolder ----------------------------------------------------------------
+
+   /*
+    * Bug fix: removeDataSourceFolder used to check permission/dependencies only on a folder's
+    * IMMEDIATE children, then unconditionally call the registry's own removeDataSourceFolder,
+    * which recursively deletes every nested data source at ANY depth with no check of its own.
+    * These tests pin the two-phase replacement: allNestedDataSourceNames() reaches every nested
+    * data source regardless of depth, every one is checked before anything is deleted, and a
+    * single failure anywhere refuses the whole operation instead of leaving a partial delete.
+    */
+
+   @Test
+   void removeDataSourceFolder_allNestedSourcesPassChecksSoEverythingIsDeleted() {
+      stubNestedDataSources(FOLDER, DIRECT_CHILD, NESTED_CHILD);
+      XDataSource directDs = mock(XDataSource.class);
+      when(directDs.getType()).thenReturn("JDBC");
+      XDataSource nestedDs = mock(XDataSource.class);
+      when(nestedDs.getType()).thenReturn("REST");
+      when(dataSourceRegistry.getDataSource(DIRECT_CHILD)).thenReturn(directDs);
+      when(dataSourceRegistry.getDataSource(NESTED_CHILD)).thenReturn(nestedDs);
+
+      FolderDeleteResult result = service.removeDataSourceFolder(FOLDER, false, principal);
+
+      assertNull(result.status());
+      assertEquals(
+         List.of(new DeletedDataSource(DIRECT_CHILD, "JDBC"),
+                 new DeletedDataSource(NESTED_CHILD, "REST")),
+         result.deletedDataSources());
+      verify(dataSourceRegistry).removeDataSource(DIRECT_CHILD);
+      verify(dataSourceRegistry).removeDataSource(NESTED_CHILD);
+      verify(dataSourceRegistry).removeDataSourceFolder(FOLDER);
+   }
+
+   /*
+    * The actual security-bug regression test: a data source nested TWO levels deep (not merely an
+    * immediate child) that fails permission must refuse the WHOLE delete -- and nothing may have
+    * been deleted, not even the direct child that passed its own check first. Today's
+    * immediate-children-only loop would never even look at this nested item before the low-level
+    * delete swept it up unconditionally; this pins that it is now checked and blocks the delete.
+    */
+   @Test
+   void removeDataSourceFolder_aDeeplyNestedSourceFailingPermissionRefusesEverything() {
+      stubNestedDataSources(FOLDER, DIRECT_CHILD, NESTED_CHILD);
+      when(securityProvider.checkPermission(
+         eq(principal), eq(ResourceType.DATA_SOURCE), eq(NESTED_CHILD), eq(ResourceAction.DELETE)))
+         .thenReturn(false);
+
+      FolderDeleteResult result = service.removeDataSourceFolder(FOLDER, false, principal);
+
+      assertNotNull(result.status());
+      assertTrue(result.deletedDataSources().isEmpty());
+      verify(dataSourceRegistry, never()).removeDataSource(any());
+      verify(dataSourceRegistry, never()).removeDataSourceFolder(any());
+   }
+
+   /*
+    * Same shape as above, but the failure is a dependency conflict (force=false) on the deeply
+    * nested item rather than a permission denial -- both check kinds must gate every nested item,
+    * not just the permission check.
+    */
+   @Test
+   void removeDataSourceFolder_aNestedSourceWithADependencyConflictRefusesEverything()
+      throws Exception
+   {
+      stubNestedDataSources(FOLDER, DIRECT_CHILD, NESTED_CHILD);
+      stubDependencyConflict(NESTED_CHILD);
+
+      FolderDeleteResult result = service.removeDataSourceFolder(FOLDER, false, principal);
+
+      assertNotNull(result.status());
+      assertTrue(result.deletedDataSources().isEmpty());
+      verify(dataSourceRegistry, never()).removeDataSource(any());
+      verify(dataSourceRegistry, never()).removeDataSourceFolder(any());
+   }
+
+   @Test
+   void removeDataSourceFolder_forceTrueBypassesADependencyConflict() throws Exception {
+      stubNestedDataSources(FOLDER, DIRECT_CHILD, NESTED_CHILD);
+      stubDependencyConflict(NESTED_CHILD);
+
+      FolderDeleteResult result = service.removeDataSourceFolder(FOLDER, true, principal);
+
+      assertNull(result.status());
+      verify(dataSourceRegistry).removeDataSource(DIRECT_CHILD);
+      verify(dataSourceRegistry).removeDataSource(NESTED_CHILD);
+      verify(dataSourceRegistry).removeDataSourceFolder(FOLDER);
+   }
+
+   /*
+    * A data source that fails to load (getDataSource throws, or returns null) must not block its
+    * own deletion -- the type is only needed by callers doing cleanup keyed on it, mirroring
+    * DataSourceBrowserService.getDataSources()'s own tolerance for the same failure.
+    */
+   @Test
+   void removeDataSourceFolder_aSourceWhoseTypeCannotBeReadStillGetsDeletedWithANullType() {
+      stubNestedDataSources(FOLDER, DIRECT_CHILD);
+      when(dataSourceRegistry.getDataSource(DIRECT_CHILD)).thenThrow(new RuntimeException("boom"));
+
+      FolderDeleteResult result = service.removeDataSourceFolder(FOLDER, false, principal);
+
+      assertNull(result.status());
+      assertEquals(List.of(new DeletedDataSource(DIRECT_CHILD, null)), result.deletedDataSources());
+      verify(dataSourceRegistry).removeDataSource(DIRECT_CHILD);
+   }
+
+   // ---- deleteNodes / DATA_SOURCE_FOLDER --------------------------------------------------------
+
+   /*
+    * deleteNodes()'s DATA_SOURCE_FOLDER case had zero coverage before this change. These two tests
+    * pin that the EM native delete path still sees a plain success/failure signal (a
+    * ConnectionStatus or null) after removeDataSourceFolder's return type changed to
+    * FolderDeleteResult -- the adaptation at the call site is a pure type unwrap, not a behavior
+    * change.
+    */
+   @Test
+   void deleteNodes_dataSourceFolderSuccessReturnsNull() throws Exception {
+      stubNestedDataSources(FOLDER);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(FOLDER)
+         .path(FOLDER)
+         .type(RepositoryEntry.DATA_SOURCE_FOLDER)
+         .build();
+
+      assertNull(service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false));
+      verify(dataSourceRegistry).removeDataSourceFolder(FOLDER);
+   }
+
+   @Test
+   void deleteNodes_dataSourceFolderFailurePropagatesTheConnectionStatus() throws Exception {
+      stubNestedDataSources(FOLDER, DIRECT_CHILD);
+      when(securityProvider.checkPermission(
+         eq(principal), eq(ResourceType.DATA_SOURCE), eq(DIRECT_CHILD), eq(ResourceAction.DELETE)))
+         .thenReturn(false);
+
+      TreeNodeInfo node = TreeNodeInfo.builder()
+         .label(FOLDER)
+         .path(FOLDER)
+         .type(RepositoryEntry.DATA_SOURCE_FOLDER)
+         .build();
+
+      assertNotNull(service.deleteNodes(new TreeNodeInfo[]{ node }, principal, false, false));
+      verify(dataSourceRegistry, never()).removeDataSourceFolder(any());
+   }
+
+   private void stubNestedDataSources(String folder, String... sources) {
+      AssetEntry[] entries = new AssetEntry[sources.length];
+
+      for(int i = 0; i < sources.length; i++) {
+         entries[i] = new AssetEntry(
+            AssetRepository.QUERY_SCOPE, AssetEntry.Type.DATA_SOURCE, sources[i], null);
+      }
+
+      when(dataSourceRegistry.getEntries(eq(folder + "/"), eq(AssetEntry.Type.DATA_SOURCE)))
+         .thenReturn(entries);
+   }
+
+   private void stubDependencyConflict(String dataSourcePath) throws Exception {
+      DependenciesInfo dependencies = new DependenciesInfo();
+      dependencies.setDependencies(List.of(new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "boundWorksheet", null)));
+      String entryId = new AssetEntry(
+         AssetRepository.QUERY_SCOPE, AssetEntry.Type.DATA_SOURCE, dataSourcePath, null)
+         .toIdentifier();
+      when(dependencyStorageService.getWithOrg(eq(entryId), any())).thenReturn(dependencies);
+   }
+
    private String identifier(AssetEntry.Type type, String name) {
       return new AssetEntry(AssetRepository.QUERY_SCOPE, type, DATA_SOURCE + "/" + name, null)
          .toIdentifier();
@@ -333,6 +510,7 @@ class RepositoryObjectServiceTest {
    private DataSourceRegistry dataSourceRegistry;
    private ResourcePermissionService resourcePermissionService;
    private DependencyHandler dependencyHandler;
+   private SecurityProvider securityProvider;
    @Autowired private DependencyStorageService dependencyStorageService;
    private XDataModel dataModel;
    private Principal principal;
@@ -344,4 +522,7 @@ class RepositoryObjectServiceTest {
    private static final String LOGICAL_MODEL_NAME = "logicalModel";
    private static final String EXTENDED_NAME = "additionalConnection";
    private static final String MODEL_FOLDER = "modelFolder";
+   private static final String FOLDER = "dsFolder";
+   private static final String DIRECT_CHILD = "dsFolder/ds1";
+   private static final String NESTED_CHILD = "dsFolder/sub/ds2";
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerDeleteMoveTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerDeleteMoveTest.java
@@ -28,6 +28,8 @@ import inetsoft.uql.util.Config;
 import inetsoft.util.MessageException;
 import inetsoft.web.admin.content.database.DatabaseTypeService;
 import inetsoft.web.admin.content.repository.DatabaseDatasourcesService;
+import inetsoft.web.admin.content.repository.DeletedDataSource;
+import inetsoft.web.admin.content.repository.FolderDeleteResult;
 import inetsoft.web.admin.security.ConnectionStatus;
 import inetsoft.web.portal.data.CheckDuplicateResponse;
 import inetsoft.web.portal.data.DataSourceBrowserService;
@@ -186,6 +188,83 @@ class WizDatabaseControllerDeleteMoveTest {
       assertEquals(WizDatasourceDeleteItemResult.PERMISSION_DENIED, result.results().get(1).reason());
       assertFalse(result.results().get(2).ok());
       assertEquals(WizDatasourceDeleteItemResult.UNKNOWN, result.results().get(2).reason());
+   }
+
+   /**
+    * A successful folder delete's result must carry every data source StyleBI actually removed
+    * as part of the cascade, so a wiz-side follow-up can clean up per-path vector-store records.
+    */
+   @Test
+   void delete_folderSuccessCarriesTheDeletedDataSources() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE_FOLDER), eq("Examples"),
+         eq(ResourceAction.DELETE)))
+         .thenReturn(true);
+      List<DeletedDataSource> deleted = List.of(
+         new DeletedDataSource("Examples/ds1", "JDBC"),
+         new DeletedDataSource("Examples/sub/ds2", "REST"));
+      when(fixture.dataSourceBrowserService.deleteDataSourceFolder(
+         eq("Examples"), any(), anyBoolean(), eq(fixture.principal)))
+         .thenReturn(FolderDeleteResult.success(deleted));
+
+      WizDatasourceDeleteResult result = fixture.controller.deleteDatasources(
+         new WizDatasourceDeleteRequest(
+            List.of(new WizDatasourceRef("Examples", "Examples", true)), false),
+         fixture.principal);
+
+      WizDatasourceDeleteItemResult item = result.results().get(0);
+      assertTrue(item.ok());
+      assertEquals(deleted, item.deletedDataSources());
+   }
+
+   /**
+    * A failed (dependency-conflict) folder delete must report {@code deletedDataSources} as
+    * null/absent, same as today's behavior for every other failure reason.
+    */
+   @Test
+   void delete_folderDependencyConflictHasNoDeletedDataSources() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE_FOLDER), eq("Examples"),
+         eq(ResourceAction.DELETE)))
+         .thenReturn(true);
+      when(fixture.dataSourceBrowserService.deleteDataSourceFolder(
+         eq("Examples"), any(), anyBoolean(), eq(fixture.principal)))
+         .thenReturn(FolderDeleteResult.failure(new ConnectionStatus("used by Worksheet1")));
+
+      WizDatasourceDeleteResult result = fixture.controller.deleteDatasources(
+         new WizDatasourceDeleteRequest(
+            List.of(new WizDatasourceRef("Examples", "Examples", true)), false),
+         fixture.principal);
+
+      WizDatasourceDeleteItemResult item = result.results().get(0);
+      assertFalse(item.ok());
+      assertEquals(WizDatasourceDeleteItemResult.HAS_DEPENDENCIES, item.reason());
+      assertEquals("used by Worksheet1", item.dependencyMessage());
+      assertNull(item.deletedDataSources());
+   }
+
+   /**
+    * A non-folder item's result must never populate {@code deletedDataSources}, even on success --
+    * that field only ever means "this was a successful folder delete".
+    */
+   @Test
+   void delete_nonFolderItemNeverPopulatesDeletedDataSources() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE), eq("/orders"), eq(ResourceAction.DELETE)))
+         .thenReturn(true);
+      when(fixture.datasourcesService.deleteDataSource(eq("/orders"), any(), eq(false)))
+         .thenReturn(null);
+
+      WizDatasourceDeleteResult result = fixture.controller.deleteDatasources(
+         new WizDatasourceDeleteRequest(List.of(new WizDatasourceRef("/orders", "orders", false)), false),
+         fixture.principal);
+
+      WizDatasourceDeleteItemResult item = result.results().get(0);
+      assertTrue(item.ok());
+      assertNull(item.deletedDataSources());
    }
 
    // ---- move --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`RepositoryObjectService.removeDataSourceFolder` only checked permission and outer dependencies on a folder's **immediate-child** data sources, then unconditionally called `DataSourceRegistry.removeDataSourceFolder`, which recursively deletes **every** nested data source at any depth with **no check of its own**. A caller with delete permission on the top-level folder could therefore remove a data source several sub-folders deep that they had no individual permission on, or that had an unresolved outer dependency — silently, with no error and no record of what was actually removed.

This also blocked a downstream wiz-services feature (companion PR in `stylebi-wiz`, not part of this repo) that needs to know exactly which data sources a folder deletion removed, to clean up their vector-store records.

## Fix

`removeDataSourceFolder` is now two-phase:
1. **Check everything, delete nothing.** Recursively enumerate every nested data source at any depth (not just immediate children), and check permission + dependencies on each.
2. **Delete only if every check passed.** A single failure anywhere refuses the whole operation — nothing gets deleted (previously: a partial failure left everything before it truly deleted, invisibly).

The result now also reports every data source actually removed, with its type (`FolderDeleteResult` / `DeletedDataSource`, new small records), threaded through `DataSourceBrowserService.deleteDataSourceFolder` and `WizDatabaseController.deleteDatasources`.

**One call site the initial design missed**, found via a compile error: `DataSourceController.deleteDatasourceFolder` (the native EM REST endpoint `DELETE api/data/datasources/browser/folder/**`) also calls this method. Fixed with the same pure `.status()` unwrap used elsewhere — no behavior change for that endpoint.

Design doc (in the `stylebi-wiz` repo, cross-repo context): `docs/superpowers/specs/2026-09-10-folder-delete-permission-fix-and-cascade-cleanup-design.md`

## Test plan

- [x] `RepositoryObjectServiceTest`: 7 → 14 tests. New: 5 `removeDataSourceFolder` scenarios (all-pass, deep-nested-permission-failure regression test, deep-nested-dependency-failure, force=true bypass, unreadable-type tolerance) + 2 `deleteNodes`/`DATA_SOURCE_FOLDER` coverage-gap tests.
- [x] `WizDatabaseControllerDeleteMoveTest`: 10 → 13 tests. New: folder-branch `deletedDataSources` population/absence.
- [x] `WizDatabaseControllerRealRegistryTest`: 4/4 unchanged and confirmed still passing against a REAL (non-mocked) `DataSourceRegistry`, including `deleteFolder_doesNotOrphanADatasourceNestedInASubfolder` — verified the fix's new permission check passes for the right reason under this suite's blanket-allow permission stub, not because it was bypassed.
- [x] The core regression test (`removeDataSourceFolder` with a data source two levels deep failing permission) proves the actual security bug: against the old implementation this data source was never even looked at before the low-level recursive delete swept it up unconditionally.

## Known follow-up (not blocking)

`DataSourceController.deleteDatasourceFolder` has no test coverage before or after this change (a pre-existing gap, not a regression). Worth a fast follow-up test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)