### PR TITLE
fix(viewsheet): VSLayoutService.findViewsheetLayout NPEs on a viewsheet with no print layout (bug #76584)

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -294,7 +294,7 @@ public class VSLayoutService {
       LayoutInfo info = viewsheet.getLayoutInfo();
 
       if(Catalog.getCatalog().getString("Print Layout").equals(name)) {
-         return Optional.of(info.getPrintLayout());
+         return Optional.ofNullable(info.getPrintLayout());
       }
       else {
          return info.getViewsheetLayouts()

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -21,7 +21,9 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.test.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.TabVSAssemblyInfo;
+import inetsoft.uql.viewsheet.vslayout.AbstractLayout;
 import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.util.Catalog;
 import inetsoft.web.composer.model.vs.VSLayoutObjectModel;
 import inetsoft.web.viewsheet.model.VSFormatModel;
 import inetsoft.web.viewsheet.model.VSObjectModel;
@@ -37,8 +39,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.*;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
@@ -321,6 +325,23 @@ class VSLayoutServiceTest {
       // top should NOT be shifted for non-bottom tabs
       assertEquals(layoutY, result.top(),
          "model top should not be shifted for non-bottom tabs");
+   }
+
+   /**
+    * Bug #76584 repro: a viewsheet that has never had a print layout configured has
+    * LayoutInfo.printLayout == null. findViewsheetLayout must report that as "not found"
+    * (Optional.empty()) rather than throwing NullPointerException via Optional.of(null).
+    */
+   @Test
+   void findViewsheetLayoutReturnsEmptyForUnconfiguredPrintLayout() {
+      Viewsheet vs = new Viewsheet();
+
+      Optional<AbstractLayout> result = service.findViewsheetLayout(
+         vs, Catalog.getCatalog().getString("Print Layout"));
+
+      assertTrue(result.isEmpty(),
+         "findViewsheetLayout should return Optional.empty() for a viewsheet with no " +
+         "print layout configured yet, not throw NullPointerException");
    }
 
    private VSObjectModel mockObjectModel() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
@@ -268,6 +268,44 @@ class LayoutSessionServiceTest {
       assertTrue(thrown.getMessage().contains("Does Not Exist"), thrown.getMessage());
    }
 
+   /**
+    * Bug #76584: a viewsheet that has never had a print layout configured
+    * ({@code LayoutInfo.printLayout == null}, the true default -- no {@code installPrintLayout()}
+    * call, unlike every other test in this file) must fail loud with the same
+    * {@code IllegalArgumentException} an unknown layout name gets, not throw
+    * {@code NullPointerException} from {@code VSLayoutService.findViewsheetLayout}'s
+    * {@code Optional.of(null)}.
+    */
+   @Test
+   void mutateLayoutOnUnconfiguredPrintLayoutFailsLoud() throws Exception {
+      Fixture fx = new Fixture();
+      // Deliberately not calling installPrintLayout() -- masterVs's LayoutInfo (set by the
+      // Viewsheet constructor) still has printLayout == null.
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT,
+                                        (clone, master, cloneRuntimeId, dispatcher) -> {}));
+
+      assertTrue(thrown.getMessage().contains(PRINT_LAYOUT), thrown.getMessage());
+   }
+
+   /**
+    * The read path ({@code get_layout}) shares the identical
+    * {@code resolveClone -> findViewsheetLayout} crash site as the mutate path above -- confirmed
+    * by the bug-76584 refutation pass reading {@code resolveForRead}'s catch clause, which passes
+    * a {@code RuntimeException} (including the pre-fix NPE) straight through unchanged.
+    */
+   @Test
+   void resolveForReadOnUnconfiguredPrintLayoutFailsLoud() throws Exception {
+      Fixture fx = new Fixture();
+      // Deliberately not calling installPrintLayout(), same as above.
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.resolveForRead("tok1", AGENT, PRINT_LAYOUT));
+
+      assertTrue(thrown.getMessage().contains(PRINT_LAYOUT), thrown.getMessage());
+   }
+
    // ── fixture ───────────────────────────────────────────────────────────────
 
    /**


### PR DESCRIPTION
## Summary

Bug #76584 (VS-043): `edit_layout_objects(add, layoutName:"Print Layout", ...)` on a paired
viewsheet that has never had a print layout configured throws an uncaught
`NullPointerException`, which surfaces to the caller as a generic HTTP 500
("An unexpected server error occurred while processing this request. This is a StyleBI-side
bug.") instead of a clear, actionable error.

## Root cause

`VSLayoutService.findViewsheetLayout` (`core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java:297`):

```java
if(Catalog.getCatalog().getString("Print Layout").equals(name)) {
   return Optional.of(info.getPrintLayout());   // throws NPE when getPrintLayout() is null
}
```

`LayoutInfo.printLayout` has no default/lazy-init — it stays `null` until
`setPrintLayout(...)` has been called at least once for the viewsheet, i.e. exactly the
"no print layout configured yet" state (`list_layouts: []`). `Optional.of(null)` throws
`NullPointerException` per its documented contract, so the very first lookup by print-layout
name on such a viewsheet throws before the method can ever return the empty `Optional` its
own callers already handle:

```java
AbstractLayout found = vsLayoutService.findViewsheetLayout(master.getViewsheet(), layoutName)
   .orElseThrow(() -> new IllegalArgumentException(
      "Unknown layout \"" + layoutName + "\" -- call list_layouts to see the print and " +
      "device layouts defined on this viewsheet."));
```

This uncaught `NullPointerException` isn't matched by any specific handler in
`WizControllerErrorHandler`, so it falls through to the generic
`@ExceptionHandler(Exception.class)` catch-all — the exact 500 message reported in the bug.

**Both call sites that share this crash site are fixed by this one change**, confirmed by
tracing the full call graph in the linked diagnosis/refutation docs:
- The mutate path: `edit_layout_objects`/`set_layout_table_options` →
  `LayoutMutationService.addObjects`/`requireLayout` → `LayoutSessionService.mutateLayout` →
  `resolveClone` → `findViewsheetLayout`.
- **The read path** (previously unreported, confirmed in this PR's regression tests):
  `get_layout` → `LayoutReadService` → `LayoutSessionService.resolveForRead` → `resolveClone`
  → `findViewsheetLayout`, unconditionally, with `resolveForRead`'s own `catch(RuntimeException e) { throw e; }`
  passing the NPE straight through unchanged.

## Fix

Minimal one-line change: `Optional.of(...)` → `Optional.ofNullable(...)`. This routes the
"print layout not configured yet" case into the pre-existing, already-tested
`.orElseThrow(IllegalArgumentException(...))` path every caller already has wired up — no
other logic changes needed. `WizControllerErrorHandler`'s existing `IllegalArgumentException`
handler then maps this to a clean HTTP 400 with the message intact.

This is a pure widening of the null-input case: behaviorally identical to
`Optional.of(...)` for every already-passing test and for every interactive (non-wiz) Composer
caller of `findViewsheetLayout` (`VSLayoutControllerService`, `ComposerViewsheetService`), all
of which already consume the `Optional` safely (`.ifPresent(...)`, `.orElse(null)`, or an
explicit `Optional` variable) rather than relying on the throw as an implicit fail-fast.

Deliberately **not** auto-creating a print layout here — `set_print_layout` already owns
seeding sane paper-size/margin defaults for a first-ever print layout, and duplicating that
here risks creating a degenerate zero-size page.

## Regression tests added

- `VSLayoutServiceTest.findViewsheetLayoutReturnsEmptyForUnconfiguredPrintLayout` — direct unit
  test: a bare `new Viewsheet()` (default `LayoutInfo`, `printLayout == null`) must return
  `Optional.empty()`, not throw.
- `LayoutSessionServiceTest.mutateLayoutOnUnconfiguredPrintLayoutFailsLoud` — the mutate path
  (`mutateLayout`/`resolveClone`), asserting `IllegalArgumentException` naming the layout, not
  `NullPointerException`.
- `LayoutSessionServiceTest.resolveForReadOnUnconfiguredPrintLayoutFailsLoud` — the read path
  (`resolveForRead`), covering the second, previously-unverified crash site (`get_layout`).

Verified all three new tests fail with the pre-fix `NullPointerException` when the one-line fix
is reverted, then pass once restored (proving they actually exercise the crash site, not just
trivially pass).

```
Tests run: 7, Failures: 0, Errors: 0  -- VSLayoutServiceTest
Tests run: 10, Failures: 0, Errors: 0 -- LayoutSessionServiceTest
Tests run: 11, Failures: 0, Errors: 0 -- LayoutMutationServiceTest (unaffected, no regression)
Tests run: 10, Failures: 0, Errors: 0 -- LayoutReadServiceTest (unaffected, no regression)
```
Command: `./mvnw test -pl core -am -Dtest=VSLayoutServiceTest,LayoutSessionServiceTest,LayoutMutationServiceTest,LayoutReadServiceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`

## References

- Redmine bug #76584
- `stylebi-wiz` diagnosis/refutation docs: `docs/teams/2026-09-10-bugs-composer-followon3/bug-76584/01-diagnosis.md` and `02-refute.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
