### PR TITLE
Bug #76531: guard against undefined result in Chart Properties onCommit

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/chart/services/vs-chart-action-handler.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/services/vs-chart-action-handler.ts
@@ -194,6 +194,10 @@ export class VSChartActionHandler extends AbstractActionHandler {
          const dialog: ChartPropertyDialog = this.showDialog(
             ChartPropertyDialog, options,
             (result: ChartPropertyDialogModel) => {
+               if(!result) {
+                  return;
+               }
+
                const result0: ChartPropertyDialogModel = Tool.clone(result);
                // clear delete info and keep index in sync
                result.chartAdvancedPaneModel.chartTargetLinesPaneModel.deletedIndexList = [];


### PR DESCRIPTION
## Summary

The Chart Properties dialog's OK/Apply callback crashed with `Cannot read properties of undefined (reading 'chartAdvancedPaneModel')` and silently dropped the user's edits, with the repro trigger initially unclear to the reporter.

**Root cause, confirmed independently across two diagnosis/refutation rounds** (see `docs/teams/2026-09-10-bugs-vscalc-chart-batch/bug-76531/` in `stylebi-wiz`, including a byte-exact stack-trace corroboration the original report's own theory missed): the reporter's own console error was misread — `result` itself is undefined at the dereference site, not `result.chartAdvancedPaneModel`. This is not caused by a real OK click (the server always populates `chartAdvancedPaneModel`, and a real click always carries a defined result). The Chart Properties dialog is a non-popup slide-out (`SlideOutRef`); `DialogService`'s sheetChange "close" handler force-closes any still-open slide-out belonging to the owning composer tab (via `ref.close()` with no argument) whenever that tab is closed, reloaded, or Preview mode is exited — resolving the same `onCommit` promise chain a real OK click uses, with `undefined`.

Refutation also flagged a related race variant (noted but out of scope for this fix): a genuine OK click's deferred close can occasionally lose a race against the synchronous forced-close, meaning a real edit could be the one silently dropped in rare timing. Whether tab-close should warn/prevent when a dialog has unsaved edits is a separate, legitimate product question this fix doesn't attempt to resolve.

## Fix

Guard on `result` itself (`if(!result) { return; }`) before the dereference chain, which stops the crash in both the plain force-close case and the race variant (though it cannot recover a genuinely-lost edit in the race variant).

## Testing

`ng build portal --configuration development` succeeds clean.

Fixes https://173.220.179.100/issues/76531

🤖 Generated with [Claude Code](https://claude.com/claude-code)