### PR TITLE
test: add delete_table + join-dependent regression coverage (bug #76582)

### DIFF
--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -4105,6 +4105,31 @@ class WorksheetEditServiceMutatorsTest {
       assertNotNull(ws.getAssembly("M"), "and so must the mirror that depends on it");
    }
 
+   /**
+    * The mirror case above and {@code removeJoinRefusesWhenSomethingIsBuiltOnIt} each cover one
+    * side of this guard, but neither exercises deleteTable with a join itself as the dependent
+    * (Redmine #76582): deleting one of a join's source tables must be refused the same way, not
+    * leave the join pointing at a table that no longer exists.
+    */
+   @Test
+   void deleteTableRefusesWhenJoinDependsOnIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+      svc.apply("TOK", agent, ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.deleteTable("L")));
+
+      assertTrue(ex.getMessage().contains("built on it"), ex.getMessage());
+      assertNotNull(ws.getAssembly("L"), "the table must still be there");
+      assertNotNull(ws.getAssembly("J"), "and so must the join that depends on it");
+   }
+
    /** A table nothing depends on still deletes — the guard must not block ordinary deletion. */
    @Test
    void deleteTableStillDeletesWhenNothingDependsOnIt() throws Exception {


### PR DESCRIPTION
## Summary
- Redmine #76582 reported `delete_table` leaving a dependent join definition dangling instead of refusing/cascading.
- Diagnosis and an independent adversarial refutation (see `stylebi-wiz`'s `docs/teams/2026-09-10-bugs-composer-followon3/bug-76582/`) both confirmed this is **already fixed** — `WorksheetEditService.deleteTable`'s `AssetEventUtil.hasDependent` guard (added by #4901) already refuses the delete via `PairingException` when a join depends on the table, via `Worksheet.getDependings` → `CompositeTableAssembly.getDependeds` walking the join's own `tnames`.
- The one real gap both passes found: no existing test exercised this guard with a **join** specifically as the dependent (`deleteTableRefusesWhenSomethingIsBuiltOnIt` uses a mirror; `removeJoinRefusesWhenSomethingIsBuiltOnIt` tests the sibling `remove_join` op, not this one).
- **Coverage-only PR — no production code changed**, since the guard already works correctly.

## Test plan
- [x] New test `deleteTableRefusesWhenJoinDependsOnIt` added to `WorksheetEditServiceMutatorsTest`
- [x] Full class run: `Tests run: 247, Failures: 0, Errors: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)