### PR TITLE
Bug #76329, add OAuth 2.0 support to Salesforce REST connectors

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/remedyforce/RemedyforceDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/remedyforce/RemedyforceDataSource.java
@@ -18,27 +18,38 @@
 package inetsoft.uql.rest.datasource.remedyforce;
 
 import inetsoft.uql.rest.datasource.salesforce.SalesforceDataSource;
-import inetsoft.uql.tabular.View;
-import inetsoft.uql.tabular.View1;
-import inetsoft.util.credential.CredentialType;
+import inetsoft.uql.tabular.*;
 
 @View(vertical = true, value = {
    @View1(value = "useCredentialId", visibleMethod = "supportToggleCredential"),
    @View1(value = "credentialId", visibleMethod = "isUseCredentialId"),
-   @View1(value = "user", visibleMethod = "useCredential"),
-   @View1(value = "password", visibleMethod = "useCredential"),
-   @View1(value = "securityToken", visibleMethod = "useCredential"),
+   @View1("authType"),
+   @View1(value = "user", visibleMethod = "useCredentialForPassword"),
+   @View1(value = "password", visibleMethod = "useCredentialForPassword"),
+   @View1(value = "securityToken", visibleMethod = "useCredentialForPassword"),
+   @View1(value = "clientId", visibleMethod = "useCredentialForOauth"),
+   @View1(value = "clientSecret", visibleMethod = "useCredentialForOauth"),
+   @View1(type = ViewType.LABEL, text = "redirect.uri.description", colspan = 2,
+          visibleMethod = "useCredentialForOauth"),
+   @View1(
+      type = ViewType.BUTTON,
+      text = "Authorize",
+      visibleMethod = "isOauth",
+      button = @Button(
+         type = ButtonType.OAUTH, method = "updateTokens", oauth = @Button.OAuth,
+         dependsOn = { "clientId", "clientSecret", "credentialId" },
+         enabledMethod = "authorizeEnabled"
+      )
+   ),
+   @View1(value = "accessToken", visibleMethod = "isOauth"),
+   @View1(value = "refreshToken", visibleMethod = "isOauth"),
+   @View1(value = "instanceUrl", visibleMethod = "isOauth"),
 })
 public class RemedyforceDataSource extends SalesforceDataSource<RemedyforceDataSource> {
    static final String TYPE = "Rest.Remedyforce";
 
    public RemedyforceDataSource() {
       super(TYPE, RemedyforceDataSource.class);
-   }
-
-   @Override
-   protected CredentialType getCredentialType() {
-      return CredentialType.PASSWORD_SECURITY_TOKEN;
    }
 
    @Override

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/salesforce/SalesforceDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/salesforce/SalesforceDataSource.java
@@ -55,6 +55,19 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
       return CredentialType.PASSWORD_OAUTH2_WITH_FLAGS;
    }
 
+   /**
+    * The base {@link AbstractRestDataSource} implementation only allows a "Use Secret ID" cloud
+    * credential for {@code AuthType.BASIC}/{@code OAUTH}, but this connector's legacy mode is
+    * {@code AuthType.NONE}. Include it so Legacy Password mode keeps the cloud-secret support it
+    * had before this class used {@code PASSWORD_OAUTH2_WITH_FLAGS} (previously
+    * {@code PASSWORD_SECURITY_TOKEN}, which always allowed it).
+    */
+   @Override
+   protected boolean supportCredentialId() {
+      AuthType type = getAuthType();
+      return type == AuthType.NONE || type == AuthType.OAUTH;
+   }
+
    // Not part of the PASSWORD_OAUTH2_WITH_FLAGS credential, so stored as a plain
    // (manually encrypted) field, same as the inherited accessToken/refreshToken fields are
    // for credential types that don't carry them.
@@ -205,6 +218,18 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
       instanceUrl = Tool.getChildValueByTagName(root, "instanceUrl");
       String token = Tool.getChildValueByTagName(root, "securityToken");
 
+      // Data sources saved before this class used PASSWORD_OAUTH2_WITH_FLAGS stored the
+      // security token nested inside the legacy <PasswordCredential> node (written by
+      // LocalSecurityTokenCredential, back when getCredentialType() was
+      // PASSWORD_SECURITY_TOKEN). Fall back to that location so upgrades don't drop it.
+      if(token == null) {
+         Element legacyCredential = Tool.getChildNodeByTagName(root, "PasswordCredential");
+
+         if(legacyCredential != null) {
+            token = Tool.getChildValueByTagName(legacyCredential, "securityToken");
+         }
+      }
+
       if(token != null) {
          securityToken = Tool.decryptPassword(token);
       }
@@ -224,12 +249,14 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
          return false;
       }
 
-      return Objects.equals(securityToken, ((SalesforceDataSource<?>) o).securityToken);
+      SalesforceDataSource<?> that = (SalesforceDataSource<?>) o;
+      return Objects.equals(securityToken, that.securityToken) &&
+         Objects.equals(instanceUrl, that.instanceUrl);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(super.hashCode(), getSecurityToken());
+      return Objects.hash(super.hashCode(), getSecurityToken(), instanceUrl);
    }
 
    private SalesforceSession getSession() {
@@ -332,7 +359,7 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
       String instanceUrl = dataSource.getInstanceUrl();
       String accessToken = dataSource.getAccessToken();
 
-      if(instanceUrl == null || accessToken == null || accessToken.isEmpty()) {
+      if(instanceUrl == null || instanceUrl.isEmpty() || accessToken == null || accessToken.isEmpty()) {
          throw new RuntimeException(
             "Salesforce OAuth authorization has not been completed for this data source");
       }

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/salesforce/SalesforceDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/salesforce/SalesforceDataSource.java
@@ -21,6 +21,7 @@ import com.github.benmanes.caffeine.cache.*;
 import inetsoft.uql.rest.auth.AuthType;
 import inetsoft.uql.rest.json.EndpointJsonDataSource;
 import inetsoft.uql.tabular.*;
+import inetsoft.uql.tabular.oauth.Tokens;
 import inetsoft.util.Tool;
 import inetsoft.util.credential.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -49,14 +50,96 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
       setAuthType(AuthType.NONE);
    }
 
+   @Override
+   protected CredentialType getCredentialType() {
+      return CredentialType.PASSWORD_OAUTH2_WITH_FLAGS;
+   }
+
+   // Not part of the PASSWORD_OAUTH2_WITH_FLAGS credential, so stored as a plain
+   // (manually encrypted) field, same as the inherited accessToken/refreshToken fields are
+   // for credential types that don't carry them.
    @Property(label = "Security Token", required = true, password = true)
-   @PropertyEditor(dependsOn = "useCredentialId")
    public String getSecurityToken() {
-      return ((SecurityTokenCredential) getCredential()).getSecurityToken();
+      return securityToken;
    }
 
    public void setSecurityToken(String securityToken) {
-      ((SecurityTokenCredential) getCredential()).setSecurityToken(securityToken);
+      this.securityToken = securityToken;
+   }
+
+   public boolean useCredentialForPassword() {
+      return useCredential() && !isOauth();
+   }
+
+   /**
+    * Restricts the inherited authentication type dropdown to the two modes this connector
+    * actually implements — {@link AuthType#BASIC}/{@code TWO_STEP}/{@code KERBEROS} are not
+    * supported here and would otherwise silently fall back to the legacy SOAP login.
+    */
+   @Override
+   @Property(label="Authentication")
+   @PropertyEditor(tags={"NONE", "OAUTH"}, labels={"Username/Password (Legacy)", "OAuth 2.0"})
+   public AuthType getAuthType() {
+      return super.getAuthType();
+   }
+
+   @Override
+   @PropertyEditor(enabled = false, dependsOn = "useCredentialId")
+   public String getAuthorizationUri() {
+      return getOAuthHostUrl() + "/services/oauth2/authorize";
+   }
+
+   @Override
+   public void setAuthorizationUri(String authorizationUri) {
+      // computed from the login URL; not directly editable
+   }
+
+   @Override
+   @PropertyEditor(enabled = false, dependsOn = "useCredentialId")
+   public String getTokenUri() {
+      return getOAuthHostUrl() + "/services/oauth2/token";
+   }
+
+   @Override
+   public void setTokenUri(String tokenUri) {
+      // computed from the login URL; not directly editable
+   }
+
+   @Override
+   @PropertyEditor(enabled = false, dependsOn = "useCredentialId")
+   public String getScope() {
+      String scope = super.getScope();
+      return scope == null || scope.isEmpty() ? "api refresh_token" : scope;
+   }
+
+   @Override
+   @PropertyEditor(enabled = false, dependsOn = "useCredentialId")
+   public String getOauthFlags() {
+      // Salesforce Connected/External Client Apps require PKCE for the Authorization Code flow.
+      return "pkce";
+   }
+
+   /**
+    * Captures the {@code instance_url} that Salesforce returns alongside the access/refresh
+    * tokens (a non-standard OAuth field), in addition to the standard token bookkeeping.
+    */
+   @Override
+   public void updateTokens(Tokens tokens) {
+      super.updateTokens(tokens);
+
+      if(tokens.properties() != null && tokens.properties().get("instance_url") != null) {
+         setInstanceUrl(String.valueOf(tokens.properties().get("instance_url")));
+      }
+   }
+
+   @Property(label = "Instance URL")
+   @PropertyEditor(enabled = false)
+   public String getInstanceUrl() {
+      return instanceUrl;
+   }
+
+   public void setInstanceUrl(String instanceUrl) {
+      this.instanceUrl = instanceUrl;
    }
 
    @Override
@@ -92,6 +175,41 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
       return "https://login.salesforce.com/services/Soap/u/35.0";
    }
 
+   /**
+    * @return the scheme+host portion of {@link #getLoginUrl()}, used to derive the OAuth
+    *         authorization/token endpoints for the same org (production, sandbox, etc).
+    */
+   private String getOAuthHostUrl() {
+      String loginUrl = getLoginUrl();
+      int index = loginUrl.indexOf("/services/");
+      return index < 0 ? loginUrl : loginUrl.substring(0, index);
+   }
+
+   @Override
+   public void writeContents(PrintWriter writer) {
+      super.writeContents(writer);
+
+      if(instanceUrl != null) {
+         writer.format("<instanceUrl><![CDATA[%s]]></instanceUrl>%n", instanceUrl);
+      }
+
+      if(securityToken != null) {
+         writer.format(
+            "<securityToken><![CDATA[%s]]></securityToken>%n", Tool.encryptPassword(securityToken));
+      }
+   }
+
+   @Override
+   public void parseContents(Element root) throws Exception {
+      super.parseContents(root);
+      instanceUrl = Tool.getChildValueByTagName(root, "instanceUrl");
+      String token = Tool.getChildValueByTagName(root, "securityToken");
+
+      if(token != null) {
+         securityToken = Tool.decryptPassword(token);
+      }
+   }
+
    @Override
    public boolean equals(Object o) {
       if(this == o) {
@@ -102,7 +220,11 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
          return false;
       }
 
-      return super.equals(o);
+      if(!super.equals(o)) {
+         return false;
+      }
+
+      return Objects.equals(securityToken, ((SalesforceDataSource<?>) o).securityToken);
    }
 
    @Override
@@ -120,6 +242,10 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
    }
 
    private static SalesforceSession createSession(SalesforceDataSource dataSource) {
+      if(dataSource.getAuthType() == AuthType.OAUTH) {
+         return createOAuthSession(dataSource);
+      }
+
       byte[] content;
 
       try {
@@ -198,6 +324,27 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
       }
    }
 
+   /**
+    * Builds a session from the OAuth 2.0 access token, instead of SOAP {@code login()}.
+    */
+   private static SalesforceSession createOAuthSession(SalesforceDataSource dataSource) {
+      dataSource.refreshTokens();
+      String instanceUrl = dataSource.getInstanceUrl();
+      String accessToken = dataSource.getAccessToken();
+
+      if(instanceUrl == null || accessToken == null || accessToken.isEmpty()) {
+         throw new RuntimeException(
+            "Salesforce OAuth authorization has not been completed for this data source");
+      }
+
+      int index = instanceUrl.indexOf("/services/");
+      String serverUrl = index < 0 ?
+         URI.create(instanceUrl).resolve("/services").toString() :
+         instanceUrl.substring(0, index + 9);
+
+      return new SalesforceSession(serverUrl, accessToken);
+   }
+
    private static final class SalesforceSession {
       SalesforceSession(String url, String sessionId) {
          this.url = url;
@@ -225,4 +372,7 @@ public abstract class SalesforceDataSource<SELF extends SalesforceDataSource<SEL
          .maximumSize(20)
          .build(SalesforceDataSource::createSession);
    }
+
+   private String instanceUrl;
+   private String securityToken;
 }

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/sfreports/SalesforceReportsDataSource.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/sfreports/SalesforceReportsDataSource.java
@@ -20,7 +20,6 @@ package inetsoft.uql.rest.datasource.sfreports;
 import inetsoft.uql.rest.datasource.salesforce.SalesforceDataSource;
 import inetsoft.uql.tabular.*;
 import inetsoft.util.Tool;
-import inetsoft.util.credential.CredentialType;
 import org.w3c.dom.Element;
 
 import java.io.PrintWriter;
@@ -31,20 +30,33 @@ import java.util.Objects;
    @View1(value = "credentialId", visibleMethod = "isUseCredentialId"),
    @View1("accountType"),
    @View1("apiVersion"),
-   @View1(value = "user", visibleMethod = "useCredential"),
-   @View1(value = "password", visibleMethod = "useCredential"),
-   @View1(value = "securityToken", visibleMethod = "useCredential")
+   @View1("authType"),
+   @View1(value = "user", visibleMethod = "useCredentialForPassword"),
+   @View1(value = "password", visibleMethod = "useCredentialForPassword"),
+   @View1(value = "securityToken", visibleMethod = "useCredentialForPassword"),
+   @View1(value = "clientId", visibleMethod = "useCredentialForOauth"),
+   @View1(value = "clientSecret", visibleMethod = "useCredentialForOauth"),
+   @View1(type = ViewType.LABEL, text = "redirect.uri.description", colspan = 2,
+          visibleMethod = "useCredentialForOauth"),
+   @View1(
+      type = ViewType.BUTTON,
+      text = "Authorize",
+      visibleMethod = "isOauth",
+      button = @Button(
+         type = ButtonType.OAUTH, method = "updateTokens", oauth = @Button.OAuth,
+         dependsOn = { "clientId", "clientSecret", "credentialId" },
+         enabledMethod = "authorizeEnabled"
+      )
+   ),
+   @View1(value = "accessToken", visibleMethod = "isOauth"),
+   @View1(value = "refreshToken", visibleMethod = "isOauth"),
+   @View1(value = "instanceUrl", visibleMethod = "isOauth"),
 })
 public class SalesforceReportsDataSource extends SalesforceDataSource<SalesforceReportsDataSource> {
    static final String TYPE = "Rest.SalesforceReports";
 
    public SalesforceReportsDataSource() {
       super(TYPE, SalesforceReportsDataSource.class);
-   }
-
-   @Override
-   protected CredentialType getCredentialType() {
-      return CredentialType.PASSWORD_SECURITY_TOKEN;
    }
 
    @Property(label = "Account Type", required = true)

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/remedyforce/Bundle.properties
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/remedyforce/Bundle.properties
@@ -18,6 +18,7 @@
 
 Rest.Remedyforce=Remedyforce
 inetsoft.uql.rest.datasource.remedyforce.RemedyforceDataSource.description=Runs queries against the Remedyforce APIs.
+redirect.uri.description=You must use https://data.inetsoft.com/oauth as the redirect URL for your application.
 User=User
 Password=Password
 Security\ Token=Security Token

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/sfreports/Bundle.properties
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/sfreports/Bundle.properties
@@ -18,6 +18,7 @@
 
 Rest.SalesforceReports=Salesforce Reports and Dashboards
 inetsoft.uql.rest.datasource.sfreports.SalesforceReportsDataSource.description=Runs queries against the Salesforce Reports and Dashboards APIs.
+redirect.uri.description=You must use https://data.inetsoft.com/oauth as the redirect URL for your application.
 Account\ Type=Account Type
 Developer=Developer
 Enterprise/Professional=Enterprise/Professional

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/datasource/remedyforce/RemedyforceDataSourceTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/datasource/remedyforce/RemedyforceDataSourceTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.datasource.remedyforce;
+
+import inetsoft.test.SreeHome;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SreeHome
+class RemedyforceDataSourceTest {
+   /**
+    * Data sources saved before the shared {@code SalesforceDataSource} base class switched to
+    * {@code CredentialType.PASSWORD_OAUTH2_WITH_FLAGS} persisted their security token nested
+    * inside the legacy {@code <PasswordCredential>} node (written by the old
+    * {@code LocalSecurityTokenCredential}). Upgrading must not silently drop it.
+    */
+   @Test
+   void legacySecurityTokenIsMigratedFromPasswordCredentialNode() throws Exception {
+      String xml =
+         "<ds_" + RemedyforceDataSource.TYPE + " name=\"test\">" +
+         "<PasswordCredential class=\"inetsoft.util.credential.LocalSecurityTokenCredential\">" +
+         "<user><![CDATA[myuser]]></user>" +
+         "<password><![CDATA[" + Tool.encryptPassword("mypassword") + "]]></password>" +
+         "<securityToken><![CDATA[" + Tool.encryptPassword("mytoken") + "]]></securityToken>" +
+         "</PasswordCredential>" +
+         "</ds_" + RemedyforceDataSource.TYPE + ">";
+
+      Element root = parse(xml);
+      RemedyforceDataSource dataSource = new RemedyforceDataSource();
+      dataSource.parseXML(root);
+
+      assertEquals("myuser", dataSource.getUser());
+      assertEquals("mypassword", dataSource.getPassword());
+      assertEquals("mytoken", dataSource.getSecurityToken());
+   }
+
+   private Element parse(String xml) throws Exception {
+      Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+         .parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+      return document.getDocumentElement();
+   }
+}


### PR DESCRIPTION
## Summary

Salesforce is retiring the SOAP `login()` API operation (Summer '27). This adds OAuth 2.0 Authorization Code flow as an alternative authentication method for `SalesforceDataSource`, `RemedyforceDataSource`, and `SalesforceReportsDataSource`, alongside the existing username/password login for backward compatibility.

## Root Cause

These connectors authenticate exclusively via the SOAP `login()` operation, which Salesforce is fully retiring. Once retired, there will be no admin workaround — connections will simply fail.

## Fix

- Added an `Authentication` toggle (Password / OAuth 2.0) to each connector's data source configuration, reusing the existing `PASSWORD_OAUTH2_WITH_FLAGS` credential type
- OAuth uses the customer's own Salesforce Connected App / External Client App (Client ID + Secret typed into the data source UI), since Salesforce requires org-specific login URLs (production/sandbox/custom domain) that a single shared app can't support
- PKCE is required by Salesforce's OAuth implementation and is now enabled automatically
- `SalesforceDataSource.createSession()` branches: OAuth mode builds the session directly from the access token + Salesforce's `instance_url` (captured from the non-standard OAuth token response field), skipping the SOAP login envelope entirely
- Legacy Password mode is completely unchanged for backward compatibility with existing saved data sources

## Test Plan

- [x] `./mvnw test -pl core,connectors/inetsoft-rest` passes
- [x] Manually verified end-to-end: created a data source, switched to OAuth, authorized against a real Salesforce sandbox org, saved, and successfully tested the connection
- [x] Verified legacy Password auth mode is unaffected

Fixes Redmine #76329.