### PR TITLE
feat(wiz): add viewsheet export endpoint (Redmine #76516 sub-cap 1)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -19,13 +19,18 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.web.AutoSaveUtils;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
 import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -37,14 +42,19 @@ import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.MessageException;
 import inetsoft.web.composer.ws.dialog.WorksheetPropertyDialogService;
 import inetsoft.web.adhoc.model.FontInfo;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.script.ScriptImageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.security.Principal;
 import java.util.Base64;
 import java.util.List;
@@ -90,7 +100,9 @@ public class ViewsheetAssemblyAgentController {
                                    LayoutReadService layoutReadService,
                                    PrintDeviceLayoutPropertyService printDeviceLayoutPropertyService,
                                    LayoutMutationService layoutMutationService,
-                                   LayoutUndoService layoutUndoService)
+                                   LayoutUndoService layoutUndoService,
+                                   VSExportService exportService,
+                                   SecurityEngine securityEngine)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -120,6 +132,8 @@ public class ViewsheetAssemblyAgentController {
       this.printDeviceLayoutPropertyService = printDeviceLayoutPropertyService;
       this.layoutMutationService = layoutMutationService;
       this.layoutUndoService = layoutUndoService;
+      this.exportService = exportService;
+      this.securityEngine = securityEngine;
    }
 
    public record JoinRequest(String code) {}
@@ -312,6 +326,107 @@ public class ViewsheetAssemblyAgentController {
       return new ImageResponse(Base64.getEncoder().encodeToString(image.pngBytes()),
                                image.isPng() ? "png" : "svg",
                                image.width(), image.height(), image.note());
+   }
+
+   /**
+    * {@code export_viewsheet}. Produces a real downloadable export file for the live, paired
+    * runtime's CURRENT state (whatever filters/selections this session has applied) -- distinct
+    * from {@link #image}, which renders a PNG for the calling agent's own inspection, not a
+    * user-deliverable file. Delegates to {@link VSExportService#exportViewsheet}, the same
+    * primitive {@code WizViewsheetExportController} already uses for a composed dashboard's own
+    * export, but against THIS session's already-resolved {@link RuntimeViewsheet} rather than
+    * reopening one from an asset identifier.
+    *
+    * <p>Writes the exported bytes directly to {@code servletResponse} (same
+    * {@code Content-Type}/{@code Content-Disposition} shape the human Viewer's own export
+    * download gets, and the same direct-servlet-write pattern {@code WizViewsheetExportController}
+    * already uses -- see its own comment for why: no combination of this app's registered
+    * {@code HttpMessageConverter}s can write an arbitrary byte[]/Resource body as e.g.
+    * {@code application/pdf}) rather than base64-encoding into a JSON body. A base64 JSON
+    * envelope would force the whole file through the calling agent's own token budget just to
+    * relay it to disk -- StyleBI's UI export was already a plain byte stream; this endpoint
+    * matches that instead of wrapping it. Returning {@code null} tells Spring MVC the response is
+    * already fully handled.
+    *
+    * <p>{@code target} (a single table/chart assembly) is only supported for {@code format=PNG}
+    * so far, reusing {@link #image}'s own {@link ScriptImageService#getAssemblyImage} -- a single
+    * table/chart to Excel/CSV/PDF/PowerPoint/HTML/Snapshot needs a materially different mechanism
+    * ({@code AssemblyImageServiceProxy}'s cluster-aware table/chart export, per
+    * {@code ExportController}'s own {@code /export/vs-table}/{@code /export/vs-chart} split) not
+    * yet wired here; refused by name rather than silently exporting the whole sheet instead.
+    */
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/export")
+   public ResponseEntity<?> export(@PathVariable String sessionToken,
+                                   @RequestParam String format,
+                                   @RequestParam(required = false) String target,
+                                   @RequestParam(required = false) Boolean match,
+                                   @RequestParam(required = false) Boolean expandSelections,
+                                   @RequestParam(required = false) Boolean current,
+                                   Principal user, HttpServletResponse servletResponse)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET_TOOLBAR_ACTION, "Export",
+                                         ResourceAction.READ))
+      {
+         throw new SecurityException("No permission for viewsheet export.");
+      }
+
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      int formatType = toFormatType(format);
+
+      if(target != null && !target.isBlank()) {
+         if(formatType != FileFormatInfo.EXPORT_TYPE_PNG) {
+            throw new IllegalArgumentException(
+               "export_viewsheet: 'target' is only supported with format=PNG for now (a single " +
+               "table/chart export to Excel/PowerPoint/PDF/HTML/CSV is not yet implemented) -- " +
+               "omit 'target' to export the whole viewsheet in '" + format + "', or use " +
+               "get_viewsheet_image for a PNG preview of just this assembly.");
+         }
+
+         ScriptImageService.ChartImage image = imageService.getAssemblyImage(rvs, target, null, null, user);
+         writeAttachment(servletResponse, image.pngBytes(), "image/png", target + ".png");
+         return null;
+      }
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      exportService.exportViewsheet(rvs, formatType, match == null || match,
+         expandSelections != null && expandSelections, current == null || current, false, false,
+         new String[0], false, new ExportResponse(out), user);
+
+      writeAttachment(servletResponse, out.toByteArray(), VSExportService.getMime(formatType),
+         "export." + VSExportService.getSuffix(formatType));
+      return null;
+   }
+
+   private static void writeAttachment(HttpServletResponse response, byte[] bytes, String mime,
+                                       String filename) throws IOException
+   {
+      response.setContentType(mime);
+      response.setHeader("Content-Disposition",
+         ContentDisposition.attachment().filename(filename).build().toString());
+      response.setContentLength(bytes.length);
+      response.getOutputStream().write(bytes);
+      response.getOutputStream().flush();
+   }
+
+   private static int toFormatType(String format) {
+      if(format != null) {
+         switch(format.toLowerCase()) {
+            case "excel": return FileFormatInfo.EXPORT_TYPE_EXCEL;
+            case "powerpoint": return FileFormatInfo.EXPORT_TYPE_POWERPOINT;
+            case "pdf": return FileFormatInfo.EXPORT_TYPE_PDF;
+            case "png": return FileFormatInfo.EXPORT_TYPE_PNG;
+            case "html": return FileFormatInfo.EXPORT_TYPE_HTML;
+            case "csv": return FileFormatInfo.EXPORT_TYPE_CSV;
+            case "snapshot": return FileFormatInfo.EXPORT_TYPE_SNAPSHOT;
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "export_viewsheet: 'format' must be one of Excel, PowerPoint, PDF, PNG, HTML, CSV, " +
+         "Snapshot, got '" + format + "'.");
    }
 
    public record PropertyPatchRequest(String assembly, Map<String, Object> properties) {}
@@ -1642,4 +1757,6 @@ public class ViewsheetAssemblyAgentController {
    private final PrintDeviceLayoutPropertyService printDeviceLayoutPropertyService;
    private final LayoutMutationService layoutMutationService;
    private final LayoutUndoService layoutUndoService;
+   private final VSExportService exportService;
+   private final SecurityEngine securityEngine;
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -18,20 +18,32 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.AssetContent;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.ByteArrayOutputStream;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -480,7 +492,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
@@ -520,7 +532,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
@@ -563,7 +575,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    /** Overload that exposes {@code broadcast} -- for the detach tab-bar-notification test. */
@@ -596,7 +608,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    /** Feature enabled, {@code sessions} and {@code conditionService} wired -- for the
@@ -633,7 +645,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    /** Feature enabled, only {@code propertyService} wired -- for the property-trio tests. */
@@ -669,7 +681,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    /** Feature enabled, only {@code hyperlinkService} wired -- for the hyperlink-targets test. */
@@ -705,7 +717,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    /**
@@ -888,7 +900,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    /** Feature enabled, {@code sessions}/{@code viewsheetService}/{@code broadcast} wired -- for the save tests. */
@@ -926,7 +938,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    // ---------------------------------------------------------------------------
@@ -2125,7 +2137,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(SheetOpenService.class),
                                           mock(LayoutSessionService.class),
                                           layoutReadService, printDeviceLayoutPropertyService,
-                                          layoutMutationService, layoutUndoService);
+                                          layoutMutationService, layoutUndoService,
+                                          mock(VSExportService.class), mock(SecurityEngine.class));
    }
 
    private static Principal principal() {
@@ -2274,6 +2287,286 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(LayoutReadService.class),
                                           mock(PrintDeviceLayoutPropertyService.class),
                                           mock(LayoutMutationService.class),
-                                          mock(LayoutUndoService.class));
+                                          mock(LayoutUndoService.class), mock(VSExportService.class), mock(SecurityEngine.class));
    }
+
+   // ---------------------------------------------------------------------------
+   // export() -- bug #76516 sub-capability 1 (Interactive Export).
+   //
+   // Writes directly to a servlet response (same direct-write pattern as
+   // WizViewsheetExportController, see that controller's own comment for why) rather than
+   // returning a JSON/base64 body -- these tests capture what gets written to a mocked
+   // HttpServletResponse instead of asserting on a return value.
+   // ---------------------------------------------------------------------------
+
+   /** A ServletOutputStream backed by a plain ByteArrayOutputStream so tests can capture what
+    *  the controller writes -- mirrors WizViewsheetExportControllerTest's own helper of the same
+    *  shape, for the same direct-servlet-write pattern. */
+   private static ServletOutputStream capturingOutputStream(ByteArrayOutputStream sink) {
+      return new ServletOutputStream() {
+         @Override
+         public boolean isReady() {
+            return true;
+         }
+
+         @Override
+         public void setWriteListener(WriteListener writeListener) {
+         }
+
+         @Override
+         public void write(int b) {
+            sink.write(b);
+         }
+      };
+   }
+
+   private static HttpServletResponse mockServletResponse(ByteArrayOutputStream written) throws Exception {
+      HttpServletResponse response = mock(HttpServletResponse.class);
+      when(response.getOutputStream()).thenReturn(capturingOutputStream(written));
+      return response;
+   }
+
+   /** Stubs {@code exportService.exportViewsheet(...)} to write {@code bytes} into the
+    *  {@link ExportResponse} argument it's called with, mimicking what the real service does. */
+   private static void stubExportBytes(VSExportService exportService, byte[] bytes) throws Exception {
+      doAnswer(invocation -> {
+         ExportResponse response = invocation.getArgument(9);
+         response.getOutputStream().write(bytes);
+         return null;
+      }).when(exportService).exportViewsheet(any(), anyInt(), anyBoolean(), anyBoolean(),
+         anyBoolean(), anyBoolean(), anyBoolean(), any(String[].class), anyBoolean(),
+         any(ExportResponse.class), any(Principal.class));
+   }
+
+   @Test
+   void export_delegatesToVSExportServiceForTheWholeViewsheet() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(rvs);
+
+      VSExportService exportService = mock(VSExportService.class);
+      byte[] fakePdf = { 1, 2, 3 };
+      stubExportBytes(exportService, fakePdf);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(Principal.class),
+         eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION), eq("Export"), eq(ResourceAction.READ)))
+         .thenReturn(true);
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, mock(inetsoft.web.wiz.script.ScriptImageService.class));
+      ByteArrayOutputStream written = new ByteArrayOutputStream();
+      HttpServletResponse servletResponse = mockServletResponse(written);
+
+      controller.export("tok", "PDF", null, true, false, true, principal(), servletResponse);
+
+      verify(exportService).exportViewsheet(eq(rvs), eq(FileFormatInfo.EXPORT_TYPE_PDF),
+         eq(true), eq(false), eq(true), eq(false), eq(false), any(String[].class), eq(false),
+         any(ExportResponse.class), any(Principal.class));
+      verify(servletResponse).setContentType("application/pdf");
+      verify(servletResponse).setContentLength(fakePdf.length);
+      assertArrayEquals(fakePdf, written.toByteArray());
+      ArgumentCaptor<String> disposition = ArgumentCaptor.forClass(String.class);
+      verify(servletResponse).setHeader(eq("Content-Disposition"), disposition.capture());
+      assertTrue(disposition.getValue().contains("export.pdf"));
+   }
+
+   /**
+    * Snapshot (.vso) writes through the exact same VSExportService#exportViewsheet byte-stream
+    * path as every other format -- it is StyleBI's own serialized-viewsheet-state format, not
+    * the unrelated MV/cube-analysis feature an earlier pass here mistook it for.
+    */
+   @Test
+   void export_supportsSnapshotFormat() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(rvs);
+
+      VSExportService exportService = mock(VSExportService.class);
+      stubExportBytes(exportService, new byte[] { 9 });
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(Principal.class),
+         eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION), eq("Export"), eq(ResourceAction.READ)))
+         .thenReturn(true);
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, mock(inetsoft.web.wiz.script.ScriptImageService.class));
+      HttpServletResponse servletResponse = mockServletResponse(new ByteArrayOutputStream());
+
+      controller.export("tok", "Snapshot", null, null, null, null, principal(), servletResponse);
+
+      verify(exportService).exportViewsheet(eq(rvs), eq(FileFormatInfo.EXPORT_TYPE_SNAPSHOT),
+         eq(true), eq(false), eq(true), eq(false), eq(false), any(String[].class), eq(false),
+         any(ExportResponse.class), any(Principal.class));
+      ArgumentCaptor<String> disposition = ArgumentCaptor.forClass(String.class);
+      verify(servletResponse).setHeader(eq("Content-Disposition"), disposition.capture());
+      assertTrue(disposition.getValue().contains("export.vso"));
+   }
+
+   @Test
+   void export_defaultsMatchAndCurrentToTrueAndExpandSelectionsToFalseWhenOmitted() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(rvs);
+
+      VSExportService exportService = mock(VSExportService.class);
+      stubExportBytes(exportService, new byte[] { 9 });
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(Principal.class),
+         eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION), eq("Export"), eq(ResourceAction.READ)))
+         .thenReturn(true);
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, mock(inetsoft.web.wiz.script.ScriptImageService.class));
+      HttpServletResponse servletResponse = mockServletResponse(new ByteArrayOutputStream());
+
+      controller.export("tok", "CSV", null, null, null, null, principal(), servletResponse);
+
+      verify(exportService).exportViewsheet(eq(rvs), eq(FileFormatInfo.EXPORT_TYPE_CSV),
+         eq(true), eq(false), eq(true), eq(false), eq(false), any(String[].class), eq(false),
+         any(ExportResponse.class), any(Principal.class));
+      // CSV's real payload is a zip archive (VSExportService#getSuffix), not a literal .csv file
+      // -- confirmed live against a real export. A wrong extension here would actively mislead
+      // once the bytes are actually saved to disk under this name.
+      ArgumentCaptor<String> disposition = ArgumentCaptor.forClass(String.class);
+      verify(servletResponse).setHeader(eq("Content-Disposition"), disposition.capture());
+      assertTrue(disposition.getValue().contains("export.zip"));
+   }
+
+   @Test
+   void export_refusesWhenPermissionDenied() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(mock(RuntimeViewsheet.class));
+
+      VSExportService exportService = mock(VSExportService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(Principal.class),
+         eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION), eq("Export"), eq(ResourceAction.READ)))
+         .thenReturn(false);
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, mock(inetsoft.web.wiz.script.ScriptImageService.class));
+
+      assertThrows(SecurityException.class,
+         () -> controller.export("tok", "PDF", null, null, null, null, principal(),
+            mock(HttpServletResponse.class)));
+      verifyNoInteractions(exportService);
+   }
+
+   @Test
+   void export_refusesAnUnrecognizedFormatWithoutCallingTheBackend() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(mock(RuntimeViewsheet.class));
+
+      VSExportService exportService = mock(VSExportService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), nullable(String.class), any()))
+         .thenReturn(true);
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, mock(inetsoft.web.wiz.script.ScriptImageService.class));
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.export("tok", "JPEG", null, null, null, null, principal(),
+            mock(HttpServletResponse.class)));
+      assertTrue(thrown.getMessage().contains("format"));
+      verifyNoInteractions(exportService);
+   }
+
+   /**
+    * A single table/chart export to anything but PNG needs {@code AssemblyImageServiceProxy}'s
+    * cluster-aware table/chart export mechanism ({@code ExportController}'s own
+    * {@code /export/vs-table}/{@code /export/vs-chart} split), not yet wired here -- refused by
+    * name rather than silently exporting the whole sheet instead.
+    */
+   @Test
+   void export_refusesATargetWithANonPngFormat() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(mock(RuntimeViewsheet.class));
+
+      VSExportService exportService = mock(VSExportService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), nullable(String.class), any()))
+         .thenReturn(true);
+      inetsoft.web.wiz.script.ScriptImageService imageService =
+         mock(inetsoft.web.wiz.script.ScriptImageService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, imageService);
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> controller.export("tok", "PDF", "Chart1", null, null, null, principal(),
+            mock(HttpServletResponse.class)));
+      assertTrue(thrown.getMessage().contains("target"));
+      verifyNoInteractions(exportService);
+      verifyNoInteractions(imageService);
+   }
+
+   @Test
+   void export_scopedToATargetWithPngFormatDelegatesToGetAssemblyImage() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(rvs);
+
+      VSExportService exportService = mock(VSExportService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), nullable(String.class), any()))
+         .thenReturn(true);
+      inetsoft.web.wiz.script.ScriptImageService imageService =
+         mock(inetsoft.web.wiz.script.ScriptImageService.class);
+      byte[] pngBytes = { 1, 2, 3 };
+      when(imageService.getAssemblyImage(eq(rvs), eq("Chart1"), isNull(), isNull(),
+         any(Principal.class)))
+         .thenReturn(new inetsoft.web.wiz.script.ScriptImageService.ChartImage(
+            pngBytes, true, 100, 100, null));
+
+      ViewsheetAssemblyAgentController controller = controllerForExport(sessions, exportService,
+         securityEngine, imageService);
+      ByteArrayOutputStream written = new ByteArrayOutputStream();
+      HttpServletResponse servletResponse = mockServletResponse(written);
+
+      controller.export("tok", "PNG", "Chart1", null, null, null, principal(), servletResponse);
+
+      assertArrayEquals(pngBytes, written.toByteArray());
+      verify(servletResponse).setContentType("image/png");
+      ArgumentCaptor<String> disposition = ArgumentCaptor.forClass(String.class);
+      verify(servletResponse).setHeader(eq("Content-Disposition"), disposition.capture());
+      assertTrue(disposition.getValue().contains("Chart1.png"));
+      verifyNoInteractions(exportService);
+   }
+
+   /** Feature enabled, only {@code sessions}/{@code exportService}/{@code securityEngine}/
+    *  {@code imageService} wired -- for the export() tests. */
+   private static ViewsheetAssemblyAgentController controllerForExport(
+      ViewsheetSessionService sessions, VSExportService exportService,
+      SecurityEngine securityEngine, inetsoft.web.wiz.script.ScriptImageService imageService)
+   {
+      return new ViewsheetAssemblyAgentController(featureOn(), mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          sessions,
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          imageService,
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class), exportService, securityEngine);
+   }
+
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -18,7 +18,6 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
-import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;


### PR DESCRIPTION
## Summary
- Adds `export()` to `ViewsheetAssemblyAgentController` (`GET /api/wiz/v1/agent/viewsheet/{sessionToken}/export`), delegating to `VSExportService#exportViewsheet` -- the same primitive `WizViewsheetExportController` already uses -- against the session's already-resolved `RuntimeViewsheet`. Supports all 7 formats StyleBI's own Export dialog offers: Excel, PowerPoint, PDF, PNG, HTML, CSV, Snapshot.
- Writes the exported bytes directly to the servlet response (same `Content-Type`/`Content-Disposition` shape the human Viewer's own export gets, and the same direct-servlet-write pattern `WizViewsheetExportController` already uses) rather than base64-encoding into a JSON body -- the companion stylebi-wiz PR (composer-chat MCP plugin) streams this straight to a local file instead of relaying it through the calling agent's own conversation/token budget.
- `target` (a single table/chart assembly) is only supported for `format=PNG` so far, reusing `ScriptImageService.getAssemblyImage` -- refused by name for other formats rather than silently exporting the whole sheet.
- Fixed in passing: the controller's own `suffixFor(CSV)` returned `"csv"`, but CSV's real payload is a zip archive (`VSExportService#getSuffix` says `"zip"` -- confirmed against a real export). Now calls `VSExportService#getMime`/`getSuffix` directly instead of maintaining a second, drifted copy of the same mapping.
- Split off from a combined export+bookmark commit; bookmark lives on a sibling branch/PR (#5141), cut from the same base commit.

## Test plan
- [x] `ViewsheetAssemblyAgentControllerTest`: 78/78 passing, capturing what gets written to a mocked `HttpServletResponse`
- [x] `core` module compiles clean
- [x] Live-verified against a real StyleBI instance via the composer MCP plugin: all 7 formats plus a `target`+PNG single-assembly export, each confirmed as a genuinely valid file of its type (opened with `file`, not just trusting the tool's own report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)