### PR TITLE
fix(wiz): stop a non-options write from persisting the manufactured percentageBy default (VTB-007, #76574)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -843,6 +843,33 @@ public final class TableBindingMutator {
    // ── options (2d Phase 3) ──────────────────────────────────────────────────
 
    /**
+    * Undoes {@code CrosstabOptionInfo(CrosstabVSAssembly)}'s null-to-{@code "1"} (col) display
+    * default on a wiz write that never asked to change {@code percentageBy}.
+    *
+    * <p>That constructor manufactures {@code "1"} purely so a never-configured crosstab has
+    * something to show when a binding model snapshot is built for it — but {@code
+    * VSCrosstabBindingFactory.updateAssembly()} persists whatever the model's option carries
+    * onto the live assembly unconditionally, on every write, not just an options write. Without
+    * this, the very first wiz touch to a never-configured crosstab — a shelf edit, a sort,
+    * anything, not just {@code set_table_options} — silently and permanently set {@code
+    * percentageBy} to {@code "col"} as a side effect.
+    *
+    * <p>Every caller in {@code TableBindingService} except {@code setOptions} passes the live
+    * assembly's own {@code VSCrosstabInfo.getPercentageByValue()}, read before the mutation, as
+    * {@code livePercentageByValue} — {@code setOptions} is the one call allowed to actually
+    * change it, so it never calls this at all.
+    */
+   public static void preserveUntouchedPercentageBy(BaseTableBindingModel model,
+                                                    String livePercentageByValue)
+   {
+      if(livePercentageByValue == null && model instanceof CrosstabBindingModel crosstab &&
+         crosstab.getOption() != null)
+      {
+         crosstab.getOption().setPercentageByValue(null);
+      }
+   }
+
+   /**
     * Crosstab and table options.
     *
     * <p><b>The crosstab totals are string-typed booleans</b> — {@code rowTotalVisibleValue} and

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -84,7 +84,9 @@ public class TableBindingService {
             ? data.getSourceInfo() : null;
          requireSourceForFieldWrite(assemblyName, shelf, model.getSource(),
                                     fields == null ? 0 : fields.size());
+         String livePercentageBy = livePercentageByValue(assembly);
          TableBindingMutator.setShelf(model, shelf, fields, rvs, source, refModelService);
+         TableBindingMutator.preserveUntouchedPercentageBy(model, livePercentageBy);
 
          ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
          event.setName(assemblyName);
@@ -402,8 +404,10 @@ public class TableBindingService {
    public void setOptions(String sessionToken, Principal user, String assemblyName,
                           Map<String, Object> options) throws Exception
    {
+      // Unlike every other mutator below, this one is allowed to actually change percentageBy
+      // — so it must not have preserveUntouchedPercentageBy undo whatever it just set.
       apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.setOptions(model, options));
+            model -> TableBindingMutator.setOptions(model, options), false, false);
    }
 
    public Map<String, Object> optionVocabulary() {
@@ -484,7 +488,7 @@ public class TableBindingService {
    private void apply(String sessionToken, Principal user, String assemblyName,
                       Consumer<BaseTableBindingModel> mutation) throws Exception
    {
-      apply(sessionToken, user, assemblyName, mutation, false);
+      apply(sessionToken, user, assemblyName, mutation, false, true);
    }
 
    /**
@@ -507,7 +511,9 @@ public class TableBindingService {
          VSAssembly assembly = rvs.getViewsheet().getAssembly(assemblyName);
          inetsoft.uql.asset.SourceInfo source = assembly instanceof DataVSAssembly data
             ? data.getSourceInfo() : null;
+         String livePercentageBy = livePercentageByValue(assembly);
          mutation.accept(model, rvs, source);
+         TableBindingMutator.preserveUntouchedPercentageBy(model, livePercentageBy);
 
          ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
          event.setName(assemblyName);
@@ -520,9 +526,28 @@ public class TableBindingService {
                       Consumer<BaseTableBindingModel> mutation, boolean allowCalcTable)
       throws Exception
    {
+      apply(sessionToken, user, assemblyName, mutation, allowCalcTable, true);
+   }
+
+   /**
+    * @param preservePercentageBy see {@link TableBindingMutator#preserveUntouchedPercentageBy} --
+    *                             {@code false} only for {@link #setOptions}, the one wiz call
+    *                             allowed to actually change {@code percentageBy}.
+    */
+   private void apply(String sessionToken, Principal user, String assemblyName,
+                      Consumer<BaseTableBindingModel> mutation, boolean allowCalcTable,
+                      boolean preservePercentageBy)
+      throws Exception
+   {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          BaseTableBindingModel model = requireTableBinding(rvs, assemblyName, allowCalcTable);
+         VSAssembly assembly = rvs.getViewsheet().getAssembly(assemblyName);
+         String livePercentageBy = preservePercentageBy ? livePercentageByValue(assembly) : null;
          mutation.accept(model);
+
+         if(preservePercentageBy) {
+            TableBindingMutator.preserveUntouchedPercentageBy(model, livePercentageBy);
+         }
 
          ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
          event.setName(assemblyName);
@@ -532,6 +557,21 @@ public class TableBindingService {
          // trading a reported problem for an unreported one.
          bindingModelService.setBinding(runtimeId, event, user, dispatcher);
       });
+   }
+
+   /**
+    * The live crosstab's own, never-manufactured {@code percentageBy}, read directly off the
+    * real assembly before this call's mutation runs -- {@code null} for a crosstab that has
+    * never had {@code set_table_options(percentageBy: ...)} called on it (or for anything that
+    * is not a crosstab). See {@link TableBindingMutator#preserveUntouchedPercentageBy}.
+    */
+   private static String livePercentageByValue(VSAssembly assembly) {
+      if(!(assembly instanceof CrosstabVSAssembly crosstab)) {
+         return null;
+      }
+
+      VSCrosstabInfo info = crosstab.getVSCrosstabInfo();
+      return info == null ? null : info.getPercentageByValue();
    }
 
    private BaseTableBindingModel requireTableBinding(RuntimeViewsheet rvs, String assemblyName) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -405,9 +405,14 @@ public class TableBindingService {
                           Map<String, Object> options) throws Exception
    {
       // Unlike every other mutator below, this one is allowed to actually change percentageBy
-      // — so it must not have preserveUntouchedPercentageBy undo whatever it just set.
+      // — but only when this call's own options map carries that key. TableBindingMutator
+      // .setCrosstabOptions only calls setPercentageByValue when options.containsKey
+      // ("percentageBy"); an options-only write that omits it (e.g. {"rowTotals": true}) must
+      // still have the manufactured default reset, or it reopens this same bug through a
+      // narrower trigger.
+      boolean changesPercentageBy = options != null && options.containsKey("percentageBy");
       apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.setOptions(model, options), false, false);
+            model -> TableBindingMutator.setOptions(model, options), false, !changesPercentageBy);
    }
 
    public Map<String, Object> optionVocabulary() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -597,6 +597,37 @@ class TableBindingServiceTest {
                    "not a genuine, caller-requested change");
    }
 
+   /**
+    * The reset gate must key on whether <em>this call's</em> {@code options} map actually
+    * contains {@code "percentageBy"}, not on which method was invoked -- {@code
+    * TableBindingMutator#setCrosstabOptions} only calls {@code setPercentageByValue} when that
+    * key is present, so a {@code set_table_options} call that touches only e.g. {@code
+    * rowTotals} must still have the manufactured default reset, or it reopens bug #76574 through
+    * a narrower, easily-reachable trigger.
+    */
+   @Test
+   void setOptionsWithoutPercentageByStillResetsTheManufacturedDefault() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS");
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
+      TableBindingMutator.setShelf(existing, "rows", List.of(dim("Region")));
+      CrosstabOptionInfo manufactured = new CrosstabOptionInfo();
+      manufactured.setPercentageByValue("1"); // stand-in for the constructor's null-to-"1" coalesce
+      existing.setOption(manufactured);
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getVSCrosstabInfo()).thenReturn(new VSCrosstabInfo());
+
+      harness(assembly, existing, bindings)
+         .setOptions("tok", principal(), "Crosstab1", Map.of("rowTotals", true));
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertNull(posted.getOption().getPercentageByValue(),
+                "a set_table_options call that never mentioned percentageBy must not persist " +
+                "the manufactured display default -- the live crosstab's own percentageBy was " +
+                "never actually set");
+   }
+
    private static CrosstabBindingModel withTables(String... names) {
       CrosstabBindingModel model = new CrosstabBindingModel();
       List<BindingModel.SourceTable> tables = new ArrayList<>();

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -25,6 +25,7 @@ import inetsoft.web.binding.model.BindingModel;
 import inetsoft.web.binding.model.table.BaseTableBindingModel;
 import inetsoft.web.binding.model.table.CalcTableBindingModel;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
+import inetsoft.web.binding.model.table.CrosstabOptionInfo;
 import inetsoft.web.binding.model.table.TableBindingModel;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.FieldRef;
@@ -535,6 +536,65 @@ class TableBindingServiceTest {
       CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
       assertEquals(1, posted.getRows().size());
       assertEquals(1, posted.getCols().size());
+   }
+
+   // ── bug #76574, VTB-007: percentageBy silently, permanently defaulted to "col" by any wiz
+   // write, not just set_table_options -- CrosstabOptionInfo(CrosstabVSAssembly)'s constructor
+   // coalesces a never-set percentageByValue to "1" (col) purely for display, but
+   // VSCrosstabBindingFactory.updateAssembly() persists whatever the model's option carries
+   // onto the live assembly unconditionally on every write. The model handed to
+   // TableBindingService here stands in for that already-coalesced-to-"1" snapshot
+   // (binding.createModel(assembly) is mocked below, so it is not built via the real
+   // constructor) -- what these assert is that a write that never asked to change
+   // percentageBy resets that manufactured value back to null before it reaches
+   // bindingModelService.setBinding, as long as the live assembly's own percentageByValue was
+   // still null.
+
+   @Test
+   void setShelfDoesNotPersistTheManufacturedPercentageByDefault() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS");
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
+      CrosstabOptionInfo manufactured = new CrosstabOptionInfo();
+      manufactured.setPercentageByValue("1"); // stand-in for the constructor's null-to-"1" coalesce
+      existing.setOption(manufactured);
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new inetsoft.uql.asset.SourceInfo());
+      when(assembly.getVSCrosstabInfo()).thenReturn(new VSCrosstabInfo());
+
+      harness(assembly, existing, bindings)
+         .setShelf("tok", principal(), "Crosstab1", "aggregates",
+                  List.of(new FieldRef("REVENUE", "measure", "Sum", null, null)), null);
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertNull(posted.getOption().getPercentageByValue(),
+                "a shelf write that never mentioned percentageBy must not persist the " +
+                "manufactured display default -- the live crosstab's own percentageBy was " +
+                "never actually set");
+   }
+
+   @Test
+   void setOptionsStillAppliesAnExplicitPercentageByChange() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS");
+      existing.setSource(new inetsoft.web.binding.model.SourceInfo());
+      existing.getSource().setSource("ORDERS");
+      TableBindingMutator.setShelf(existing, "rows", List.of(dim("Region")));
+      CrosstabOptionInfo manufactured = new CrosstabOptionInfo();
+      manufactured.setPercentageByValue("1");
+      existing.setOption(manufactured);
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getVSCrosstabInfo()).thenReturn(new VSCrosstabInfo());
+
+      harness(assembly, existing, bindings)
+         .setOptions("tok", principal(), "Crosstab1", Map.of("percentageBy", "row"));
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals("2", posted.getOption().getPercentageByValue(),
+                   "an explicit set_table_options(percentageBy: ...) call must still take " +
+                   "effect -- this fix only stops an untouched default from being persisted, " +
+                   "not a genuine, caller-requested change");
    }
 
    private static CrosstabBindingModel withTables(String... names) {


### PR DESCRIPTION
## Bug
Redmine #76574 / VTB-007. Diagnosis + refutation history (in `inetsoft-technology/stylebi-wiz`):
`docs/teams/2026-09-10-bugs-vtb-p1/bug-76574-vtb007/01-diagnosis.md` and `02-refute.md`.

## Root cause
`CrosstabOptionInfo(CrosstabVSAssembly)`'s constructor
(`core/src/main/java/inetsoft/web/binding/model/table/CrosstabOptionInfo.java:34-45`) coalesces a
never-set `percentageByValue` (`null`) to `"1"` (`PERCENTAGE_BY_COL`) purely for display when
building a binding model snapshot. But
`VSCrosstabBindingFactory.updateAssembly()` (`:281-282`) persists whatever the model's option
carries onto the live assembly unconditionally, on every wiz write — not just an options write.
So the very first wiz touch to a never-configured crosstab (a shelf edit, a sort, anything)
silently and permanently set `percentageBy` to `"col"` as a side effect, even if the caller never
called `set_table_options`.

Live-confirmed by the lead: a brand-new crosstab with only `rows`/`cols` bound (no aggregate, no
options call) already reported `get_table_binding`'s `options.percentageBy: "col"`.

## Fix
Scoped to the wiz-only layer (`inetsoft.web.wiz.binding`), not the shared
`VSCrosstabBindingFactory`/`CrosstabOptionInfo` the native Composer's own ~15 controllers also use
— avoids a native-UI regression risk.

- `TableBindingMutator.preserveUntouchedPercentageBy(model, livePercentageByValue)` (new): resets
  a `CrosstabBindingModel`'s option back to `null` when the live crosstab's own `percentageBy`
  was still `null` at the start of the call.
- `TableBindingService`: wired into every write path except `setOptions` (the one call allowed
  to actually change `percentageBy`) — `setShelf`'s inline mutate, `applyWithContext`
  (`addField`/`removeField`/`moveField`), and a new `preservePercentageBy` flag on the shared
  `apply()` overload (`setSort`/`setRanking`/`setColumnLabels` default it `true`; `setOptions`
  passes `false`).

`TableBindingMutator.percentageByName()`'s existing null-guard is unchanged — it was already
correct and is now meaningful again, since a real, persisted crosstab can actually be `null`.

## Tests
Added to `TableBindingServiceTest.java`:
1. `setShelfDoesNotPersistTheManufacturedPercentageByDefault` — a non-options write no longer
   persists a manufactured `"1"`.
2. `setOptionsStillAppliesAnExplicitPercentageByChange` — an explicit
   `set_table_options(percentageBy: "row")` still applies normally.

`./mvnw -pl core test -Dtest=TableBindingServiceTest` → 30/30 pass. Also re-ran
`TableBindingMutatorTest,FieldRefFactoryTest,FieldRefBindingTest,BindingAgentControllerTest,BindingReadServiceTest`
(sibling wiz-binding suites) → all pass, no regressions.

**Note**: a third regression case from the diagnosis (calculateInfo `byRow`/`byColumn`/`prefix`
tracking `percentageBy` in lock-step across two `set_table_options` calls) was not added —
it exercises `syncPercentCalcs()`/`VSCrosstabBindingFactory.updateAssembly()`, which
`TableBindingServiceTest`'s mock-based harness doesn't wire up for real (`VSBindingModelService`/
`VSBindingService` are both plain mocks). Per the diagnosis, this mechanism already works
correctly and is a nice-to-have regression guard, not part of this bug's fix.

Do not merge — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)