### PR TITLE
fix(wiz): reject null/blank runtimeId in SheetPairingService.mint (Redmine #76578)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
@@ -135,13 +135,18 @@ public class SheetPairingService {
     * editor that produced it, so the browser can show a real error — rather than deferring the
     * failure to join time, where it would surface to an agent with no way back to the user.
     *
-    * @throws PairingException if editorContext names an assembly (or, for {@code calcField}, a
-    *                          table+field) that the runtime does not have.
+    * @throws PairingException if {@code runtimeId} is blank, or editorContext names an assembly
+    *                          (or, for {@code calcField}, a table+field) that the runtime does
+    *                          not have.
     */
    public String mint(String runtimeId, String ownerIdentity, String socketSessionId,
                       String socketUserName, SheetType sheetType, EditorContext editorContext)
       throws PairingException
    {
+      if(isBlank(runtimeId)) {
+         throw new PairingException(PairingException.Kind.INVALID_ARGUMENT, "runtimeId is required");
+      }
+
       if(editorContext != null) {
          validateEditorContext(sheetType, runtimeId, ownerIdentity, editorContext);
       }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
@@ -110,6 +110,48 @@ class SheetPairingControllerTest {
       assertNotNull(resp.error(), "error should be non-null when feature is off");
    }
 
+   /**
+    * Regression for Redmine #76578: mintViaSocket previously had no null/blank guard on
+    * req.runtimeId(), unlike its sibling STOMP handlers -- a blank runtimeId was accepted and
+    * stored in a PairingGrant, then echoed back unchanged at join time (a "successful" join
+    * response missing runtimeId). The guard now lives in SheetPairingService#mint and surfaces
+    * here as an ordinary MintResponse.err(...), the same shape mintViaSocket already uses for
+    * every other mint failure.
+    */
+   @Test
+   void stompMintRefusedWithNullRuntimeId() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
+      Principal owner = TestPrincipals.user("alice", "host-org");
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("stomp-x");
+
+      SheetPairingController.MintResponse resp = c.mintViaSocket(
+         new SheetPairingController.MintRequest(null, SheetType.WORKSHEET, null), owner, accessor);
+
+      assertNull(resp.code(), "code should be null when runtimeId is missing");
+      assertNotNull(resp.error(), "error should be non-null when runtimeId is missing");
+   }
+
+   @Test
+   void stompMintRefusedWithBlankRuntimeId() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
+      Principal owner = TestPrincipals.user("alice", "host-org");
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("stomp-x");
+
+      SheetPairingController.MintResponse resp = c.mintViaSocket(
+         new SheetPairingController.MintRequest("   ", SheetType.WORKSHEET, null), owner, accessor);
+
+      assertNull(resp.code(), "code should be null when runtimeId is blank");
+      assertNotNull(resp.error(), "error should be non-null when runtimeId is blank");
+   }
+
    @Test
    void detachEndsThePaneScopedSessionBoundToTheCallersSocket() {
       SheetPairingService pairing = new SheetPairingService();

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
@@ -84,6 +84,8 @@ import static org.mockito.Mockito.when;
  *                            naming a column the table does not have
  * [Kinds: exhaustive]        every ScriptTarget.Kind wire name is in RECOGNIZED_KINDS -- catches
  *                            a new Kind added there but never wired into this hand-maintained list
+ * [Mint: null runtimeId]     mint refuses a null runtimeId instead of storing an unresolvable grant
+ * [Mint: blank runtimeId]    mint refuses a blank runtimeId instead of storing an unresolvable grant
  */
 /*
  * @WizAgentTestSupport (which itself carries @Tag("core")) replaces a bare @Tag: the
@@ -159,6 +161,30 @@ class SheetPairingServiceTest {
       PairingGrant first = svc.consume(code);
       assertNotNull(first);
       assertNull(svc.consume(code), "second consume must return null (single-use)");
+   }
+
+   /**
+    * Regression for Redmine #76578: mintViaSocket had no null/blank guard on runtimeId, unlike
+    * its sibling STOMP handlers (followFocusViaSocket, retargetViaSocket, popFocusViaSocket) --
+    * a blank runtimeId was stored unchecked in a PairingGrant and echoed back unchanged at join
+    * time, producing a "successful" join response the plugin's own connect.ts then rejected as
+    * missing runtimeId. The guard lives here in mint() (not only in mintViaSocket) because the
+    * REST mint entry point (SheetPairingController#mint) calls this method directly too.
+    */
+   @Test
+   void mintRefusesANullRuntimeId() {
+      SheetPairingService svc = serviceAt(FIXED_NOW);
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.mint(null, "alice~;~org", "sock-1", null, SheetType.WORKSHEET, null));
+      assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
+   }
+
+   @Test
+   void mintRefusesABlankRuntimeId() {
+      SheetPairingService svc = serviceAt(FIXED_NOW);
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.mint("   ", "alice~;~org", "sock-1", null, SheetType.WORKSHEET, null));
+      assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
    }
 
    @Test


### PR DESCRIPTION
## Root cause

`SheetPairingService.mint()` accepted a `null`/blank `runtimeId` with no
validation, unlike its three sibling STOMP handlers in the same controller
file (`followFocusViaSocket`, `retargetViaSocket`, `popFocusViaSocket`),
which all null-check `req.runtimeId()` before proceeding.

A grant minted with a blank `runtimeId` was later echoed back unchanged by
`SheetJoinService.join()` as an ordinary `200 OK` `JoinResponse`. The wiz
plugin's own `connect.ts` then correctly rejects that response client-side
("Pairing succeeded, but the server's join response is missing required
field(s): runtimeId..."), producing a permanent, silent, hard-to-diagnose
join failure with no server-side error surfaced at the point where the bad
value actually originated (mint time).

This was found by an adversarial refute pass on the original debugging
session for Redmine #76578 (a previously-working viewsheet runtime
permanently refusing new agent joins). The reporter's own theory — that an
unrelated Ignite `AffinityKey` NPE on the `OpenViewsheetController` path was
corrupting the runtime — was investigated and does **not** hold up from
source (see the diagnosis/refute docs in the internal debug session); this
PR fixes the actual, independently-demonstrated defect the refute pass
found instead.

## Fix

Added the guard to `SheetPairingService.mint()` itself, not only to
`mintViaSocket`: the REST mint entry point
(`SheetPairingController#mint`, test-only/back-compat, disabled by
default) calls `mint()` directly and bypasses `mintViaSocket` entirely, so
a controller-only guard would have left that path unprotected. The check
reuses the same `isBlank()` helper and `PairingException.Kind.INVALID_ARGUMENT`
pattern this method already uses for `editorContext` validation.

`mintViaSocket`'s existing `catch(Exception e)` → `MintResponse.err(...)`
already surfaces this new failure with the same clean error shape it uses
for every other mint failure — no change needed there. The REST mint
entry point already declares `throws PairingException`, handled by the
controller's existing `@ExceptionHandler(PairingException.class)`.

## Tests

Added regression tests to both existing test classes:
- `SheetPairingServiceTest`: `mintRefusesANullRuntimeId`,
  `mintRefusesABlankRuntimeId`
- `SheetPairingControllerTest`: `stompMintRefusedWithNullRuntimeId`,
  `stompMintRefusedWithBlankRuntimeId`

```
./mvnw -pl core -o test -Dtest=SheetPairingControllerTest,SheetPairingServiceTest,SheetJoinServiceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
```
All 71 tests pass (14 + 33 + 24), no regressions in the neighboring
`SheetJoinServiceTest` suite (every existing call site already passes a
real, non-blank `runtimeId`).

## Scope note

This closes the deterministic server-side mechanism (mint-time silent
acceptance of a bad `runtimeId`). It does **not** answer why a specific
browser tab's client-side `runtimeId` binding might go blank in the first
place — that remains open as a lighter follow-up requiring live browser
access, and does not need to be answered for this fix to be correct and
complete for its own scope (per this repo's tool-misuse principle: make
`mint()` fail loud instead of silently accepting bad input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)