### PR TITLE
fix(#76536): widen two more DataVSAssembly narrow-casts to DynamicBindableVSAssembly

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -29,7 +29,7 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.OutputVSAssembly;
-import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.DynamicBindableVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Catalog;
@@ -311,7 +311,7 @@ public class ViewsheetRuntimeController {
     * filter is THERE is enough to stop the caller from destroying it unknowingly.
     */
    private boolean hasPreCondition(VSAssembly assembly) {
-      if(!(assembly instanceof DataVSAssembly dataAsm)) {
+      if(!(assembly instanceof DynamicBindableVSAssembly dataAsm)) {
          return false;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2218,8 +2218,8 @@ public class WizVsService {
                syncMode, existingTarget, replacedAssembly, previousPrimaryAssembly);
 
             if(carryCondition(model.isKeepCondition(), replaceInPlace) &&
-               displacedForCondition instanceof DataVSAssembly oldDataAsm &&
-               assembly instanceof DataVSAssembly newDataAsm)
+               displacedForCondition instanceof DynamicBindableVSAssembly oldDataAsm &&
+               assembly instanceof DynamicBindableVSAssembly newDataAsm)
             {
                ConditionList cond = oldDataAsm.getPreConditionList();
 

--- a/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerHasPreConditionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerHasPreConditionTest.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.GaugeVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.OpenViewsheetResult;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import inetsoft.web.wiz.service.WizVsService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * THE BUG THIS PINS DOWN. {@code hasPreCondition} gated on {@code instanceof DataVSAssembly}, so a
+ * saved Gauge/Text (OutputVSAssembly) with a real, non-empty pre-condition was unconditionally
+ * reported as {@code hasCondition=false} on reopen. Per the method's own doc comment, the plugin
+ * treats that as "unfiltered" and calling apply_filter (REPLACE semantics) on it would silently
+ * erase a real filter the chart actually had. Same class of defect as
+ * {@link WizVsServiceCarryConditionOutputAssemblyTest} (site 1) and the already-fixed
+ * {@code applyConditionModel} (commit 190db1b3e); fixed by widening the cast to
+ * {@code DynamicBindableVSAssembly}, the shared interface both hierarchies implement.
+ *
+ * <p>Follows {@link ViewsheetRuntimeControllerVerifyDispatchTest}'s dispatch-test construction
+ * pattern for the controller/mocks, but (unlike that test) needs a real {@link Viewsheet} and
+ * {@link GaugeVSAssembly} rather than mocks of them, since this bug is specifically about a real
+ * {@code instanceof} check against a real assembly type — those constructors need a live Spring
+ * context (see {@code VSAssemblyInfo}'s constructor -> {@code SreeEnv.getProperty}), hence the
+ * {@code @SreeHome}/{@code SpringExtension} setup mirroring
+ * {@link inetsoft.web.wiz.service.WizVsServiceCarryConditionOutputAssemblyTest} (site 1's test).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ViewsheetRuntimeControllerHasPreConditionTest {
+
+   private static String managedIdentifier() {
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/abc", null);
+      return entry.toIdentifier();
+   }
+
+   private static ConditionList plainCondition(String field) {
+      Condition condition = new Condition();
+      condition.setOperation(XCondition.EQUAL_TO);
+      condition.addValue("A");
+
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef(null, field), condition, 0));
+      return conds;
+   }
+
+   @Test
+   void reopeningAFilteredGaugeReportsHasCondition() throws Exception {
+      Principal principal = mock(Principal.class);
+
+      Viewsheet vs = new Viewsheet();
+      GaugeVSAssembly gauge = new GaugeVSAssembly(vs, "Gauge1");
+      gauge.setPreConditionList(plainCondition("Category"));
+      vs.addAssembly(gauge);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      when(vsService.openViewsheet(any(AssetEntry.class), eq(principal), eq(true)))
+         .thenReturn("rt1");
+      when(vsService.getViewsheet("rt1", principal)).thenReturn(rvs);
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      WizVsService wizVsService = mock(WizVsService.class);
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      OpenViewsheetResult result = controller.openViewsheet(managedIdentifier(), null, principal);
+
+      // THE REGRESSION. Before the fix, `assembly instanceof DataVSAssembly` evaluated false for
+      // the Gauge (findChartAssembly's fallback-to-first-assembly path), so hasPreCondition returned
+      // false unconditionally even though the chart is genuinely filtered.
+      assertEquals("Gauge1", result.getAssemblyName());
+      assertTrue(result.getHasCondition(), "a Gauge with a real pre-condition must report hasCondition=true");
+   }
+
+   @Test
+   void reopeningAnUnfilteredGaugeReportsNoCondition() throws Exception {
+      Principal principal = mock(Principal.class);
+
+      Viewsheet vs = new Viewsheet();
+      GaugeVSAssembly gauge = new GaugeVSAssembly(vs, "Gauge1");
+      vs.addAssembly(gauge);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      when(vsService.openViewsheet(any(AssetEntry.class), eq(principal), eq(true)))
+         .thenReturn("rt1");
+      when(vsService.getViewsheet("rt1", principal)).thenReturn(rvs);
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(
+         eq(principal), eq(ResourceType.VIEWSHEET), eq("*"), eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      WizVsService wizVsService = mock(WizVsService.class);
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      OpenViewsheetResult result = controller.openViewsheet(managedIdentifier(), null, principal);
+
+      assertEquals("Gauge1", result.getAssemblyName());
+      assertEquals(Boolean.FALSE, result.getHasCondition());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCarryConditionOutputAssemblyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceCarryConditionOutputAssemblyTest.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.GaugeVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.model.CreateVisualizationModel;
+import inetsoft.web.wiz.model.VisualizationConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * THE BUG THIS FIXES. {@code createViewsheetInternal}'s replace-in-place condition-carry block
+ * (right after {@code resolveConditionSource}) gated on {@code instanceof DataVSAssembly} for both
+ * the displaced and the freshly-bound assembly. A Gauge/Text (OutputVSAssembly) is a SIBLING
+ * hierarchy to DataVSAssembly, not a subtype of it, so replacing (or type-changing away from) a
+ * filtered Gauge/Text silently dropped the {@code PreConditionList} instead of carrying it onto the
+ * new assembly — no error, no warning, just a silently widened result set. Same class of defect as
+ * {@code applyConditionModel} (commit 190db1b3e) and {@code hasPreCondition}, fixed by widening the
+ * cast to {@code DynamicBindableVSAssembly}, the shared interface both hierarchies implement.
+ *
+ * <p>Follows {@link WizVsServiceRebindClearsStaleRuntimeChartRefsTest}'s construction pattern (real
+ * {@link WizVsService} wrapped in a spy, real {@link Viewsheet}/assembly objects so the actual
+ * {@code instanceof} check runs against real types instead of mocks).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceCarryConditionOutputAssemblyTest {
+
+   private static ConditionList plainCondition(String field) {
+      Condition condition = new Condition();
+      condition.setOperation(XCondition.EQUAL_TO);
+      condition.addValue("A");
+
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef(null, field), condition, 0));
+      return conds;
+   }
+
+   @Test
+   void replacingAFilteredGaugeInPlaceCarriesItsPreConditionOntoTheNewChart() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AssetRepository engine = mock(AssetRepository.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      Principal user = mock(Principal.class);
+
+      WizVsService real = new WizVsService(viewsheetService, engine, securityEngine, null, null, null);
+      WizVsService service = spy(real);
+
+      AssetEntry sourceWsEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+      Worksheet worksheet = new Worksheet();
+      PhysicalBoundTableAssembly baseTable = new PhysicalBoundTableAssembly(worksheet, "BASE");
+      worksheet.addAssembly(baseTable);
+      worksheet.setPrimaryAssembly("BASE");
+      when(engine.getSheet(any(AssetEntry.class), eq(user), eq(true), any()))
+         .thenReturn(worksheet);
+
+      // An existing, already-executed runtime whose primary assembly is a Gauge carrying a real,
+      // non-empty pre-condition (the filter that must survive the replace).
+      Viewsheet vs = new Viewsheet(sourceWsEntry, false, true, null, null);
+      GaugeVSAssembly gauge = new GaugeVSAssembly(vs, "vs_1");
+      gauge.setPrimary(true);
+      ConditionList original = plainCondition("Category");
+      gauge.setPreConditionList(original);
+      vs.addAssembly(gauge);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(viewsheetService.getViewsheet(eq("rt-1"), eq(user))).thenReturn(rvs);
+
+      doReturn(new CreateViewsheetResult()).when(service).executeAndExtract(any(), any(), anyInt());
+      doReturn(null).when(service).collectFlatBinding(any());
+      doReturn("vs-identifier").when(service).persistViewsheet(any(), any(), any());
+
+      Viewsheet wizardVs = new Viewsheet();
+      ChartVSAssembly newChart = new ChartVSAssembly(wizardVs, "wizardChart");
+      newChart.setPrimary(true);
+
+      VisualizationConfig.DataSource dataSource = new VisualizationConfig.DataSource();
+      dataSource.setSource(sourceWsEntry.toIdentifier());
+      VisualizationConfig config = new VisualizationConfig();
+      config.setData(dataSource);
+
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      model.setRuntimeId("rt-1");
+      // Named target: replace "vs_1" (the filtered Gauge) in place — this is what makes
+      // carryCondition true (replaceInPlace) without needing keepCondition at all.
+      model.setAssemblyName("vs_1");
+      model.setConfig(config);
+      model.setPrimaryAssembly(newChart);
+
+      CreateViewsheetResult result = service.createViewsheet(model, user);
+
+      VSAssembly reboundAssembly = vs.getAssembly(result.getAssemblyName());
+      ChartVSAssembly reboundChart = assertInstanceOf(ChartVSAssembly.class, reboundAssembly);
+
+      // THE REGRESSION. Before the fix, `displacedForCondition instanceof DataVSAssembly` evaluated
+      // false for the Gauge, so this whole block was skipped and the new chart's PreConditionList
+      // stayed null — the filter silently vanished instead of carrying over.
+      ConditionList carried = reboundChart.getPreConditionList();
+      assertNotNull(carried, "the Gauge's pre-condition must be carried onto the replacing chart");
+      assertFalse(carried.isEmpty());
+      assertEquals("Category", carried.getConditionItem(0).getAttribute().getName());
+   }
+}


### PR DESCRIPTION
## Summary

Fixes Redmine bug #76536 — two more `instanceof DataVSAssembly` narrow-cast sites (4th/5th occurrence of this class of defect) that excluded Gauge/Text (`OutputVSAssembly`) from pre-condition handling, matching the pattern already fixed twice in this file family (commits `190db1b3e` / PR #4606, and `b6be49907`).

- `core/src/main/java/inetsoft/web/wiz/service/WizVsService.java` (`carryCondition` block, ~line 2220): when replacing a filtered Gauge/Text chart in place (or type-changing away from it), the `instanceof DataVSAssembly` guard evaluated false for the Output assembly, so the whole condition-carry block was skipped — the filter silently vanished instead of carrying onto the new assembly.
- `core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java` (`hasPreCondition`, ~line 313): a saved Gauge/Text with a real, non-empty pre-condition was unconditionally reported as `hasCondition=false` on reopen — since `apply_filter` uses REPLACE semantics, a caller trusting that false could silently erase a real filter.

Both `DataVSAssembly` and `OutputVSAssembly` are sibling hierarchies that independently implement `DynamicBindableVSAssembly`, the interface `getPreConditionList()`/`setPreConditionList()` actually live on. Both sites only ever call those two accessors, so widening the cast to `DynamicBindableVSAssembly` is type-safe and matches the exact type/null-handling convention the two prior fixes already established in this same file.

## Test plan

- [x] Added `WizVsServiceCarryConditionOutputAssemblyTest` (site 1) — drives the real replace-in-place path through `WizVsService#createViewsheet` with a real `GaugeVSAssembly` carrying a non-empty `PreConditionList`, asserts the condition is carried onto the chart that replaces it.
- [x] Added `ViewsheetRuntimeControllerHasPreConditionTest` (site 2) — drives `ViewsheetRuntimeController#openViewsheet` with a real filtered Gauge, asserts `OpenViewsheetResult.hasCondition == true` (plus a companion unfiltered-Gauge case asserting `false`, to guard against over-widening).
- [x] Both new tests confirmed to **fail** against the pre-fix code (`AssertionFailedError`) and **pass** after the fix — closes the one gap the diagnosis/refute review explicitly flagged (neither had executed these tests, only read/compiled).
- [x] Ran via `./mvnw -pl core -Dtest=WizVsServiceCarryConditionOutputAssemblyTest,ViewsheetRuntimeControllerHasPreConditionTest test`: `Tests run: 3, Failures: 0, Errors: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)