### PR TITLE
fix(admin/presentation): pin reviewed task narrative into audit record via taskToken (#76588)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/AdminPresentationController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/AdminPresentationController.java
@@ -179,6 +179,16 @@ public class AdminPresentationController {
                     "plan", ex.current());
    }
 
+   @ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handleTaskTokenMismatch(
+      AdminChangesetApplyService.TaskTokenMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
    private final PresentationSettingsAccess access;
    private final PresentationChangePlanService planService;
    private final PresentationChangesetApplyService applyService;

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationApplyRequest.java
@@ -36,6 +36,14 @@ public class PresentationApplyRequest extends PresentationChangePlanRequest {
       this.planHash = v;
    }
 
+   public String getTaskToken() {
+      return taskToken;
+   }
+
+   public void setTaskToken(String v) {
+      this.taskToken = v;
+   }
+
    public String getReviewOutcome() {
       return reviewOutcome;
    }
@@ -53,6 +61,7 @@ public class PresentationApplyRequest extends PresentationChangePlanRequest {
    }
 
    private String planHash;
+   private String taskToken;
    private String reviewOutcome;
    private Boolean acknowledgeIrreversibleUpdate;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyService.java
@@ -92,9 +92,24 @@ public class PresentationChangesetApplyService {
          String currentHash = PresentationChangePlanService.hash(planChanges);
 
          if(req.getPlanHash() == null || !currentHash.equals(req.getPlanHash())) {
+            // A 409 conflict response must never hand back a taskToken (see
+            // AdminChangesetApplyService#withoutTaskToken) -- the exception constructor already
+            // strips whatever is passed here, so issuing one would be a wasted encryption call for
+            // a value that is unconditionally discarded one stack frame later.
             throw new AdminChangesetApplyService.PlanHashMismatchException(
                new inetsoft.web.admin.ai.ResolvedPlan(task, planChanges, true, true,
-                  currentHash, TaskAuditToken.issue(currentHash, task)));
+                  currentHash, null));
+         }
+
+         String reviewedTask;
+
+         try {
+            reviewedTask = TaskAuditToken.verify(req.getTaskToken(), currentHash);
+         }
+         catch(TaskAuditToken.TaskTokenException e) {
+            throw new AdminChangesetApplyService.TaskTokenMismatchException(
+               new inetsoft.web.admin.ai.ResolvedPlan(task, planChanges, true, true,
+                  currentHash, null), e.getMessage());
          }
 
          if(req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()) {
@@ -136,7 +151,7 @@ public class PresentationChangesetApplyService {
                   ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
                results.add(new PresentationApplyOutcome(key, before, actualAfter, status,
                   verified ? null : "value did not read back as written", null));
-               writeAudit(txId, task, key, entry, AdminChangeRecord.ACTION_APPLY, before, actualAfter, status,
+               writeAudit(txId, reviewedTask, key, entry, AdminChangeRecord.ACTION_APPLY, before, actualAfter, status,
                          backupRef, reviewOutcome, user);
 
                if(!verified) {
@@ -158,7 +173,7 @@ public class PresentationChangesetApplyService {
                   AdminChangeRecord.STATUS_FAILED, messageOf(e), null));
                unknownStateFailures.add(new RollbackFailure(key,
                   "state unknown: apply did not return a verifiable outcome (" + messageOf(e) + ")"));
-               writeAudit(txId, task, key, entry, AdminChangeRecord.ACTION_APPLY, before, null,
+               writeAudit(txId, reviewedTask, key, entry, AdminChangeRecord.ACTION_APPLY, before, null,
                          AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
                failed = true;
                break;
@@ -182,7 +197,7 @@ public class PresentationChangesetApplyService {
                txId + " (backupRef: " + backupRef + ")"));
          }
 
-         failures.addAll(rollback(txId, task, undoableValue, backupRef, reviewOutcome, user));
+         failures.addAll(rollback(txId, reviewedTask, undoableValue, backupRef, reviewOutcome, user));
 
          String status = failures.isEmpty()
             ? AdminChangesetApplyService.STATUS_ROLLED_BACK

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/AdminPresentationControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/AdminPresentationControllerTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.presentation;
+
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers only the exception-handler mapping this bugfix adds -- {@code handleTaskTokenMismatch}
+ * -- mirroring {@code AdminAiControllerTest#handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan}
+ * and its {@code @ResponseStatus} counterpart. No prior test file existed for
+ * {@code AdminPresentationController}; the full delegation surface (getSettings/preview/apply) is
+ * out of scope for this fix.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminPresentationControllerTest {
+   @Mock private PresentationSettingsAccess access;
+   @Mock private PresentationChangePlanService planService;
+   @Mock private PresentationChangesetApplyService applyService;
+
+   @Test void handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan() {
+      AdminPresentationController controller =
+         new AdminPresentationController(access, planService, applyService);
+      ResolvedPlan current = new ResolvedPlan("update date format", List.of(), true, true,
+                                              "hash456", "token456");
+      AdminChangesetApplyService.TaskTokenMismatchException ex =
+         new AdminChangesetApplyService.TaskTokenMismatchException(current,
+            "taskToken: does not match the current plan; re-review before applying");
+
+      Map<String, Object> actual = controller.handleTaskTokenMismatch(ex);
+
+      assertEquals("conflict", actual.get("status"));
+      assertEquals(ex.getMessage(), actual.get("error"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) actual.get("plan");
+      assertEquals(current.task(), returnedPlan.task());
+      assertEquals(current.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
+   }
+
+   @Test void handleTaskTokenMismatchIsAnnotatedConflict() throws NoSuchMethodException {
+      ResponseStatus annotation = AdminPresentationController.class
+         .getMethod("handleTaskTokenMismatch",
+                    AdminChangesetApplyService.TaskTokenMismatchException.class)
+         .getAnnotation(ResponseStatus.class);
+
+      assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
+      assertEquals(HttpStatus.CONFLICT, annotation.value());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangesetApplyServiceTest.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.uql.XPrincipal;
 import inetsoft.util.Tool;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.util.audit.Audit;
 import inetsoft.web.admin.ai.AdminBackupService;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
 import inetsoft.web.admin.presentation.model.LookAndFeelSettingsModel;
@@ -29,6 +31,7 @@ import inetsoft.web.admin.presentation.model.PresentationFormatsSettingsModel;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -77,6 +80,16 @@ class PresentationChangesetApplyServiceTest {
          .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
 
       lenient().when(access.read(any(), any(), anyBoolean())).thenAnswer(inv -> {
          PresentationSubModel subModel = inv.getArgument(0);
@@ -133,9 +146,17 @@ class PresentationChangesetApplyServiceTest {
       apply.setTask(task);
       apply.setChanges(List.of(changes));
       apply.setPlanHash(plan.planHash());
+      apply.setTaskToken(plan.taskToken());
       apply.setReviewOutcome(reviewOutcome);
       apply.setAcknowledgeIrreversibleUpdate(acknowledgeIrreversibleUpdate);
       return apply;
+   }
+
+   private static MockedStatic<Audit> mockAudit() {
+      MockedStatic<Audit> audit = mockStatic(Audit.class);
+      Audit instance = mock(Audit.class);
+      audit.when(Audit::getInstance).thenReturn(instance);
+      return audit;
    }
 
    private static PresentationFormatsSettingsModel formats(String dateFormat) {
@@ -187,6 +208,11 @@ class PresentationChangesetApplyServiceTest {
       // second place from PresentationChangePlanService.resolve() where the same "task must not
       // affect the hash" mistake could be reintroduced independently -- this test guards that
       // second call site specifically, not just the plan-service-level hash contract.
+      //
+      // Post-fix behavior: the apply request's own (paraphrased) task field is purely
+      // informational and must not block apply -- see applyAuditsThePreviewedTaskEvenWhenApply-
+      // TaskDiffers below for the companion assertion that the AUDIT RECORD still carries the
+      // originally-previewed narrative, not this paraphrase.
       seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
       PresentationChangeRequest changeReq =
          change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd"));
@@ -200,11 +226,48 @@ class PresentationChangesetApplyServiceTest {
       apply.setTask("Change the date format to ISO 8601");
       apply.setChanges(List.of(changeReq));
       apply.setPlanHash(plan.planHash());
+      apply.setTaskToken(plan.taskToken());
       apply.setReviewOutcome("looks good");
 
       var result = service.apply(apply, user);
 
       assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+   }
+
+   @Test
+   void applyAuditsThePreviewedTaskEvenWhenApplyTaskDiffers() throws Exception {
+      // scope=global (not organization), so writeAudit's setOrganizationId branch never calls the
+      // real, unmocked OrganizationManager.getInstance() -- the point of this test is the
+      // taskToken/audit-narrative wiring, not the org-scope branch.
+      seed(PresentationSubModel.FORMATS, true, formats("MM/dd/yyyy"));
+      PresentationChangeRequest changeReq =
+         change("formats", "global", obj().put("dateFormat", "yyyy-MM-dd"));
+
+      PresentationChangePlanRequest preview = new PresentationChangePlanRequest();
+      preview.setTask("Update date format to ISO");
+      preview.setChanges(List.of(changeReq));
+      var plan = planService.resolve(preview, user);
+
+      PresentationApplyRequest apply = new PresentationApplyRequest();
+      apply.setTask("Change the date format to ISO 8601");
+      apply.setChanges(List.of(changeReq));
+      apply.setPlanHash(plan.planHash());
+      apply.setTaskToken(plan.taskToken());
+      apply.setReviewOutcome("looks good");
+
+      Audit auditInstance = mock(Audit.class);
+      tool.when(Tool::getHost).thenReturn("test-host");
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         service.apply(apply, user);
+      }
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      // The core regression proof: the audit record carries the PREVIEWED narrative embedded in
+      // the taskToken, not the apply request's own (paraphrased) task field.
+      assertEquals("Update date format to ISO", captor.getValue().getTaskDescription());
    }
 
    @Test
@@ -216,6 +279,48 @@ class PresentationChangesetApplyServiceTest {
 
       assertThrows(AdminChangesetApplyService.PlanHashMismatchException.class,
                   () -> service.apply(req, user));
+   }
+
+   @Test
+   void conflictPathNeverHandsBackAUsableTaskToken() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationApplyRequest req = applyRequest("t", "ok", null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")));
+      req.setPlanHash("not-the-real-hash");
+
+      AdminChangesetApplyService.PlanHashMismatchException ex = assertThrows(
+         AdminChangesetApplyService.PlanHashMismatchException.class,
+         () -> service.apply(req, user));
+
+      assertNull(ex.current().taskToken(),
+         "a 409 conflict must never hand back a usable taskToken");
+   }
+
+   @Test
+   void applyRefusesWithoutATaskToken() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationApplyRequest req = applyRequest("t", "ok", null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")));
+      req.setTaskToken(null);
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex = assertThrows(
+         AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().startsWith("taskToken:"));
+      assertNotNull(ex.current());
+   }
+
+   @Test
+   void applyRefusesATaskTokenIssuedForADifferentPlan() throws Exception {
+      seed(PresentationSubModel.FORMATS, false, formats("MM/dd/yyyy"));
+      PresentationApplyRequest req = applyRequest("t", "ok", null,
+         change("formats", "organization", obj().put("dateFormat", "yyyy-MM-dd")));
+      PresentationApplyRequest otherPlanReq = applyRequest("t", "ok", null,
+         change("formats", "organization", obj().put("dateFormat", "MM-dd-yyyy")));
+      req.setTaskToken(otherPlanReq.getTaskToken());
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
    }
 
    // ---------------------------------------------------------------- storage-scope acknowledgement gate


### PR DESCRIPTION
## Summary
- `apply_presentation_changes` audited every change from the apply request's own, unverified `task` field instead of the narrative actually reviewed at `preview_presentation_changes` — the same gap PR #2282 closed for the properties area (Redmine #76588, Presentation sub-area).
- `PresentationApplyRequest` gains a `taskToken` field; `PresentationChangesetApplyService.apply()` verifies it against the freshly re-resolved plan hash (`TaskAuditToken.verify`) and audits the token's embedded, previewed narrative (`reviewedTask`) instead of the raw request field.
- `AdminPresentationController` gains the missing `@ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)` 409 mapping (mirrors the existing `PlanHashMismatchException` handler and `AdminAiController`'s own).
- Conflict-path hygiene: stop calling `TaskAuditToken.issue(currentHash, task)` for a value `PlanHashMismatchException`'s constructor unconditionally strips before it reaches the client — pass `null` directly instead (behaviorally a no-op, removes a wasted encryption call and a misleading call site).
- Updates the existing `applySucceedsWhenTaskIsParaphrasedBetweenPreviewAndApply` test to also carry a valid `taskToken` and adds a companion test asserting the audit record carries the *previewed* narrative, not the apply call's paraphrase; adds missing-token / wrong-plan-token / conflict-scrubs-token / controller-mapping regression tests.

Companion plugin-side PR: inetsoft-technology/stylebi-wiz#2420

## Test plan
- [x] `./mvnw -pl core test -Dtest=PresentationChangesetApplyServiceTest,PresentationChangePlanServiceTest,AdminPresentationControllerTest -DfailIfNoTests=false` → `BUILD SUCCESS`, 40/40