### PR TITLE
fix(wiz): add_table queryParams exclusion check missed parameters/lookup/customLookups

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -302,6 +302,21 @@ public class WorksheetAgentController {
                "endpoint or suffix -- choose exactly one add_table form.");
          }
 
+         if(req.parameters() != null && !req.parameters().isEmpty()) {
+            throw new PairingException("add_table cannot carry queryParams together with " +
+               "parameters -- parameters only applies to the endpoint form.");
+         }
+
+         if(req.lookup() != null && !req.lookup().isEmpty()) {
+            throw new PairingException("add_table cannot carry queryParams together with " +
+               "lookup -- lookup only applies to the endpoint form.");
+         }
+
+         if(req.customLookups() != null && !req.customLookups().isEmpty()) {
+            throw new PairingException("add_table cannot carry queryParams together with " +
+               "customLookups -- customLookups only applies to the suffix form.");
+         }
+
          if(req.datasource() == null || req.datasource().isBlank()) {
             throw new PairingException("datasource is required when queryParams is specified.");
          }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -418,6 +418,30 @@ class WorksheetAgentControllerTest {
    }
 
    /**
+    * Same as {@link #addQueryParamsTableRequest}, but also carrying {@code parameters}/
+    * {@code lookup}/{@code customLookups} -- the three endpoint/suffix-only fields
+    * {@code addQueryParamsTable} silently ignores unless {@code editOp} rejects the
+    * combination up front.
+    */
+   private static EditRequest addQueryParamsTableRequestWithConflictingField(
+      String table, String datasource, Map<String, Object> queryParams,
+      Map<String, String> parameters, List<String> lookup,
+      List<Map<String, Object>> customLookups) throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(queryParams != null) body.put("queryParams", queryParams);
+      if(parameters != null) body.put("parameters", parameters);
+      if(lookup != null) body.put("lookup", lookup);
+      if(customLookups != null) body.put("customLookups", customLookups);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
+   /**
     * Builds a {@code delete_table} EditRequest -- a plainly destructive op that routes through
     * {@code editService}, so a scope guard that failed to fire would show up as a real write
     * attempt rather than an early return.
@@ -4021,6 +4045,70 @@ class WorksheetAgentControllerTest {
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-QP2", req, agent));
       assertTrue(ex.getMessage().contains("queryParams together with endpoint or suffix"),
+         ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsQueryParamsTogetherWithParameters() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequestWithConflictingField("t1", "MyDatasource",
+         Map.of("entitySet", "Orders"), Map.of("id", "123"), null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP7", req, agent));
+      assertTrue(ex.getMessage().contains("queryParams together with parameters"),
+         ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsQueryParamsTogetherWithLookup() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequestWithConflictingField("t1", "MyDatasource",
+         Map.of("entitySet", "Orders"), null, List.of("Issue Event"), null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP8", req, agent));
+      assertTrue(ex.getMessage().contains("queryParams together with lookup"),
+         ex.getMessage());
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addQueryParamsTableRejectsQueryParamsTogetherWithCustomLookups() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequestWithConflictingField("t1", "MyDatasource",
+         Map.of("entitySet", "Orders"), null, null,
+         List.of(Map.of("url", "/v1/events", "jsonPath", "$.data", "key", "id")));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-QP9", req, agent));
+      assertTrue(ex.getMessage().contains("queryParams together with customLookups"),
          ex.getMessage());
       verifyNoInteractions(dataSourceService);
       verifyNoInteractions(editSvc);


### PR DESCRIPTION
## Summary
- Bug 76581's PR-review-bot addendum (and my own follow-up code analysis) found that `add_table`'s `queryParams` mutual-exclusion check in `WorksheetAgentController.editOp` only rejected `queryParams` combined with `endpoint`/`suffix`, never with `parameters`/`lookup`/`customLookups` -- even though the composer plugin's own tool description documents all five as mutually exclusive.
- `addQueryParamsTable` never reads `parameters`/`lookup`/`customLookups` at all, so a request combining `queryParams` with any of them previously passed validation silently and dropped the extra fields with no error -- the "tool accepts malformed input and produces a plausible-but-wrong result" pattern this repo's CLAUDE.md calls a plugin defect.
- Extends the existing check to also reject `queryParams` + `parameters`/`lookup`/`customLookups`, each with its own named error.

## Test plan
- [x] New tests added (`WorksheetAgentControllerTest`) confirmed red against the unfixed code (fell through to a different error instead of the expected rejection), then green after the fix.
- [x] `./mvnw -q -pl core -am test -Dtest=WorksheetAgentControllerTest -Dsurefire.failIfNoSpecifiedTests=false` -- 168 tests, all passing, including the pre-existing endpoint/suffix rejection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)