### PR TITLE
Bug #76564: fix NPE in Calc Table Show Details when table lens build fails

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableService.java
@@ -738,6 +738,11 @@ public abstract class BaseTableService<T extends BaseTableEvent> {
    {
       TableLens lens = (TableLens) box.getData(name);
       RuntimeCalcTableLens rlens = (RuntimeCalcTableLens) Util.getNestedTable(lens, RuntimeCalcTableLens.class);
+
+      if(lens == null || rlens == null) {
+         return true;
+      }
+
       boolean isEmpty = true;
 
       for(int i = 0; i < rowcols.length; i++) {


### PR DESCRIPTION
## Summary

`BaseTableService.isEmptyCell()` dereferenced `rlens` (derived from `box.getData(name)`) without a null check. When `CalcTableVSAQuery.getTableLens()` swallows an exception during calc-table construction (e.g. evaluating an Aggregate calc field's expression against a raw/unaggregated column) it returns `null`, which propagates through to a null `lens`/`rlens` here and NPEs at `rlens.getRow()`.

Root cause and fix scope confirmed independently across two diagnosis/refutation rounds (see the batch archive: `docs/teams/2026-09-10-bugs-vscalc-chart-batch/bug-76564/` in `stylebi-wiz`). The refuter's key finding: `createCalcTableConditions()` already has a ready `isEmpty -> MessageCommand(composer.vs.calctable.empty.cell.showdetail)` path immediately around the `isEmptyCell()` call, so a properly-scoped null check alone satisfies both halves of the bug's expected result (no crash, and a graceful message) — no change needed to `CalcTableVSAQuery.getTableLens()`.

## Fix

`isEmptyCell()` now returns `true` (treat as empty) when `lens` or `rlens` is null, routing into the existing message-command path instead of crashing.

## Testing

`core` module compiles clean. No existing unit test covers this exact path; adding one was judged disproportionate to the scope of a one-line null-guard.

Fixes https://173.220.179.100/issues/76564

🤖 Generated with [Claude Code](https://claude.com/claude-code)