### PR TITLE
Bug #76577, don't show Highlight menu for chart target line labels

### DIFF
--- a/web/projects/portal/src/app/graph/model/chart-tool.ts
+++ b/web/projects/portal/src/app/graph/model/chart-tool.ts
@@ -368,7 +368,9 @@ export namespace ChartTool {
 
       if(regions && regions.length > 0) {
          return (!measureRequired || ChartTool.hasMeasure(model, regions[0])) &&
-            ChartTool.areaType(model, regions[0]) !== "axis" ||
+            ChartTool.areaType(model, regions[0]) !== "axis" &&
+            // target line labels are non-interactive decorations, not highlightable measures
+            ChartTool.areaType(model, regions[0]) !== "label" ||
             // radar1
             GraphTypes.isRadar(model.chartType) &&
             ChartTool.areaType(model, regions[0]) == "axis" ||

--- a/web/projects/portal/src/app/vsobjects/action/chart-actions.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/action/chart-actions.spec.ts
@@ -252,6 +252,34 @@ describe("ChartActions", () => {
       // expect(menuActions[1].actions[2].visible()).toBeFalsy();
    });
 
+   // Bug #76577, target line labels are non-interactive decorations and should not
+   // offer the Highlight menu item since configuring it has no rendering effect.
+   it("should not show highlight action when a target line label is selected", () => {
+      const model: VSChartModel = createModel();
+      model.chartType = GraphTypes.CHART_BAR;
+      model.chartSelection = {
+         chartObject: <Plot> {
+            areaName: "plot_area",
+            bounds: null,
+            layoutBounds: null,
+            tiles: null,
+            regions: [],
+            secondary: false,
+            xboundaries: [],
+            yboundaries: [],
+            showReferenceLine: false,
+            showPlotResizers: false,
+         },
+         regions: [ createRegion() ]
+      };
+      model.regionMetaDictionary = [{areaType: "label", hasMeasure: false}];
+      const actions = new ChartActions(model, popService, composerContext);
+      const menuActions = actions.menuActions;
+      const action = menuActions[1].actions[3];
+      expect(action.id()).toBe("chart highlight");
+      expect(action.visible()).toBeFalsy();
+   });
+
    // Bug #17179
    it("should have visible title property action when axis title is selected", () => {
       const model = createModel();


### PR DESCRIPTION
## Summary

Right-clicking a chart target line label showed a "Highlight" context menu item, but configuring a highlight condition through it had no visual effect on the chart.

## Root Cause

Target line labels are non-interactive decorations rendered via `TargetForm`/`LabelArea` (`community/core/src/main/java/inetsoft/report/composition/region/LabelArea.java`) and are never wired into the backend's `GraphGenerator.applyHighlight()`, which only applies highlight conditions to `HighlightRef`-bound chart fields and axis labels.

`ChartTool.isPlotMeasureSelected(model, false)` in `chart-tool.ts` treated any selected plot-area region as highlightable as long as its `areaType !== "axis"`. Target labels have `areaType === "label"` (set exclusively by `LabelArea.getChartAreaInfo()` — verified no other region type produces this areaType), so `"label" !== "axis"` let the check pass, causing `ChartTool.isHighlightable()` / `chartHighlightVisible()` to show the "Highlight..." menu item for target labels even though it's a no-op.

## Fix

In `isPlotMeasureSelected`, exclude `areaType === "label"` the same way `"axis"` is already excluded, so the Highlight menu item is hidden for target line labels while remaining available for actual data-bound regions (bars, points, axis labels, VO text, etc.).

## Test Plan

- Added a regression test in `chart-actions.spec.ts` asserting the "chart highlight" action is not visible when a target-label region (`areaType: "label"`) is selected; verified it fails without the fix and passes with it.
- Full `portal` Vitest suite (198 files / 1005 tests) passes with no regressions.
- `tsc --noEmit` and `eslint` on changed files are clean.
- Manually reproduced and verified in the running app: right-clicking the target label in the `targetlabel` viewsheet no longer shows "Highlight...", while data-point labels under the same chart still correctly show both "Hyperlink..." and "Highlight...".

Fixes Redmine #76577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)