### PR TITLE
fix(portal): pass followFocusService in formula-editor-dialog spec (bug #76586)

### DIFF
--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts
@@ -346,7 +346,7 @@ describe("FormulaEditorDialog Unit Test", () => {
       };
       modalService = { open: vi.fn() };
 
-      dialog = new FormulaEditorDialog(editorService, modalService, null, null, null);
+      dialog = new FormulaEditorDialog(editorService, modalService, null, null, null, null);
       dialog.vsId = "vs1";
       dialog.assemblyName = "Table1";
       dialog.isCube = false;


### PR DESCRIPTION
## Summary

- CI `build` check was failing on `stylebi-wiz-main-rebase` (and every open PR against it, regardless of what the PR touched) with:
  ```
  ✘ [ERROR] TS2554: Expected 6 arguments, but got 5. [plugin angular-compiler]
  projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts:349:15
  An argument for 'followFocusService' was not provided.
  ```
- Root cause confirmed: `FormulaEditorDialog`'s constructor gained a 6th parameter, `followFocusService: FollowFocusService`, in #4683 (Follow Focus push/pop wiring). The spec file's separate "Unit Test" `describe` block builds the component with a manual `new FormulaEditorDialog(...)` call (last touched by the unrelated pane-scoped-pairing commit `ec46b37d9`) that was never updated for the new argument.
- Fix: pass `null` as the 6th argument in that call, matching the existing style already used there for `renderer`/`element`/`dropdownService` (this describe block only calls `populateColumnTree()` directly and never exercises `ngOnInit`/`ngOnDestroy`, so `followFocusService` is never dereferenced).

## Test plan

- [x] `npx ng test portal --include "projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.spec.ts" --watch=false` — 25/25 tests pass, TS2554 build error gone.

Refs bug #76586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)