### PR TITLE
Bug #76576, fix NPE and race in HTML viewsheet export

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLCrosstabHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLCrosstabHelper.java
@@ -71,13 +71,11 @@ public class HTMLCrosstabHelper extends HTMLTableDataHelper {
    public void write(PrintWriter writer, TableDataVSAssembly assembly, VSTableLens lens) {
       TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
 
-      if(info == null) {
+      if(info == null || lens == null) {
          return;
       }
 
-      if(lens != null) {
-         lens.initTableGrid(info);
-      }
+      lens.initTableGrid(info);
 
       isWritten = new SparseMatrix();
       Rectangle2D bounds = vHelper.getBounds(info);

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLTableHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLTableHelper.java
@@ -70,7 +70,7 @@ public class HTMLTableHelper extends HTMLTableDataHelper {
    public void write(PrintWriter writer, TableDataVSAssembly assembly, VSTableLens lens) {
       TableDataVSAssemblyInfo info = (TableDataVSAssemblyInfo) assembly.getVSAssemblyInfo();
 
-      if(info == null) {
+      if(info == null || lens == null) {
          return;
       }
 

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
@@ -212,57 +212,65 @@ public class ExportControllerService {
       exporter.setLogExport(true);
 
       if(current) {
-         Viewsheet cviewsheet = viewsheet.clone();
-         rvs.setViewsheet(cviewsheet);
+         // Bug #76576: the live ViewsheetSandbox is mutated in place below (setViewsheet()
+         // is not synchronized), so overlapping exports of the same runtime viewsheet can
+         // swap each other's cloned viewsheet mid-export, producing null table lenses (NPE
+         // in the exporters) and leaving in-flight queries waiting on stale assembly state
+         // (perceived as a hang). Serialize this swap/export/restore per runtime viewsheet.
+         synchronized(rvs) {
+            Viewsheet originalViewsheet = rvs.getViewsheet();
+            Viewsheet cviewsheet = originalViewsheet.clone();
+            rvs.setViewsheet(cviewsheet);
 
-         try {
-            // don't use the scale-to-screen size for export
-            VSEventUtil.clearScale(cviewsheet);
-            Assembly[] assemblies = cviewsheet.getAssemblies(false);
+            try {
+               // don't use the scale-to-screen size for export
+               VSEventUtil.clearScale(cviewsheet);
+               Assembly[] assemblies = cviewsheet.getAssemblies(false);
 
-            for(int i = 0; rbox != null && i < assemblies.length; i++) {
-               VSAssembly assembly = (VSAssembly) assemblies[i];
-
-               if(assembly instanceof CalcTableVSAssembly) {
-                  continue;
-               }
-
-               AnnotationVSUtil.refreshAllAnnotations(rvs, assembly, null, null);
-            }
-
-            ViewsheetSandbox exportBox = rbox.get();
-
-            if(previewPrintLayout && rbox.get().getMode() == AbstractSheet.SHEET_DESIGN_MODE) {
-               exportBox =
-                  new ViewsheetSandbox(cviewsheet, vmode, rbox.get().getUser(), rbox.get().getAssetEntry());
-               exportBox.prepareMVCreation();
-
-               for(int i = 0; exportBox != null && i < assemblies.length; i++) {
+               for(int i = 0; rbox != null && i < assemblies.length; i++) {
                   VSAssembly assembly = (VSAssembly) assemblies[i];
-                  exportBox.executeScript(assembly);
+
+                  if(assembly instanceof CalcTableVSAssembly) {
+                     continue;
+                  }
+
+                  AnnotationVSUtil.refreshAllAnnotations(rvs, assembly, null, null);
                }
 
-               final AssetQuerySandbox assetQuerySandbox = exportBox.getAssetQuerySandbox();
+               ViewsheetSandbox exportBox = rbox.get();
 
-               if(assetQuerySandbox != null) {
-                  assetQuerySandbox.refreshVariableTable(rbox.get().getVariableTable());
+               if(previewPrintLayout && rbox.get().getMode() == AbstractSheet.SHEET_DESIGN_MODE) {
+                  exportBox =
+                     new ViewsheetSandbox(cviewsheet, vmode, rbox.get().getUser(), rbox.get().getAssetEntry());
+                  exportBox.prepareMVCreation();
+
+                  for(int i = 0; exportBox != null && i < assemblies.length; i++) {
+                     VSAssembly assembly = (VSAssembly) assemblies[i];
+                     exportBox.executeScript(assembly);
+                  }
+
+                  final AssetQuerySandbox assetQuerySandbox = exportBox.getAssetQuerySandbox();
+
+                  if(assetQuerySandbox != null) {
+                     assetQuerySandbox.refreshVariableTable(rbox.get().getVariableTable());
+                  }
                }
-            }
-            else {
-               exportBox.setViewsheet(cviewsheet, false);
-            }
-            Catalog catalog = Catalog.getCatalog(principal);
-            exporter.setSandbox(exportBox);
+               else {
+                  exportBox.setViewsheet(cviewsheet, false);
+               }
+               Catalog catalog = Catalog.getCatalog(principal);
+               exporter.setSandbox(exportBox);
 
-            if(exporter instanceof AbstractVSExporter) {
-               ((AbstractVSExporter) exporter).setRuntimeViewsheet(rvs);
-            }
+               if(exporter instanceof AbstractVSExporter) {
+                  ((AbstractVSExporter) exporter).setRuntimeViewsheet(rvs);
+               }
 
-            exporter.export(exportBox, catalog.getString("Current View"), new VSPortalHelper());
-         }
-         finally {
-            rbox.get().setViewsheet(viewsheet, false);
-            rvs.setViewsheet(viewsheet);
+               exporter.export(exportBox, catalog.getString("Current View"), new VSPortalHelper());
+            }
+            finally {
+               rbox.get().setViewsheet(originalViewsheet, false);
+               rvs.setViewsheet(originalViewsheet);
+            }
          }
       }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
@@ -767,64 +767,72 @@ public class VSExportService {
       exporter.setLogExport(true);
 
       if(current) {
-         Viewsheet cviewsheet = viewsheet.clone();
-         rvs.setViewsheet(cviewsheet);
+         // Bug #76576: the live ViewsheetSandbox is mutated in place below (setViewsheet()
+         // is not synchronized), so overlapping exports of the same runtime viewsheet can
+         // swap each other's cloned viewsheet mid-export, producing null table lenses (NPE
+         // in the exporters) and leaving in-flight queries waiting on stale assembly state
+         // (perceived as a hang). Serialize this swap/export/restore per runtime viewsheet.
+         synchronized(rvs) {
+            Viewsheet originalViewsheet = rvs.getViewsheet();
+            Viewsheet cviewsheet = originalViewsheet.clone();
+            rvs.setViewsheet(cviewsheet);
 
-         try {
-            // don't use the scale-to-screen size for export
-            VSEventUtil.clearScale(cviewsheet);
-            Assembly[] assemblies = cviewsheet.getAssemblies(false);
+            try {
+               // don't use the scale-to-screen size for export
+               VSEventUtil.clearScale(cviewsheet);
+               Assembly[] assemblies = cviewsheet.getAssemblies(false);
 
-            for(int i = 0; rbox != null && i < assemblies.length; i++) {
-               VSAssembly assembly = (VSAssembly) assemblies[i];
-
-               if(assembly instanceof CalcTableVSAssembly) {
-                  continue;
-               }
-
-               AnnotationVSUtil.refreshAllAnnotations(rvs, assembly, null, null);
-            }
-
-            ViewsheetSandbox exportBox = rbox.get();
-
-            if(previewPrintLayout && rbox.get().getMode() == AbstractSheet.SHEET_DESIGN_MODE) {
-               exportBox = new ViewsheetSandbox(null, cviewsheet, vmode, rbox.get().getUser(),
-                  false, rbox.get().getAssetEntry(), null);
-
-               if(exportBox.getAssetQuerySandbox() != null) {
-                  exportBox.getAssetQuerySandbox().refreshVariableTable(rbox.get().getVariableTable());
-               }
-
-               exportBox.reset(new ChangedAssemblyList());
-               exportBox.prepareMVCreation();
-               exportBox.getScope().prepareVariables(rbox.get().getVariableTable());
-
-               for(int i = 0; exportBox != null && i < assemblies.length; i++) {
+               for(int i = 0; rbox != null && i < assemblies.length; i++) {
                   VSAssembly assembly = (VSAssembly) assemblies[i];
-                  exportBox.executeScript(assembly);
+
+                  if(assembly instanceof CalcTableVSAssembly) {
+                     continue;
+                  }
+
+                  AnnotationVSUtil.refreshAllAnnotations(rvs, assembly, null, null);
                }
 
-               final AssetQuerySandbox assetQuerySandbox = exportBox.getAssetQuerySandbox();
+               ViewsheetSandbox exportBox = rbox.get();
 
-               if(assetQuerySandbox != null) {
-                  assetQuerySandbox.refreshVariableTable(rbox.get().getVariableTable());
+               if(previewPrintLayout && rbox.get().getMode() == AbstractSheet.SHEET_DESIGN_MODE) {
+                  exportBox = new ViewsheetSandbox(null, cviewsheet, vmode, rbox.get().getUser(),
+                     false, rbox.get().getAssetEntry(), null);
+
+                  if(exportBox.getAssetQuerySandbox() != null) {
+                     exportBox.getAssetQuerySandbox().refreshVariableTable(rbox.get().getVariableTable());
+                  }
+
+                  exportBox.reset(new ChangedAssemblyList());
+                  exportBox.prepareMVCreation();
+                  exportBox.getScope().prepareVariables(rbox.get().getVariableTable());
+
+                  for(int i = 0; exportBox != null && i < assemblies.length; i++) {
+                     VSAssembly assembly = (VSAssembly) assemblies[i];
+                     exportBox.executeScript(assembly);
+                  }
+
+                  final AssetQuerySandbox assetQuerySandbox = exportBox.getAssetQuerySandbox();
+
+                  if(assetQuerySandbox != null) {
+                     assetQuerySandbox.refreshVariableTable(rbox.get().getVariableTable());
+                  }
                }
-            }
-            else {
-               exportBox.setViewsheet(cviewsheet, false);
-            }
-            Catalog catalog = Catalog.getCatalog(principal);
-            exporter.setSandbox(exportBox);
+               else {
+                  exportBox.setViewsheet(cviewsheet, false);
+               }
+               Catalog catalog = Catalog.getCatalog(principal);
+               exporter.setSandbox(exportBox);
 
-            if(exporter instanceof AbstractVSExporter) {
-               ((AbstractVSExporter) exporter).setRuntimeViewsheet(rvs);
-            }
+               if(exporter instanceof AbstractVSExporter) {
+                  ((AbstractVSExporter) exporter).setRuntimeViewsheet(rvs);
+               }
 
-            exporter.export(exportBox, catalog.getString("Current View"), new VSPortalHelper());
-         }
-         finally {
-            rbox.get().setViewsheet(viewsheet, false);
-            rvs.setViewsheet(viewsheet);
+               exporter.export(exportBox, catalog.getString("Current View"), new VSPortalHelper());
+            }
+            finally {
+               rbox.get().setViewsheet(originalViewsheet, false);
+               rvs.setViewsheet(originalViewsheet);
+            }
          }
       }
 


### PR DESCRIPTION
## Summary

Exporting a viewsheet to HTML from the Portal viewer (Current View, Match Layout) intermittently threw an NPE and, when a repeat export overlapped with an in-flight one, could hang indefinitely.

## Root Cause

1. **NPE**: `HTMLCrosstabHelper.write()` and `HTMLTableHelper.write()` only guarded against a null `VSTableLens` before calling `initTableGrid()`, but then unconditionally dereferenced `lens` in `initRowColumns()` (`lens.getRowCount()`/`lens.moreRows()`). `ViewsheetSandbox.getVSTableLens()` legitimately returns `null` when an assembly's data isn't ready yet — the PDF/SVG/Excel exporters already handle this gracefully via `VSCrosstabHelper.calculateColumnsPosition()`'s null check; the HTML helpers were the outliers that crashed instead.

2. **Hang**: `ExportControllerService.writeViewsheetExport()` and `VSExportService.writeViewsheetExport()`'s "Current View" export path mutate the shared, live `RuntimeViewsheet`/`ViewsheetSandbox` in place (`rvs.setViewsheet(cviewsheet)`, `exportBox.setViewsheet(cviewsheet, false)`) with no synchronization, and `ViewsheetSandbox.setViewsheet()` itself acquires no lock. The `@ClusterWriteMethod`/`@ClusterProxyMethod` annotations on the export entry point provide no mutual exclusion (verified against their definitions — they only handle async cache write-back and cluster colocation routing). So two overlapping exports of the same runtime viewsheet can race: the second export's clone-and-swap happens mid-flight of the first, corrupting assembly identity out from under the first export (producing the NPE above) and potentially leaving an in-flight query waiting on now-stale assembly state (the reported indefinite hang). The two `finally` restores also stomp on each other.

## Fix

- Added a `lens == null` guard (alongside the existing `info == null` guard) to `HTMLCrosstabHelper.write()` and `HTMLTableHelper.write()`, matching the graceful-degradation behavior of the other format exporters.
- Wrapped the "Current View" clone/swap/export/restore critical section in both `ExportControllerService.writeViewsheetExport()` and `VSExportService.writeViewsheetExport()` in `synchronized(rvs)`, and capture the "original" viewsheet to restore fresh inside the lock (instead of a value captured before waiting on it) — serializing overlapping exports of the same runtime viewsheet. This mirrors `RuntimeViewsheet`'s existing use of `synchronized` instance methods (e.g. `undo()`/`redo()`).

## Test Plan

- `./mvnw clean install -pl core -am -DskipTests` — build succeeds.
- `./mvnw test -pl core -Dtest=VSExportServiceTest,AbstractVSExporterLabelTest,VSFontHelperTest` — 48/48 tests pass.
- Two independent code-review passes against the diff found no remaining issues.
- Manually verified against the reported repro (export "vs" to HTML, Current View + Match Layout, then immediately repeat) — no NPE, no hang.

Fixes Redmine #76576.