### PR TITLE
Bug #76566: harden CalcFieldFormula/ScriptEnvRepository/AssetQuerySandbox against null ScriptEnv

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetQuerySandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetQuerySandbox.java
@@ -399,7 +399,10 @@ public class AssetQuerySandbox implements Serializable, Cloneable, ActionListene
       resetTableLens();
       resetDefaultColumnSelection();
 
-      senv = null;
+      synchronized(lock) {
+         senv = null;
+      }
+
       scope = null;
    }
 
@@ -1546,8 +1549,11 @@ public class AssetQuerySandbox implements Serializable, Cloneable, ActionListene
          }
 
          scope = null;
-         senv = null;
          vprovider2 = null;
+      }
+
+      synchronized(lock) {
+         senv = null;
       }
    }
 
@@ -1919,7 +1925,7 @@ public class AssetQuerySandbox implements Serializable, Cloneable, ActionListene
    private Hashtable<String, SelectionVSAssembly> selections; // selection assembly map,
    private ViewsheetSandbox vsbox;
    private AssetQueryScope scope; // scope for executing formulas
-   private ScriptEnv senv; // scripting env for executing scripts
+   private volatile ScriptEnv senv; // scripting env for executing scripts
    private final MVSession mvsession;
    private final Set<String> nolimit; // tables to ignore time limit
    private QueryManager queryMgr; // track pending queries

--- a/core/src/main/java/inetsoft/report/filter/CalcFieldFormula.java
+++ b/core/src/main/java/inetsoft/report/filter/CalcFieldFormula.java
@@ -275,6 +275,13 @@ public class CalcFieldFormula implements PercentageFormula, Formula2 {
          result = senv.exec(script, scope = updateParameter(), null, null);
       }
       catch(Exception ex) {
+         if(senv == null) {
+            String msg = "Script failed, ScriptEnv is not available:\n" +
+               XUtil.numbering(runtimeFormula);
+            LOG.warn(msg, ex);
+            throw new ScriptException(msg, ex);
+         }
+
          String suggestion = senv.getSuggestion(ex, "field", scope);
          String msg = "Script error: " + ex.getMessage() +
             (suggestion != null ? "\nTo fix: " + suggestion : "") +

--- a/core/src/main/java/inetsoft/util/script/ScriptEnvRepository.java
+++ b/core/src/main/java/inetsoft/util/script/ScriptEnvRepository.java
@@ -17,6 +17,9 @@
  */
 package inetsoft.util.script;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * ScriptEnvRepository creates script environment.
  *
@@ -24,6 +27,8 @@ package inetsoft.util.script;
  * @author InetSoft Technology Corp
  */
 public class ScriptEnvRepository {
+   private static final Logger LOG = LoggerFactory.getLogger(ScriptEnvRepository.class);
+
    static boolean found = false;
    static {
       try {
@@ -31,6 +36,8 @@ public class ScriptEnvRepository {
          found = true;
       }
       catch(Throwable e) {
+         LOG.warn("Failed to load GraalJavaScriptEngine on thread {}, found={}",
+                  Thread.currentThread().getName(), found, e);
       }
    }
 
@@ -45,6 +52,8 @@ public class ScriptEnvRepository {
             return (ScriptEnv) Class.forName(cls).newInstance();
          }
          catch(Throwable e) {
+            LOG.warn("Failed to create GraalJavaScriptEnv on thread {}, found={}",
+                     Thread.currentThread().getName(), found, e);
          }
       }
 

--- a/core/src/test/java/inetsoft/report/filter/CalcFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/report/filter/CalcFieldFormulaTest.java
@@ -22,6 +22,7 @@ import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.test.*;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.util.Tool;
+import inetsoft.util.script.ScriptException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -388,6 +389,34 @@ public class CalcFieldFormulaTest {
    // -----------------------------------------------------------------------
    // Script evaluation: expression combining child formula results
    // -----------------------------------------------------------------------
+
+   // -----------------------------------------------------------------------
+   // Regression test for Bug #76566: a null ScriptEnv (e.g. AssetQuerySandbox
+   // handed out a null senv snapshot) must fail as a clear, diagnosable
+   // ScriptException, not an unhandled NullPointerException.
+   // -----------------------------------------------------------------------
+
+   @Test
+   void getResult_nullScriptEnv_throwsScriptExceptionNotNPE() {
+      // Warm the static script compile cache for this expression using a real
+      // ScriptEnv first, so the null-senv instance below hits a cache hit
+      // (see ScriptCache.get) instead of exercising the unrelated compile path.
+      buildSingleChildFormula("SUM", new SumFormula(), "SUM");
+
+      CalcFieldFormula formula = new CalcFieldFormula(
+         "SUM",
+         new String[]{ "SUM" },
+         new Formula[]{ new SumFormula() },
+         new int[]{ 0 },
+         null,
+         box.getScope()
+      );
+      formula.addValue(new Object[]{ null, Double.valueOf(5.0) });
+
+      ScriptException ex = assertThrows(ScriptException.class, formula::getResult);
+      assertTrue(ex.getMessage().contains("ScriptEnv is not available"));
+      assertInstanceOf(NullPointerException.class, ex.getCause());
+   }
 
    @Test
    void getResult_withSumChildFormula_scriptEvaluatesCorrectly() {


### PR DESCRIPTION
## Summary

An unhandled NPE (`this.senv` is null) in `CalcFieldFormula.getResult0()` via `SummaryFilter`, reported to reproduce only on the first viewsheet open after a server restart.

**Scope note, after two diagnosis/refutation rounds** (see `docs/teams/2026-09-10-bugs-vscalc-chart-batch/bug-76566/` in `stylebi-wiz`): the exact restart-timing mechanism (why it happens on the first post-restart open specifically) was not conclusively established from static reading alone — two candidate `ScriptEnvRepository` classloading theories were ruled out, and a genuine, independently-found synchronization defect in `AssetQuerySandbox.senv` was identified as a better-targeted candidate, but its reachability during a real restart wasn't confirmed without live instrumentation. This PR ships the confirmed-safe hardening below; it does **not** claim to resolve the restart-timing root cause, which remains open (recommended follow-up: temporary logging + a live restart repro, noted in the investigation docs).

## Fix

Three changes:
1. `CalcFieldFormula.getResult0()`: no longer double-NPEs when `senv` is null — throws one clear, diagnosable `ScriptException` instead.
2. `ScriptEnvRepository.getScriptEnv()`: logs the previously-swallowed `Throwable` in both catch blocks (thread name and the `found` flag), so a future occurrence is diagnosable in production instead of silent.
3. `AssetQuerySandbox.senv`: made `volatile`; `reset()`/`dispose()` now null it under the same lock monitor `getScriptEnv()` uses, instead of no synchronization / a different monitor — closing a real, independently-confirmed data race between the field's three writers.

## Testing

`core` module compiles clean.

Fixes https://173.220.179.100/issues/76566

🤖 Generated with [Claude Code](https://claude.com/claude-code)