### PR TITLE
fix(admin/schedule): pin reviewed task narrative into audit record via taskToken (#76588)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/AdminScheduleController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/AdminScheduleController.java
@@ -139,6 +139,16 @@ public class AdminScheduleController {
                     "plan", ex.current());
    }
 
+   @ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handleTaskTokenMismatch(
+      AdminChangesetApplyService.TaskTokenMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
    private final AdminScheduleGateway scheduleGateway;
    private final ScheduleChangePlanService planService;
    private final ScheduleChangesetApplyService applyService;

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleApplyRequest.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ScheduleApplyRequest extends ScheduleChangePlanRequest {
    public String getPlanHash() { return planHash; }
    public void setPlanHash(String v) { this.planHash = v; }
+   public String getTaskToken() { return taskToken; }
+   public void setTaskToken(String v) { this.taskToken = v; }
    public String getReviewOutcome() { return reviewOutcome; }
    public void setReviewOutcome(String v) { this.reviewOutcome = v; }
 
-   private String planHash, reviewOutcome;
+   private String planHash, taskToken, reviewOutcome;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyService.java
@@ -70,11 +70,15 @@ public class ScheduleChangesetApplyService {
    }
 
    /**
-    * Resolves, gates on the plan hash, then executes.
+    * Resolves, gates on the plan hash and task token, then executes.
     *
     * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
     *         (maps to HTTP 409) -- the exception type is reused verbatim from the properties area
     *         (spec §6), not redeclared.
+    * @throws AdminChangesetApplyService.TaskTokenMismatchException if the taskToken is missing,
+    *         malformed, or was issued for a different planHash (also maps to HTTP 409, also reused
+    *         verbatim) -- the audit record must be written from the token's verified narrative,
+    *         never from this request's own (unverified) task field.
     * @throws Exception if the Tier-2 backup fails, in which case nothing was applied.
     */
    public ApplyResult apply(ScheduleApplyRequest req, Principal user) throws Exception {
@@ -85,6 +89,15 @@ public class ScheduleChangesetApplyService {
 
          if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
             throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
+         }
+
+         String reviewedTask;
+
+         try {
+            reviewedTask = TaskAuditToken.verify(req.getTaskToken(), plan.planHash());
+         }
+         catch(TaskAuditToken.TaskTokenException e) {
+            throw new AdminChangesetApplyService.TaskTokenMismatchException(plan, e.getMessage());
          }
 
          if(plan.requiresAgentSignoff() &&
@@ -110,11 +123,11 @@ public class ScheduleChangesetApplyService {
 
             try {
                if(ScheduleChangeRequest.VERB_CREATE.equals(original.getVerb())) {
-                  applyCreate(txId, plan.task(), taskId, original.getSpec(), backupRef,
+                  applyCreate(txId, reviewedTask, taskId, original.getSpec(), backupRef,
                              req.getReviewOutcome(), user, results, undoable);
                }
                else {
-                  applyDelete(txId, plan.task(), taskId, backupRef, req.getReviewOutcome(), user,
+                  applyDelete(txId, reviewedTask, taskId, backupRef, req.getReviewOutcome(), user,
                              results, undoable);
                }
             }
@@ -154,7 +167,7 @@ public class ScheduleChangesetApplyService {
          }
 
          List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
-         failures.addAll(rollback(txId, plan.task(), undoable, backupRef, req.getReviewOutcome(),
+         failures.addAll(rollback(txId, reviewedTask, undoable, backupRef, req.getReviewOutcome(),
                                   user));
 
          if(failures.isEmpty()) {

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/AdminScheduleControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/AdminScheduleControllerTest.java
@@ -184,4 +184,20 @@ class AdminScheduleControllerTest {
       assertEquals(fresh.planHash(), returnedPlan.planHash());
       assertNull(returnedPlan.taskToken());
    }
+
+   // Same scrubbing rule as PlanHashMismatchException above, for the taskToken gate this fix adds:
+   // a 409 conflict must never hand back a taskToken either, or a caller could replay an
+   // unreviewed narrative against the freshly resolved plan.
+   @Test void handleTaskTokenMismatchReturnsConflictWithFreshPlan() {
+      ResolvedPlan fresh = new ResolvedPlan("t", Collections.emptyList(), false, false, "new-hash", "new-token");
+      var body = controller.handleTaskTokenMismatch(
+         new AdminChangesetApplyService.TaskTokenMismatchException(fresh, "taskToken: required"));
+
+      assertEquals("conflict", body.get("status"));
+      assertEquals("taskToken: required", body.get("error"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) body.get("plan");
+      assertEquals(fresh.task(), returnedPlan.task());
+      assertEquals(fresh.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyServiceTest.java
@@ -351,6 +351,55 @@ class ScheduleChangesetApplyServiceTest {
       verify(scheduleGateway, never()).removeScheduleTask(anyString(), any(), eq(user));
    }
 
+   // The rollback-path regression proof: even when the first change's own apply narrative and the
+   // second change's failure trigger a rollback, the rollback's OWN writeAudit call (a separate
+   // call site from applyCreate/applyDelete -- see rollback()'s ACTION_ROLLBACK writeAudit calls)
+   // must still carry the previewed/reviewed task narrative, not the apply request's own
+   // (possibly diverged) task field. Same shape as secondChangeFailingRollsBackTheFirst below, but
+   // built via requestWithDivergentApplyTask so a regression that reverted the rollback call site
+   // to plan.task() (or the raw request task) would be caught here.
+   @Test void auditsThePreviewedTaskForARollbackEvenWhenApplyTaskDiffers() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String createdId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      inetsoft.sree.schedule.ScheduleTask other = sreeTask("t2", "admin");
+
+      when(scheduleManager.getScheduleTask(createdId))
+         .thenReturn(null)                       // preview
+         .thenReturn(null)                       // re-resolve
+         .thenReturn(sreeTask("t1", "admin"))     // apply-time verify: created
+         .thenReturn(null);                       // rollback-time verify: deleted
+      when(scheduleManager.getScheduleTask("t2"))
+         .thenReturn(other, other, other, other); // "exists" the whole time -- delete never verifies
+
+      when(scheduleGateway.hasDeletePermission(createdId, user)).thenReturn(true);
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      when(scheduleGateway.getScheduleTask(eq("t2"), any(), eq(user)))
+         .thenReturn(dtoTask("t2", "admin"));
+      when(scheduleGateway.getTaskConditions(eq("t2"), any(), eq(user)))
+         .thenReturn(new ScheduleConditionList());
+      when(scheduleGateway.getTaskActions(eq("t2"), any(), eq(user)))
+         .thenReturn(new ScheduleActionList());
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = requestWithDivergentApplyTask(
+         "reviewed: two changes", "totally different apply-time text",
+         createChange(spec), deleteChange("t2"));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, result.status());
+      verify(scheduleGateway).removeScheduleTask(eq(createdId), any(), eq(user));
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditMock, atLeastOnce()).auditAdminChange(captor.capture(), eq(user));
+      List<AdminChangeRecord> rollbackRecords = captor.getAllValues().stream()
+         .filter(r -> AdminChangeRecord.ACTION_ROLLBACK.equals(r.getAction()))
+         .toList();
+      assertFalse(rollbackRecords.isEmpty());
+      assertTrue(rollbackRecords.stream()
+         .allMatch(r -> "reviewed: two changes".equals(r.getTaskDescription())));
+   }
+
    // N-change plan: the first change (create) succeeds, the second (delete of an unrelated task)
    // fails verification -- rollback must undo the first, newest-first (trivially, since it's the
    // only undoable one), by deleting what it created.

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangesetApplyServiceTest.java
@@ -18,18 +18,24 @@
 package inetsoft.web.admin.ai.schedule;
 
 import inetsoft.web.api.schedule.*;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.schedule.ScheduleManager;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.util.Tool;
+import inetsoft.util.audit.Audit;
+import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
 import inetsoft.web.admin.ai.ApplyResult;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -56,20 +62,47 @@ class ScheduleChangesetApplyServiceTest {
    @Mock private Principal user;
    private ScheduleChangePlanService planService;
    private ScheduleChangesetApplyService service;
+   private MockedStatic<SreeEnv> sreeEnv;
    private MockedStatic<Tool> tool;
+   private MockedStatic<Audit> auditStatic;
+   private Audit auditMock;
 
    @BeforeEach void setUp() {
       planService = new ScheduleChangePlanService(scheduleGateway, scheduleManager);
       service = new ScheduleChangesetApplyService(planService, scheduleGateway, scheduleManager,
                                                    backupService);
+      // writeAudit's Tool.getHost() call falls through to SreeEnv.getProperty("local.host.name")
+      // when unset; a lenient, unstubbed static mock returns null there instead of throwing
+      // ShutdownException for a Spring context that isn't up in this unit test, same as
+      // AdminChangesetApplyServiceTest's own setUp.
+      sreeEnv = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
       tool = mockStatic(Tool.class, withSettings().strictness(Strictness.LENIENT)
          .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
+
+      // writeAudit calls the static Audit.getInstance() singleton directly (no injectable
+      // AdminChangeService to intercept, unlike properties) -- mock it statically so tests can
+      // inspect what task narrative actually reached the audit record.
+      auditMock = mock(Audit.class);
+      auditStatic = mockStatic(Audit.class, withSettings().strictness(Strictness.LENIENT));
+      auditStatic.when(Audit::getInstance).thenReturn(auditMock);
    }
 
    @AfterEach void tearDown() {
+      sreeEnv.close();
       tool.close();
+      auditStatic.close();
    }
 
    // -------------------------------------------------------------------------
@@ -124,6 +157,60 @@ class ScheduleChangesetApplyServiceTest {
       verify(scheduleGateway).removeScheduleTask(eq("t1"), any(), eq(user));
    }
 
+   // The core regression proof for a create: the audit record's taskDescription must come from
+   // the taskToken's embedded (reviewed) narrative, not from this apply request's own (possibly
+   // diverged) task field.
+   @Test void auditsThePreviewedTaskForACreateEvenWhenApplyTaskDiffers() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId))
+         .thenReturn(null)
+         .thenReturn(null)
+         .thenReturn(sreeTask("t1", "admin"));
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = requestWithDivergentApplyTask(
+         "reviewed: create t1", "totally different apply-time text", createChange(spec));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditMock, atLeastOnce()).auditAdminChange(captor.capture(), eq(user));
+      assertTrue(captor.getAllValues().stream()
+         .allMatch(r -> "reviewed: create t1".equals(r.getTaskDescription())));
+   }
+
+   // Same proof for a delete.
+   @Test void auditsThePreviewedTaskForADeleteEvenWhenApplyTaskDiffers() throws Exception {
+      inetsoft.sree.schedule.ScheduleTask existing = sreeTask("t1", "admin");
+      when(scheduleManager.getScheduleTask("t1"))
+         .thenReturn(existing)
+         .thenReturn(existing)
+         .thenReturn(existing)
+         .thenReturn(null);
+      when(scheduleGateway.hasOwnerAdminPermission(any(), any(), eq(user))).thenReturn(true);
+      when(scheduleGateway.getScheduleTask(eq("t1"), any(), eq(user)))
+         .thenReturn(dtoTask("t1", "admin"));
+      when(scheduleGateway.getTaskConditions(eq("t1"), any(), eq(user)))
+         .thenReturn(new ScheduleConditionList());
+      when(scheduleGateway.getTaskActions(eq("t1"), any(), eq(user)))
+         .thenReturn(new ScheduleActionList());
+      when(backupService.backup(anyString())).thenReturn("snap-ref");
+
+      ScheduleApplyRequest req = requestWithDivergentApplyTask(
+         "reviewed: delete t1", "totally different apply-time text", deleteChange("t1"));
+
+      ApplyResult result = service.apply(req, user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditMock, atLeastOnce()).auditAdminChange(captor.capture(), eq(user));
+      assertTrue(captor.getAllValues().stream()
+         .allMatch(r -> "reviewed: delete t1".equals(r.getTaskDescription())));
+   }
+
    // -------------------------------------------------------------------------
    // gates
    // -------------------------------------------------------------------------
@@ -156,6 +243,60 @@ class ScheduleChangesetApplyServiceTest {
       IllegalArgumentException ex =
          assertThrows(IllegalArgumentException.class, () -> service.apply(req, user));
       assertTrue(ex.getMessage().contains("reviewOutcome"));
+   }
+
+   @Test void rejectsAMissingTaskToken() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+      req.setTaskToken(null);
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex = assertThrows(
+         AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().startsWith("taskToken:"));
+      assertNotNull(ex.current());
+      verify(scheduleGateway, never())
+         .addScheduleTask(any(), anyBoolean(), anyBoolean(), anyLong(), anyLong(), any(), any(),
+                          any(), any(), any(), any(), any(), eq(user));
+   }
+
+   @Test void rejectsABlankTaskToken() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+      req.setTaskToken("   ");
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+   }
+
+   @Test void rejectsATaskTokenIssuedForADifferentPlan() throws Exception {
+      CreateScheduleTaskRequest spec = createSpec("t1", "admin");
+      CreateScheduleTaskRequest otherSpec = createSpec("t2", "admin");
+      String taskId = ScheduleManager.getTaskId(spec.getOwner().convertToKey(), spec.getName());
+      String otherTaskId =
+         ScheduleManager.getTaskId(otherSpec.getOwner().convertToKey(), otherSpec.getName());
+      when(scheduleManager.getScheduleTask(taskId)).thenReturn(null);
+      when(scheduleManager.getScheduleTask(otherTaskId)).thenReturn(null);
+      when(scheduleGateway.hasDeletePermission(taskId, user)).thenReturn(true);
+      when(scheduleGateway.hasDeletePermission(otherTaskId, user)).thenReturn(true);
+
+      ScheduleApplyRequest req = applyRequest("create a task", createChange(spec));
+      ScheduleApplyRequest otherPlan = applyRequest("create another task", createChange(otherSpec));
+      req.setTaskToken(otherPlan.getTaskToken());
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      verify(scheduleGateway, never())
+         .addScheduleTask(any(), anyBoolean(), anyBoolean(), anyLong(), anyLong(), any(), any(),
+                          any(), any(), any(), any(), any(), eq(user));
    }
 
    // -------------------------------------------------------------------------
@@ -289,12 +430,37 @@ class ScheduleChangesetApplyServiceTest {
       ScheduleChangePlanRequest probe = new ScheduleChangePlanRequest();
       probe.setTask(task);
       probe.setChanges(List.of(changes));
-      String hash = planService.resolve(probe, user).planHash();
+      ResolvedPlan resolved = planService.resolve(probe, user);
 
       ScheduleApplyRequest req = new ScheduleApplyRequest();
       req.setTask(task);
       req.setChanges(List.of(changes));
-      req.setPlanHash(hash);
+      req.setPlanHash(resolved.planHash());
+      req.setTaskToken(resolved.taskToken());
+      req.setReviewOutcome("approved");
+      return req;
+   }
+
+   /**
+    * Builds an apply request whose taskToken was issued for a DIFFERENT task string than the one
+    * this request's own {@code task} field carries -- the shape a caller previewing an honest
+    * description then applying with different text produces. Mirrors {@code
+    * AdminChangesetApplyServiceTest#requestWithDivergentApplyTask}.
+    */
+   private ScheduleApplyRequest requestWithDivergentApplyTask(String previewTask, String applyTask,
+                                                               ScheduleChangeRequest... changes)
+      throws Exception
+   {
+      ScheduleChangePlanRequest preview = new ScheduleChangePlanRequest();
+      preview.setTask(previewTask);
+      preview.setChanges(List.of(changes));
+      ResolvedPlan previewed = planService.resolve(preview, user);
+
+      ScheduleApplyRequest req = new ScheduleApplyRequest();
+      req.setTask(applyTask);
+      req.setChanges(List.of(changes));
+      req.setPlanHash(previewed.planHash());
+      req.setTaskToken(previewed.taskToken());
       req.setReviewOutcome("approved");
       return req;
    }


### PR DESCRIPTION
## Summary
- Part of Redmine bug #76588 (taskToken audit-pinning sweep), Schedule area.
- `ScheduleChangePlanService.resolve()` already issues a `taskToken` (via `TaskAuditToken.issue`), but `ScheduleApplyRequest` had no field for it and `ScheduleChangesetApplyService.apply()` never verified one — every audit write (create, delete, and the rollback branch, three call sites) used the apply request's own re-resolved `task` string instead of the narrative actually reviewed at preview.
- Adds `taskToken` to `ScheduleApplyRequest`, verifies it via `TaskAuditToken.verify()` right after the existing `planHash` gate, and threads the verified `reviewedTask` through all three call sites (`applyCreate`, `applyDelete`, `rollback`) instead of `plan.task()`. Reuses the shared, already-tested `AdminChangesetApplyService.TaskTokenMismatchException` (same as `PlanHashMismatchException` is already reused) and adds a matching `@ExceptionHandler` in `AdminScheduleController`.
- Companion plugin PR: inetsoft-technology/stylebi-wiz#2417

## Test plan
- [x] `./mvnw -pl core test -Dtest=ScheduleChangesetApplyServiceTest,AdminScheduleControllerTest -DfailIfNoTests=false` — 24 tests run, 0 failures