### PR TITLE
fix(admin/cluster): pin reviewed task narrative into audit record via taskToken (#76588)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/AdminClusterController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/AdminClusterController.java
@@ -165,6 +165,16 @@ public class AdminClusterController {
                     "plan", ex.current());
    }
 
+   @ExceptionHandler(AdminChangesetApplyService.TaskTokenMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handleTaskTokenMismatch(
+      AdminChangesetApplyService.TaskTokenMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
    private final ClusterChangePlanService planService;
    private final ClusterChangesetApplyService applyService;
    private final ServerClusterClient client;

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyRequest.java
@@ -27,8 +27,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ClusterApplyRequest extends ClusterChangePlanRequest {
    public String getPlanHash() { return planHash; }
    public void setPlanHash(String v) { this.planHash = v; }
+   public String getTaskToken() { return taskToken; }
+   public void setTaskToken(String v) { this.taskToken = v; }
    public String getReviewOutcome() { return reviewOutcome; }
    public void setReviewOutcome(String v) { this.reviewOutcome = v; }
 
-   private String planHash, reviewOutcome;
+   private String planHash, taskToken, reviewOutcome;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
@@ -23,6 +23,7 @@ import inetsoft.util.audit.*;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
 import inetsoft.web.admin.ai.PlanChange;
 import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import inetsoft.web.admin.cluster.ClusterService;
 import inetsoft.web.cluster.ServerClusterClient;
 import inetsoft.web.cluster.ServerClusterStatus;
@@ -103,6 +104,15 @@ public class ClusterChangesetApplyService {
             throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
          }
 
+         String reviewedTask;
+
+         try {
+            reviewedTask = TaskAuditToken.verify(req.getTaskToken(), plan.planHash());
+         }
+         catch(TaskAuditToken.TaskTokenException e) {
+            throw new AdminChangesetApplyService.TaskTokenMismatchException(plan, e.getMessage());
+         }
+
          if(req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()) {
             throw new IllegalArgumentException(
                "reviewOutcome: required -- risk: high is unconditional for this area (01-spec.md " +
@@ -119,7 +129,7 @@ public class ClusterChangesetApplyService {
             ClusterChangeRequest original = originals.get(i);
 
             try {
-               applyOne(txId, plan.task(), change, original, reviewOutcome, user, results);
+               applyOne(txId, reviewedTask, change, original, reviewOutcome, user, results);
             }
             catch(Exception e) {
                // A throw carries no verifiable before/after evidence for THIS entry, but must never
@@ -128,7 +138,7 @@ public class ClusterChangesetApplyService {
                String message = messageOf(e);
                results.add(new ClusterApplyOutcome(server, change.currentValue(), null, STATUS_FAILED,
                                                     message));
-               writeAudit(txId, plan.task(), server, change.currentValue(), null, STATUS_FAILED,
+               writeAudit(txId, reviewedTask, server, change.currentValue(), null, STATUS_FAILED,
                          reviewOutcome, user);
             }
          }

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/AdminClusterControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/AdminClusterControllerTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.cluster.ServerClusterClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * bug #76588 (cluster taskToken audit-pinning): {@link AdminClusterController} must map a
+ * {@code TaskTokenMismatchException} to a structured 409, mirroring
+ * {@code AdminAiController#handleTaskTokenMismatch} exactly -- otherwise the exception falls
+ * through to the global {@code AdminExceptionHandler} catch-all and comes back as a 500.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminClusterControllerTest {
+   @Mock private ClusterChangePlanService planService;
+   @Mock private ClusterChangesetApplyService applyService;
+   @Mock private ServerClusterClient client;
+   private AdminClusterController controller;
+
+   @BeforeEach void setUp() {
+      controller = new AdminClusterController(planService, applyService, client);
+   }
+
+   @Test void handleTaskTokenMismatchReturnsConflictStatusWithCurrentPlan() {
+      ResolvedPlan current = new ResolvedPlan("pause node1", List.of(), false, true,
+                                              "hash456", "token456");
+      AdminChangesetApplyService.TaskTokenMismatchException ex =
+         new AdminChangesetApplyService.TaskTokenMismatchException(current,
+            "taskToken: does not match the current plan; re-review before applying");
+
+      Map<String, Object> actual = controller.handleTaskTokenMismatch(ex);
+
+      assertEquals("conflict", actual.get("status"));
+      assertEquals(ex.getMessage(), actual.get("error"));
+      ResolvedPlan returnedPlan = (ResolvedPlan) actual.get("plan");
+      assertEquals(current.task(), returnedPlan.task());
+      assertEquals(current.planHash(), returnedPlan.planHash());
+      assertNull(returnedPlan.taskToken());
+   }
+
+   @Test void handleTaskTokenMismatchIsAnnotatedConflict() throws NoSuchMethodException {
+      ResponseStatus annotation = AdminClusterController.class
+         .getMethod("handleTaskTokenMismatch",
+                    AdminChangesetApplyService.TaskTokenMismatchException.class)
+         .getAnnotation(ResponseStatus.class);
+
+      assertNotNull(annotation, "handleTaskTokenMismatch must be annotated @ResponseStatus");
+      assertEquals(HttpStatus.CONFLICT, annotation.value());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
@@ -23,6 +23,7 @@ import inetsoft.util.audit.AdminChangeRecord;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.Audit;
 import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.TaskAuditToken;
 import inetsoft.web.admin.cluster.ClusterEnabledModel;
 import inetsoft.web.admin.cluster.ClusterService;
 import inetsoft.web.cluster.ServerClusterClient;
@@ -70,6 +71,16 @@ class ClusterChangesetApplyServiceTest {
          .defaultAnswer(Answers.CALLS_REAL_METHODS));
       tool.when(() -> Tool.encryptPassword(anyString()))
          .thenAnswer(inv -> "TKN:" + inv.getArgument(0));
+      tool.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+
+            if(!s.startsWith("TKN:")) {
+               throw new IllegalArgumentException("not a token");
+            }
+
+            return s.substring(4);
+         });
    }
 
    @AfterEach void tearDown() {
@@ -95,6 +106,43 @@ class ClusterChangesetApplyServiceTest {
       IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
          () -> service.apply(req, user));
       assertTrue(ex.getMessage().contains("reviewOutcome"));
+   }
+
+   // -------------------------------------------------------------------------
+   // taskToken gate -- audit-pinning parity with AdminChangesetApplyService (bug #76588)
+   // -------------------------------------------------------------------------
+
+   @Test void applyThrowsTaskTokenMismatchOnMissingToken() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+      ClusterApplyRequest req = applyRequest("task", hash, "looks good", pause("s1"));
+      req.setTaskToken(null);
+
+      AdminChangesetApplyService.TaskTokenMismatchException ex = assertThrows(
+         AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().startsWith("taskToken:"));
+      assertNotNull(ex.current());
+   }
+
+   @Test void applyThrowsTaskTokenMismatchOnBlankToken() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+      ClusterApplyRequest req = applyRequest("task", hash, "looks good", pause("s1"));
+      req.setTaskToken("   ");
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
+   }
+
+   @Test void applyThrowsTaskTokenMismatchOnTokenIssuedForDifferentPlanHash() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+      ClusterApplyRequest req = applyRequest("task", hash, "looks good", pause("s1"));
+      req.setTaskToken(TaskAuditToken.issue("not-the-real-hash", "task"));
+
+      assertThrows(AdminChangesetApplyService.TaskTokenMismatchException.class,
+         () -> service.apply(req, user));
    }
 
    // -------------------------------------------------------------------------
@@ -310,6 +358,30 @@ class ClusterChangesetApplyServiceTest {
       assertNull(record.getOrganizationId());
    }
 
+   @Test void auditsThePreviewedTaskNarrativeEvenWhenApplyRequestTaskDiffers() throws Exception {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(request("raise pause count", List.of(pause("s1")))).planHash();
+      // The token is issued for the previewed task, but the apply request's own task field carries
+      // different text -- exactly the shape the fix must not let win.
+      ClusterApplyRequest req = applyRequest("raise pause count", hash, "looks good", pause("s1"));
+      req.setTask("totally different apply-time text");
+      Audit auditInstance = mock(Audit.class);
+      tool.when(Tool::getHost).thenReturn("test-host");
+
+      doAnswer(inv -> { stubStatus("s1", ServerClusterStatus.Status.OK, true); return null; })
+         .when(clusterService).pauseServers(new String[] { "s1" });
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class)) {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         var result = service.apply(req, user);
+         assertEquals(ClusterChangesetApplyService.STATUS_APPLIED, result.status());
+      }
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      assertEquals("raise pause count", captor.getValue().getTaskDescription());
+   }
+
    // -------------------------------------------------------------------------
    // helpers
    // -------------------------------------------------------------------------
@@ -354,6 +426,7 @@ class ClusterChangesetApplyServiceTest {
       req.setChanges(List.of(changes));
       req.setPlanHash(planHash);
       req.setReviewOutcome(reviewOutcome);
+      req.setTaskToken(TaskAuditToken.issue(planHash, task));
       return req;
    }
 }


### PR DESCRIPTION
## Summary
- `ClusterChangePlanService.resolve()` already issues a `taskToken` (via `TaskAuditToken.issue()`), but `ClusterChangesetApplyService.apply()` never verified one and wrote every per-server audit record from the apply request's own re-resolved `task` field instead — the same audit-pinning gap PR #2282 closed for `AdminChangesetApplyService`/Properties.
- Adds `taskToken` to `ClusterApplyRequest`, verifies it in `apply()` via `TaskAuditToken.verify()` (throwing the shared `AdminChangesetApplyService.TaskTokenMismatchException` on failure, same as the Properties template), and threads the verified `reviewedTask` through both `writeAudit` call sites (the loop's `applyOne` call and the catch-block fallback — Cluster has no rollback pass, so these are the only two sites, one fewer than Properties).
- Maps the new exception to HTTP 409 in `AdminClusterController`, mirroring `AdminAiController`.

## Test-fixture fix (required prerequisite, not a functional change)
- Added the missing `Tool.decryptPassword` stub to `ClusterChangesetApplyServiceTest`'s `setUp()` (mirrors `AdminChangesetApplyServiceTest`).
- Added `req.setTaskToken(TaskAuditToken.issue(planHash, task))` inside the shared `applyRequest()` test helper — a one-line fix that keeps all pre-existing tests green without touching any of their call sites, since `TaskAuditToken.verify()` only checks planHash equality, not task text.
- Added new regression tests: missing/blank/wrong-planHash taskToken all throw `TaskTokenMismatchException`; a valid token whose embedded task differs from the apply request's own `task` field still wins in the written audit record.
- Added a new `AdminClusterControllerTest` covering the new `handleTaskTokenMismatch` 409 mapping (no controller test previously existed for this area).

## Companion PR
Plugin side: inetsoft-technology/stylebi-wiz#2423

Cross-references bug #76588 (Cluster sub-task of the taskToken audit-pinning sweep).

## Test plan
- [x] `./mvnw -pl core test -Dtest=ClusterChangesetApplyServiceTest,AdminClusterControllerTest -DfailIfNoTests=false` — 16/16 pass (14 in `ClusterChangesetApplyServiceTest`: 10 pre-existing + 4 new; 2 in the new `AdminClusterControllerTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)