### PR TITLE
feat(wiz): add_table extraProperties for the endpoint/suffix forms

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -429,7 +429,19 @@ public record EditRequest(
     * name, a file path) is itself one entry in this map, exactly like wiz-services' own
     * {@code tabularSource.queryParams} shape — not a second addressing scheme.
     */
-   Map<String, Object> queryParams
+   Map<String, Object> queryParams,
+   /**
+    * Additional connector-specific properties to set on the query alongside {@code endpoint} or
+    * {@code suffix} (+ optional {@code lookup}/{@code customLookups}) — e.g. a row-selection
+    * path ({@code jsonPath} for a JSON connector, {@code xpath} for Rest.XML), an expand-arrays
+    * toggle, a timeout, a request type, or pagination settings. Keyed by the connector's OWN
+    * property names, exactly like {@code queryParams} — call {@code GET .../tabular/query-schema}
+    * to learn them. Requires {@code endpoint} or {@code suffix} to also be present (use
+    * {@code queryParams} instead for a datasource addressed without an endpoint/suffix identity);
+    * mutually exclusive with {@code queryParams}. Must not contain {@code endpoint} or
+    * {@code suffix} as a key — that identity is already established by the dedicated field.
+    */
+   Map<String, Object> extraProperties
 ) {
    /**
     * Compatibility constructor for callers built before {@code queryParams} was added, but after
@@ -715,5 +727,44 @@ public record EditRequest(
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
            lookupTopLevelOnly, suffix, customLookups, crosstab, labels, null);
+   }
+
+   /**
+    * Compatibility constructor for callers built before {@code extraProperties} was added, but
+    * after {@code queryParams} — defaults {@code extraProperties} to {@code null}.
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, Object> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups, Boolean crosstab,
+      List<String> labels, WorksheetMutationSupport.VariableChoicesSpec choices,
+      List<WorksheetMutationSupport.JoinPathSpec> joinPaths, Boolean mergeable,
+      Boolean visibleInViewsheet, Boolean confirmed, Integer rowCount, Boolean concatDistinct,
+      List<WorksheetMutationSupport.RankingSpec> rankings, Map<String, Object> queryParams)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, choices, joinPaths,
+           mergeable, visibleInViewsheet, confirmed, rowCount, concatDistinct, rankings,
+           queryParams, null);
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -795,6 +795,7 @@ public class WorksheetAgentController {
       }
 
       final String extraApplied;
+      final String resolvedSuffix;
 
       if(req.extraProperties() != null && !req.extraProperties().isEmpty()) {
          if(req.extraProperties().containsKey("endpoint") || req.extraProperties().containsKey("suffix")) {
@@ -809,14 +810,22 @@ public class WorksheetAgentController {
          // endpoint/suffix property is itself required (e.g. FakeNamedConnectorQuery's endpoint)
          // would be rejected as "missing" what this call already set moments earlier. Re-writing
          // it to the SAME value it already holds is a no-op on the query.
+         String identityKey = namedConnector ? "endpoint" : "suffix";
          Map<String, Object> contractParams = new java.util.LinkedHashMap<>(req.extraProperties());
-         contractParams.put(namedConnector ? "endpoint" : "suffix",
-            namedConnector ? req.endpoint() : req.suffix());
+         contractParams.put(identityKey, namedConnector ? req.endpoint() : req.suffix());
 
          TabularQuerySchema extraSchema =
             new TabularSchemaExtractor().extract(query, dataSource.getType());
-         extraApplied = TabularQueryContractSupport.applyQueryContract(
+         String rawApplied = TabularQueryContractSupport.applyQueryContract(
             query, pmap, extraSchema, contractParams, dsName);
+
+         // rawApplied also reports identityKey (re-supplied above only to satisfy
+         // applyQueryContract's required-field check, not something the caller actually sent in
+         // extraProperties) -- stripped here so the diagnostic doesn't suggest 'endpoint'/'suffix'
+         // are settable through extraProperties, which the check above explicitly forbids.
+         extraApplied = java.util.Arrays.stream(rawApplied.split(", "))
+            .filter(entry -> !entry.startsWith(identityKey + "="))
+            .collect(java.util.stream.Collectors.joining(", "));
 
          // extraProperties is applied after the row-cap guard below has already run once for the
          // endpoint/suffix form -- if it set a pagination-triggering property (e.g.
@@ -824,9 +833,21 @@ public class WorksheetAgentController {
          // uncapped paginated query would slip through untouched.
          TabularEndpointBindingSupport.requireRowCapWhenPaged(
             query, namedConnector ? req.endpoint() : req.suffix(), dsName);
+
+         // For a named connector, "suffix" (reported in the no-columns message below) is DERIVED
+         // from endpoint + parameter values -- extraProperties can change parameters (a composite
+         // property applyQueryContract's fillNamedSkeleton can write), so the suffix captured
+         // before this block can be stale. Re-read it so the message never reports a URL that no
+         // longer matches what was actually requested. A NEW variable, not a reassignment of
+         // `suffix` -- `suffix` is captured by the lambda below and reassigning it here would
+         // break its effectively-final status.
+         PropertyMeta suffixProp = pmap.get("suffix");
+         Object refreshedSuffix = suffixProp == null ? null : suffixProp.getValue(query);
+         resolvedSuffix = refreshedSuffix == null ? suffix : refreshedSuffix.toString();
       }
       else {
          extraApplied = null;
+         resolvedSuffix = suffix;
       }
 
       String tableName = req.table();
@@ -864,7 +885,7 @@ public class WorksheetAgentController {
             Object loadError = query.getProperty("wizLoadColumnsError");
             throw new PairingException("The request to '" + target + "' of '" + dsName +
                "' returned no columns" + (loadError == null ? "" : " (" + loadError + ")") +
-               ". URL suffix sent: " + suffix +
+               ". URL suffix sent: " + resolvedSuffix +
                (extraApplied == null || extraApplied.isBlank() ? "" :
                   ". Extra properties sent: " + extraApplied) +
                ". Check the parameter " +

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -287,6 +287,29 @@ public class WorksheetAgentController {
    {
       requireEnabled();
 
+      // add_table's extraProperties requires endpoint/suffix identity and excludes queryParams
+      // (which is already its own complete, self-sufficient form) -- checked first, before either
+      // of those blocks, for the same reason queryParams's own contradiction checks below are
+      // checked first: a request carrying extraProperties in a combination this field doesn't
+      // support must get ITS OWN contradiction error, not be silently routed into a form that
+      // never reads it.
+      if("add_table".equals(req.op()) && req.extraProperties() != null && !req.extraProperties().isEmpty()) {
+         boolean hasQueryParams = req.queryParams() != null && !req.queryParams().isEmpty();
+         boolean hasEndpoint = req.endpoint() != null && !req.endpoint().isBlank();
+         boolean hasSuffix = req.suffix() != null && !req.suffix().isBlank();
+
+         if(hasQueryParams) {
+            throw new PairingException("add_table cannot carry extraProperties together with " +
+               "queryParams -- queryParams is already its own complete, self-sufficient form.");
+         }
+
+         if(!hasEndpoint && !hasSuffix) {
+            throw new PairingException("add_table's extraProperties requires endpoint or " +
+               "suffix -- use queryParams instead for a datasource addressed without an " +
+               "endpoint/suffix identity.");
+         }
+      }
+
       // add_table with queryParams binds a TabularTableAssembly via the SAME generic,
       // connector-agnostic path WorksheetTableService.buildTabularTable uses for wiz-services'
       // /ws/table -- see addQueryParamsTable's own doc comment for why this is a fourth,
@@ -769,6 +792,29 @@ public class WorksheetAgentController {
             TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, req.customLookups(),
                dsName);
          }
+      }
+
+      if(req.extraProperties() != null && !req.extraProperties().isEmpty()) {
+         if(req.extraProperties().containsKey("endpoint") || req.extraProperties().containsKey("suffix")) {
+            throw new PairingException("add_table's extraProperties cannot set 'endpoint' or " +
+               "'suffix' -- their identity is already established by the endpoint/suffix field " +
+               "on this call.");
+         }
+
+         // applyQueryContract's own required-field check validates presence WITHIN the map it is
+         // given, not against the live query -- so the identity value already resolved above via
+         // TabularEndpointBindingSupport has to be re-supplied here too, or a connector whose
+         // endpoint/suffix property is itself required (e.g. FakeNamedConnectorQuery's endpoint)
+         // would be rejected as "missing" what this call already set moments earlier. Re-writing
+         // it to the SAME value it already holds is a no-op on the query.
+         Map<String, Object> contractParams = new java.util.LinkedHashMap<>(req.extraProperties());
+         contractParams.put(namedConnector ? "endpoint" : "suffix",
+            namedConnector ? req.endpoint() : req.suffix());
+
+         TabularQuerySchema extraSchema =
+            new TabularSchemaExtractor().extract(query, dataSource.getType());
+         TabularQueryContractSupport.applyQueryContract(
+            query, pmap, extraSchema, contractParams, dsName);
       }
 
       String tableName = req.table();

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -794,6 +794,8 @@ public class WorksheetAgentController {
          }
       }
 
+      final String extraApplied;
+
       if(req.extraProperties() != null && !req.extraProperties().isEmpty()) {
          if(req.extraProperties().containsKey("endpoint") || req.extraProperties().containsKey("suffix")) {
             throw new PairingException("add_table's extraProperties cannot set 'endpoint' or " +
@@ -813,8 +815,18 @@ public class WorksheetAgentController {
 
          TabularQuerySchema extraSchema =
             new TabularSchemaExtractor().extract(query, dataSource.getType());
-         TabularQueryContractSupport.applyQueryContract(
+         extraApplied = TabularQueryContractSupport.applyQueryContract(
             query, pmap, extraSchema, contractParams, dsName);
+
+         // extraProperties is applied after the row-cap guard below has already run once for the
+         // endpoint/suffix form -- if it set a pagination-triggering property (e.g.
+         // paginationType), the query only becomes paged now, so the guard must re-run or an
+         // uncapped paginated query would slip through untouched.
+         TabularEndpointBindingSupport.requireRowCapWhenPaged(
+            query, namedConnector ? req.endpoint() : req.suffix(), dsName);
+      }
+      else {
+         extraApplied = null;
       }
 
       String tableName = req.table();
@@ -852,7 +864,10 @@ public class WorksheetAgentController {
             Object loadError = query.getProperty("wizLoadColumnsError");
             throw new PairingException("The request to '" + target + "' of '" + dsName +
                "' returned no columns" + (loadError == null ? "" : " (" + loadError + ")") +
-               ". URL suffix sent: " + suffix + ". Check the parameter " +
+               ". URL suffix sent: " + suffix +
+               (extraApplied == null || extraApplied.isBlank() ? "" :
+                  ". Extra properties sent: " + extraApplied) +
+               ". Check the parameter " +
                "values and datasource credentials -- see the server log for the cause.");
          }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeCustomRestQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeCustomRestQuery.java
@@ -47,6 +47,7 @@ import java.util.List;
 @View(vertical = true, value = {
    @View1("suffix"),
    @View1("jsonPath"),
+   @View1("paginationMode"),
    @View1("lookupUrl0"),
    @View1("lookupJsonPath0"),
    @View1("lookupKey0"),
@@ -75,10 +76,14 @@ public class FakeCustomRestQuery extends TabularQuery {
     * pattern for the generic/custom (no {@code endpoint} property) shape: a custom REST-JSON
     * connector's pagination is driven by its own connector-specific properties, not a name lookup,
     * so this fixture ties it to the one property the suffix form actually sets -- {@code suffix}
-    * itself -- rather than adding an unrelated property no caller sets.
+    * itself -- rather than adding an unrelated property no caller sets. Also tied to {@link
+    * #paginationMode}, a real, independently-settable {@code @Property} (mirroring {@code
+    * RestJsonQuery.setPaginationType}), so a test can drive {@code isPaged()} to {@code true}
+    * purely through a reflective property write (e.g. via {@code extraProperties}) on a
+    * suffix that is NOT itself {@code "/paged"} -- the row-cap guard's own bypass regression.
     */
    public boolean isPaged() {
-      return "/paged".equals(suffix);
+      return "/paged".equals(suffix) || "PAGE_COUNT".equals(paginationMode);
    }
 
    @Property(label = "Json Path")
@@ -88,6 +93,15 @@ public class FakeCustomRestQuery extends TabularQuery {
 
    public void setJsonPath(String jsonPath) {
       this.jsonPath = jsonPath;
+   }
+
+   @Property(label = "Pagination Mode")
+   public String getPaginationMode() {
+      return paginationMode;
+   }
+
+   public void setPaginationMode(String paginationMode) {
+      this.paginationMode = paginationMode;
    }
 
    @Property(label = "Lookup Url 0")
@@ -235,6 +249,7 @@ public class FakeCustomRestQuery extends TabularQuery {
    private static final int LIMIT = 2;
    private String suffix;
    private String jsonPath;
+   private String paginationMode;
    private final List<String> lookupUrls = new ArrayList<>();
    private final List<String> lookupJsonPaths = new ArrayList<>();
    private final List<String> lookupKeys = new ArrayList<>();

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
@@ -100,6 +100,31 @@ class EditRequestParametersDeserializationTest {
    }
 
    /**
+    * extraProperties is appended as the LAST field of the canonical record (after
+    * {@code queryParams}), matching this file's own established every-new-field-goes-at-the-end
+    * convention -- confirms it round-trips through the real app ObjectMapper the same way
+    * {@code queryParams} does above.
+    */
+   @Test
+   void deserializesAddTableWithExtraProperties() throws Exception {
+      EditRequest req = mapper.readValue("""
+         {
+           "op": "add_table",
+           "table": "Widgets",
+           "datasource": "SaaS/Generic REST",
+           "suffix": "/v1/widgets",
+           "extraProperties": {"jsonPath": "$.items[*]", "timeout": 30, "expanded": true}
+         }
+         """, EditRequest.class);
+
+      assertNotNull(req.extraProperties());
+      assertEquals(3, req.extraProperties().size());
+      assertEquals("$.items[*]", req.extraProperties().get("jsonPath"));
+      assertEquals(30, req.extraProperties().get("timeout"));
+      assertEquals(true, req.extraProperties().get("expanded"));
+   }
+
+   /**
     * WBS-029 (bug 76502): {@code variableValues} is now {@code Map<String, Object>} so a JSON
     * array can bind to a genuine multi-value assignment. Confirms the real app
     * {@code ObjectMapper}'s default binding for an untyped {@code Object} map value -- a plain

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -442,6 +442,64 @@ class WorksheetAgentControllerTest {
    }
 
    /**
+    * Same {@code add_table} endpoint/suffix shape as {@link #addTabularTableRequest}, but also
+    * carrying {@code extraProperties} (and optionally {@code parameters}, for the required-param
+    * case) -- built through the real app {@link ObjectMapper}, the same technique
+    * {@link #addQueryParamsTableRequest} uses, since hand-counting nulls to a new position in the
+    * 70+ field positional record risks the exact silent off-by-one that technique exists to
+    * avoid.
+    */
+   private static EditRequest addTabularTableRequestWithExtraProperties(
+      String table, String datasource, String endpoint, String suffix,
+      Map<String, Object> extraProperties, Map<String, String> parameters) throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(endpoint != null) body.put("endpoint", endpoint);
+      if(suffix != null) body.put("suffix", suffix);
+      if(extraProperties != null) body.put("extraProperties", extraProperties);
+      if(parameters != null) body.put("parameters", parameters);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
+   /**
+    * Same as {@link #addQueryParamsTableRequest}, but also carrying {@code extraProperties} --
+    * proves the two forms are rejected together even though queryParams itself never reads it.
+    */
+   private static EditRequest addQueryParamsTableRequestWithExtraProperties(
+      String table, String datasource, Map<String, Object> queryParams,
+      Map<String, Object> extraProperties) throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(queryParams != null) body.put("queryParams", queryParams);
+      if(extraProperties != null) body.put("extraProperties", extraProperties);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
+   /** add_table carrying ONLY extraProperties (+datasource/table) -- no endpoint/suffix/queryParams. */
+   private static EditRequest addTableRequestWithBareExtraProperties(
+      String table, String datasource, Map<String, Object> extraProperties) throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(extraProperties != null) body.put("extraProperties", extraProperties);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
+   /**
     * Builds a {@code delete_table} EditRequest -- a plainly destructive op that routes through
     * {@code editService}, so a scope guard that failed to fire would show up as a real write
     * attempt rather than an early return.
@@ -4112,6 +4170,263 @@ class WorksheetAgentControllerTest {
          ex.getMessage());
       verifyNoInteractions(dataSourceService);
       verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTableRejectsExtraPropertiesTogetherWithQueryParams() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      EditRequest req = addQueryParamsTableRequestWithExtraProperties(
+         "t1", "OData/Northwind", Map.of("entitySet", "Orders"), Map.of("jsonPath", "$.items"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-EP1", req, agent));
+      assertTrue(ex.getMessage().contains("extraProperties"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("queryParams"), ex.getMessage());
+      verifyNoInteractions(dataSourceService, editSvc, xrepository);
+   }
+
+   @Test
+   void addTableRejectsExtraPropertiesWithoutEndpointOrSuffix() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      EditRequest req = addTableRequestWithBareExtraProperties(
+         "t1", "OData/Northwind", Map.of("jsonPath", "$.items"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-EP2", req, agent));
+      assertTrue(ex.getMessage().contains("extraProperties"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("endpoint"), ex.getMessage());
+      verifyNoInteractions(dataSourceService, editSvc, xrepository);
+   }
+
+   @Test
+   void addTabularTableRejectsExtraPropertiesContainingEndpointKey() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", "Comments", null,
+         Map.of("endpoint", "Issues"), null);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.edit("TOK-EP3", req, agent));
+         assertTrue(ex.getMessage().contains("endpoint"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+   }
+
+   @Test
+   void addTabularTableRejectsExtraPropertiesContainingSuffixKey() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", null, "/v1/widgets",
+         Map.of("suffix", "/v1/other"), null);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.edit("TOK-EP4", req, agent));
+         assertTrue(ex.getMessage().contains("suffix"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+   }
+
+   /**
+    * Proves extraProperties actually reaches TabularQueryContractSupport.applyQueryContract
+    * through addTabularTable's endpoint branch. TabularSchemaExtractor.extract resolves
+    * connector labels through a Spring-bean Config.getConfig(), not registered in this class's
+    * minimal test context -- wraps the real installed ApplicationContext with a delegating spy
+    * for this test's duration only, matching addQueryParamsTableThreadsQueryParamsIntoTheSharedHelper's
+    * own established workaround (restored in every case, including failure).
+    */
+   @Test
+   void addTabularTableThreadsExtraPropertiesIntoTheSharedHelperViaEndpoint() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeNamedConnector");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", "Comments", null,
+         Map.of("jsonPath", "$.items[*]"), null);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-EP5", req, agent));
+         assertEquals("$.items[*]", query.getJsonPath());
+         verify(editSvc).applyOnRuntime(eq("TOK-EP5"), eq(agent), any());
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
+   /** Same as the endpoint-form test above, but through the suffix (generic/custom) branch. */
+   @Test
+   void addTabularTableThreadsExtraPropertiesIntoTheSharedHelperViaSuffix() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeCustomRest");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", null, "/v1/widgets",
+         Map.of("jsonPath", "$.data[*]"), null);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-EP6", req, agent));
+         assertEquals("$.data[*]", query.getJsonPath());
+         verify(editSvc).applyOnRuntime(eq("TOK-EP6"), eq(agent), any());
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
+   /** Proves extraProperties genuinely reuses applyQueryContract's own validation, not a no-op. */
+   @Test
+   void addTabularTableRejectsAnUnknownExtraPropertiesKey() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeCustomRest");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", null, "/v1/widgets",
+         Map.of("notARealProperty", "x"), null);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ctrl.edit("TOK-EP7", req, agent));
+         assertTrue(ex.getMessage().contains("notARealProperty"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -485,6 +485,29 @@ class WorksheetAgentControllerTest {
       return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
    }
 
+   /**
+    * Same as {@link #addTabularTableRequestWithExtraProperties}, but also carrying {@code
+    * maxRows} -- needed for the row-cap-guard-recheck regression, where the guard must accept a
+    * pagination property set THROUGH {@code extraProperties} once a {@code maxRows} is supplied,
+    * the same way it already accepts one set directly via {@code endpoint}/{@code suffix}.
+    */
+   private static EditRequest addTabularTableRequestWithExtraPropertiesAndMaxRows(
+      String table, String datasource, String endpoint, String suffix,
+      Map<String, Object> extraProperties, Integer maxRows) throws Exception
+   {
+      Map<String, Object> body = new java.util.LinkedHashMap<>();
+      body.put("op", "add_table");
+      if(table != null) body.put("table", table);
+      if(datasource != null) body.put("datasource", datasource);
+      if(endpoint != null) body.put("endpoint", endpoint);
+      if(suffix != null) body.put("suffix", suffix);
+      if(extraProperties != null) body.put("extraProperties", extraProperties);
+      if(maxRows != null) body.put("maxRows", maxRows);
+
+      ObjectMapper mapper = new WebConfig().objectMapper();
+      return mapper.readValue(mapper.writeValueAsString(body), EditRequest.class);
+   }
+
    /** add_table carrying ONLY extraProperties (+datasource/table) -- no endpoint/suffix/queryParams. */
    private static EditRequest addTableRequestWithBareExtraProperties(
       String table, String datasource, Map<String, Object> extraProperties) throws Exception
@@ -4062,6 +4085,115 @@ class WorksheetAgentControllerTest {
       }
    }
 
+   /**
+    * Regression for the final whole-branch review's Important finding 1: {@code
+    * requireRowCapWhenPaged} ran ONLY before the new {@code extraProperties} block, so a caller
+    * could set a pagination-triggering property THROUGH {@code extraProperties} (not through
+    * {@code endpoint}/{@code suffix} directly) and reach the live call fully uncapped -- the
+    * exact failure the guard exists to prevent. The suffix here ({@code "/v1/widgets"}) is
+    * deliberately NOT {@code "/paged"}, so {@code FakeCustomRestQuery.isPaged()} is false when
+    * the FIRST guard check runs (right after the suffix is applied); only the {@code
+    * paginationMode} property set via {@code extraProperties} afterward flips it to paged, which
+    * only a SECOND guard call -- re-run after the {@code extraProperties} block -- can catch.
+    */
+   @Test
+   void addTabularTableRejectsPaginationTriggeredByExtraPropertiesWithoutMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeCustomRest");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", null, "/v1/widgets",
+         Map.of("paginationMode", "PAGE_COUNT"), null);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ctrl.edit("TOK-TT13", req, agent));
+         assertTrue(ex.getMessage().contains("paginated"), ex.getMessage());
+         verifyNoInteractions(editSvc);
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
+   /** Same wiring as {@link #addTabularTableRejectsPaginationTriggeredByExtraPropertiesWithoutMaxRows},
+    *  but a positive {@code maxRows} must satisfy the re-run guard and let execution reach {@code
+    *  editService} -- proving the fix does not simply reject every {@code extraProperties} call
+    *  that touches pagination, only the uncapped ones. */
+   @Test
+   void addTabularTableAllowsPaginationTriggeredByExtraPropertiesWithMaxRows() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeCustomRest");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraPropertiesAndMaxRows(
+         "t1", "MyDatasource", null, "/v1/widgets",
+         Map.of("paginationMode", "PAGE_COUNT"), 500);
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-TT14", req, agent),
+            "a positive maxRows must satisfy the re-run row-cap check on a suffix paginated " +
+            "only via extraProperties");
+         verify(editSvc).applyOnRuntime(eq("TOK-TT14"), eq(agent), any());
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
    // ---------------------------------------------------------------------------
    // add_table with queryParams — naming for addQueryParamsTable()
    // ---------------------------------------------------------------------------
@@ -4423,6 +4555,74 @@ class WorksheetAgentControllerTest {
             () -> ctrl.edit("TOK-EP7", req, agent));
          assertTrue(ex.getMessage().contains("notARealProperty"), ex.getMessage());
          verifyNoInteractions(editSvc);
+      }
+      finally {
+         configContext.setApplicationContext(realAppContext);
+      }
+   }
+
+   /**
+    * Regression for the final whole-branch review's Important finding 2: the endpoint/suffix
+    * "returned no columns" message discarded {@code applyQueryContract}'s own applied-properties
+    * summary, unlike {@code addQueryParamsTable}'s equivalent message (which reports {@code
+    * "Properties sent: " + applied}). {@code FakeNamedConnectorQuery.loadOutputColumns} is
+    * overridden to produce zero output columns whenever no response shape is staged (see its own
+    * doc), so routing this through a REAL {@code editService.applyOnRuntime} answer (rather than
+    * the unstubbed mock the other extraProperties tests use, which never invokes its function
+    * argument at all) reaches the empty-column branch with {@code jsonPath} genuinely applied.
+    */
+   @Test
+   void addTabularTableNoColumnsErrorIncludesAppliedExtraProperties() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(ds.getType()).thenReturn("FakeNamedConnector");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+
+      EditRequest req = addTabularTableRequestWithExtraProperties(
+         "t1", "MyDatasource", "Comments", null,
+         Map.of("jsonPath", "$.items[*]"), null);
+
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(editSvc.applyOnRuntime(eq("TOK-EP8"), eq(agent), any())).thenAnswer(inv -> {
+         WorksheetEditService.ThrowingFunction<RuntimeWorksheet, ?> fn = inv.getArgument(2);
+         return fn.apply(rws);
+      });
+
+      inetsoft.util.ConfigurationContext configContext = inetsoft.util.ConfigurationContext.getContext();
+      org.springframework.context.ApplicationContext realAppContext = configContext.getApplicationContext();
+      inetsoft.uql.util.Config configStub = mock(inetsoft.uql.util.Config.class);
+      when(configStub.getResourceBundle(any())).thenReturn(null);
+      org.springframework.context.ApplicationContext delegatingContext =
+         mock(org.springframework.context.ApplicationContext.class,
+              org.mockito.AdditionalAnswers.delegatesTo(realAppContext));
+      doReturn(configStub).when(delegatingContext).getBean(inetsoft.uql.util.Config.class);
+      configContext.setApplicationContext(delegatingContext);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         PairingException ex = assertThrows(PairingException.class,
+            () -> ctrl.edit("TOK-EP8", req, agent));
+         assertTrue(ex.getMessage().contains("returned no columns"), ex.getMessage());
+         assertTrue(ex.getMessage().contains("URL suffix sent:"), ex.getMessage());
+         assertTrue(ex.getMessage().contains("Extra properties sent:"), ex.getMessage());
+         assertTrue(ex.getMessage().contains("jsonPath"), ex.getMessage());
+         assertTrue(ex.getMessage().contains("$.items[*]"), ex.getMessage());
       }
       finally {
          configContext.setApplicationContext(realAppContext);


### PR DESCRIPTION
## Summary
Batch 2 of Redmine bug 76581 (composer-chat tabular datasource capability gap). Design: `docs/superpowers/specs/2026-09-11-add-table-extra-connector-properties-design.md` (stylebi-wiz repo). Plan: `docs/superpowers/plans/2026-09-11-add-table-extra-connector-properties.md` (stylebi-wiz repo).

Adds `extraProperties` (`Map<String, Object>`) to `EditRequest` and wires it into `WorksheetAgentController.addTabularTable`'s `endpoint`/`suffix` forms via the existing `TabularQueryContractSupport.applyQueryContract` reflection path (previously only used by the standalone `queryParams` form) — closes the jsonPath/xpath/expand-arrays/timeout/pagination/requestType/schemaUrl gap without hand-naming every connector property.

Companion TS-side PR (stylebi-wiz repo, PR #2431, already reviewed clean) adds the matching field to the composer plugin's `add_table` tool and forwards it unchanged.

## Notable review findings (fixed in this branch)
- extraProperties setting a pagination-triggering property (e.g. `paginationType`) could bypass the row-cap guard, since the guard ran before extraProperties was applied — fixed by re-running the guard after.
- The "no columns" error dropped the applied-properties summary, unlike the sibling `queryParams` path — fixed by surfacing it, with the synthetic re-supplied identity key stripped from the diagnostic.

## Test plan
- [x] `WorksheetAgentControllerTest` — 178/178 passing.
- [x] 3 review rounds on this branch (2 Important findings fixed + verified, 2 additional Minor polish items fixed + verified) — Ready to merge: Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)