### PR TITLE
fix(admin/providers): pin reviewed task narrative into audit record via taskToken (#76588)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/providers/AdminProviderController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/AdminProviderController.java
@@ -182,6 +182,23 @@ public class AdminProviderController {
                     "plan", ex.current());
    }
 
+   /**
+    * Maps a missing/invalid/foreign {@code taskToken} to {@code 409} carrying the current plan,
+    * the same shape {@link #handlePlanHashMismatch} uses - a caller cannot pin an audit record to
+    * a narrative it cannot prove was reviewed, so this forces a re-preview rather than accepting
+    * whatever task text (if any) the apply request itself carries.
+    */
+   @ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handleTaskTokenMismatch(
+      AdminChangesetApplyService.TaskTokenMismatchException ex)
+   {
+      return Map.of("status", "conflict",
+                    "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
    private final AuthenticationProviderService authenticationProviderService;
    private final AuthorizationProviderService authorizationProviderService;
    private final ProviderChangePlanService planService;

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderApplyRequest.java
@@ -28,8 +28,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ProviderApplyRequest extends ProviderChangePlanRequest {
    public String getPlanHash() { return planHash; }
    public void setPlanHash(String v) { this.planHash = v; }
+   public String getTaskToken() { return taskToken; }
+   public void setTaskToken(String v) { this.taskToken = v; }
    public String getReviewOutcome() { return reviewOutcome; }
    public void setReviewOutcome(String v) { this.reviewOutcome = v; }
 
-   private String planHash, reviewOutcome;
+   private String planHash, taskToken, reviewOutcome;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
@@ -74,6 +74,15 @@ public class ProviderChangesetApplyService {
             throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
          }
 
+         String reviewedTask;
+
+         try {
+            reviewedTask = TaskAuditToken.verify(req.getTaskToken(), plan.planHash());
+         }
+         catch(TaskAuditToken.TaskTokenException e) {
+            throw new AdminChangesetApplyService.TaskTokenMismatchException(plan, e.getMessage());
+         }
+
          if(plan.requiresAgentSignoff() &&
             (req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()))
          {
@@ -97,7 +106,7 @@ public class ProviderChangesetApplyService {
             String key = change.property();
 
             try {
-               applyOne(txId, plan.task(), key, original, user, backupRef, reviewOutcome, results,
+               applyOne(txId, reviewedTask, key, original, user, backupRef, reviewOutcome, results,
                        undoable);
             }
             catch(Exception e) {
@@ -124,7 +133,7 @@ public class ProviderChangesetApplyService {
 
          Map<String, String> rollbackAdvisories = new LinkedHashMap<>();
          List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
-         failures.addAll(rollback(txId, plan.task(), undoable, backupRef, reviewOutcome, user,
+         failures.addAll(rollback(txId, reviewedTask, undoable, backupRef, reviewOutcome, user,
                                   rollbackAdvisories));
          // Merge each rollback's own disclosure (the "restored at the end of the chain, not its
          // original position" notice, 01-spec.md section 6/11) into that entry's ORIGINAL outcome

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/AdminProviderControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/AdminProviderControllerTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.security.AuthenticationProviderService;
+import inetsoft.web.admin.security.AuthorizationProviderService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.Map;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * bug #76588 -- {@code AdminProviderController} has no {@code @ControllerAdvice} equivalent for
+ * {@link AdminChangesetApplyService.TaskTokenMismatchException} (confirmed by
+ * bug-provider/02-refute.md Claim 2: {@code AdminExceptionHandler}'s shared advice only maps it to
+ * a generic 500), so the local {@code @ExceptionHandler} added alongside the existing
+ * {@code handlePlanHashMismatch} is load-bearing, not optional -- this covers that new handler
+ * directly, mirroring {@code AdminAiControllerTest}'s equivalent coverage for the Properties area.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminProviderControllerTest {
+   @Mock private AuthenticationProviderService authenticationProviderService;
+   @Mock private AuthorizationProviderService authorizationProviderService;
+   @Mock private ProviderChangePlanService planService;
+   @Mock private ProviderChangesetApplyService applyService;
+   private AdminProviderController controller;
+
+   @BeforeEach void setup() {
+      controller = new AdminProviderController(authenticationProviderService,
+         authorizationProviderService, planService, applyService);
+   }
+
+   @Test void handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan() {
+      ResolvedPlan current = new ResolvedPlan("create p1", List.of(), true, true,
+                                              "hash456", "token456");
+      AdminChangesetApplyService.TaskTokenMismatchException ex =
+         new AdminChangesetApplyService.TaskTokenMismatchException(current,
+            "taskToken: does not match the current plan; re-review before applying");
+
+      Map<String, Object> actual = controller.handleTaskTokenMismatch(ex);
+
+      assertEquals("conflict", actual.get("status"));
+      assertEquals(ex.getMessage(), actual.get("error"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) actual.get("plan");
+      assertEquals(current.task(), returnedPlan.task());
+      assertEquals(current.planHash(), returnedPlan.planHash());
+      // The 409 body must never hand back a fresh, still-unverified taskToken a caller could
+      // replay without re-review (AdminChangesetApplyService.TaskTokenMismatchException scrubs it).
+      assertNull(returnedPlan.taskToken());
+   }
+
+   @Test void handleTaskTokenMismatchIsAnnotatedConflict() throws NoSuchMethodException {
+      ResponseStatus annotation = AdminProviderController.class
+         .getMethod("handleTaskTokenMismatch",
+                    AdminChangesetApplyService.TaskTokenMismatchException.class)
+         .getAnnotation(ResponseStatus.class);
+
+      assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
+      assertEquals(HttpStatus.CONFLICT, annotation.value());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
@@ -22,7 +22,9 @@ import inetsoft.uql.XPrincipal;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.MessageException;
 import inetsoft.util.Tool;
+import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.util.audit.Audit;
 import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
 import inetsoft.web.admin.ai.ResolvedPlan;
@@ -30,6 +32,7 @@ import inetsoft.web.admin.security.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -82,6 +85,16 @@ class ProviderChangesetApplyServiceTest {
          .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
       wireAuthenticationFake();
       wireAuthorizationFake();
    }
@@ -400,6 +413,85 @@ class ProviderChangesetApplyServiceTest {
    }
 
    // -------------------------------------------------------------------------
+   // bug #76588 -- taskToken pins the audit record's task narrative to what was actually
+   // reviewed at preview, not to whatever task text the apply call itself carries.
+   // -------------------------------------------------------------------------
+
+   @Test void auditsThePreviewedTaskEvenWhenApplyTaskDiffersForAuthenticationChain() throws Exception {
+      tool.when(Tool::getHost).thenReturn("test-host");
+      Audit auditInstance = mock(Audit.class);
+      ProviderApplyRequest req = applyRequestWithDivergentApplyTask(
+         "create p1 -- reviewed narrative", "totally different apply-time text",
+         createFile(ProviderChain.AUTHENTICATION, "p1"));
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         var result = service.apply(req, user);
+
+         assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      }
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      // The core regression proof: the AUTHENTICATION chain's audit record carries the reviewed
+      // task, never the substituted apply-time text -- only `changes` is hash-protected.
+      assertEquals("create p1 -- reviewed narrative", captor.getValue().getTaskDescription());
+   }
+
+   @Test void auditsThePreviewedTaskEvenWhenApplyTaskDiffersForAuthorizationChain() throws Exception {
+      tool.when(Tool::getHost).thenReturn("test-host");
+      Audit auditInstance = mock(Audit.class);
+      ProviderApplyRequest req = applyRequestWithDivergentApplyTask(
+         "create z1 -- reviewed narrative", "totally different apply-time text",
+         createFile(ProviderChain.AUTHORIZATION, "z1"));
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         var result = service.apply(req, user);
+
+         assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      }
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      // Same proof as above, on the AUTHORIZATION chain -- confirms the single shared apply()
+      // path (02-refute.md Claim 4) covers both chains, not just authentication.
+      assertEquals("create z1 -- reviewed narrative", captor.getValue().getTaskDescription());
+   }
+
+   @Test void rejectsAMissingTaskToken() throws Exception {
+      ProviderApplyRequest req = applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1"));
+      req.setTaskToken(null);
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex = assertThrows(
+         AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().startsWith("taskToken:"));
+      assertNotNull(ex.current());
+      assertTrue(authChainNames.isEmpty());
+   }
+
+   @Test void rejectsABlankTaskToken() throws Exception {
+      ProviderApplyRequest req = applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1"));
+      req.setTaskToken("   ");
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(authChainNames.isEmpty());
+   }
+
+   @Test void rejectsATaskTokenIssuedForADifferentPlan() throws Exception {
+      ProviderApplyRequest req = applyRequest("create p1", createFile(ProviderChain.AUTHENTICATION, "p1"));
+      ProviderApplyRequest otherPlan =
+         applyRequest("create p2", createFile(ProviderChain.AUTHENTICATION, "p2"));
+      req.setTaskToken(otherPlan.getTaskToken());
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(authChainNames.isEmpty());
+   }
+
+   // -------------------------------------------------------------------------
    // helpers
    // -------------------------------------------------------------------------
 
@@ -554,6 +646,28 @@ class ProviderChangesetApplyServiceTest {
       req.setTask(task);
       req.setChanges(list);
       req.setPlanHash(plan.planHash());
+      req.setTaskToken(plan.taskToken());
+      req.setReviewOutcome("looks safe");
+      return req;
+   }
+
+   /**
+    * Builds an apply request whose taskToken was issued for a DIFFERENT task string than the one
+    * this request's own {@code task} field carries — the shape a caller previewing an honest
+    * description then applying with different text produces.
+    */
+   private ProviderApplyRequest applyRequestWithDivergentApplyTask(String previewTask,
+                                                                    String applyTask,
+                                                                    ProviderChangeRequest... changes)
+      throws Exception
+   {
+      List<ProviderChangeRequest> list = List.of(changes);
+      ResolvedPlan previewed = planService.resolve(request(previewTask, list), user);
+      ProviderApplyRequest req = new ProviderApplyRequest();
+      req.setTask(applyTask);
+      req.setChanges(list);
+      req.setPlanHash(previewed.planHash());
+      req.setTaskToken(previewed.taskToken());
       req.setReviewOutcome("looks safe");
       return req;
    }


### PR DESCRIPTION
## Summary

Part of the taskToken audit-pinning sweep for Redmine bug #76588 (Provider area).

- `preview_provider_changes` already issued a `taskToken` binding the reviewed `task` narrative to the plan's `planHash`, but `apply_provider_changes`'s Java side never accepted, verified, or forwarded one -- every provider create/delete audit record (both authentication and authorization chains) was written from whatever `task` string the apply call itself carried, unverified against what was actually reviewed at preview.
- `ProviderApplyRequest` now carries a `taskToken`; `ProviderChangesetApplyService.apply()` verifies it via `TaskAuditToken.verify()` and threads the recovered `reviewedTask` (not `plan.task()`) into every `applyOne`/`rollback`/`writeAudit` call, covering both the authentication and authorization provider chains (confirmed there is exactly one `apply()` entry point covering both, per the refutation pass).
- A missing/blank/foreign token throws `AdminChangesetApplyService.TaskTokenMismatchException`, mirroring the already-shipped Properties-area mechanism.
- `AdminProviderController` gets a new `@ExceptionHandler` mapping that exception to 409 -- the shared `AdminExceptionHandler` `@ControllerAdvice` has no handler for it and would otherwise let it fall through to a bare 500 (a real, worse-than-just-missing-409 production symptom, per the refutation pass's Claim 2).

Companion PR (plugin side, `apply_provider_changes` schema/guard/body): inetsoft-technology/stylebi-wiz#2419

## Test plan

- [x] `./mvnw -pl core -am -Dtest=ProviderChangesetApplyServiceTest,AdminProviderControllerTest,ProviderChangePlanServiceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test` -- 54 tests, 0 failures/errors
- [x] New regression tests: audit narrative pinned to previewed task even when apply's own task field diverges (both chains), missing/blank taskToken refused, foreign (wrong-planHash) taskToken refused, controller-level 409 mapping test
- [x] Also fixed a pre-existing gap in the test fixture: `Tool.encryptPassword` was stubbed but `Tool.decryptPassword` was not, so `TaskAuditToken.verify`'s real crypto path was being exercised (and failing) once `taskToken` was wired into `applyRequest()` -- all 17 pre-existing tests were failing before this fix, now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)