### PR TITLE
Bug #76565: fix missing selected-row highlight in Filters list

### DIFF
--- a/web/projects/portal/src/app/composer/dialog/vs/filters-pane.component.scss
+++ b/web/projects/portal/src/app/composer/dialog/vs/filters-pane.component.scss
@@ -26,6 +26,11 @@
       width: 100%;
     }
   }
+
+  td.selected {
+    --bs-table-bg-state: var(--inet-selected-item-bg-color);
+    --bs-table-color-state: var(--inet-selected-item-text-color);
+  }
 }
 
 .filters-col {


### PR DESCRIPTION
## Summary

In Composer > viewsheet > Dashboard Options > Filters tab, clicking a row in the left "Filters" list updated selection internally but showed no highlight color.

**Root cause (confirmed via CSS specificity analysis + live browser rendering):** the left "Filters" list applies `.selected` directly to the `<td>` (`filters-pane.component.html`). `.selected` (`_themeable.scss`, specificity `(0,1,0)`) loses a same-element specificity contest to Bootstrap's own `.table > :not(caption) > * > *` rule (specificity `(0,1,1)`, `background-color: var(--bs-table-bg)`), because `_bootstrap-override.scss` forces `--bs-table-bg: transparent` for all `.table` elements. Both rules are same-origin, no `!important`, no `@layer`, so specificity alone decides regardless of stylesheet load order — the `<td>`'s background is always transparent.

The right "Shared Filters" list applies `.selected` to the `<tr>` instead, which is one DOM level short of Bootstrap's colliding selector, so there is no specificity collision there. This was independently verified via live browser rendering to already highlight correctly, and is **not touched by this fix**.

## Fix

Instead of trying to out-specificity Bootstrap on `background-color` (a losing, brittle battle), this follows Bootstrap's own pattern for `.table-hover`/`.table-active`: those states set the `--bs-table-bg-state` custom property, which the base `.table > :not(caption) > * > *` rule already reads via `box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, ...)` — the same rule that provides the transparent `background-color`, so this box-shadow always paints on top of it.

Added to `filters-pane.component.scss` (component-scoped, cannot leak to other `.selected` usages elsewhere in the app):

```scss
.filters-table td.selected {
  --bs-table-bg-state: var(--inet-selected-item-bg-color);
  --bs-table-color-state: var(--inet-selected-item-text-color);
}
```

Verified the box-shadow/custom-property mechanism against the actual resolved Bootstrap version in this project's lockfile (5.3.8) before implementing.

## Test plan

- [x] `npx ng build portal --configuration development` compiles cleanly with the change
- [x] Confirmed via analysis + prior live-render checks in this investigation that the right "Shared Filters" list is unaffected (unchanged code path, already renders correctly)
- [ ] Manual verification in a running app: open viewsheet in Composer > Options > Filters tab, click a row in the left list, confirm the highlight now appears; confirm right list still highlights correctly

Redmine: https://173.220.179.100/issues/76565

🤖 Generated with [Claude Code](https://claude.com/claude-code)