### PR TITLE
fix(tabular): distinguish a genuine zero-row success from a failed probe

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -52,7 +52,9 @@ import inetsoft.uql.tabular.TabularUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import inetsoft.util.Catalog;
+import inetsoft.util.CoreTool;
 import inetsoft.util.Tool;
+import inetsoft.util.UserMessage;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.portal.controller.database.DataSourceService;
@@ -1547,6 +1549,12 @@ public class WorksheetTableService {
       probeVars.put(XQuery.HINT_MAX_ROWS,
                     String.valueOf(Math.max(20, src.getSampleRows() == null ? 0 : src.getSampleRows())));
 
+      // Clear any user-message residue from an earlier table in this same batch. createTables loops
+      // over every requested table on ONE thread and nothing clears CoreTool's per-thread message
+      // list between iterations (see recoveredExceptionDetail) — without this, a message left behind
+      // by an earlier table's connector could be read below and misattributed to THIS table's probe.
+      CoreTool.clearUserMessage();
+
       // A null QueryManager, matching what TabularTableAssembly.dependencyChanged passes and what
       // buildSqlTable uses for its own column resolution. Taking an AssetQuerySandbox instead would
       // mean either disposing it — leaving the "queryManager" property pointing at a dead object on
@@ -1562,16 +1570,117 @@ public class WorksheetTableService {
       ColumnSelection columns = table.getColumnSelection(false);
 
       if(columns == null || columns.getAttributeCount() == 0) {
-         throw new IllegalArgumentException(
-            "The query on '" + dsName + "' returned no columns. Parameters sent: " + probeDesc +
-            ". Check them against GET /api/wiz/tabular/query-schema — in particular that each " +
-            "one applies to the others, since one that does not is stored and never read — and " +
-            "that the data source's credentials are valid; the underlying cause is in the " +
-            "server log for this request.");
+         throw new IllegalArgumentException(emptyColumnsMessage(query, dsName, probeDesc));
       }
 
       worksheet.addAssembly(table);
       return table;
+   }
+
+   /**
+    * The two-branch empty-columns message. Branch is decided by {@code query.getResponseShape()}:
+    * non-null iff the request returned a parseable body (see {@link #applyResponseShape}, which
+    * reads the same slot on the success path — the copy-back in {@code TabularHandler.execute} that
+    * fills it runs unconditionally, before the success/failure branch). Both branches may carry an
+    * appended exception detail when the connector recovered one — see {@link #recoveredExceptionDetail}.
+    */
+   private String emptyColumnsMessage(TabularQuery query, String dsName, String probeDesc) {
+      Object shape = query.getResponseShape();
+      String detail = recoveredExceptionDetail();
+
+      if(shape == null) {
+         return "The query on '" + dsName + "' returned no columns. Parameters sent: " + probeDesc +
+            ". Check them against GET /api/wiz/tabular/query-schema — in particular that each " +
+            "one applies to the others, since one that does not is stored and never read — and " +
+            "that the data source's credentials are valid; the underlying cause is in the " +
+            "server log for this request." + detail;
+      }
+
+      String rowPath = effectiveRowPath(query);
+      String rowPathClause = rowPath == null ? "" : " Rows were read from '" + rowPath + "'.";
+      String truncatedClause = query.isResponseShapeTruncated()
+         ? " (capped — some fields may be missing from this description)" : "";
+      String hint = singleArrayFieldHint(shape, rowPath);
+      String hintClause = hint == null ? "" : " The rows look like they belong at '" + hint + "'.";
+
+      return "The query on '" + dsName + "' completed successfully and returned a response, but " +
+         "selected zero rows — for a JSON REST endpoint, columns are derived from the rows " +
+         "returned, so zero rows means zero columns." + rowPathClause + " The response's shape " +
+         "was: " + shape + truncatedClause + "." + hintClause + " Parameters sent: " + probeDesc +
+         ". This is not a connection or credentials problem — the request itself succeeded. If " +
+         "this is unexpected, check the parameters (especially any date range or id filter) " +
+         "against the endpoint's actual data." + detail;
+   }
+
+   /**
+    * The connector's own answer to "where are the rows", when it has one — reflective, so core never
+    * imports a connector type such as {@code RestJsonQuery}. Returns null for any connector with no
+    * such method (ServerFile, a generic non-JSON connector, ...), which the caller must treat as
+    * "omit the clause," never as "assume '$'."
+    */
+   private String effectiveRowPath(TabularQuery query) {
+      try {
+         Object path = query.getClass().getMethod("getValidJsonPath").invoke(query);
+         return path instanceof String s && !s.isBlank() ? s : null;
+      }
+      catch(Exception ex) {
+         return null;
+      }
+   }
+
+   /**
+    * A best-effort suggestion for where rows actually are, used only when the response's shape
+    * names exactly one top-level field holding an array — an object with two or more array-valued
+    * fields, or none, is ambiguous and returns null rather than guess: a wrong guess is worse than
+    * no hint. Also null when the candidate is already what {@code rowPath} points to, since then
+    * there is nothing new to tell the caller.
+    */
+   private String singleArrayFieldHint(Object shape, String rowPath) {
+      if(shape instanceof List<?>) {
+         return "$".equals(rowPath) ? null : "$";
+      }
+
+      if(!(shape instanceof Map<?, ?> map)) {
+         return null;
+      }
+
+      String onlyArrayField = null;
+
+      for(Map.Entry<?, ?> entry : map.entrySet()) {
+         if(entry.getValue() instanceof List) {
+            if(onlyArrayField != null) {
+               return null;
+            }
+
+            onlyArrayField = String.valueOf(entry.getKey());
+         }
+      }
+
+      if(onlyArrayField == null) {
+         return null;
+      }
+
+      String candidate = "$." + onlyArrayField + "[*]";
+      return candidate.equals(rowPath) ? null : candidate;
+   }
+
+   /**
+    * The connector's own exception detail, if it recovered and reported one during the probe just
+    * run — see {@code AbstractQueryRunner.logException}, relayed onto this thread by
+    * {@code AbstractRestRuntime.runQuery}'s worker-thread handoff. Sanitized to one line: {@link
+    * #rootMessage} truncates the thrown message at the first '\n', and {@code UserMessage.merge()}
+    * joins multiple recovered messages with '\n' — an unsanitized suffix here would otherwise be
+    * silently cut, or silently cut everything appended after it.
+    */
+   private String recoveredExceptionDetail() {
+      UserMessage msg = CoreTool.getUserMessage();
+
+      if(msg == null || msg.getMessage() == null || msg.getMessage().isBlank()) {
+         return "";
+      }
+
+      String oneLine = msg.getMessage().replace('\n', ' ').replace('\r', ' ').trim();
+      return " The connector reported: " + oneLine;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1583,33 +1583,57 @@ public class WorksheetTableService {
     * reads the same slot on the success path — the copy-back in {@code TabularHandler.execute} that
     * fills it runs unconditionally, before the success/failure branch). Both branches may carry an
     * appended exception detail when the connector recovered one — see {@link #recoveredExceptionDetail}.
+    *
+    * <p>Sanitized ONCE, at this single return point, rather than ingredient-by-ingredient: every
+    * piece assembled below can originate from data the connector or the caller controls — the
+    * response shape's own field NAMES (not just its leaf values — see {@link #singleArrayFieldHint}'s
+    * sibling, {@code JsonShapeDistiller.objectShape}, which carries a response's real field names
+    * through verbatim), the effective row path (a caller-supplied {@code jsonPath}), {@code
+    * probeDesc} (caller-supplied parameter values), and the recovered exception detail. {@link
+    * #rootMessage} truncates the THROWN message at the first '\n' it finds, so any one of those
+    * silently drops everything appended after it — the exact silent-misinformation class this whole
+    * method exists to remove. One sanitize call here is right by construction for whatever a future
+    * ingredient adds; sanitizing four separate pieces is right only until someone adds a fifth.</p>
     */
    private String emptyColumnsMessage(TabularQuery query, String dsName, String probeDesc) {
       Object shape = query.getResponseShape();
       String detail = recoveredExceptionDetail();
+      String message;
 
       if(shape == null) {
-         return "The query on '" + dsName + "' returned no columns. Parameters sent: " + probeDesc +
+         message = "The query on '" + dsName + "' returned no columns. Parameters sent: " + probeDesc +
             ". Check them against GET /api/wiz/tabular/query-schema — in particular that each " +
             "one applies to the others, since one that does not is stored and never read — and " +
             "that the data source's credentials are valid; the underlying cause is in the " +
             "server log for this request." + detail;
       }
+      else {
+         String rowPath = effectiveRowPath(query);
+         String rowPathClause = rowPath == null ? "" : " Rows were read from '" + rowPath + "'.";
+         String truncatedClause = query.isResponseShapeTruncated()
+            ? " (capped — some fields may be missing from this description)" : "";
+         String hint = singleArrayFieldHint(shape, rowPath);
+         String hintClause = hint == null ? "" : " The rows look like they belong at '" + hint + "'.";
 
-      String rowPath = effectiveRowPath(query);
-      String rowPathClause = rowPath == null ? "" : " Rows were read from '" + rowPath + "'.";
-      String truncatedClause = query.isResponseShapeTruncated()
-         ? " (capped — some fields may be missing from this description)" : "";
-      String hint = singleArrayFieldHint(shape, rowPath);
-      String hintClause = hint == null ? "" : " The rows look like they belong at '" + hint + "'.";
+         message = "The query on '" + dsName + "' completed successfully and returned a response, " +
+            "but selected zero rows — for a JSON REST endpoint, columns are derived from the rows " +
+            "returned, so zero rows means zero columns." + rowPathClause + " The response's shape " +
+            "was: " + shape + truncatedClause + "." + hintClause + " Parameters sent: " + probeDesc +
+            ". This is not a connection or credentials problem — the request itself succeeded. If " +
+            "this is unexpected, check the parameters (especially any date range or id filter) " +
+            "against the endpoint's actual data." + detail;
+      }
 
-      return "The query on '" + dsName + "' completed successfully and returned a response, but " +
-         "selected zero rows — for a JSON REST endpoint, columns are derived from the rows " +
-         "returned, so zero rows means zero columns." + rowPathClause + " The response's shape " +
-         "was: " + shape + truncatedClause + "." + hintClause + " Parameters sent: " + probeDesc +
-         ". This is not a connection or credentials problem — the request itself succeeded. If " +
-         "this is unexpected, check the parameters (especially any date range or id filter) " +
-         "against the endpoint's actual data." + detail;
+      return singleLine(message);
+   }
+
+   /**
+    * Collapse to one line. Applied exactly once, to the fully-assembled {@code
+    * emptyColumnsMessage} — see that method's doc for why sanitizing the whole is preferred over
+    * sanitizing each ingredient that might carry connector- or caller-controlled text.
+    */
+   private static String singleLine(String message) {
+      return message.replace('\n', ' ').replace('\r', ' ');
    }
 
    /**
@@ -1667,10 +1691,11 @@ public class WorksheetTableService {
    /**
     * The connector's own exception detail, if it recovered and reported one during the probe just
     * run — see {@code AbstractQueryRunner.logException}, relayed onto this thread by
-    * {@code AbstractRestRuntime.runQuery}'s worker-thread handoff. Sanitized to one line: {@link
-    * #rootMessage} truncates the thrown message at the first '\n', and {@code UserMessage.merge()}
-    * joins multiple recovered messages with '\n' — an unsanitized suffix here would otherwise be
-    * silently cut, or silently cut everything appended after it.
+    * {@code AbstractRestRuntime.runQuery}'s worker-thread handoff. {@code UserMessage.merge()} joins
+    * multiple recovered messages with '\n', so this can itself carry an embedded newline — left
+    * un-sanitized HERE deliberately: {@link #emptyColumnsMessage} sanitizes the whole assembled
+    * message exactly once, at its single return point, rather than each ingredient sanitizing
+    * itself.
     */
    private String recoveredExceptionDetail() {
       UserMessage msg = CoreTool.getUserMessage();
@@ -1679,8 +1704,7 @@ public class WorksheetTableService {
          return "";
       }
 
-      String oneLine = msg.getMessage().replace('\n', ' ').replace('\r', ' ').trim();
-      return " The connector reported: " + oneLine;
+      return " The connector reported: " + msg.getMessage().trim();
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/CoreHasNoConnectorKnowledgeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/CoreHasNoConnectorKnowledgeTest.java
@@ -54,6 +54,24 @@ class CoreHasNoConnectorKnowledgeTest {
          "annotation's catalog path must not depend on the query-builder schema contract");
    }
 
+   /**
+    * Charter C6 (tabular empty-result error report, 2026-09-10): {@code WorksheetTableService}
+    * reads a connector's {@code getValidJsonPath()} (the effective row path, for the empty-columns
+    * message) reflectively -- {@code Class.getMethod("getValidJsonPath").invoke(query)} -- so that
+    * core never needs a compile-time reference to {@code RestJsonQuery} or any other type under
+    * {@code inetsoft.uql.rest}. This scans the same way as the test above: a raw Latin-1 read of
+    * the compiled class file's constant pool, which would contain the connector package name as a
+    * UTF-8 constant if an import (or any other compile-time reference) existed.
+    */
+   @Test
+   void worksheetTableServiceReferencesNoRestConnectorType() throws IOException {
+      String classFile = classFileAsLatin1(WorksheetTableService.class);
+
+      assertFalse(classFile.contains("inetsoft/uql/rest"),
+         "WorksheetTableService must reach RestJsonQuery.getValidJsonPath() only by reflection, " +
+            "never by importing an inetsoft-rest connector type");
+   }
+
    private String classFileAsLatin1(Class<?> clazz) throws IOException {
       String resourceName = clazz.getSimpleName() + ".class";
 

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeNamedConnectorQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeNamedConnectorQuery.java
@@ -27,6 +27,7 @@ import inetsoft.uql.tabular.RestParameters;
 import inetsoft.uql.tabular.TabularQuery;
 import inetsoft.uql.tabular.View;
 import inetsoft.uql.tabular.View1;
+import inetsoft.util.CoreTool;
 
 import java.util.*;
 
@@ -76,14 +77,51 @@ public class FakeNamedConnectorQuery extends TabularQuery {
     * one thing {@code WorksheetTableServiceProbeHintTest} needs to observe. No columns are
     * produced, matching a connector this probe got nothing back from; the caller's own
     * empty-column check is expected to fire afterward and is not this fixture's concern.
+    *
+    * <p>{@code reportResponseShape}/{@code reportException} let a test control what a real
+    * connector's probe would have left behind on this same query/thread -- {@code setResponseShape}
+    * (inherited from {@code TabularQuery} itself, no connector dependency) and
+    * {@code CoreTool.addUserMessage} (the exact channel {@code AbstractQueryRunner.logException}
+    * uses), respectively. Both are opt-in and no-ops by default, matching every other test on this
+    * fixture that does not call them.</p>
     */
    @Override
    public void loadOutputColumns(VariableTable vtable) throws Exception {
       capturedHintMaxRows = (String) vtable.get(XQuery.HINT_MAX_ROWS);
+
+      if(shapeToReport != null) {
+         setResponseShape(shapeToReport, shapeTruncated);
+      }
+
+      if(exceptionToReport != null) {
+         CoreTool.addUserMessage("Error executing Rest query: " + exceptionToReport);
+      }
    }
 
    public String getCapturedHintMaxRows() {
       return capturedHintMaxRows;
+   }
+
+   /** Mirrors what a real connector's probe run leaves on {@code TabularQuery.getResponseShape()}. */
+   void reportResponseShape(Object shape, boolean truncated) {
+      this.shapeToReport = shape;
+      this.shapeTruncated = truncated;
+   }
+
+   /** Mirrors what {@code AbstractQueryRunner.logException} leaves in {@code CoreTool}'s per-thread
+    *  user-message list when the connector recovered a real exception during the probe. */
+   void reportException(String message) {
+      this.exceptionToReport = message;
+   }
+
+   private Object shapeToReport;
+   private boolean shapeTruncated;
+   private String exceptionToReport;
+
+   /** Mirrors {@code RestJsonQuery.getValidJsonPath()} exactly, so the reflective row-path lookup
+    *  in {@code WorksheetTableService} finds it here the same way it finds it on a real connector. */
+   public String getValidJsonPath() {
+      return jsonPath == null || jsonPath.isBlank() ? "$" : jsonPath;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceEmptyResultMessageTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceEmptyResultMessageTest.java
@@ -1,0 +1,360 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.schema.XTypeNode;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.uql.util.Config;
+import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.portal.controller.database.QueryManagerService;
+import inetsoft.web.wiz.model.WorksheetTableRequest;
+import inetsoft.web.wiz.model.WorksheetTableResponse;
+import inetsoft.web.wiz.model.WorksheetTablesResponse;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * The two-branch empty-columns message ({@code WorksheetTableService.emptyColumnsMessage}):
+ * whether {@code TabularQuery.getResponseShape()} is non-null decides whether the probe's zero
+ * columns mean "the request never got a parseable response" (today's parameters/credentials
+ * wording, unchanged) or "the request succeeded and genuinely selected zero rows" (new wording,
+ * carrying the response shape, the row path in effect, and any recovered connector exception).
+ *
+ * <p>Same skeleton as {@code WorksheetTableServiceProbeHintTest} -- same {@code TestConfig}, same
+ * {@code service(...)} helper -- adapted to (1) pre-configure the {@code FakeNamedConnectorQuery}
+ * fixture BEFORE the build, since the shape/exception a real connector would have left behind must
+ * be in place before {@code loadOutputColumns} runs, and (2) support more than one table per batch,
+ * needed only by the cross-table leak test below.</p>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, WorksheetTableServiceEmptyResultMessageTest.TestConfig.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceEmptyResultMessageTest {
+   @Configuration
+   static class TestConfig {
+      @Bean
+      public Config config() {
+         Config config = mock(Config.class);
+         when(config.getResourceBundle(ArgumentMatchers.any())).thenReturn(null);
+         return config;
+      }
+   }
+
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+   private static final Principal USER = mock(Principal.class);
+
+   private static WorksheetTableResponse only(WorksheetTablesResponse response) {
+      assertEquals(1, response.getTables().size(), "expected exactly one table result");
+      return response.getTables().get(0);
+   }
+
+   private WorksheetTableService service(XRepository xrepository,
+                                         DataSourceService dataSourceService,
+                                         SecurityEngine securityEngine)
+      throws Exception
+   {
+      // Stubbed (unlike WorksheetTableServiceProbeHintTest's identical helper) because this test
+      // class, unlike that one, also builds a genuinely successful table (A8) -- createTables then
+      // reaches WsServiceHelper.persistWorksheet, which dereferences getAssetRepository() directly.
+      // Harmless for the failure-path tests: a rolled-back table never gets that far.
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      when(assetRepository.containsEntry(any())).thenReturn(true);
+      when(viewsheetService.getAssetRepository()).thenReturn(assetRepository);
+
+      return new WorksheetTableService(viewsheetService, mock(MetadataApiService.class),
+         mock(InnerJoinService.class), mock(LayoutGraphService.class),
+         mock(QueryManagerService.class), xrepository, new ObjectMapper(), dataSourceService,
+         securityEngine);
+   }
+
+   /**
+    * Build one tabular table per fixture given, all in one {@code createTables} batch, against a
+    * shared mocked {@code myds} data source. Each fixture is expected to have already been
+    * configured (shape/exception/output columns) by the caller -- unlike
+    * {@code WorksheetTableServiceProbeHintTest.build}, which constructs its own fixture, this one
+    * takes pre-built fixtures because the whole point here is to control what a real connector's
+    * probe would have left on the query BEFORE {@code loadOutputColumns} runs.
+    */
+   private WorksheetTablesResponse build(FakeNamedConnectorQuery... queries) throws Exception {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                          eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("myds"))).thenReturn(ds);
+
+      StringBuilder tablesJson = new StringBuilder();
+
+      for(int i = 0; i < queries.length; i++) {
+         if(i > 0) {
+            tablesJson.append(",");
+         }
+
+         tablesJson.append("""
+            { "tableName": "t%d", "tableType": "tabular table",
+              "tabularSource": { "datasourcePath": "myds", "queryParams": { "endpoint": "Repos" } } }
+            """.formatted(i + 1));
+      }
+
+      WorksheetTableRequest request =
+         MAPPER.readValue("{ \"tables\": [ " + tablesJson + " ] }", WorksheetTableRequest.class);
+
+      try(MockedStatic<TabularUtil> tabularUtil =
+             mockStatic(TabularUtil.class, CALLS_REAL_METHODS))
+      {
+         TabularQuery first = queries[0];
+         TabularQuery[] rest = Arrays.copyOfRange(queries, 1, queries.length);
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("myds"))).thenReturn(first, rest);
+
+         return service(xrepository, dataSourceService, securityEngine).createTables(request, USER);
+      }
+   }
+
+   // ─── A1: shape present -> success-framed message ──────────────────────────────────────────
+
+   @Test
+   void shapePresentReportsSuccessAndTheShape() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("data", List.of()), false);
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains("completed successfully"),
+         "shape present must state the request succeeded: " + message);
+      // Not a broad contains("credentials") -- the A1 branch legitimately says "this is not a
+      // connection or credentials problem" as reassurance, which contains the word without
+      // repeating the A2 branch's actual guidance. The sentinel below is A2's specific advisory
+      // phrase; see shapePresenceAloneFlipsTheMessageBranch for the exact mutual-exclusion check.
+      assertFalse(message.contains("credentials are valid"),
+         "the success-framed branch must not repeat the A2 branch's credentials guidance: " +
+            message);
+      assertTrue(message.contains("data="),
+         "the rendered response shape must appear in the message: " + message);
+   }
+
+   @Test
+   void shapePresentWithRowPathNamesThePathInEffect() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("data", List.of()), false);
+      query.setJsonPath("$.data[*]");
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains("Rows were read from '$.data[*]'"),
+         "the effective row path must be named in the message: " + message);
+   }
+
+   @Test
+   void truncatedShapeIsFlagged() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("data", List.of()), true);
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains("capped"),
+         "a truncated shape must say so, per TabularQuery's own not-present/not-reached " +
+            "distinction: " + message);
+   }
+
+   // ─── A2: shape absent -> unchanged wording ─────────────────────────────────────────────────
+
+   @Test
+   void noShapeKeepsTodaysWording() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains(
+         "Check them against GET /api/wiz/tabular/query-schema"),
+         "the no-shape branch's wording must be preserved verbatim for existing consumers: " +
+            message);
+   }
+
+   // ─── A9: the no-shape behaviour generalizes past SERVER_FILE to any connector that never ──
+   // ─── populates a shape, including a generic non-endpoint REST source (reconcile amendment) ─
+
+   /**
+    * BR1 (the verifier's plan, {@code test/docs/tabular/2026-08-25-tabular-module-test-plan.md}
+    * §3.3.1) asserted this invariant for {@code SERVER_FILE} specifically. The architect's task 5
+    * found the affected surface is wider: a generic non-endpoint REST source (plain
+    * {@code RestJsonQuery}, base {@code RestJsonQueryRunner.runStream()} with no
+    * {@code shapeResponse} call) never populates a shape either, even on a genuine, parseable,
+    * zero-row success — same as {@code SERVER_FILE}/OneDrive.
+    *
+    * <p>One fixture suffices for all three: {@code emptyColumnsMessage} never inspects connector
+    * type, only {@code query.getResponseShape() == null}, which the design confirmed is
+    * non-null if and only if {@code EndpointJsonQueryRunner.shapeResponse} ran. Nothing here
+    * distinguishes SERVER_FILE (no {@code getValidJsonPath()} method at all) from a generic REST
+    * source (has the method, but nothing ever calls {@code setResponseShape}) -- the reflective
+    * {@code effectiveRowPath} lookup is not even reached on this branch, since the no-shape branch
+    * returns before calling it. So the load-bearing thing to prove is the invariant itself: no
+    * shape, whatever the reason, must never crash and must never claim success.</p>
+    */
+   @Test
+   void noShapeBehavesTheSameForAnyConnectorThatNeverPopulatesOne() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      WorksheetTableResponse response = only(build(query));
+
+      assertFalse(response.isSuccess(),
+         "zero columns must never become a successful build (C1), regardless of connector kind");
+      String message = response.getErrorMessage();
+      assertNotNull(message, "the no-shape path must produce a readable message, not a crash");
+      assertFalse(message.contains("completed successfully"),
+         "a connector that never reports a shape must not be told it succeeded: " + message);
+      assertTrue(message.contains("credentials are valid"), message);
+   }
+
+   // ─── A3 + A6: recovered exception detail, sanitized to one line ───────────────────────────
+
+   @Test
+   void exceptionDetailReachesTheNoShapeMessage() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportException("timeout");
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains("The connector reported: Error executing Rest query: timeout"),
+         "the recovered exception detail must reach the thrown message: " + message);
+      assertFalse(message.contains("\n"), "the thrown message must never contain a newline " +
+         "-- rootMessage() truncates at the first one: " + message);
+      assertFalse(message.contains("\r"), message);
+   }
+
+   @Test
+   void exceptionDetailReachesTheShapePresentMessageToo() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("data", List.of()), false);
+      query.reportException("timeout");
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains("completed successfully"), message);
+      assertTrue(message.contains("The connector reported"), message);
+      assertFalse(message.contains("\n"), message);
+   }
+
+   // ─── Pairwise swap (reconcile amendment 1): the two branches must actually differ ──────────
+
+   /**
+    * Two fixtures identical but for {@code getResponseShape()} nullity. Run as separate tests (as
+    * the cases above are), a future reword that drops "credentials" from BOTH branches would pass
+    * every substring assertion above vacuously without anyone noticing the branches had drifted
+    * into agreement. This one catches exactly that: it fails unless the two messages differ AND
+    * the no-shape sentinel appears in exactly one of them.
+    */
+   @Test
+   void shapePresenceAloneFlipsTheMessageBranch() throws Exception {
+      FakeNamedConnectorQuery withShape = new FakeNamedConnectorQuery();
+      withShape.reportResponseShape(Map.of("data", List.of()), false);
+      FakeNamedConnectorQuery withoutShape = new FakeNamedConnectorQuery();
+
+      String withShapeMessage = only(build(withShape)).getErrorMessage();
+      String withoutShapeMessage = only(build(withoutShape)).getErrorMessage();
+
+      assertNotEquals(withShapeMessage, withoutShapeMessage,
+         "shape presence alone must change the message");
+
+      boolean shapeHasSentinel = withShapeMessage.contains("credentials are valid");
+      boolean noShapeHasSentinel = withoutShapeMessage.contains("credentials are valid");
+      assertTrue(noShapeHasSentinel ^ shapeHasSentinel,
+         "the credentials sentinel must appear in exactly one branch's message -- shape: " +
+            withShapeMessage + " | no-shape: " + withoutShapeMessage);
+      assertTrue(noShapeHasSentinel, "the no-shape branch is the one that must carry it");
+   }
+
+   // ─── A7: a stale message from an earlier table in the same batch must not leak forward ────
+
+   @Test
+   void exceptionFromOneTableIsNotAttributedToTheNext() throws Exception {
+      FakeNamedConnectorQuery firstTable = new FakeNamedConnectorQuery();
+      firstTable.reportException("first table's own failure");
+
+      FakeNamedConnectorQuery secondTable = new FakeNamedConnectorQuery();
+      secondTable.reportResponseShape(Map.of("data", List.of()), false);
+
+      WorksheetTablesResponse response = build(firstTable, secondTable);
+      assertEquals(2, response.getTables().size());
+
+      String secondMessage = response.getTables().get(1).getErrorMessage();
+      assertFalse(secondMessage.contains("first table's own failure"),
+         "table 2's message must not carry table 1's recovered exception: " + secondMessage);
+      assertTrue(secondMessage.contains("completed successfully"), secondMessage);
+   }
+
+   // ─── A8: a successful build is unaffected by the new clearUserMessage() call ──────────────
+
+   @Test
+   void successfulBuildIsUnaffectedByTheClear() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      XTypeNode idColumn = XSchema.createPrimitiveType(XSchema.STRING);
+      idColumn.setName("id");
+      query.setOutputColumns(new XTypeNode[] { idColumn });
+
+      WorksheetTableResponse response = only(build(query));
+
+      assertTrue(response.isSuccess(), "columns present must still succeed: " +
+         response.getErrorMessage());
+      assertNull(response.getErrorMessage());
+      assertNotNull(response.getColumns());
+      assertEquals(1, response.getColumns().size());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceEmptyResultMessageTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceEmptyResultMessageTest.java
@@ -175,7 +175,16 @@ class WorksheetTableServiceEmptyResultMessageTest {
       FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
       query.reportResponseShape(Map.of("data", List.of()), false);
 
-      String message = only(build(query)).getErrorMessage();
+      WorksheetTableResponse response = only(build(query));
+      // C1, named explicitly (review round 1): every other test on this branch asserts on
+      // getErrorMessage() without checking isSuccess() first, so a future "don't throw when a
+      // shape exists" regression would surface as an uninformative NPE rather than a named
+      // charter-C1 failure. This is the shape-present sibling of the check
+      // noShapeBehavesTheSameForAnyConnectorThatNeverPopulatesOne already has on the no-shape branch.
+      assertFalse(response.isSuccess(),
+         "C1: zero rows must never become a successful build, even when a shape was recovered");
+
+      String message = response.getErrorMessage();
 
       assertTrue(message.contains("completed successfully"),
          "shape present must state the request succeeded: " + message);
@@ -212,6 +221,105 @@ class WorksheetTableServiceEmptyResultMessageTest {
       assertTrue(message.contains("capped"),
          "a truncated shape must say so, per TabularQuery's own not-present/not-reached " +
             "distinction: " + message);
+   }
+
+   // ─── R1-1 (review round 1, blocker): connector-/caller-controlled text embedded in the ────
+   // ─── message must never carry a raw newline through to the thrown message ─────────────────
+
+   /**
+    * {@code JsonShapeDistiller} replaces every leaf VALUE with a fixed type-name literal, but
+    * carries a response's real field NAMES through verbatim as map keys. A JSON object key may
+    * legally contain a literal newline ({@code {"a\nb": []}} is valid JSON), and {@code
+    * Map.toString()} renders it raw. Built directly here rather than routed through the real
+    * distiller -- the point is that {@code emptyColumnsMessage} sanitizes whatever shape it is
+    * given, not that the distiller happens not to produce this today.
+    */
+   @Test
+   void shapeKeyWithEmbeddedNewlineIsSanitized() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("a\nb", List.of()), false);
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertFalse(message.contains("\n"),
+         "an embedded newline in a shape's field name must not reach the thrown message -- " +
+            "rootMessage() truncates at the first one: " + message);
+      assertFalse(message.contains("\r"), message);
+      assertTrue(message.contains("Parameters sent"),
+         "text that would follow the injected newline must survive sanitizing, not be silently " +
+            "truncated: " + message);
+   }
+
+   /**
+    * The row path comes from the connector's {@code getValidJsonPath()}, which on a real connector
+    * returns the caller-supplied {@code jsonPath} from {@code queryParams} -- caller-controlled
+    * text, independent of anything the response itself contains.
+    */
+   @Test
+   void rowPathWithEmbeddedNewlineIsSanitized() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("data", List.of()), false);
+      query.setJsonPath("$.data[*]\nX-Injected: not really a header");
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertFalse(message.contains("\n"),
+         "an embedded newline in the caller-supplied row path must not reach the thrown " +
+            "message: " + message);
+      assertFalse(message.contains("\r"), message);
+      assertTrue(message.contains("Parameters sent"),
+         "text that would follow the injected newline must survive sanitizing: " + message);
+   }
+
+   // ─── singleArrayFieldHint coverage (verifier finding, P4): every branch, not just the ─────
+   // ─── one-array-field fixture every other test above happens to use ─────────────────────────
+
+   @Test
+   void noArrayFieldEmitsNoHint() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("id", "string", "count", "double"), false);
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertFalse(message.contains("belong at"),
+         "a shape with no array-valued field must not guess a hint: " + message);
+   }
+
+   @Test
+   void twoArrayFieldsAreAmbiguousAndEmitNoHint() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("data", List.of(), "errors", List.of()), false);
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertFalse(message.contains("belong at"),
+         "two candidate array fields is ambiguous -- per D2, omit rather than guess: " + message);
+   }
+
+   @Test
+   void nestedArrayIsNotDetectedAtTheTopLevel() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(Map.of("envelope", Map.of("data", List.of())), false);
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertFalse(message.contains("belong at"),
+         "an array nested below the top level must not be guessed at -- no false positive, " +
+            "no invented path: " + message);
+   }
+
+   @Test
+   void bareTopLevelArrayShapeHintsTheRootPath() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      query.reportResponseShape(List.of(Map.of("id", "string")), false);
+      // Deliberately mismatched, so the hint (root path "$") differs from the row path in effect
+      // and is therefore not suppressed by singleArrayFieldHint's "nothing new to say" check.
+      query.setJsonPath("$.wrong");
+
+      String message = only(build(query)).getErrorMessage();
+
+      assertTrue(message.contains("The rows look like they belong at '$'"),
+         "a shape that is itself a top-level array must hint the root path: " + message);
    }
 
    // ─── A2: shape absent -> unchanged wording ─────────────────────────────────────────────────


### PR DESCRIPTION
`buildTabularTable` throws a single message when the column-discovery probe
returns zero columns, and that message names the parameters and the credentials
as the suspects. The commonest real cause is neither: the request succeeded and
the endpoint has no rows under the parameters given — an ordinary outcome for a
date-filtered query.

Reproduced against a live Stripe account. `GET /v1/payment_intents` returned
HTTP 200 with an empty `data` array; every suspect the message named was
innocent. A caller acting on it concluded the data source was unusable and
rebuilt the table against an unrelated local file instead.

The evidence needed to tell the two cases apart was already at the throw site
and never read. `EndpointJsonQueryRunner` records the response shape before the
row path narrows it, and `TabularHandler.execute` copies that shape back onto
the caller's own query unconditionally, above the success/failure branch — so
`getResponseShape()` is non-null exactly when the request returned a parseable
body. `applyResponseShape` already reads the same slot, but only on the success
path.

## Changes

- `emptyColumnsMessage` splits the message on that signal. The no-shape branch
  keeps today's wording verbatim, so a caller matching on it still matches. The
  shape-present branch states that the request succeeded, carries the recorded
  shape, names the row path in effect, and says that zero rows means zero
  columns.
- The row path is read reflectively, so `core` gains no compile-time dependency
  on a connector type. A constant-pool assertion in
  `CoreHasNoConnectorKnowledgeTest` holds that boundary.
- The connector's own recovered exception message is appended to both branches,
  sanitized to a single line: `rootMessage` truncates at the first newline and
  `UserMessage.merge` joins with one, so an unsanitized suffix would be cut.
- `CoreTool`'s user-message list is thread-local and nothing cleared it between
  tables in one `createTables` batch, so one table's connector error could be
  reported as the next table's cause. It is now cleared before the probe.

## Behaviour that does not change

Zero rows still fails the build. For a JSON REST endpoint columns are derived
from the rows returned, so admitting a zero-column table would only move the
failure downstream into binding, where it reads as an unknown-field error.

A `SERVER_FILE` or generic non-endpoint REST source takes the no-shape branch
even on a genuine zero-row success — only `EndpointJsonQueryRunner` records a
shape, and the base `RestJsonQueryRunner` does not. Tests pin that behaviour so
a later change to it is deliberate.

## Tests

`WorksheetTableServiceEmptyResultMessageTest` (10 cases) covers both branches,
the recovered detail on each, the single-line guarantee, the cross-table
attribution leak, the unchanged success path, and a pairwise case asserting
that shape presence alone flips the branch. 148 tests across every
`WorksheetTableService*Test` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
