### PR TITLE
Bug #76560: fix dead tbody height guard in scrollable-table directive

### DIFF
--- a/web/projects/portal/src/app/widget/scrollable-table/scrollable-table.directive.ts
+++ b/web/projects/portal/src/app/widget/scrollable-table/scrollable-table.directive.ts
@@ -70,7 +70,7 @@ export class ScrollableTableDirective implements AfterContentInit, AfterContentC
 
       const tableStyle = window.getComputedStyle(table);
 
-      if(tbody.style.height == null) {
+      if(!tbody.style.height) {
          let tableHeight: string;
 
          if(tableStyle.maxHeight && tableStyle.maxHeight !== "none") {


### PR DESCRIPTION
## Summary

The Filters table in the Dashboard Options dialog was reported to have no internal scrollbar, growing unbounded and pushing the whole dialog taller instead.

**Root cause, confirmed independently across diagnosis and refutation rounds** (see `docs/teams/2026-09-10-bugs-vscalc-chart-batch/bug-76560/` in `stylebi-wiz`) — a different, more fundamental bug than the reporter's own theory (which blamed early-return branches for 0-row/hidden-tab tables): `ScrollableTableDirective`'s guard `if(tbody.style.height == null)` is dead code. `tbody.style.height` is a CSSStyleDeclaration property that defaults to the empty string `""` when unset, never `null` — so `"" == null` is always `false` in JavaScript, and the one-time tbody height calculation never runs at all, for any table using `wScrollableTable`, regardless of row count or tab visibility. This leaves `tbody` without a bounded height, so the outer `<table>`'s own `max-height` gets violated by overflowing rows instead, with no `overflow` rule on the `<table>` element itself to contain them.

## Fix

Change the guard to `if(!tbody.style.height)`, which correctly covers the empty-string case, so the intended height calculation actually runs.

## Testing

`ng build portal --configuration development` succeeds clean.

Fixes https://173.220.179.100/issues/76560

🤖 Generated with [Claude Code](https://claude.com/claude-code)