### PR TITLE
Bug #76537: cancel superseded flyover query before re-executing tip assembly

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartFlyoverService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartFlyoverService.java
@@ -172,6 +172,9 @@ public class VSChartFlyoverService extends VSChartControllerService<VSChartFlyov
          int hint = hints.remove(0);
 
          if(hint != VSAssembly.NONE_CHANGED) {
+            // cancel any query still in flight for this tip assembly from a
+            // prior, now-superseded hover event before starting the new one
+            box.getQueryManager(tip.getAbsoluteName()).cancel();
             execute(rvs, tip.getAbsoluteName(), linkUri, hint, dispatcher);
             refreshVSAssembly(rvs, view, dispatcher);
          }


### PR DESCRIPTION
## Summary

`VSChartFlyoverService.processFlyover` re-runs a full flyover crosstab query for each hover event that changes a tip assembly's condition, but never cancelled a still-in-flight query for that same assembly left over from a prior, superseded hover. Under fast hovering against a slow crosstab, this let multiple full queries pile up and run to completion in parallel under shared read locks, wasting DB/thread/CPU resources.

**Scope note, confirmed across two diagnosis/refutation rounds** (see `docs/teams/2026-09-10-bugs-vscalc-chart-batch/bug-76537/` in `stylebi-wiz`): this fixes the confirmed resource-pileup problem. It does **not** confirm the ticket's literal "hangs indefinitely" framing — the codebase already has a separate, tested `@LoadingMask` watchdog (`EventAspect`, ~30s default, built for the symptomatically identical bug #76524) that is not exempted for this endpoint and should auto-clear the client spinner with an informational toast regardless of this race. A Redmine comment has been posted asking the reporter to confirm whether they saw that toast and to check their `loadingmask.watchdog.timeout` config, to help determine whether there's a second, separate issue with the watchdog itself.

## Fix

Cancel the tip assembly's `QueryManager` immediately before re-executing it, using the same per-assembly cancellation mechanism the manual Cancel button already uses (`ViewsheetSandbox.cancelAllQueries`), just scoped automatically to the one superseded assembly instead of requiring a user click.

## Testing

`core` module compiles clean.

Fixes https://173.220.179.100/issues/76537

🤖 Generated with [Claude Code](https://claude.com/claude-code)