### PR TITLE
fix(admin/licensing): pin reviewed task narrative into audit record via taskToken (#76588)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/AdminLicensingController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/AdminLicensingController.java
@@ -168,6 +168,16 @@ public class AdminLicensingController {
                     "plan", ex.current());
    }
 
+   @ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handleTaskTokenMismatch(
+      AdminChangesetApplyService.TaskTokenMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
    private final LicenseManager licenseManager;
    private final LicenseChangePlanService planService;
    private final LicenseChangesetApplyService applyService;

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyRequest.java
@@ -31,11 +31,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class LicenseApplyRequest extends LicenseChangePlanRequest {
    public String getPlanHash() { return planHash; }
    public void setPlanHash(String v) { this.planHash = v; }
+   public String getTaskToken() { return taskToken; }
+   public void setTaskToken(String v) { this.taskToken = v; }
    public String getReviewOutcome() { return reviewOutcome; }
    public void setReviewOutcome(String v) { this.reviewOutcome = v; }
    public Boolean getAcknowledgeDelicensing() { return acknowledgeDelicensing; }
    public void setAcknowledgeDelicensing(Boolean v) { this.acknowledgeDelicensing = v; }
 
-   private String planHash, reviewOutcome;
+   private String planHash, taskToken, reviewOutcome;
    private Boolean acknowledgeDelicensing;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyService.java
@@ -71,6 +71,9 @@ public class LicenseChangesetApplyService {
     *
     * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
     *         (maps to HTTP 409) -- reused verbatim, per 01-spec.md section 6.
+    * @throws AdminChangesetApplyService.TaskTokenMismatchException if the taskToken is missing,
+    *         invalid, or was issued for a different plan (maps to HTTP 409) -- reused verbatim, same
+    *         as PlanHashMismatchException above.
     * @throws Exception if the Tier-2 backup itself fails, in which case nothing was applied.
     */
    public LicenseApplyResult apply(LicenseApplyRequest req, Principal user) throws Exception {
@@ -81,6 +84,15 @@ public class LicenseChangesetApplyService {
 
          if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
             throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
+         }
+
+         String reviewedTask;
+
+         try {
+            reviewedTask = TaskAuditToken.verify(req.getTaskToken(), plan.planHash());
+         }
+         catch(TaskAuditToken.TaskTokenException e) {
+            throw new AdminChangesetApplyService.TaskTokenMismatchException(plan, e.getMessage());
          }
 
          if(plan.requiresAgentSignoff() &&
@@ -138,7 +150,7 @@ public class LicenseChangesetApplyService {
             AtomicBoolean mutationEntered = new AtomicBoolean(false);
 
             try {
-               applyOne(txId, plan.task(), key, original, backupRef, reviewOutcome, user, results,
+               applyOne(txId, reviewedTask, key, original, backupRef, reviewOutcome, user, results,
                        undoable, mutationEntered);
             }
             catch(Exception e) {
@@ -165,7 +177,7 @@ public class LicenseChangesetApplyService {
          }
 
          Map<String, String> rollbackAdvisories = new LinkedHashMap<>();
-         List<RollbackFailure> rollbackOwnFailures = rollback(txId, plan.task(), undoable, backupRef,
+         List<RollbackFailure> rollbackOwnFailures = rollback(txId, reviewedTask, undoable, backupRef,
                                                               reviewOutcome, user, rollbackAdvisories);
          List<LicenseApplyOutcome> finalResults = results.stream()
             .map(o -> mergeAdvisory(o, rollbackAdvisories.get(o.property())))

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/AdminLicensingControllerGetKeyTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/AdminLicensingControllerGetKeyTest.java
@@ -21,20 +21,27 @@ import inetsoft.report.internal.license.License;
 import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.report.internal.license.LicenseType;
 import inetsoft.sree.security.OrganizationManager;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.net.URI;
 import java.security.Principal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -66,6 +73,7 @@ class AdminLicensingControllerGetKeyTest {
    private MockedStatic<OrganizationManager> orgManagerStatic;
    private MockedStatic<LicenseManager> licenseManagerStatic;
    private MockMvc mvc;
+   private AdminLicensingController controller;
 
    private static final Principal TEST_PRINCIPAL = () -> "test-user";
 
@@ -78,7 +86,8 @@ class AdminLicensingControllerGetKeyTest {
       licenseManagerStatic = mockStatic(LicenseManager.class, withSettings().lenient());
       licenseManagerStatic.when(LicenseManager::isEnterprise).thenReturn(true);
 
-      mvc = standaloneSetup(new AdminLicensingController(licenseManager, planService, applyService))
+      controller = new AdminLicensingController(licenseManager, planService, applyService);
+      mvc = standaloneSetup(controller)
          .setMessageConverters(new MappingJackson2HttpMessageConverter())
          .build();
    }
@@ -136,5 +145,40 @@ class AdminLicensingControllerGetKeyTest {
             .header("Authorization", "Bearer test-token"))
          .andExpect(status().isOk())
          .andExpect(content().string(containsString("\"found\":false")));
+   }
+
+   // -------------------------------------------------------------------------
+   // taskToken audit-pinning fix (bug #76588): a thrown TaskTokenMismatchException must map to a
+   // clean 409, mirroring AdminAiControllerTest's own handleTaskTokenMismatch* tests for the
+   // Properties area's identical exception handler. Before this handler existed, the same throw
+   // would have been caught by AdminExceptionHandler's global @ControllerAdvice and returned as a
+   // structured 500 GenericError -- not "unmapped"/a raw framework default page.
+   // -------------------------------------------------------------------------
+
+   @Test void handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan() {
+      ResolvedPlan current = new ResolvedPlan("install trial key", List.of(), true, true,
+                                              "hash456", "token456");
+      AdminChangesetApplyService.TaskTokenMismatchException ex =
+         new AdminChangesetApplyService.TaskTokenMismatchException(current,
+            "taskToken: does not match the current plan; re-review before applying");
+
+      Map<String, Object> actual = controller.handleTaskTokenMismatch(ex);
+
+      assertEquals("conflict", actual.get("status"));
+      assertEquals(ex.getMessage(), actual.get("error"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) actual.get("plan");
+      assertEquals(current.task(), returnedPlan.task());
+      assertEquals(current.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
+   }
+
+   @Test void handleTaskTokenMismatchIsAnnotatedConflict() throws NoSuchMethodException {
+      ResponseStatus annotation = AdminLicensingController.class
+         .getMethod("handleTaskTokenMismatch",
+                    AdminChangesetApplyService.TaskTokenMismatchException.class)
+         .getAnnotation(ResponseStatus.class);
+
+      assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
+      assertEquals(HttpStatus.CONFLICT, annotation.value());
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
@@ -27,6 +27,7 @@ import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.util.audit.Audit;
 import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import inetsoft.web.admin.general.LicenseKeySettingsService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,6 +84,16 @@ class LicenseChangesetApplyServiceTest {
          .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
 
       lenient().doAnswer(inv -> {
          String key = inv.getArgument(0);
@@ -131,6 +142,14 @@ class LicenseChangesetApplyServiceTest {
       return req;
    }
 
+   /**
+    * Defaults taskToken to a token issued for exactly (hash, task) -- correct for every existing
+    * caller, whose hash is either the real freshly-resolved plan hash (the normal case, where
+    * verification must succeed) or a deliberately wrong one used to exercise the planHash-mismatch
+    * gate, which is checked and throws before taskToken is ever verified (see
+    * LicenseChangesetApplyService.apply's ordering), so an issued-but-irrelevant token there is
+    * harmless.
+    */
    private static LicenseApplyRequest applyRequest(String task, String hash, String reviewOutcome,
                                                     Boolean acknowledgeDelicensing,
                                                     LicenseChangeRequest... changes)
@@ -139,6 +158,7 @@ class LicenseChangesetApplyServiceTest {
       req.setTask(task);
       req.setChanges(Arrays.asList(changes));
       req.setPlanHash(hash);
+      req.setTaskToken(TaskAuditToken.issue(hash, task));
       req.setReviewOutcome(reviewOutcome);
       req.setAcknowledgeDelicensing(acknowledgeDelicensing);
       return req;
@@ -182,6 +202,66 @@ class LicenseChangesetApplyServiceTest {
       IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
          () -> service.apply(req, user));
       assertTrue(ex.getMessage().contains("already installed"));
+   }
+
+   // -------------------------------------------------------------------------
+   // taskToken audit-pinning (bug #76588) -- mirrors AdminChangesetApplyServiceTest's own
+   // auditsThePreviewedTaskEvenWhenApplyTaskDiffers/rejectsAMissingTaskToken/
+   // rejectsATaskTokenIssuedForADifferentPlan tests for the Properties area's identical defect.
+   // -------------------------------------------------------------------------
+
+   @Test void auditsThePreviewedTaskEvenWhenApplyTaskDiffers() throws Exception {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String previewTask = "install trial key for Q3 pilot";
+      String hash = planService.resolve(request(previewTask, List.of(add("K1")))).planHash();
+      String taskToken = TaskAuditToken.issue(hash, previewTask);
+
+      LicenseApplyRequest req = applyRequest(
+         "unrelated substituted text", hash, "looks good", null, add("K1"));
+      req.setTaskToken(taskToken);
+
+      tool.when(Tool::getHost).thenReturn("test-host");
+      Audit auditInstance = mock(Audit.class);
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         result = service.apply(req, user);
+      }
+
+      // The core regression proof: apply still succeeds -- task text diverging between preview
+      // and apply must never be treated as drift (only the plan's `changes` are hash-protected).
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      assertEquals(previewTask, captor.getValue().getTaskDescription());
+   }
+
+   @Test void rejectsAMissingTaskToken() {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
+      req.setTaskToken(null);
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex = assertThrows(
+         AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().startsWith("taskToken:"));
+      assertNotNull(ex.current());
+   }
+
+   @Test void rejectsATaskTokenIssuedForADifferentPlan() {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      when(licenseManager.parseLicense("K2")).thenReturn(valid("K2"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      String otherHash = planService.resolve(request("other task", List.of(add("K2")))).planHash();
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
+      req.setTaskToken(TaskAuditToken.issue(otherHash, "other task"));
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
    }
 
    // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Redmine #76588 (Licensing sub-task): `LicenseChangesetApplyService.apply` never verified a `taskToken`, so an operator could preview an accurate task narrative, get sign-off, then call `apply_license_changes` with a substituted task string and a valid `planHash` -- the substituted text landed in every `AdminChangeRecord` for the whole transaction (add, remove, and rollback entries alike) instead of the reviewed narrative. Same defect class PR #2282 closed for Properties.
- Add `taskToken` to `LicenseApplyRequest` (getter/setter, matching `ApplyRequest`'s shape).
- In `LicenseChangesetApplyService.apply`, after the existing `planHash` check, verify the token via `TaskAuditToken.verify(req.getTaskToken(), plan.planHash())`, throwing the shared `AdminChangesetApplyService.TaskTokenMismatchException` on failure (reused verbatim, exactly as this service already reuses `PlanHashMismatchException`). Thread the recovered `reviewedTask` through `applyOne`/`rollback` (both call sites feeding `writeAudit`) instead of `plan.task()`.
- Add the missing `@ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)` to `AdminLicensingController`, mapping to HTTP 409 -- mirrors `AdminAiController`'s existing handler for the identical exception. Before this handler existed, a thrown `TaskTokenMismatchException` would have been caught by the pre-existing global `@ControllerAdvice` `AdminExceptionHandler` and returned as a structured 500 `GenericError`, not an unmapped/raw default error page -- the local handler now intercepts first, giving the intended clean 409.

## Test plan
- [x] `LicenseChangesetApplyServiceTest`: added `auditsThePreviewedTaskEvenWhenApplyTaskDiffers` (apply still succeeds and the audit record carries the *previewed* task text even when apply's own `task` field diverges), `rejectsAMissingTaskToken`, `rejectsATaskTokenIssuedForADifferentPlan` -- mirrors `AdminChangesetApplyServiceTest`'s identical regression tests for the Properties area.
- [x] `AdminLicensingControllerGetKeyTest`: added `handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan` / `handleTaskTokenMismatchIsAnnotatedConflict` -- mirrors `AdminAiControllerTest`'s identical handler tests.
- [x] Ran `./mvnw -pl core test -Dtest=LicenseChangesetApplyServiceTest,LicenseChangePlanServiceTest,AdminLicensingControllerGetKeyTest -DfailIfNoTests=false` -- `Tests run: 43, Failures: 0, Errors: 0`.

Companion plugin PR: inetsoft-technology/stylebi-wiz#2416

🤖 Generated with [Claude Code](https://claude.com/claude-code)