### PR TITLE
fix(wiz-hyperlink): SELF target frame, dead bookmarks, shared axis/data-point link storage (bug #76580)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -23,6 +23,8 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.VSBookmarkInfo;
+import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
 import inetsoft.web.composer.model.vs.InputParameterDialogModel;
@@ -138,6 +140,11 @@ public class AssemblyHyperlinkService {
       // validation above exists to prevent, arrived at by another road.
       String assetId = "viewsheet".equals(type)
          ? resolveViewsheetTarget(link, sessionToken, user) : null;
+
+      // Also validated here, before the runtime is touched, and after assetId so it isn't
+      // resolved twice: a bookmark that HyperlinkDialogService.getHyperlink would otherwise
+      // silently drop (wrong linkType, or a name matching no VSBookmarkInfo) is refused instead.
+      requireValidBookmark(type, link, assetId, user);
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          Region target = region == null ? Region.whole() : region;
@@ -326,6 +333,53 @@ public class AssemblyHyperlinkService {
          "'s own scope. A link to a viewsheet that does not exist is accepted by the dialog and " +
          "then does nothing when clicked, so it is refused here instead. Pass 'assetLinkId' " +
          "directly if you already hold the asset identifier.");
+   }
+
+   /**
+    * {@code bookmark} is only ever wired into persistence for a {@code viewsheet}-type link
+    * ({@code HyperlinkDialogService.getHyperlink}'s bookmark block sits inside an
+    * {@code if(linkType == VIEWSHEET_LINK)}), and even there it silently no-ops -- no exception,
+    * no signal -- when the supplied name matches no {@link VSBookmarkInfo} for that viewsheet.
+    * Both are refused here instead, at the agent-facing layer, rather than in the shared
+    * {@code HyperlinkDialogService} the real Composer dialog also uses.
+    */
+   private static void requireValidBookmark(String type, Map<String, Object> link, String assetId,
+                                            Principal user)
+   {
+      String bookmark = str(link, "bookmark");
+
+      if(bookmark == null) {
+         return;
+      }
+
+      if(!"viewsheet".equals(type)) {
+         throw new IllegalArgumentException(
+            "'bookmark' only applies to a 'viewsheet' hyperlink, got linkType '" + type + "'. " +
+            "It is silently ignored at persist time for any other type, so it is refused here " +
+            "instead.");
+      }
+
+      IdentityID currentUser = IdentityID.getIdentityIDFromKey(user.getName());
+      VSBookmarkInfo[] bookmarks = VSUtil.getBookmarks(assetId, currentUser);
+
+      // Mirrors HyperlinkDialogService.getHyperlink's own parsing exactly, so a name this
+      // validation accepts is guaranteed to be one persistence itself would also match: a
+      // trailing "(Owner)" (the composer bookmark dropdown's own display form) is stripped
+      // before comparing.
+      int userIdx = bookmark.lastIndexOf('(') > 0 ? bookmark.lastIndexOf('(') : bookmark.length();
+      String bookmarkName = bookmark.substring(0, userIdx);
+      boolean matches = Arrays.stream(bookmarks).anyMatch(b -> b.getName().equals(bookmarkName));
+
+      if(!matches) {
+         List<String> names = Arrays.stream(bookmarks)
+            .map(VSBookmarkInfo::getName)
+            .collect(Collectors.toList());
+         Collections.sort(names);
+         throw new IllegalArgumentException(
+            "No bookmark named '" + bookmark + "' on this viewsheet. A name that matches none " +
+            "is silently ignored at persist time, so it is refused here instead. Known " +
+            "bookmarks: " + names);
+      }
    }
 
    private static void require(Map<String, Object> link, String field, String type) {
@@ -522,7 +576,17 @@ public class AssemblyHyperlinkService {
       // same-named assets across scopes a link actually resolved to.
       out.put("assetLinkId", model.getAssetLinkId());
       out.put("bookmark", model.getBookmark());
-      out.put("targetFrame", model.getTargetFrame());
+      // model.isSelf() is dialog-model UI sugar: HyperlinkDialogService.getHyperlinkDialogModel
+      // blanks targetFrame to "" and sets self=true whenever the persisted Hyperlink.targetFrame
+      // was the literal "SELF", so it must be reconstructed here for this class's own wire
+      // contract to hold. But self=true is ALSO the default for a never-linked assembly (line 182
+      // of that class, hyperlink == null) -- guarding on linkType != NONE mirrors the real
+      // Angular dialog's own rewrite (hyperlink-dialog.component.ts:309-310), which only fires
+      // when there is an actual link, so an unlinked assembly still reads back an absent/blank
+      // targetFrame rather than a fabricated "SELF".
+      boolean selfWithARealLink =
+         model.isSelf() && model.getLinkType() != HyperlinkDialogService.NONE;
+      out.put("targetFrame", selfWithARealLink ? "SELF" : model.getTargetFrame());
       out.put("tooltip", model.getTooltip());
       out.put("self", model.isSelf());
       out.put("disableParameterPrompt", model.isDisableParameterPrompt());
@@ -537,6 +601,17 @@ public class AssemblyHyperlinkService {
       // it is the name this read was scoped to, whether or not the model repeats it.
       out.put("colName", model.getColName() != null ? model.getColName()
                  : asked == null ? null : asked.colName());
+      // A chart field's data-point link and its axis-label link are the same underlying storage:
+      // HyperlinkRef (VSChartAggregateRef/VSChartDimensionRef) declares exactly one Hyperlink
+      // field, with no second, axis-specific slot, and HyperlinkDialogService.getHyperlinkDialogModel
+      // only sets model.colName from its chart branch -- so a non-null model colName here, outside
+      // a title/empty-plot-link request, is exactly the shape where axis:true resolves to the same
+      // ChartRef (and therefore the same Hyperlink) as a plain colName call. Setting one overwrites
+      // the other's destination. This is the "fail loud" half of VHL-001 (bug #76580): a caller is
+      // told plainly rather than silently losing the other link.
+      out.put("axisAndDataPointShareLink",
+              model.getColName() != null &&
+              !(asked != null && (asked.titleLink() || asked.emptyPlotLink())));
       return out;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceBookmarkValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceBookmarkValidationTest.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.VSBookmarkInfo;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.VSUtil;
+import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
+import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The "matches an existing bookmark" / "matches none" halves of VHL-004's sibling, VHL-003
+ * (bug #76580): {@code AssemblyHyperlinkService.requireValidBookmark} calls the real, static
+ * {@code VSUtil.getBookmarks} -- the same call {@code HyperlinkDialogService.getHyperlink}
+ * already makes at persist time -- and that class's static initializer touches
+ * Spring-context-dependent caching ({@code DataCacheSweeper}/{@code ConfigurationContext}), so
+ * mocking it needs the same Spring bootstrap {@code ComposerBindingControllerTest} already uses
+ * for the identical {@code Mockito.mockStatic(VSUtil.class)} call, rather than the plain-Mockito
+ * harness the rest of {@code AssemblyHyperlinkServiceTest} uses. The "wrong linkType" bookmark
+ * refusal (web/message) needs none of this -- it short-circuits before ever calling
+ * {@code VSUtil.getBookmarks} -- and stays in that faster file.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@ExtendWith({MockitoExtension.class})
+@MockitoSettings(strictness = Strictness.LENIENT)
+@Tag("core")
+class AssemblyHyperlinkServiceBookmarkValidationTest {
+   private static Map<String, Object> link(Object... pairs) {
+      Map<String, Object> link = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         link.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return link;
+   }
+
+   private static final IdentityID OWNER = IdentityID.getIdentityIDFromKey("admin");
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+
+   private record Harness(AssemblyHyperlinkService service, HyperlinkDialogService links) {}
+
+   private static Harness harness() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      HyperlinkDialogService links = mock(HyperlinkDialogService.class);
+      AssetRepository repository = mock(AssetRepository.class);
+
+      when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+      when(rvs.getAssetRepository()).thenReturn(repository);
+      when(repository.containsEntry(any())).thenReturn(true);
+      doAnswer(invocation -> {
+         ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+         mutation.run(rvs, "rt1", null);
+         return null;
+      }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      when(links.getHyperlinkDialogModel(anyString(), anyString(), any(), any(), any(),
+                                         anyBoolean(), anyBoolean(), anyBoolean(),
+                                         anyBoolean(), any(Principal.class)))
+         .thenReturn(new HyperlinkDialogModel());
+
+      return new Harness(new AssemblyHyperlinkService(sessions, links), links);
+   }
+
+   private static HyperlinkDialogModel capture(HyperlinkDialogService links) throws Exception {
+      ArgumentCaptor<HyperlinkDialogModel> captor =
+         ArgumentCaptor.forClass(HyperlinkDialogModel.class);
+      verify(links).setHyperlinkDialogModel(eq("rt1"), anyString(), captor.capture(),
+                                            anyString(), any(Principal.class), any());
+      return captor.getValue();
+   }
+
+   /**
+    * {@code HyperlinkDialogService.getHyperlink} silently no-ops -- no exception, no signal --
+    * when the supplied bookmark name matches no {@code VSBookmarkInfo} for the target viewsheet.
+    * This must be refused instead, naming the bookmarks that do exist.
+    */
+   @Test
+   void bookmarkIsRefusedWhenItMatchesNoExistingBookmark() throws Exception {
+      Harness h = harness();
+
+      try(MockedStatic<VSUtil> vsutil = Mockito.mockStatic(VSUtil.class)) {
+         vsutil.when(() -> VSUtil.getBookmarks(anyString(), any(IdentityID.class)))
+            .thenReturn(new VSBookmarkInfo[]{
+               new VSBookmarkInfo("Q3", VSBookmarkInfo.PRIVATE, OWNER, false, 0L) });
+
+         Exception thrown = assertThrows(
+            Exception.class,
+            () -> h.service().set("tok", principal(), "Chart1", null,
+                                  link("linkType", "viewsheet", "assetLinkPath", "Reports/Detail",
+                                       "bookmark", "Nope"),
+                                  ""));
+
+         assertTrue(thrown.getMessage().contains("Nope"));
+         assertTrue(thrown.getMessage().contains("Q3"), "name the bookmarks that do exist");
+      }
+   }
+
+   @Test
+   void bookmarkSucceedsWhenItMatchesAnExistingBookmark() throws Exception {
+      Harness h = harness();
+
+      try(MockedStatic<VSUtil> vsutil = Mockito.mockStatic(VSUtil.class)) {
+         vsutil.when(() -> VSUtil.getBookmarks(anyString(), any(IdentityID.class)))
+            .thenReturn(new VSBookmarkInfo[]{
+               new VSBookmarkInfo("Q3", VSBookmarkInfo.PRIVATE, OWNER, false, 0L) });
+
+         h.service().set("tok", principal(), "Chart1", null,
+                        link("linkType", "viewsheet", "assetLinkPath", "Reports/Detail",
+                             "bookmark", "Q3"),
+                        "");
+
+         assertEquals("Q3", capture(h.links()).getBookmark());
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -861,6 +861,131 @@ class AssemblyHyperlinkServiceTest {
       assertNull(read.get("colName"));
    }
 
+   // ── VHL-004: self:true reads back targetFrame:"SELF", not "" ───────────────
+
+   /**
+    * {@code HyperlinkDialogService.getHyperlinkDialogModel} blanks {@code targetFrame} to
+    * {@code ""} and reports the fact via {@code self} whenever the persisted
+    * {@code Hyperlink.targetFrame} was the literal {@code "SELF"} -- {@code describe()} must
+    * reconstruct that literal for this tool's own contract to hold.
+    */
+   @Test
+   void selfWithARealLinkReadsBackTargetFrameAsSelf() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(Hyperlink.WEB_LINK);
+      model.setWebLink("https://example.com");
+      model.setSelf(true);
+      model.setTargetFrame("");
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      assertEquals("SELF", read.get("targetFrame"));
+   }
+
+   /**
+    * A never-linked assembly also carries {@code self=true} by default
+    * ({@code HyperlinkDialogService.java:182}, taken whenever {@code hyperlink == null}) -- not
+    * because a "SELF" target frame was ever persisted. Reporting {@code targetFrame:"SELF"} here
+    * would fabricate a link property for an assembly that has no link at all, so this must stay
+    * as the model's own (unset) target frame, mirroring the real Angular dialog's own guard
+    * ({@code hyperlink-dialog.component.ts:309-310}, which only rewrites for
+    * {@code linkType !== NONE}).
+    */
+   @Test
+   void selfDefaultOnANeverLinkedAssemblyDoesNotFabricateTargetFrameSelf() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(HyperlinkDialogService.NONE);
+      model.setSelf(true);
+      model.setTargetFrame("");
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      assertEquals("none", read.get("linkType"));
+      assertNotEquals("SELF", read.get("targetFrame"));
+   }
+
+   // ── VHL-001: chart data-point and axis-label links share one storage slot ──
+
+   /**
+    * {@code HyperlinkDialogService.getHyperlinkDialogModel} only sets {@code model.colName} from
+    * its chart branch, so a non-null model colName here (outside a title/empty-plot-link ask) is
+    * exactly the shape where {@code axis:true} and a plain call resolve to the same
+    * {@code ChartRef}'s single {@code Hyperlink} slot. The response must disclose that plainly.
+    */
+   @Test
+   void disclosesTheSharedStorageForAnOrdinaryChartFieldAddressedByColName() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setColName("Revenue");
+
+      Map<String, Object> read = harness(model).service.read(
+         "tok", principal(), "Chart1",
+         new AssemblyHyperlinkService.Region(null, null, "Revenue", true, false, false, false));
+
+      assertEquals(true, read.get("axisAndDataPointShareLink"));
+   }
+
+   /** A title link lives on {@code ChartVSAssemblyInfo} itself, independent of any ChartRef. */
+   @Test
+   void doesNotDiscloseSharedStorageForATitleLink() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setColName("Revenue");
+
+      Map<String, Object> read = harness(model).service.read(
+         "tok", principal(), "Chart1",
+         new AssemblyHyperlinkService.Region(null, null, null, false, false, true, false));
+
+      assertEquals(false, read.get("axisAndDataPointShareLink"));
+   }
+
+   /** A table cell has no colName-addressed ChartRef at all -- nothing is shared. */
+   @Test
+   void doesNotDiscloseSharedStorageWhenTheModelCarriesNoColName() throws Exception {
+      Map<String, Object> read = harness(new HyperlinkDialogModel())
+         .service.read("tok", principal(), "Table1",
+                       new AssemblyHyperlinkService.Region(2, 1, "Sales", false, false, false,
+                                                           false));
+
+      assertEquals(false, read.get("axisAndDataPointShareLink"));
+   }
+
+   // ── VHL-003: link.bookmark silently dropped ─────────────────────────────────
+
+   @Test
+   void bookmarkIsRefusedForAWebLink() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Chart1", null,
+                             link("linkType", "web", "webLink", "https://example.com",
+                                  "bookmark", "Q3"),
+                             ""));
+
+      assertTrue(thrown.getMessage().contains("bookmark"));
+      assertTrue(thrown.getMessage().contains("web"));
+   }
+
+   @Test
+   void bookmarkIsRefusedForAMessageLink() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Chart1", null,
+                             link("linkType", "message", "webLink", "hello",
+                                  "bookmark", "Q3"),
+                             ""));
+
+      assertTrue(thrown.getMessage().contains("bookmark"));
+   }
+
+   // The "matches an existing bookmark" / "matches none" cases call the real, unmocked
+   // VSUtil.getBookmarks (via Mockito.mockStatic) -- that class's static initializer touches
+   // Spring-context-dependent caching, so those two live in
+   // AssemblyHyperlinkServiceBookmarkValidationTest, bootstrapped the same way
+   // ComposerBindingControllerTest bootstraps it, rather than dragging that setup into this
+   // file's fast, plain-Mockito harness for every other test in it.
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private record Harness(AssemblyHyperlinkService service, ViewsheetSessionService sessions,


### PR DESCRIPTION
## Summary

Three findings from bug #76580's backend track (VHL-004/VHL-003/VHL-001), all confirmed by both a debugger and refuter pass (see `docs/teams/2026-09-11-bug-76580-viewsheet-hyperlink/bug-76580-backend/` in the `stylebi-wiz` repo).

- **VHL-004 (P3)**: `describe()` forwarded `HyperlinkDialogModel.getTargetFrame()` unchanged, so a `self:true` link (blanked to `""` by `HyperlinkDialogService`, reported via a separate `self` flag) read back `targetFrame:""` instead of the literal `"SELF"` actually persisted. Fixed by reconstructing `"SELF"` when `self` is true **and** the assembly actually has a link (`linkType != NONE`) — the guard the refuter found missing from the original one-line sketch, matching the real Angular dialog's own guard (`hyperlink-dialog.component.ts:309-310`).
- **VHL-003 (P2)**: `link.bookmark` was silently dropped — never wired for `web`/`message` link types, and silently no-op'd for `viewsheet`-type links when the name didn't exactly match an existing `VSBookmarkInfo`. Fixed in `AssemblyHyperlinkService.set()`, before the runtime is touched: `bookmark` is refused outright for `web`/`message`, and validated against `VSUtil.getBookmarks(assetId, user)` for `viewsheet`, naming the bookmarks that do exist on a miss.
- **VHL-001 (P1)**: a chart field's data-point link and axis-label link share exactly one `Hyperlink` slot per `ChartRef` — a genuine data-model limitation, not a lookup bug, out of scope to fix at the storage layer here. `describe()` now discloses `axisAndDataPointShareLink:true` for an ordinary bound chart field addressed by `colName`, so a caller is told plainly instead of silently losing the other link's destination.

## Test plan

- [x] `./mvnw -pl core test -Dtest=AssemblyHyperlinkServiceTest -DfailIfNoTests=false` — 56/56 pass (49 pre-existing + 7 new)
- [x] `./mvnw -pl core test -Dtest=AssemblyHyperlinkServiceBookmarkValidationTest -DfailIfNoTests=false` — 2/2 pass (new Spring-bootstrapped class for the two cases needing a real `VSUtil.getBookmarks` mock)
- [x] `./mvnw -pl core test -Dtest=ViewsheetAssemblyAgentControllerTest -DfailIfNoTests=false` — 71/71 pass (collateral check, this controller wires `AssemblyHyperlinkService`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)