### PR TITLE
Fix bug 76525: SelectionTree deepest-level path validation, Range Slider set_selection no-op, and deselect ancestor-flag residue

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
@@ -199,8 +199,32 @@ public class SelectionRuntimeService {
                }
             }
 
-            selections.applySelection(runtimeId, assemblyName, applyEvent(values), user, dispatcher,
-                                      linkUri);
+            if(assembly instanceof TimeSliderVSAssembly slider) {
+               // doApplySelection's TimeSliderVSAssembly branch never reads event.getValues() --
+               // it only reads event.getSelectStart()/getSelectEnd(), two bucket-index ints. A
+               // plain value-array apply (what every other assembly type above uses) is a total
+               // no-op here, silently: no exception, and the response still claims success.
+               SelectionValue[] buckets = bucketsOf(slider);
+               List<Map<String, Object>> clamped = new ArrayList<>();
+               int[] range = sliderBucketRange(assemblyName, buckets, values, clamped);
+               ApplySelectionListEvent event = new ApplySelectionListEvent();
+               event.setType(ApplySelectionListEvent.Type.APPLY);
+               event.setSelectStart(range[0]);
+               event.setSelectEnd(adjustedEnd(slider.isUpperInclusive(), range[1]));
+               selections.applySelection(runtimeId, assemblyName, event, user, dispatcher, linkUri);
+
+               if(!clamped.isEmpty()) {
+                  // A requested bound outside the slider's actual bucket range was silently
+                  // substituted with the nearest one -- disclose which, the same way
+                  // scopedBySearch discloses a write landing on a narrower scope than asked.
+                  result.put("clampedBounds", clamped);
+               }
+            }
+            else {
+               selections.applySelection(runtimeId, assemblyName, applyEvent(values), user, dispatcher,
+                                         linkUri);
+            }
+
             result.put("valuesSelected", values.size());
          }
       });
@@ -228,17 +252,42 @@ public class SelectionRuntimeService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          SelectionVSAssembly assembly = requireSelection(rvs, assemblyName);
-         List<List<String>> current = selectedPaths(assembly);
 
          result.put("assembly", assemblyName);
          result.put("type", describe(assembly));
-         result.put("clearedCount", current.size());
 
-         if(!current.isEmpty()) {
-            // The client composes "unselect" the same way: send every currently selected value back
-            // with selected=false. There is no single clear endpoint for one assembly.
-            selections.applySelection(runtimeId, assemblyName, deselectEvent(current), user,
-                                      dispatcher, linkUri);
+         if(assembly instanceof TimeSliderVSAssembly slider) {
+            // "Nothing selected" on a range slider is represented as EVERY bucket marked
+            // selected (the full range), not an empty/null state like a list/tree -- so the
+            // list/tree clearedCount bookkeeping below (raw count of selected nodes) is
+            // meaningless here: a genuinely untouched slider would misreport every one of its
+            // buckets as "was filtering". And the list/tree deselect event is a no-op on a
+            // slider for the same reason set_selection's plain value-array apply was (see
+            // above) -- doApplySelection's TimeSlider branch never reads it -- so clearing an
+            // actually-filtered slider needs its own full-range apply, not deselectEvent.
+            SelectionValue[] buckets = bucketsOf(slider);
+            boolean fullRange = isFullRangeSelected(buckets);
+            result.put("clearedCount", fullRange ? 0 : buckets.length);
+
+            if(!fullRange && buckets.length > 0) {
+               ApplySelectionListEvent event = new ApplySelectionListEvent();
+               event.setType(ApplySelectionListEvent.Type.APPLY);
+               event.setSelectStart(0);
+               event.setSelectEnd(adjustedEnd(slider.isUpperInclusive(), buckets.length - 1));
+               selections.applySelection(runtimeId, assemblyName, event, user, dispatcher, linkUri);
+            }
+         }
+         else {
+            List<List<String>> current = selectedPaths(assembly);
+            result.put("clearedCount", current.size());
+
+            if(!current.isEmpty()) {
+               // The client composes "unselect" the same way: send every currently selected
+               // value back with selected=false. There is no single clear endpoint for one
+               // assembly.
+               selections.applySelection(runtimeId, assemblyName, deselectEvent(current), user,
+                                         dispatcher, linkUri);
+            }
          }
       });
 
@@ -629,6 +678,148 @@ public class SelectionRuntimeService {
       }
 
       return false;
+   }
+
+   // ── range slider bucket resolution ──────────────────────────────────────────
+
+   /**
+    * The result of resolving one requested Range Slider bound to a bucket: which index it landed
+    * on, the bucket's own value (what actually gets applied), and whether that differs from what
+    * was requested (an out-of-range numeric bound clamped to the nearest bucket).
+    */
+   record BucketResolution(int index, String appliedValue, boolean clamped) {}
+
+   /**
+    * Resolves every requested value into the {@code [start, end]} bucket-index range a Range
+    * Slider apply should select, collecting a disclosure entry for each bound that had to be
+    * clamped. {@code values} is one bucket-value per single-segment path -- a slider has no
+    * hierarchy, so anything longer is refused.
+    */
+   static int[] sliderBucketRange(String assemblyName, SelectionValue[] buckets,
+                                  List<List<String>> values, List<Map<String, Object>> clampedOut)
+   {
+      if(buckets.length == 0) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' has no values to select from yet.");
+      }
+
+      int start = Integer.MAX_VALUE;
+      int end = Integer.MIN_VALUE;
+
+      for(List<String> path : values) {
+         if(path.size() != 1) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' is a range slider, which has no hierarchy -- each value " +
+               "must be a single bound, not a path of " + path.size() + ".");
+         }
+
+         BucketResolution resolved = bucketIndex(assemblyName, buckets, path.get(0));
+         start = Math.min(start, resolved.index());
+         end = Math.max(end, resolved.index());
+
+         if(resolved.clamped()) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("requested", path.get(0));
+            entry.put("applied", resolved.appliedValue());
+            clampedOut.add(entry);
+         }
+      }
+
+      return new int[]{start, end};
+   }
+
+   /**
+    * Resolves one requested bound to a bucket index: an exact match against a bucket's own raw
+    * {@code SelectionValue.getValue()} first (the same value the assembly's own apply/clear paths
+    * compare, per {@code TimeSliderSelection.populateNumberList}/{@code populateDateList}); failing
+    * that, for a value that parses as a number, the numerically nearest bucket -- clamping an
+    * out-of-range bound to the slider's actual extent rather than refusing it, matching this file's
+    * existing forgiving-on-unambiguous-intent convention ({@link #requireSortOrder}'s aliases).
+    * Anything else (unparseable, no exact match) fails loud by name rather than silently landing on
+    * some default.
+    */
+   static BucketResolution bucketIndex(String assemblyName, SelectionValue[] buckets,
+                                       String requested)
+   {
+      for(int i = 0; i < buckets.length; i++) {
+         if(buckets[i] != null && Tool.equals(requested, buckets[i].getValue())) {
+            return new BucketResolution(i, buckets[i].getValue(), false);
+         }
+      }
+
+      Double requestedNumber = parseNumeric(requested);
+
+      if(requestedNumber != null) {
+         int nearest = -1;
+         double nearestDistance = Double.MAX_VALUE;
+
+         for(int i = 0; i < buckets.length; i++) {
+            Double bucketNumber = buckets[i] == null ? null : parseNumeric(buckets[i].getValue());
+
+            if(bucketNumber == null) {
+               continue;
+            }
+
+            double distance = Math.abs(bucketNumber - requestedNumber);
+
+            if(distance < nearestDistance) {
+               nearestDistance = distance;
+               nearest = i;
+            }
+         }
+
+         if(nearest >= 0) {
+            return new BucketResolution(nearest, buckets[nearest].getValue(), true);
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assemblyName + "' has no bucket matching '" + requested + "'.");
+   }
+
+   private static Double parseNumeric(String value) {
+      if(value == null) {
+         return null;
+      }
+
+      try {
+         return Double.parseDouble(value);
+      }
+      catch(NumberFormatException e) {
+         return null;
+      }
+   }
+
+   /**
+    * {@code doApplySelection} decrements {@code selectEnd} by one when the slider is not
+    * upper-inclusive, so the index actually wanted has to be sent one past itself for that
+    * decrement to land back on it.
+    */
+   static int adjustedEnd(boolean upperInclusive, int endIndex) {
+      return upperInclusive ? endIndex : endIndex + 1;
+   }
+
+   /**
+    * Whether every bucket is currently selected -- the Range Slider's own representation of "not
+    * filtering anything", unlike a list/tree's empty/null state.
+    */
+   static boolean isFullRangeSelected(SelectionValue[] buckets) {
+      if(buckets.length == 0) {
+         return true;
+      }
+
+      for(SelectionValue bucket : buckets) {
+         if(bucket == null || !bucket.isSelected()) {
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   private static SelectionValue[] bucketsOf(TimeSliderVSAssembly slider) {
+      SelectionList list = slider.getSelectionList();
+      return list == null ? new SelectionValue[0] : list.getSelectionValues();
    }
 
    private static SelectionList selectionListOf(SelectionVSAssembly assembly) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
@@ -98,19 +98,47 @@ public class SelectionRuntimeService {
     *
     * @param values      the values to select. For a tree, each entry is a path from the root, so
     *                    {@code ["East","NY"]} selects NY under East. Null leaves the selection alone.
+    *                    On a list or non-ID-mode tree, {@code values} <b>replaces</b> the current
+    *                    selection by default (bug-76548) — pass {@code additive:true} to make it
+    *                    add to the current selection instead, without touching anything else.
+    * @param deselect    values/paths to explicitly remove from the current selection, independent
+    *                    of {@code additive} — the counterpart to {@code values} for a caller that
+    *                    knows exactly what to un-check without needing to first read (or
+    *                    re-specify) everything that should stay selected. Same shape as
+    *                    {@code values}; null or empty leaves the selection alone. Only valid on a
+    *                    list or non-ID-mode tree (the only assemblies {@code values}'s own replace
+    *                    diff already applies to).
     * @param sortOrder   {@code asc} | {@code desc} | {@code specific}, or null to leave it.
     * @param singleSelect whether the assembly should accept one value only, or null to leave it.
+    * @param additive    when true, {@code values} only adds — the automatic replace-diff (deselect
+    *                    anything current but unmentioned) is skipped. Ignored where that diff
+    *                    never ran anyway (single-select, a range slider, ID-mode tree, calendar).
     */
    public Map<String, Object> setSelection(String sessionToken, Principal user, String assemblyName,
-                                           List<List<String>> values, String sortOrder,
-                                           Boolean singleSelect, String linkUri)
+                                           List<List<String>> values, List<List<String>> deselect,
+                                           String sortOrder, Boolean singleSelect, Boolean additive,
+                                           String linkUri)
       throws Exception
    {
       requireName(assemblyName);
 
-      if(values == null && sortOrder == null && singleSelect == null) {
+      boolean hasDeselect = deselect != null && !deselect.isEmpty();
+
+      if(values == null && sortOrder == null && singleSelect == null && !hasDeselect) {
          throw new IllegalArgumentException(
-            "Nothing to do — give at least one of 'values', 'sortOrder' or 'singleSelect'.");
+            "Nothing to do — give at least one of 'values', 'deselect', 'sortOrder' or " +
+            "'singleSelect'.");
+      }
+
+      if(values != null && hasDeselect) {
+         List<List<String>> overlap = new ArrayList<>(values);
+         overlap.retainAll(deselect);
+
+         if(!overlap.isEmpty()) {
+            throw new IllegalArgumentException(
+               "'values' and 'deselect' both name " + overlap + " — that's a contradiction: " +
+               "select it or remove it, not both in the same call.");
+         }
       }
 
       final Integer targetSort = sortOrder == null ? null : requireSortOrder(sortOrder);
@@ -186,15 +214,18 @@ public class SelectionRuntimeService {
                result.put("scopedBySearch", search);
             }
 
-            if(!single && isPathDiffable(assembly)) {
+            if(!single && isPathDiffable(assembly) && !Boolean.TRUE.equals(additive)) {
                // Multi-select apply is a delta patch -- doApplySelection only ever turns matched
                // values on, so anything currently selected but missing from the new values has to
                // be turned off explicitly, or it stays selected alongside them. Single-select
-               // already gets a full reset for free via unselectChildren.
-               List<List<String>> toDeselect = toDeselect(selectedPaths(assembly), values);
+               // already gets a full reset for free via unselectChildren. additive:true is the
+               // caller explicitly opting out of this replace behaviour -- see the javadoc above.
+               List<List<String>> currentPaths = selectedPaths(assembly);
+               List<List<String>> toRemove = toDeselect(currentPaths, values);
 
-               if(!toDeselect.isEmpty()) {
-                  selections.applySelection(runtimeId, assemblyName, deselectEvent(toDeselect),
+               if(!toRemove.isEmpty()) {
+                  selections.applySelection(runtimeId, assemblyName,
+                                            deselectEvent(deselectTargets(currentPaths, toRemove)),
                                             user, dispatcher, linkUri);
                }
             }
@@ -226,6 +257,24 @@ public class SelectionRuntimeService {
             }
 
             result.put("valuesSelected", values.size());
+         }
+
+         if(hasDeselect) {
+            if(!isPathDiffable(assembly)) {
+               throw new IllegalArgumentException(
+                  "'" + assemblyName + "' is " + describe(assembly) + " -- 'deselect' only works " +
+                  "on a selection list or a non-ID-mode selection tree. Use clear_selection to " +
+                  "remove everything, or set_selection's plain 'values' for a range slider.");
+            }
+
+            List<List<String>> currentPaths = selectedPaths(assembly);
+            List<List<String>> targets = deselectTargets(currentPaths, deselect);
+
+            if(!targets.isEmpty()) {
+               selections.applySelection(runtimeId, assemblyName, deselectEvent(targets), user,
+                                         dispatcher, linkUri);
+               result.put("deselected", deselect.size());
+            }
          }
       });
 
@@ -284,8 +333,10 @@ public class SelectionRuntimeService {
             if(!current.isEmpty()) {
                // The client composes "unselect" the same way: send every currently selected
                // value back with selected=false. There is no single clear endpoint for one
-               // assembly.
-               selections.applySelection(runtimeId, assemblyName, deselectEvent(current), user,
+               // assembly. Cleared via deselectTargets (not the leaf paths directly) for the
+               // same reason set_selection's own diff-deselect does -- see that javadoc.
+               selections.applySelection(runtimeId, assemblyName,
+                                         deselectEvent(deselectTargets(current, current)), user,
                                          dispatcher, linkUri);
             }
          }
@@ -534,6 +585,80 @@ public class SelectionRuntimeService {
       List<List<String>> toDeselect = new ArrayList<>(current);
       toDeselect.removeAll(requested);
       return toDeselect;
+   }
+
+   /**
+    * The actual paths to send in a deselect event for {@code toRemove}, given everything
+    * currently selected ({@code current}) — not simply {@code toRemove} itself.
+    *
+    * <p><b>The bug this works around:</b> a deselect event only clears its exact TARGET (deepest)
+    * node's own {@code selected} flag in the shared {@code updateSelectionOfChangedAssembly} —
+    * unlike a select, which also marks every ancestor along the path selected via its own
+    * {@code isParent && selected} branch, a deselect's matching condition is
+    * {@code isParent && false}, always false, so an ancestor's own flag is never cleared there.
+    * Left stale, that flag resurfaces on the very next read: {@link #selectedPaths} treats "a
+    * composite selected as a whole with no selected children of its own" as a legitimate
+    * top-level selection in its own right (an empty-fallback rule this file needs for the
+    * opposite, genuinely-correct case of a whole parent node selected on purpose) — so an
+    * ancestor whose one live child was just deselected gets reported right back as if it had been
+    * freshly selected on its own, reappearing in the very next diff as a spurious "currently
+    * selected" path that was never actually requested. A caller who changes one leaf under a
+    * previously-selected branch (even to a sibling at the exact same depth) sees the old branch's
+    * top level accumulate alongside the new selection instead of being replaced by it.
+    *
+    * <p><b>The fix:</b> for each path being removed, find the SHORTEST prefix (from its root)
+    * that, once {@code toRemove} is applied, no remaining selected path shares — the highest
+    * ancestor whose entire subtree is safe to fully clear. Deselecting there instead of at the
+    * exact leaf reaches the same leaf via the shared method's own {@code unselectChildren}
+    * cascade, but also correctly clears every ancestor flag along the way, since nothing under it
+    * is meant to survive. Falls back to the leaf path itself if no such prefix is found (should
+    * not happen in practice, since the leaf itself is always a valid, if maximally specific,
+    * choice). Entirely a wiz-layer fix — {@code updateSelectionOfChangedAssembly} itself is
+    * untouched, so this carries no risk to the Composer UI or any other caller sharing it.
+    *
+    * <p>A no-op for a flat {@code SelectionListVSAssembly}: every path there is already exactly
+    * one segment, so the shortest-prefix search always lands on the path itself, unchanged.
+    */
+   static List<List<String>> deselectTargets(List<List<String>> current, List<List<String>> toRemove) {
+      List<List<String>> remaining = new ArrayList<>(current);
+      remaining.removeAll(toRemove);
+
+      List<List<String>> targets = new ArrayList<>();
+
+      for(List<String> path : toRemove) {
+         List<String> target = path;
+
+         for(int len = 1; len <= path.size(); len++) {
+            List<String> prefix = path.subList(0, len);
+
+            if(remaining.stream().noneMatch(p -> startsWithPath(p, prefix))) {
+               target = prefix;
+               break;
+            }
+         }
+
+         List<String> copy = new ArrayList<>(target);
+
+         if(!targets.contains(copy)) {
+            targets.add(copy);
+         }
+      }
+
+      return targets;
+   }
+
+   private static boolean startsWithPath(List<String> path, List<String> prefix) {
+      if(path.size() < prefix.size()) {
+         return false;
+      }
+
+      for(int i = 0; i < prefix.size(); i++) {
+         if(!Objects.equals(path.get(i), prefix.get(i))) {
+            return false;
+         }
+      }
+
+      return true;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -553,7 +553,8 @@ public class ViewsheetAssemblyAgentController {
    {
       requireEnabled();
       return selectionService.setSelection(sessionToken, user, request.assembly(), request.values(),
-                                          request.sortOrder(), request.singleSelect(), linkUri);
+                                          request.deselect(), request.sortOrder(),
+                                          request.singleSelect(), request.additive(), linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/selection/clear")
@@ -582,7 +583,8 @@ public class ViewsheetAssemblyAgentController {
    }
 
    public record SelectionRequest(String assembly, java.util.List<java.util.List<String>> values,
-                                  String sortOrder, Boolean singleSelect) {}
+                                  java.util.List<java.util.List<String>> deselect, String sortOrder,
+                                  Boolean singleSelect, Boolean additive) {}
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/calendar/display")
    public Map<String, Object> setCalendarDisplay(@PathVariable String sessionToken,

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
@@ -260,21 +260,176 @@ class SelectionRuntimeServiceTest {
 
    /**
     * A range slider always fully overwrites its own selection per call (index range against every
-    * value), so it must never be diffed — reading its current selection at all would be wasted work
-    * and, unlike list/tree, {@code TimeSliderVSAssembly} was never in scope for this fix.
+    * value), so it must never be <i>diffed</i> like a list/tree — that invariant is unaffected by
+    * VFO-009 below and still holds via {@link #excludesARangeSliderFromTheDiff}.
+    *
+    * <p><b>Superseded by VFO-009 (2026-09-10):</b> this used to also assert
+    * {@code verify(slider, never()).getSelectionList()} — true under the old (buggy) plain
+    * value-array apply, which never looked at the slider's own bucket list at all and so never
+    * actually filtered anything (see the range-slider section below). Resolving requested values
+    * into a bucket-index range genuinely needs that list, so a slider now legitimately reads it.
     */
    @Test
-   void neverReadsCurrentSelectionForARangeSlider() throws Exception {
+   void throwsWhenARangeSliderHasNoBucketsToSelectFrom() throws Exception {
       TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
       TimeSliderVSAssemblyInfo info = mock(TimeSliderVSAssemblyInfo.class);
       doReturn(info).when(slider).getInfo();
       Harness h = harness(slider);
 
-      h.service.setSelection("tok", principal(), "Slider1", List.of(List.of("2")), null, null, "");
+      // SelectionList cannot be constructed or mocked outside a Spring context (see the
+      // class-level note on selectedPaths(SelectionValue[]) below), so getSelectionList() returns
+      // null here (Mockito's default) -- this exercises the integration wiring
+      // (setSelection -> bucketsOf -> sliderBucketRange) without real bucket data. The
+      // bucket-resolution logic itself is unit tested directly, over SelectionValue[], in the
+      // range-slider section below.
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Slider1", List.of(List.of("2")), null,
+                                      null, ""));
 
-      verify(slider, never()).getSelectionList();
-      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
-                                                    any(Principal.class), any(), anyString());
+      assertTrue(e.getMessage().contains("Slider1"), e.getMessage());
+      verify(h.selections, never()).applySelection(anyString(), anyString(), any(),
+                                                   any(Principal.class), any(), anyString());
+   }
+
+   // ── range slider bucket resolution (VFO-009: set_selection was a total no-op on a range
+   // slider -- doApplySelection's TimeSliderVSAssembly branch never reads event.getValues(), only
+   // event.getSelectStart()/getSelectEnd(), which the plain value-array apply above never set) ──
+
+   /** Every requested value matches a bucket exactly, so nothing is clamped. */
+   @Test
+   void resolvesRangeSliderValuesIntoABucketIndexRange() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.getValue()).thenReturn("0");
+      SelectionValue b1 = mock(SelectionValue.class);
+      when(b1.getValue()).thenReturn("1");
+      SelectionValue b2 = mock(SelectionValue.class);
+      when(b2.getValue()).thenReturn("2");
+      SelectionValue[] buckets = { b0, b1, b2 };
+
+      List<Map<String, Object>> clamped = new ArrayList<>();
+      int[] range = SelectionRuntimeService.sliderBucketRange("Slider1", buckets,
+         List.of(List.of("0"), List.of("2")), clamped);
+
+      assertArrayEquals(new int[]{ 0, 2 }, range);
+      assertEquals(List.of(), clamped);
+   }
+
+   /**
+    * A single requested value narrows to a one-bucket range ({@code start == end}), not the whole
+    * slider — the exact shape the original bug reported as a total no-op.
+    */
+   @Test
+   void narrowsToASingleBucketWhenOnlyOneValueIsRequested() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.getValue()).thenReturn("0");
+      SelectionValue b1 = mock(SelectionValue.class);
+      when(b1.getValue()).thenReturn("1");
+
+      int[] range = SelectionRuntimeService.sliderBucketRange("Slider1",
+         new SelectionValue[]{ b0, b1 }, List.of(List.of("1")), new ArrayList<>());
+
+      assertArrayEquals(new int[]{ 1, 1 }, range);
+   }
+
+   /**
+    * An out-of-range numeric bound clamps to the nearest bucket rather than being refused outright
+    * — matching {@link #requireSortOrder}-style forgiving-on-unambiguous-intent — but the
+    * substitution has to be disclosed, the same way {@code scopedBySearch} discloses an apply
+    * landing on a narrower scope than the literal request.
+    */
+   @Test
+   void clampsAnOutOfRangeNumericBoundToTheNearestBucketAndDisclosesIt() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.getValue()).thenReturn("0");
+      SelectionValue b18 = mock(SelectionValue.class);
+      when(b18.getValue()).thenReturn("18");
+
+      List<Map<String, Object>> clamped = new ArrayList<>();
+      int[] range = SelectionRuntimeService.sliderBucketRange("Slider1",
+         new SelectionValue[]{ b0, b18 }, List.of(List.of("500")), clamped);
+
+      assertArrayEquals(new int[]{ 1, 1 }, range, "500 is nearer to bucket 18 (index 1) than 0");
+      assertEquals(1, clamped.size());
+      assertEquals("500", clamped.get(0).get("requested"));
+      assertEquals("18", clamped.get(0).get("applied"));
+   }
+
+   /** A value that neither matches a bucket nor parses as a number is refused by name. */
+   @Test
+   void refusesARangeSliderValueThatMatchesNoBucketAndIsntNumeric() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.getValue()).thenReturn("0");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> SelectionRuntimeService.bucketIndex("Slider1", new SelectionValue[]{ b0 }, "nope"));
+
+      assertTrue(e.getMessage().contains("nope"), e.getMessage());
+   }
+
+   /** A slider has no hierarchy, so a multi-segment path is refused rather than silently flattened. */
+   @Test
+   void refusesAMultiSegmentPathOnARangeSlider() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.getValue()).thenReturn("0");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> SelectionRuntimeService.sliderBucketRange("Slider1", new SelectionValue[]{ b0 },
+            List.of(List.of("0", "1")), new ArrayList<>()));
+
+      assertTrue(e.getMessage().contains("no hierarchy"), e.getMessage());
+   }
+
+   /**
+    * {@code doApplySelection} decrements {@code selectEnd} by one when the slider is not
+    * upper-inclusive, so the sent value has to be one past the wanted index for that decrement to
+    * land back on it; an upper-inclusive slider sends the index unchanged.
+    */
+   @Test
+   void adjustsTheEndBucketForANonUpperInclusiveSlider() {
+      assertEquals(5, SelectionRuntimeService.adjustedEnd(true, 5));
+      assertEquals(6, SelectionRuntimeService.adjustedEnd(false, 5));
+   }
+
+   /** "Nothing filtered" on a range slider is every bucket selected, not an empty/null state. */
+   @Test
+   void treatsEveryBucketSelectedAsTheFullRange() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.isSelected()).thenReturn(true);
+      SelectionValue b1 = mock(SelectionValue.class);
+      when(b1.isSelected()).thenReturn(true);
+
+      assertTrue(SelectionRuntimeService.isFullRangeSelected(new SelectionValue[]{ b0, b1 }));
+      assertTrue(SelectionRuntimeService.isFullRangeSelected(new SelectionValue[0]),
+                "a slider with no buckets at all has nothing to filter, so it counts as full range");
+   }
+
+   @Test
+   void treatsAnyUnselectedBucketAsNotTheFullRange() {
+      SelectionValue b0 = mock(SelectionValue.class);
+      when(b0.isSelected()).thenReturn(true);
+      SelectionValue b1 = mock(SelectionValue.class);
+      when(b1.isSelected()).thenReturn(false);
+
+      assertFalse(SelectionRuntimeService.isFullRangeSelected(new SelectionValue[]{ b0, b1 }));
+   }
+
+   /**
+    * The integration-wiring half of the {@code clearedCount} fix: a range slider that reports
+    * itself as already at full range (here, via the same "no buckets stubbed" shape
+    * {@link #throwsWhenARangeSliderHasNoBucketsToSelectFrom} uses — {@code isFullRangeSelected}
+    * treats zero buckets as full range) must report {@code clearedCount: 0} and never call
+    * {@code applySelection} — unlike the old bookkeeping, which would have misreported "20 buckets
+    * were filtering" on a slider nobody ever touched.
+    */
+   @Test
+   void reportsZeroClearedCountForAnAlreadyFullRangeSlider() throws Exception {
+      TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
+      Harness h = harness(slider);
+
+      Map<String, Object> result = h.service.clearSelection("tok", principal(), "Slider1", "");
+
+      assertEquals(0, result.get("clearedCount"));
+      verifyNoInteractions(h.selections);
    }
 
    // ── value validation (bug-76544: a typo'd value is silently dropped, not refused) ─────────────

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
@@ -672,33 +672,50 @@ class SelectionRuntimeServiceTest {
     * additive:true is the caller explicitly opting into "just add" -- the automatic replace-diff
     * must not fire, so whatever was selected before survives alongside the new value.
     */
+   /**
+    * Asserting only "one applySelection call" here would pass even if the {@code additive} gate
+    * were deleted entirely: with no populated {@code SelectionList} stubbed (the usual
+    * {@code SelectionList}-cannot-be-mocked constraint), {@code toDeselect} is always empty
+    * regardless of the flag, so the diff step firing or not never changes the apply count in
+    * this harness. Asserting on {@code getSelectionList()}'s own call count instead is a real
+    * discriminator: value-validation (bug-76544) reads it once unconditionally
+    * ({@link #skipsTheDiffStepForASingleSelectAssembly} establishes that baseline), and the diff
+    * step reads it a SECOND time via {@code selectedPaths(assembly)} -- but only when it
+    * actually runs. additive:true must suppress that second read.
+    */
    @Test
    void additiveTrueSkipsTheReplaceDiff() throws Exception {
-      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+      SelectionListVSAssembly assembly = list(XConstants.SORT_ASC, false, null);
+      Harness h = harness(assembly);
 
       h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null,
                              null, true, "");
 
+      verify(assembly, times(1)).getSelectionList();
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
                                                     any(Principal.class), any(), anyString());
    }
 
    /**
-    * Without additive, the default stays full-replace -- bug-76548's own fix is unchanged. No
-    * prior selection is stubbed here (matching every other "domain not yet known" fixture in
-    * this file), so there is nothing to diff away in this particular call, but the point is that
-    * additive being unset/false runs the exact same code path as before this change existed, not
-    * a new one -- the diff step itself is exercised end-to-end above
+    * The other half of the same discriminator: without additive, the diff step's own
+    * {@code selectedPaths(assembly)} call genuinely happens -- a SECOND {@code getSelectionList()}
+    * read, on top of value-validation's own -- confirming additive being unset/false still runs
+    * the diff step (bug-76548's own fix is unchanged, not silently bypassed). No prior selection
+    * is stubbed, so there is nothing to actually diff away in this particular call; the point is
+    * that the diff step's read happens at all, not what it finds -- the ancestor-collapse logic
+    * itself is exercised end-to-end above
     * ({@code collapsesALeafDeselectToItsRootAncestorWhenNothingElseRemainsUnderIt} et al.) and by
     * bug-76548's own pre-existing tests.
     */
    @Test
    void defaultsToTheReplaceDiffWithoutAdditive() throws Exception {
-      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+      SelectionListVSAssembly assembly = list(XConstants.SORT_ASC, false, null);
+      Harness h = harness(assembly);
 
       h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null,
                              null, null, "");
 
+      verify(assembly, times(2)).getSelectionList();
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
                                                     any(Principal.class), any(), anyString());
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
@@ -69,7 +69,7 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_DESC, false, null));
 
       Map<String, Object> result =
-         h.service.setSelection("tok", principal(), "Filter1", null, "desc", null, "");
+         h.service.setSelection("tok", principal(), "Filter1", null, null, "desc", null, null, "");
 
       assertEquals(0, result.get("sortCycles"));
       verify(h.selections, never()).sortSelection(anyString(), anyString(), any(),
@@ -81,7 +81,7 @@ class SelectionRuntimeServiceTest {
    void cyclesTwiceInsideASingleMutate() throws Exception {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
-      h.service.setSelection("tok", principal(), "Filter1", null, "specific", null, "");
+      h.service.setSelection("tok", principal(), "Filter1", null, null, "specific", null, null, "");
 
       verify(h.selections, times(2)).sortSelection(anyString(), anyString(), any(),
                                                    any(Principal.class), any(), anyString());
@@ -97,7 +97,8 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(slider);
 
       Exception e = assertThrows(IllegalArgumentException.class,
-         () -> h.service.setSelection("tok", principal(), "Slider1", null, "asc", null, ""));
+         () -> h.service.setSelection("tok", principal(), "Slider1", null, null, "asc", null, null,
+                                      ""));
 
       assertTrue(e.getMessage().contains("no sort order"), e.getMessage());
    }
@@ -109,7 +110,7 @@ class SelectionRuntimeServiceTest {
    void togglesSelectionStyleOnlyWhenItDiffers() throws Exception {
       Harness already = harness(list(XConstants.SORT_ASC, true, null));
 
-      already.service.setSelection("tok", principal(), "Filter1", null, null, true, "");
+      already.service.setSelection("tok", principal(), "Filter1", null, null, null, true, null, "");
 
       verify(already.selections, never()).toggleSelectionStyle(anyString(), anyString(),
                                                                any(Principal.class), any(),
@@ -117,7 +118,7 @@ class SelectionRuntimeServiceTest {
 
       Harness differs = harness(list(XConstants.SORT_ASC, false, null));
 
-      differs.service.setSelection("tok", principal(), "Filter1", null, null, true, "");
+      differs.service.setSelection("tok", principal(), "Filter1", null, null, null, true, null, "");
 
       verify(differs.selections, times(1)).toggleSelectionStyle(anyString(), anyString(),
                                                                 any(Principal.class), any(),
@@ -131,7 +132,8 @@ class SelectionRuntimeServiceTest {
 
       Exception e = assertThrows(IllegalArgumentException.class,
          () -> h.service.setSelection("tok", principal(), "Filter1",
-                                      List.of(List.of("East"), List.of("West")), null, null, ""));
+                                      List.of(List.of("East"), List.of("West")), null, null, null,
+                                      null, ""));
 
       assertTrue(e.getMessage().contains("single-select"), e.getMessage());
    }
@@ -145,7 +147,7 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_ASC, true, null));
 
       h.service.setSelection("tok", principal(), "Filter1",
-                             List.of(List.of("East"), List.of("West")), null, false, "");
+                             List.of(List.of("East"), List.of("West")), null, null, false, null, "");
 
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
                                                     any(Principal.class), any(), anyString());
@@ -162,7 +164,8 @@ class SelectionRuntimeServiceTest {
    void sendsAPlainApplyThatCannotFlipTheSelectionStyle() throws Exception {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
-      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("East")), null, null,
+                             null, null, "");
 
       ArgumentCaptor<ApplySelectionListEvent> sent =
          ArgumentCaptor.forClass(ApplySelectionListEvent.class);
@@ -183,8 +186,8 @@ class SelectionRuntimeServiceTest {
    void sendsATreeValueAsAPath() throws Exception {
       Harness h = harness(tree(XConstants.SORT_ASC, false));
 
-      h.service.setSelection("tok", principal(), "Tree1", List.of(List.of("East", "NY")), null,
-                             null, "");
+      h.service.setSelection("tok", principal(), "Tree1", List.of(List.of("East", "NY")), null, null,
+                             null, null, "");
 
       ArgumentCaptor<ApplySelectionListEvent> sent =
          ArgumentCaptor.forClass(ApplySelectionListEvent.class);
@@ -204,7 +207,7 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_ASC, false, "Eas"));
 
       Map<String, Object> result = h.service.setSelection(
-         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, null, null, "");
 
       assertEquals("Eas", result.get("scopedBySearch"));
    }
@@ -215,7 +218,7 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
       Map<String, Object> result = h.service.setSelection(
-         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, null, null, "");
 
       assertFalse(result.containsKey("scopedBySearch"));
    }
@@ -229,7 +232,8 @@ class SelectionRuntimeServiceTest {
    void sendsOnlyOneApplyWhenNothingWasPreviouslySelected() throws Exception {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
-      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null, "");
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null,
+                             null, null, "");
 
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
                                                     any(Principal.class), any(), anyString());
@@ -251,7 +255,8 @@ class SelectionRuntimeServiceTest {
       SelectionListVSAssembly assembly = list(XConstants.SORT_ASC, true, null);
       Harness h = harness(assembly);
 
-      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null, "");
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null,
+                             null, null, "");
 
       verify(assembly, times(1)).getSelectionList();
       verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
@@ -284,7 +289,7 @@ class SelectionRuntimeServiceTest {
       // range-slider section below.
       Exception e = assertThrows(IllegalArgumentException.class,
          () -> h.service.setSelection("tok", principal(), "Slider1", List.of(List.of("2")), null,
-                                      null, ""));
+                                      null, null, null, ""));
 
       assertTrue(e.getMessage().contains("Slider1"), e.getMessage());
       verify(h.selections, never()).applySelection(anyString(), anyString(), any(),
@@ -484,7 +489,8 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
       assertDoesNotThrow(() -> h.service.setSelection(
-         "tok", principal(), "Filter1", List.of(List.of("Anything At All")), null, null, ""));
+         "tok", principal(), "Filter1", List.of(List.of("Anything At All")), null, null, null, null,
+         ""));
    }
 
    /**
@@ -601,6 +607,166 @@ class SelectionRuntimeServiceTest {
    @Test
    void excludesARangeSliderFromTheDiff() {
       assertFalse(SelectionRuntimeService.isPathDiffable(mock(TimeSliderVSAssembly.class)));
+   }
+
+   // ── deselectTargets (the ancestor-flag-residue fix) ─────────────────────
+
+   /**
+    * The direct regression test for the newly-found symptom: switching a SelectionTree's
+    * selection to a sibling at the SAME depth left the old branch's top-level node accumulated
+    * alongside the new one, because a leaf-level deselect never clears the ancestor flag a prior
+    * select had set. Removing "NY/New York" with nothing else remaining under "NY" must resolve
+    * to a single "NY"-level deselect target, not the leaf path — that's what reaches
+    * {@code unselectChildren} and actually clears NY's own stale flag.
+    */
+   @Test
+   void collapsesALeafDeselectToItsRootAncestorWhenNothingElseRemainsUnderIt() {
+      List<List<String>> current = List.of(List.of("NY", "New York"));
+      List<List<String>> toRemove = List.of(List.of("NY", "New York"));
+
+      assertEquals(List.of(List.of("NY")),
+                  SelectionRuntimeService.deselectTargets(current, toRemove),
+                  "NY has no other selected child left, so clearing it at the NY level (which " +
+                  "cascades via unselectChildren) is what actually clears NY's own residual flag");
+   }
+
+   /**
+    * The precise case the fix has to get right in the other direction: a sibling under the SAME
+    * ancestor must survive. Collapsing to the ancestor here would wrongly clear "NY/Buffalo" too,
+    * so the exact leaf path is what has to be sent.
+    */
+   @Test
+   void keepsTheExactLeafWhenASiblingUnderTheSameAncestorStaysSelected() {
+      List<List<String>> current = List.of(List.of("NY", "New York"), List.of("NY", "Buffalo"));
+      List<List<String>> toRemove = List.of(List.of("NY", "New York"));
+
+      assertEquals(List.of(List.of("NY", "New York")),
+                  SelectionRuntimeService.deselectTargets(current, toRemove),
+                  "Buffalo is still selected under NY, so collapsing to the NY-level ancestor " +
+                  "would clear a selection the caller never asked to remove");
+   }
+
+   /** Removing several branches at once collapses each independently and de-duplicates. */
+   @Test
+   void collapsesEachRemovedBranchIndependently() {
+      List<List<String>> current = List.of(List.of("NY", "New York"), List.of("FL", "Orlando"));
+      List<List<String>> toRemove = current;
+
+      assertEquals(List.of(List.of("NY"), List.of("FL")),
+                  SelectionRuntimeService.deselectTargets(current, toRemove));
+   }
+
+   /** A flat SelectionList has no ancestors to collapse to — every path is already one segment. */
+   @Test
+   void isANoOpForAFlatSelectionListsSingleSegmentPaths() {
+      List<List<String>> current = List.of(List.of("East"), List.of("West"));
+      List<List<String>> toRemove = List.of(List.of("East"));
+
+      assertEquals(List.of(List.of("East")),
+                  SelectionRuntimeService.deselectTargets(current, toRemove));
+   }
+
+   // ── additive and deselect (the accumulate-vs-replace design gap) ────────
+
+   /**
+    * additive:true is the caller explicitly opting into "just add" -- the automatic replace-diff
+    * must not fire, so whatever was selected before survives alongside the new value.
+    */
+   @Test
+   void additiveTrueSkipsTheReplaceDiff() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null,
+                             null, true, "");
+
+      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
+                                                    any(Principal.class), any(), anyString());
+   }
+
+   /**
+    * Without additive, the default stays full-replace -- bug-76548's own fix is unchanged. No
+    * prior selection is stubbed here (matching every other "domain not yet known" fixture in
+    * this file), so there is nothing to diff away in this particular call, but the point is that
+    * additive being unset/false runs the exact same code path as before this change existed, not
+    * a new one -- the diff step itself is exercised end-to-end above
+    * ({@code collapsesALeafDeselectToItsRootAncestorWhenNothingElseRemainsUnderIt} et al.) and by
+    * bug-76548's own pre-existing tests.
+    */
+   @Test
+   void defaultsToTheReplaceDiffWithoutAdditive() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("West")), null, null,
+                             null, null, "");
+
+      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
+                                                    any(Principal.class), any(), anyString());
+   }
+
+   /**
+    * An explicit deselect list reaches the endpoint as a deselect event for exactly those values.
+    *
+    * <p>{@code getSelectionList()} is left unstubbed (null, the same "domain not yet known"
+    * shape every other integration test in this file uses — {@code SelectionList} cannot be
+    * mocked outside a Spring context) — so {@code selectedPaths(assembly)} sees an empty current
+    * selection here, not a real one. That does not weaken this test: {@link #deselectTargets}
+    * degenerates safely against an empty {@code current} (every requested path's own first
+    * segment always qualifies as its shortest clearable prefix, since nothing remains to protect),
+    * so the exact single-segment "East" path this asserts is what a real populated selection
+    * would produce too — this test is about the wiring reaching {@code applySelection} with the
+    * right value, not about the ancestor-collapse logic itself (covered directly, over
+    * {@code List<List<String>>}, above).
+    */
+   @Test
+   void explicitDeselectRemovesExactlyTheNamedValues() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      Map<String, Object> result = h.service.setSelection("tok", principal(), "Filter1", null,
+         List.of(List.of("East")), null, null, null, "");
+
+      assertEquals(1, result.get("deselected"));
+      ArgumentCaptor<ApplySelectionListEvent> sent =
+         ArgumentCaptor.forClass(ApplySelectionListEvent.class);
+      verify(h.selections).applySelection(anyString(), anyString(), sent.capture(),
+                                          any(Principal.class), any(), anyString());
+      assertArrayEquals(new String[]{ "East" }, sent.getValue().getValues().get(0).getValue());
+      assertFalse(sent.getValue().getValues().get(0).isSelected());
+   }
+
+   /** Naming the same value in both 'values' and 'deselect' is a contradiction, refused by name. */
+   @Test
+   void refusesAValueNamedInBothValuesAndDeselect() {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("East")),
+                                      List.of(List.of("East")), null, null, null, ""));
+
+      assertTrue(e.getMessage().contains("East"), e.getMessage());
+   }
+
+   /** 'deselect' only makes sense where the replace-diff already applies -- same gate, same reason. */
+   @Test
+   void refusesDeselectOnARangeSlider() {
+      TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
+      TimeSliderVSAssemblyInfo info = mock(TimeSliderVSAssemblyInfo.class);
+      doReturn(info).when(slider).getInfo();
+      Harness h = harness(slider);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Slider1", null,
+                                      List.of(List.of("2")), null, null, null, ""));
+
+      assertTrue(e.getMessage().contains("range slider"), e.getMessage());
+   }
+
+   /** 'deselect' alone (no 'values') is a legitimate call -- "just remove these" needs no new add. */
+   @Test
+   void acceptsDeselectAloneWithNoValues() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      assertDoesNotThrow(() -> h.service.setSelection("tok", principal(), "Filter1", null,
+         List.of(List.of("East")), null, null, null, ""));
    }
 
    // ── selectedPaths recursion into a SelectionTree ────────────────────────
@@ -745,7 +911,7 @@ class SelectionRuntimeServiceTest {
 
       Exception e = assertThrows(IllegalArgumentException.class,
          () -> h.service.setSelection("tok", principal(), "Nope", List.of(List.of("x")), null,
-                                      null, ""));
+                                      null, null, null, ""));
 
       assertTrue(e.getMessage().contains("Nope"), e.getMessage());
       verifyNoInteractions(h.selections);
@@ -757,7 +923,7 @@ class SelectionRuntimeServiceTest {
 
       Exception e = assertThrows(IllegalArgumentException.class,
          () -> h.service.setSelection("tok", principal(), "Chart1", List.of(List.of("x")), null,
-                                      null, ""));
+                                      null, null, null, ""));
 
       assertTrue(e.getMessage().contains("not a selection assembly"), e.getMessage());
       verifyNoInteractions(h.selections);
@@ -768,7 +934,8 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
       assertThrows(IllegalArgumentException.class,
-         () -> h.service.setSelection("tok", principal(), "Filter1", null, null, null, ""));
+         () -> h.service.setSelection("tok", principal(), "Filter1", null, null, null, null, null,
+                                      ""));
    }
 
    @Test
@@ -776,7 +943,7 @@ class SelectionRuntimeServiceTest {
       Harness h = harness(list(XConstants.SORT_ASC, false, null));
 
       Map<String, Object> result = h.service.setSelection(
-         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, null, null, "");
 
       assertEquals(true, result.get("persistsOnSave"),
                    "writeStateContent writes the selection on the save path, so a caller must know");


### PR DESCRIPTION
## Summary

Redmine [#76525](https://173.220.179.100/issues/76525) bundled three related but distinct
defects in the wiz agent's selection-runtime layer (`SelectionRuntimeService.java`), all
scoped to that wiz-specific integration layer — `VSSelectionService`/
`updateSelectionOfChangedAssembly` (shared with the Composer UI and other products) is
untouched throughout.

**VFO-007 (SelectionTree deepest level silently non-functional)** — confirmed already fixed
by `74c0fb266` (bug 76544)'s `findUnmatchedPaths` pre-validation, which refuses an unresolvable
tree-path segment by name before applying anything. No new code needed for this one; covered
here only by live re-verification.

**VFO-009 (Range Slider `set_selection` is a total no-op)** — `doApplySelection`'s
`TimeSliderVSAssembly` branch only ever reads `event.getSelectStart()`/`getSelectEnd()`
(bucket-index ints), never `event.getValues()`, so the plain value-array apply every other
assembly type uses silently did nothing on a range slider. `setSelection()` now resolves
requested values into a `[start, end]` bucket-index range (`sliderBucketRange`/`bucketIndex`)
and populates `selectStart`/`selectEnd` instead. An out-of-range numeric bound clamps to the
nearest bucket, disclosed via a new `clampedBounds` response field. `clearSelection`'s
`clearedCount` was also wrong for a slider ("nothing filtered" is every bucket selected, not
an empty/null state) — fixed, and a filtered slider is now actually reset on clear (the old
value-array deselect was equally inert there).

**Deselect ancestor-flag residue (found live-testing this bug's own fix)** — switching a
`SelectionTree`'s selection, same depth or across depths, left the old branch's top-level node
selected alongside the new one. Root cause: a deselect event only clears its exact target
(deepest) node's own flag in the shared `updateSelectionOfChangedAssembly` — a select also
marks every ancestor along the path (`isParent && selected`), but a deselect's matching
condition is `isParent && false`, always false, so an ancestor's flag is never cleared there.
The stale flag resurfaces via `selectedPaths`'s own empty-fallback rule (needed for the
opposite, correct case) as a fresh top-level selection. Fixed via `deselectTargets`: for each
path being removed, find the shortest prefix that no remaining selected path shares, and
deselect there instead of at the exact leaf — reaches the same leaf via the shared method's
own `unselectChildren` cascade, but also clears every ancestor flag along the way. A no-op for
a flat `SelectionList`. Used by both `setSelection`'s diff step and `clearSelection`.

**`additive`/`deselect` on `set_selection`** — bug-76548's own fix made every `set_selection`
call replace by default; its original report had floated "unless an explicit additive flag is
added" as the alternative, never implemented. Added: `additive:true` skips the replace-diff
(values only adds); `deselect:[...]` explicitly removes named values/paths independent of
`additive`. Refused on a range slider or ID-mode tree (same gate `isPathDiffable` already
uses), and refused if a value is named in both `values` and `deselect`. Default behavior
unchanged — bug-76548's own tests still pass.

## Test plan

- 59 JUnit tests in `SelectionRuntimeServiceTest`/`SelectionTreeVSAssemblyTest`, all passing —
  new coverage for `deselectTargets`, `additive`, `deselect`, the contradiction refusal, and
  the range-slider/ID-mode-tree refusals.
- Live-verified end to end against a real StyleBI instance via the companion `stylebi-wiz`
  plugin PR (inetsoft-technology/stylebi-wiz#<TBD>): same-depth and cross-depth selection
  switches no longer leave residue; `additive:true` genuinely accumulates; `deselect` removes
  exactly the named value without touching siblings; range-slider `set_selection` narrows the
  widget and data correctly; `clampedBounds` surfaces an out-of-range bound's actual applied
  value.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>