### PR TITLE
Bug #76572, fix chart data annotation misalignment after scrolling

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -386,8 +386,8 @@
   @for (vsObject of vsInfo.vsObjects; track vsObject.absoluteName; let i = $index) {
     @if (vsObject.objectType === 'VSChart' && viewer && !context.binding &&
       !$any(vsObject).maxMode && !!$any(vsObject).plot) {
-      <div [style.top.px]="getVsObjectPosition(vsObject, i, true)"
-        [style.left.px]="getVsObjectPosition(vsObject, i, false)"
+      <div [style.top.px]="getVsObjectPosition(vsObject, i, true) - ($any(vsObject).annotationScrollTop || 0)"
+        [style.left.px]="getVsObjectPosition(vsObject, i, false) - ($any(vsObject).annotationScrollLeft || 0)"
         style="position: absolute;">
         @for (ann of getChartDataAnnotations(vsObject); track ann.absoluteName) {
           <vs-annotation


### PR DESCRIPTION
## Summary

After adding an annotation on a chart data point in viewer mode, dragging the plot area's horizontal or vertical scrollbar left the annotation's connector line and text box fixed in place instead of moving with the chart, causing the annotation to become misaligned with its data point.

## Root Cause

Chart data-point annotations are rendered outside the chart's own component tree, in the `chart-annotation-overlay` block of `vs-object-container.component.html`, to avoid stacking-context issues with the chart's canvas/tile layers. `vs-chart.component.ts`'s `onScroll()` captures the plot's current scroll position into `model.annotationScrollLeft`/`annotationScrollTop`, and the overlay already passed `offsetX`/`offsetY` (the negated scroll values) into `<vs-annotation>` — but those inputs are only used by `VSAnnotation.isLineInContainer()`, a visibility check that hides the annotation once it scrolls out of the plot's visible bounds. They were never applied to the actual rendered position of the connector line or text box.

The wrapping `<div>` around the chart's data annotations had its `top`/`left` pinned to the chart's static assembly position (`getVsObjectPosition(vsObject, i, ...)`), with no scroll term at all — unlike the equivalent table/crosstab/calc-table annotation overlays, whose wrapping containers already apply `[style.top.px]="-scrollY"` / `[style.left.px]="-scrollX"` directly.

## Fix

Apply the same scroll offset already computed for the visibility check to the wrapping div's position in `vs-object-container.component.html`, mirroring the table annotation pattern:

```html
<div [style.top.px]="getVsObjectPosition(vsObject, i, true) - ($any(vsObject).annotationScrollTop || 0)"
  [style.left.px]="getVsObjectPosition(vsObject, i, false) - ($any(vsObject).annotationScrollLeft || 0)"
  style="position: absolute;">
```

## Test Plan

- Verified in the browser against the `annotation1` viewsheet (matching the bug report's repro asset): scrolling the chart's plot area now moves the annotation's connector line and text box in lock-step with the underlying data point (confirmed pixel-exact via `getBoundingClientRect()` — a 150px scroll produced an exact 150px shift), and the annotation correctly hides once its data point scrolls out of the visible plot area.
- `npm run build` (portal, elements, viewer-element, em) succeeds.
- `npm run test:portal` — all 376 existing tests pass, no regressions.
- Change is scoped to a single template expression; `getVsObjectPosition()` itself is unmodified, so no other caller (tables, selections, embedded viewsheets) is affected.

Fixes Redmine #76572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)