### PR TITLE
Bug #76568: fix annotation position when chart is scrolled

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -691,8 +691,8 @@ export class VSChart extends AbstractVSObject<VSChartModel>
          .reverse()
          .find((region) => region != null);
       const chartContainerBounds = this.chartContainer.nativeElement.getBoundingClientRect();
-      let x = (event.clientX - chartContainerBounds.left) / this.scale;
-      let y = (event.clientY - chartContainerBounds.top) / this.scale;
+      let x = (event.clientX - chartContainerBounds.left) / this.scale + this.scrollLeft;
+      let y = (event.clientY - chartContainerBounds.top) / this.scale + this.scrollTop;
 
       // triggered from mini menu
       if(event.button == 0) {

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -386,8 +386,8 @@
   @for (vsObject of vsInfo.vsObjects; track vsObject.absoluteName; let i = $index) {
     @if (vsObject.objectType === 'VSChart' && viewer && !context.binding &&
       !$any(vsObject).maxMode && !!$any(vsObject).plot) {
-      <div [style.top.px]="getVsObjectPosition(vsObject, i, true)"
-        [style.left.px]="getVsObjectPosition(vsObject, i, false)"
+      <div [style.top.px]="getVsObjectPosition(vsObject, i, true) - ($any(vsObject).annotationScrollTop || 0)"
+        [style.left.px]="getVsObjectPosition(vsObject, i, false) - ($any(vsObject).annotationScrollLeft || 0)"
         style="position: absolute;">
         @for (ann of getChartDataAnnotations(vsObject); track ann.absoluteName) {
           <vs-annotation


### PR DESCRIPTION
## Summary

Adding a data-point annotation on a chart that is horizontally scrolled sent viewport-relative click coordinates to the server instead of full-content coordinates, unlike the table/crosstab/calc-table cell-annotation paths which already add the live scroll offset. The chart data-annotation render path also never subtracted the live scroll offset from the actual rendered CSS position (it was only used for the `isLineInContainer()` visibility check), so a newly created annotation ended up gated invisible by that check for large scroll offsets — e.g. when the horizontal scrollbar is dragged all the way to the end, matching the reported symptom.

Root cause and fix scope confirmed independently across two diagnosis/refutation rounds (see the batch archive: `docs/teams/2026-09-10-bugs-vscalc-chart-batch/bug-76568/` in `stylebi-wiz`), including an explicit check that the two changes below don't double-compensate (`isLineInContainer()`'s bounds check uses a synthetic `Rectangular` model, not the wrapper div's live rendered position — the two computations are structurally decoupled).

## Fix

Two coordinated changes:
- `vs-chart.component.ts` `addAnnotation()`: add `scrollLeft`/`scrollTop` to the computed x/y before sending `AddAnnotationEvent`, so the stored position is a full-content coordinate (matching the table family's existing behavior).
- `vs-object-container.component.html`: subtract the chart's live `annotationScrollLeft`/`annotationScrollTop` from the per-chart data-annotation wrapper div's position, scoped to `getChartDataAnnotations()`/`dataAnnotationModels` only, so chart-assembly annotations and table/crosstab/calc-table annotations (which already work via `positionAnnotationsToCell`) are unaffected.

## Testing

`ng build portal --configuration development` succeeds clean.

Fixes https://173.220.179.100/issues/76568

🤖 Generated with [Claude Code](https://claude.com/claude-code)