### PR TITLE
fix(portal): pass followFocusService arg to FormulaEditorDialog test ctor

### DIFF
--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts
@@ -346,7 +346,7 @@ describe("FormulaEditorDialog Unit Test", () => {
       };
       modalService = { open: vi.fn() };
 
-      dialog = new FormulaEditorDialog(editorService, modalService, null, null, null);
+      dialog = new FormulaEditorDialog(editorService, modalService, null, null, null, null);
       dialog.vsId = "vs1";
       dialog.assemblyName = "Table1";
       dialog.isCube = false;


### PR DESCRIPTION
## Problem

Whole-repo Angular build (\`npm run verify\`'s bundle compile step) is broken
on \`stylebi-wiz-main-rebase\` itself with:

\`\`\`
TS2554: Expected 6 arguments, but got 5.
projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts:349
\`\`\`

\`FormulaEditorDialog\`'s constructor gained a 6th parameter
(\`followFocusService: FollowFocusService\`, used only inside \`ngOnInit\`/
\`ngOnDestroy\` for Follow Focus push/pop) but this spec's one direct
\`new FormulaEditorDialog(...)\` call site was never updated to match.

Confirmed pre-existing on \`origin/stylebi-wiz-main-rebase\` (unrelated to any
specific in-flight PR) — found while verifying stylebi PR #5134, whose own CI
build check fails for this reason despite touching none of these files.

## Fix

Add the missing 6th argument (\`null\`), matching this test's existing
null-for-unused-DI pattern on \`renderer\`/\`element\`/\`dropdownService\`.
Confirmed safe: no test in this file calls \`ngOnInit\`/\`ngOnDestroy\`, the only
two call sites that touch \`followFocusService\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)