### PR TITLE
Add test-connection, directory-listing, duplicate, and clear-cache to AdminProviderController (#76602)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/providers/AdminProviderController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/AdminProviderController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -112,8 +113,116 @@ public class AdminProviderController {
    }
 
    /**
-    * Resolves a provider change plan (create/delete, either or both chains) without mutating
-    * anything. See {@code AdminAiController#preview} for the shape this mirrors.
+    * Tests an authentication-chain provider's live connection using its OWN currently-stored
+    * configuration -- authentication-chain only, no authorization equivalent (bug 76602, confirmed:
+    * {@code AuthorizationProviderController} has no test-connection-shaped endpoint at all).
+    * Deliberately does NOT accept a caller-supplied model the way the real EM UI's
+    * {@code get-connection-status} endpoint does (which supports testing an in-progress, not-yet-
+    * saved edit): {@link AuthenticationProviderService#getAuthenticationProvider} already sets
+    * {@code oldName := name} on the model it returns (line ~119), so calling it here -- rather than
+    * accepting any model from the request body -- is what forces the real stored credential to be
+    * resolved server-side via {@code replacePlaceholderWithPassword}, never a literal placeholder
+    * string (bug 76602's load-bearing fix; a caller cannot even construct the failure mode, since
+    * there is no model parameter to smuggle a stale/masked password through).
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/providers/authentication/{name}/test-connection")
+   public ConnectionStatus testAuthenticationProviderConnection(@PathVariable("name") String name,
+                                                                 Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      requireExists(name, authenticationProviderService.getProviderListModel().providers());
+      AuthenticationProviderModel model = authenticationProviderService.getAuthenticationProvider(name);
+      return new ConnectionStatus(authenticationProviderService.testConnection(model));
+   }
+
+   /**
+    * Lists one authentication-chain provider's live directory entries (bug 76602) -- a live query
+    * against the provider's OWN directory (e.g. an LDAP bind), NOT StyleBI's already-resolved
+    * identity store ({@code list_identity_users} et al. cannot do this: they have no
+    * provider-scoped view at all). Authentication-chain only, same reasoning as
+    * {@link #testAuthenticationProviderConnection}. {@code kind} is one discriminated path segment
+    * rather than three separate endpoints, matching how {@code chain}/{@code unitType} are already
+    * single discriminators elsewhere in this area rather than one endpoint per value (03-fix.md).
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/providers/authentication/{name}/directory/{kind}")
+   public IdentityListModel getAuthenticationProviderDirectory(@PathVariable("name") String name,
+                                                                @PathVariable("kind") String kind,
+                                                                Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      requireExists(name, authenticationProviderService.getProviderListModel().providers());
+      AuthenticationProviderModel model = authenticationProviderService.getAuthenticationProvider(name);
+
+      return switch(kind) {
+         case "users" -> authenticationProviderService.getUsers(model);
+         case "groups" -> authenticationProviderService.getGroups(model);
+         case "roles" -> authenticationProviderService.getRoles(model);
+         default -> throw new IllegalArgumentException(
+            "kind: must be \"users\", \"groups\", or \"roles\"; got \"" + kind + "\"");
+      };
+   }
+
+   /**
+    * Clears one authentication-chain provider's cache, resolved by NAME (bug 76602) --
+    * {@link AuthenticationProviderService#clearAuthenticationProviderCache} is index-only, so the
+    * index is resolved fresh here, right before the call, via
+    * {@link ProviderChangesetApplyService#indexOfName} (promoted from {@code private}, not
+    * duplicated). A provider whose type does not enable caching (e.g. FILE) is refused loud, naming
+    * it, rather than silently succeeding as a no-op -- {@code CachableProvider.clearCache()}'s own
+    * default implementation is an unconditional no-op, so calling through unconditionally would
+    * report success for a call that changed nothing (03-fix.md's FILE-provider decision).
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/providers/authentication/{name}/clear-cache")
+   public SecurityProviderStatus clearAuthenticationProviderCacheByName(
+      @PathVariable("name") String name, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      List<SecurityProviderStatus> list = authenticationProviderService.getProviderListModel().providers();
+      requireExists(name, list);
+      int index = ProviderChangesetApplyService.indexOfName(list, name);
+      AuthenticationProvider provider = authenticationProviderService.getAuthenticationChain()
+         .orElseThrow(() -> new Exception("The authentication chain has not been initialized."))
+         .getProviders().get(index);
+      requireCacheable(name, provider);
+      return authenticationProviderService.clearAuthenticationProviderCache(index);
+   }
+
+   /** Authorization-chain counterpart of {@link #clearAuthenticationProviderCacheByName} -- same
+    * name-to-index resolution and same FILE-refuses-loud behavior, different chain's service. */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/providers/authorization/{name}/clear-cache")
+   public SecurityProviderStatus clearAuthorizationProviderCacheByName(
+      @PathVariable("name") String name, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      List<SecurityProviderStatus> list = authorizationProviderService.getProviderListModel().providers();
+      requireExists(name, list);
+      int index = ProviderChangesetApplyService.indexOfName(list, name);
+      AuthorizationProvider provider = authorizationProviderService.getAuthorizationChain()
+         .orElseThrow(() -> new Exception("The authorization chain has not been initialized."))
+         .getProviders().get(index);
+      requireCacheable(name, provider);
+      return authorizationProviderService.clearAuthorizationProviderCache(index);
+   }
+
+   /**
+    * Resolves a provider change plan (create/delete/duplicate, either or both chains) without
+    * mutating anything. See {@code AdminAiController#preview} for the shape this mirrors.
     */
    @Secured(@RequiredPermission(
       resourceType = ResourceType.EM_COMPONENT, resource = "settings/security/provider",
@@ -163,6 +272,21 @@ public class AdminProviderController {
 
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
          "not found: no provider named \"" + name + "\" in this chain");
+   }
+
+   /** Both {@code AuthenticationProvider} and {@code AuthorizationProvider} extend
+    * {@code CachableProvider} directly, so {@code isCacheEnabled()} is the generic capability check
+    * for either chain -- confirmed by refute: {@code LdapAuthenticationProvider} hardcodes
+    * {@code true}, {@code FileAuthenticationProvider} does not override it (inherits the interface's
+    * {@code false} default). Refuses loud rather than letting {@code clearCache()}'s own no-op
+    * default silently report success for a provider with nothing to clear. */
+   private static void requireCacheable(String name, CachableProvider provider) {
+      if(!provider.isCacheEnabled()) {
+         throw new IllegalArgumentException(
+            "name: provider \"" + name + "\" has no cache to clear -- this provider's type does " +
+            "not enable caching, refused rather than silently reporting success for a call that " +
+            "would change nothing");
+      }
    }
 
    @ExceptionHandler(IllegalArgumentException.class)

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangePlanService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin.ai.providers;
 
+import inetsoft.report.internal.Util;
 import inetsoft.report.internal.license.LicenseManager;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
@@ -106,6 +107,23 @@ public class ProviderChangePlanService {
             String providerType = requireNonBlank(label + ".providerType", change.getProviderType());
             changes.add(resolveCreate(label, chain, name, providerType, change.getSpec(),
                                       currentList, seenKeys));
+            continue;
+         }
+
+         if(ProviderChangeRequest.VERB_DUPLICATE.equals(verb)) {
+            if(change.getProviderType() != null) {
+               throw new IllegalArgumentException(
+                  label + ".providerType: not used for verb=duplicate; a duplicate keeps the " +
+                  "source provider's own type");
+            }
+            if(change.getSpec() != null) {
+               throw new IllegalArgumentException(
+                  label + ".spec: not used for verb=duplicate; a duplicate keeps the source " +
+                  "provider's own configuration -- use newName to control only its name");
+            }
+
+            changes.add(resolveDuplicate(label, chain, name, change.getNewName(), currentList,
+                                         seenKeys));
             continue;
          }
 
@@ -235,6 +253,82 @@ public class ProviderChangePlanService {
             "which AuthenticationProviderService.getProviderFromModel itself does not enforce -- " +
             "this area's own service does, 03-reconcile.md Addition 2)");
       }
+   }
+
+   // ---------------------------------------------------------------- duplicate
+
+   /**
+    * Resolves a {@code duplicate} entry: the source must exist, {@code newName} (if given) must not
+    * collide, and the proposed value is the source's own projection with its name swapped to the
+    * copy's name -- reusing {@link ProviderProjection#projectAuthenticationProvider}/
+    * {@link ProviderProjection#projectAuthorizationProvider} rather than a bespoke projection, since
+    * a duplicate is otherwise byte-for-byte the source (bug 76602). Unlike {@code create}, no
+    * provider-type restriction applies here (03-fix.md): the real EM "Duplicate" button is
+    * unconditional, not gated by type, and duplicating an already-existing, already-licensed
+    * provider does not reintroduce the risk {@link #resolveCreate}'s DATABASE/CUSTOM exclusion
+    * guards against (there is no fresh, unvetted instance being spun up).
+    */
+   private PlanChange resolveDuplicate(String label, ProviderChain chain, String name, String newName,
+                                       List<SecurityProviderStatus> currentList, Set<String> seenKeys)
+      throws Exception
+   {
+      String key = key(chain, name);
+      requireUnseen(label, key, seenKeys);
+      requireNameExists(label, currentList, name);
+
+      String actualNewName = resolveDuplicateName(label, newName, name, currentList);
+
+      if(chain == ProviderChain.AUTHENTICATION) {
+         AuthenticationProviderModel source = authenticationProviderService.getAuthenticationProvider(name);
+         AuthenticationProviderModel duplicated =
+            ((ImmutableAuthenticationProviderModel) source).withProviderName(actualNewName);
+         String proposed = ProviderProjection.projectAuthenticationProvider(duplicated);
+         return new PlanChange(key, NOT_ORG_SCOPED, null, proposed, AdminChangeRecord.RISK_HIGH,
+                               AdminChangeRecord.SCOPE_STORAGE, true,
+                               "duplicate authentication provider " + name + " as " + actualNewName);
+      }
+
+      AuthorizationProviderModel source = authorizationProviderService.getAuthorizationProvider(name);
+      AuthorizationProviderModel duplicated =
+         ((ImmutableAuthorizationProviderModel) source).withProviderName(actualNewName);
+      String proposed = ProviderProjection.projectAuthorizationProvider(duplicated);
+      return new PlanChange(key, NOT_ORG_SCOPED, null, proposed, AdminChangeRecord.RISK_HIGH,
+                            AdminChangeRecord.SCOPE_STORAGE, true,
+                            "duplicate authorization provider " + name + " as " + actualNewName);
+   }
+
+   /**
+    * Computes the copy's actual name: an explicit, non-colliding {@code newName} if given, otherwise
+    * the same {@code Util.getCopyName}/{@code getNextCopyName} collision loop
+    * {@code AuthenticationProviderController#copyAuthenticationProvider}/
+    * {@code AuthorizationProviderController#copyAuthorizationProviderCache} already use (bug 76602 --
+    * called through, not reimplemented independently). Package-visible and {@code static} so
+    * {@link ProviderChangesetApplyService} can recompute this SAME deterministic result fresh at
+    * apply time, against the live list read at that moment, rather than trusting a value captured at
+    * preview time (matching every other verb's "resolved fresh at apply" discipline in this area).
+    */
+   static String resolveDuplicateName(String label, String requestedNewName, String sourceName,
+                                      List<SecurityProviderStatus> currentList)
+   {
+      if(requestedNewName != null && !requestedNewName.trim().isEmpty()) {
+         String trimmed = requestedNewName.trim();
+
+         if(existsInList(currentList, trimmed)) {
+            throw new IllegalArgumentException(
+               label + ".newName: \"" + trimmed + "\" already exists in this chain; choose a " +
+               "different name or omit newName to auto-generate one");
+         }
+
+         return trimmed;
+      }
+
+      String copyName = Util.getCopyName(sourceName);
+
+      while(existsInList(currentList, copyName)) {
+         copyName = Util.getNextCopyName(sourceName, copyName);
+      }
+
+      return copyName;
    }
 
    // ---------------------------------------------------------------- delete
@@ -450,13 +544,16 @@ public class ProviderChangePlanService {
    }
 
    static String requireVerb(String label, String verb) {
-      if(ProviderChangeRequest.VERB_CREATE.equals(verb) || ProviderChangeRequest.VERB_DELETE.equals(verb)) {
+      if(ProviderChangeRequest.VERB_CREATE.equals(verb) || ProviderChangeRequest.VERB_DELETE.equals(verb) ||
+         ProviderChangeRequest.VERB_DUPLICATE.equals(verb))
+      {
          return verb;
       }
 
       throw new IllegalArgumentException(
-         label + ".verb: must be \"" + ProviderChangeRequest.VERB_CREATE + "\" or \"" +
-         ProviderChangeRequest.VERB_DELETE + "\", got " + String.valueOf(verb));
+         label + ".verb: must be \"" + ProviderChangeRequest.VERB_CREATE + "\", \"" +
+         ProviderChangeRequest.VERB_DELETE + "\", or \"" + ProviderChangeRequest.VERB_DUPLICATE +
+         "\", got " + String.valueOf(verb));
    }
 
    /** Deliberately case-insensitive/trimmed exact-label match, no abbreviation aliasing -- "auth" is

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangeRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangeRequest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ProviderChangeRequest {
    public static final String VERB_CREATE = "create";
    public static final String VERB_DELETE = "delete";
+   public static final String VERB_DUPLICATE = "duplicate";
 
    public String getVerb() { return verb; }
    public void setVerb(String v) { this.verb = v; }
@@ -38,23 +39,33 @@ public class ProviderChangeRequest {
    public String getChain() { return chain; }
    public void setChain(String v) { this.chain = v; }
 
-   /** Required for both verbs: for {@code create}, the id the new provider will have; for
-    * {@code delete}, the existing provider's id. */
+   /** Required for all three verbs: for {@code create}/{@code duplicate}, the id the new provider
+    * will have (for {@code duplicate}, it is the id of the SOURCE being copied, not the copy --
+    * see {@link #getNewName()}); for {@code delete}, the existing provider's id. */
    public String getName() { return name; }
    public void setName(String v) { this.name = v; }
 
    /** Required for {@code create} ({@code "FILE"} or, authentication-chain only, {@code "LDAP"});
-    * rejected for {@code delete} (01-spec.md section 11). */
+    * rejected for {@code delete}/{@code duplicate} (01-spec.md section 11 -- a duplicate always
+    * keeps the source provider's own type, matching the real EM "Duplicate" action). */
    public String getProviderType() { return providerType; }
    public void setProviderType(String v) { this.providerType = v; }
 
-   /** Required for {@code providerType: "LDAP"}; rejected otherwise, including for {@code delete}. */
+   /** Required for {@code providerType: "LDAP"}; rejected otherwise, including for {@code delete}/
+    * {@code duplicate}. */
    public ProviderLdapSpec getSpec() { return spec; }
    public void setSpec(ProviderLdapSpec v) { this.spec = v; }
+
+   /** Optional, {@code duplicate} only: the copy's name. When omitted, the copy's name is
+    * auto-generated the same way the real EM "Duplicate" action does ({@code Util.getCopyName}/
+    * {@code getNextCopyName}, bug 76602). Rejected for every other verb. */
+   public String getNewName() { return newName; }
+   public void setNewName(String v) { this.newName = v; }
 
    private String verb;
    private String chain;
    private String name;
    private String providerType;
    private ProviderLdapSpec spec;
+   private String newName;
 }

--- a/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyService.java
@@ -171,6 +171,19 @@ public class ProviderChangesetApplyService {
          return;
       }
 
+      if(ProviderChangeRequest.VERB_DUPLICATE.equals(original.getVerb())) {
+         if(chain == ProviderChain.AUTHENTICATION) {
+            applyDuplicateAuthentication(txId, task, key, name, original, backupRef, reviewOutcome,
+                                        user, results, undoable);
+         }
+         else {
+            applyDuplicateAuthorization(txId, task, key, name, original, backupRef, reviewOutcome,
+                                       user, results, undoable);
+         }
+
+         return;
+      }
+
       if(chain == ProviderChain.AUTHENTICATION) {
          applyDeleteAuthentication(txId, task, key, name, backupRef, reviewOutcome, user, results,
                                   undoable);
@@ -269,6 +282,150 @@ public class ProviderChangesetApplyService {
 
       if(verified) {
          undoable.add(Undo.createdAuthorization(key, name));
+      }
+   }
+
+   // ---------------------------------------------------------------- duplicate
+
+   /**
+    * Recomputes the copy's name fresh, against the live list read right now -- never trusts a name
+    * captured at preview time (same "resolved fresh" discipline {@link #applyDeleteAuthentication}'s
+    * javadoc documents for its own index). If the plan hash still matched (checked by {@link #apply}
+    * before this is ever called), the live list is unchanged since preview, so
+    * {@link ProviderChangePlanService#resolveDuplicateName} necessarily reproduces the identical
+    * name deterministically.
+    */
+   private void applyDuplicateAuthentication(String txId, String task, String key, String name,
+                                             ProviderChangeRequest original, String backupRef,
+                                             String reviewOutcome, Principal user,
+                                             List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      AuthenticationProviderModel source;
+
+      try {
+         source = authenticationProviderService.getAuthenticationProvider(name);
+      }
+      catch(Exception e) {
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+            "source provider not found at apply time (concurrent change): " + messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      String newName;
+
+      try {
+         newName = ProviderChangePlanService.resolveDuplicateName("apply." + key,
+            original.getNewName(), name, authenticationProviderService.getProviderListModel().providers());
+      }
+      catch(IllegalArgumentException e) {
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                              messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      AuthenticationProviderModel duplicated =
+         ((ImmutableAuthenticationProviderModel) source).withProviderName(newName);
+
+      try {
+         authenticationProviderService.addAuthenticationProvider(duplicated, newName, user);
+      }
+      catch(Exception e) {
+         // Same pre-mutation reasoning as applyCreateAuthentication's catch above.
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                              messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      AuthenticationProviderModel after =
+         tryGet(() -> authenticationProviderService.getAuthenticationProvider(newName),
+               list -> indexOfName(list, newName) >= 0,
+               authenticationProviderService.getProviderListModel().providers());
+      boolean verified = after != null;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      String afterProjection = verified ? ProviderProjection.projectAuthenticationProvider(after) : null;
+      results.add(new ProviderApplyOutcome(key, null, afterProjection, status,
+                                           verified ? null : "duplicated provider not found after create",
+                                           null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                null, afterProjection, status, backupRef, reviewOutcome, user);
+
+      // The duplicate's own rollback is identical to a plain create's (delete the new name) -- no
+      // new Undo.Kind needed.
+      if(verified) {
+         undoable.add(Undo.createdAuthentication(key, newName));
+      }
+   }
+
+   private void applyDuplicateAuthorization(String txId, String task, String key, String name,
+                                            ProviderChangeRequest original, String backupRef,
+                                            String reviewOutcome, Principal user,
+                                            List<ProviderApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      AuthorizationProviderModel source;
+
+      try {
+         source = authorizationProviderService.getAuthorizationProvider(name);
+      }
+      catch(Exception e) {
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+            "source provider not found at apply time (concurrent change): " + messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      String newName;
+
+      try {
+         newName = ProviderChangePlanService.resolveDuplicateName("apply." + key,
+            original.getNewName(), name, authorizationProviderService.getProviderListModel().providers());
+      }
+      catch(IllegalArgumentException e) {
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                              messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      AuthorizationProviderModel duplicated =
+         ((ImmutableAuthorizationProviderModel) source).withProviderName(newName);
+
+      try {
+         authorizationProviderService.addAuthorizationProvider(duplicated, newName, user);
+      }
+      catch(Exception e) {
+         // Same pre-mutation reasoning as applyCreateAuthorization's catch above.
+         results.add(new ProviderApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                              messageOf(e), null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      List<SecurityProviderStatus> afterList =
+         authorizationProviderService.getProviderListModel().providers();
+      boolean verified = indexOfName(afterList, newName) >= 0;
+      AuthorizationProviderModel after =
+         verified ? authorizationProviderService.getAuthorizationProvider(newName) : null;
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      String afterProjection = verified ? ProviderProjection.projectAuthorizationProvider(after) : null;
+      results.add(new ProviderApplyOutcome(key, null, afterProjection, status,
+                                           verified ? null : "duplicated provider not found after create",
+                                           null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                null, afterProjection, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.createdAuthorization(key, newName));
       }
    }
 
@@ -616,7 +773,10 @@ public class ProviderChangesetApplyService {
       return present.test(list) ? getter.get() : null;
    }
 
-   private static int indexOfName(List<SecurityProviderStatus> list, String name) {
+   /** Package-visible (not {@code private}), so {@link AdminProviderController}'s new
+    * clear-provider-cache-by-name endpoints can reuse this exact name-to-index resolution rather
+    * than duplicating it (bug 76602 -- the diagnosis's own promotion candidate). */
+   static int indexOfName(List<SecurityProviderStatus> list, String name) {
       for(int i = 0; i < list.size(); i++) {
          if(list.get(i).name().equals(name)) {
             return i;

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/AdminProviderControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/AdminProviderControllerTest.java
@@ -1,0 +1,262 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.providers;
+
+/*
+ * Test strategy (bug 76602)
+ *
+ * Covers the four new bare-action endpoints this bug adds to AdminProviderController:
+ *   1. testAuthenticationProviderConnection -- must resolve the model via
+ *      authenticationProviderService.getAuthenticationProvider(name) (which already sets
+ *      oldName := name), never accept/forward a caller-supplied model, so a masked placeholder
+ *      password is never tested literally (the bug's load-bearing fix).
+ *   2. getAuthenticationProviderDirectory -- kind dispatch (users/groups/roles) + invalid kind.
+ *   3/4. clear*ProviderCacheByName -- name-to-index resolution + FILE-provider refuse-loud.
+ * requireSiteAdmin/requireExists are exercised indirectly (not-found path); the full site-admin
+ * gate is already covered by every other endpoint's existing behavior and AdminAiCallerGuard's own
+ * tests, not re-verified here.
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.security.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminProviderControllerTest {
+   @Mock private AuthenticationProviderService authenticationProviderService;
+   @Mock private AuthorizationProviderService authorizationProviderService;
+   @Mock private ProviderChangePlanService planService;
+   @Mock private ProviderChangesetApplyService applyService;
+   @Mock private Principal user;
+   @Mock private OrganizationManager orgManager;
+
+   private AdminProviderController controller;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+
+   @BeforeEach void setUp() {
+      controller = new AdminProviderController(authenticationProviderService,
+                                                authorizationProviderService, planService,
+                                                applyService);
+      lenient().when(user.getName()).thenReturn("admin");
+
+      // requireSiteAdmin() gates every endpoint on AdminAiCallerGuard's bearer-token check first,
+      // then OrganizationManager.isSiteAdmin -- both mocked here rather than in each test, mirroring
+      // AdminPropertiesControllerTest's own setUp precedent for the identical guard.
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().strictness(Strictness.LENIENT));
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.isSiteAdmin(user)).thenReturn(true);
+
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer test-jwt");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+   }
+
+   @AfterEach void tearDown() {
+      orgManagerStatic.close();
+      RequestContextHolder.resetRequestAttributes();
+   }
+
+   // -------------------------------------------------------------------------
+   // testAuthenticationProviderConnection() -- oldName/placeholder-forcing (bug 76602)
+   // -------------------------------------------------------------------------
+
+   @Test void testConnection_resolvesModelServerSideRatherThanAcceptingOne() throws Exception {
+      stubProviderList("p1");
+      // getAuthenticationProvider(name) is the real service method that already forces
+      // oldName := name (AuthenticationProviderService.java:119) -- the controller must call
+      // THIS, not accept any model from the request, so a caller can never even smuggle a
+      // literal placeholder password through this endpoint.
+      AuthenticationProviderModel resolvedModel = AuthenticationProviderModel.builder()
+         .providerName("p1").oldName("p1").providerType(SecurityProviderType.LDAP).build();
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(resolvedModel);
+      when(authenticationProviderService.testConnection(resolvedModel)).thenReturn("Connection is OK.");
+
+      ConnectionStatus result = controller.testAuthenticationProviderConnection("p1", user);
+
+      assertEquals("Connection is OK.", result.getStatus());
+      verify(authenticationProviderService).testConnection(resolvedModel);
+   }
+
+   @Test void testConnection_unknownName_throwsStructuredNotFound() throws Exception {
+      stubProviderList();
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> controller.testAuthenticationProviderConnection("missing", user));
+      assertEquals(404, ex.getStatusCode().value());
+      verify(authenticationProviderService, never()).testConnection(any());
+   }
+
+   // -------------------------------------------------------------------------
+   // getAuthenticationProviderDirectory() -- kind dispatch (bug 76602)
+   // -------------------------------------------------------------------------
+
+   @Test void directory_usersKind_delegatesToGetUsers() throws Exception {
+      stubProviderList("p1");
+      AuthenticationProviderModel model = AuthenticationProviderModel.builder()
+         .providerName("p1").oldName("p1").providerType(SecurityProviderType.FILE).build();
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(model);
+      IdentityListModel expected = IdentityListModel.builder().ids(new IdentityID[0]).type(0).build();
+      when(authenticationProviderService.getUsers(model)).thenReturn(expected);
+
+      IdentityListModel result = controller.getAuthenticationProviderDirectory("p1", "users", user);
+
+      assertSame(expected, result);
+   }
+
+   @Test void directory_groupsKind_delegatesToGetGroups() throws Exception {
+      stubProviderList("p1");
+      AuthenticationProviderModel model = AuthenticationProviderModel.builder()
+         .providerName("p1").oldName("p1").providerType(SecurityProviderType.FILE).build();
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(model);
+      IdentityListModel expected = IdentityListModel.builder().ids(new IdentityID[0]).type(1).build();
+      when(authenticationProviderService.getGroups(model)).thenReturn(expected);
+
+      IdentityListModel result = controller.getAuthenticationProviderDirectory("p1", "groups", user);
+
+      assertSame(expected, result);
+   }
+
+   @Test void directory_rolesKind_delegatesToGetRoles() throws Exception {
+      stubProviderList("p1");
+      AuthenticationProviderModel model = AuthenticationProviderModel.builder()
+         .providerName("p1").oldName("p1").providerType(SecurityProviderType.FILE).build();
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(model);
+      IdentityListModel expected = IdentityListModel.builder().ids(new IdentityID[0]).type(2).build();
+      when(authenticationProviderService.getRoles(model)).thenReturn(expected);
+
+      IdentityListModel result = controller.getAuthenticationProviderDirectory("p1", "roles", user);
+
+      assertSame(expected, result);
+   }
+
+   @Test void directory_unrecognizedKind_throwsIllegalArgument() throws Exception {
+      stubProviderList("p1");
+      AuthenticationProviderModel model = AuthenticationProviderModel.builder()
+         .providerName("p1").oldName("p1").providerType(SecurityProviderType.FILE).build();
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(model);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> controller.getAuthenticationProviderDirectory("p1", "permissions", user));
+      assertTrue(ex.getMessage().contains("kind"));
+   }
+
+   // -------------------------------------------------------------------------
+   // clearAuthenticationProviderCacheByName() -- name-to-index + FILE refuse-loud (bug 76602)
+   // -------------------------------------------------------------------------
+
+   @Test void clearAuthenticationCache_cacheableProvider_clearsByResolvedIndex() throws Exception {
+      stubProviderList("keep", "p1");
+      AuthenticationChain chain = mock(AuthenticationChain.class);
+      AuthenticationProvider keepProvider = mock(AuthenticationProvider.class);
+      // AuthenticationProvider extends CachableProvider directly (confirmed by refute) -- a plain
+      // mock with isCacheEnabled() stubbed true stands in for LdapAuthenticationProvider's own
+      // hardcoded-true override, no need for a hand-written fake implementing the whole interface.
+      AuthenticationProvider ldapProvider = mock(AuthenticationProvider.class);
+      lenient().when(ldapProvider.isCacheEnabled()).thenReturn(true);
+      when(chain.getProviders()).thenReturn(List.of(keepProvider, ldapProvider));
+      when(authenticationProviderService.getAuthenticationChain()).thenReturn(Optional.of(chain));
+      SecurityProviderStatus expected = SecurityProviderStatus.builder()
+         .name("p1").label("p1").cacheEnabled(true).cacheAge(0).loading(false).build();
+      when(authenticationProviderService.clearAuthenticationProviderCache(1)).thenReturn(expected);
+
+      SecurityProviderStatus result = controller.clearAuthenticationProviderCacheByName("p1", user);
+
+      assertSame(expected, result);
+      verify(authenticationProviderService).clearAuthenticationProviderCache(1);
+   }
+
+   @Test void clearAuthenticationCache_fileProvider_refusesLoudRatherThanNoOp() throws Exception {
+      stubProviderList("p1");
+      AuthenticationChain chain = mock(AuthenticationChain.class);
+      AuthenticationProvider fileProvider = mock(AuthenticationProvider.class); // not CachableProvider
+      when(chain.getProviders()).thenReturn(List.of(fileProvider));
+      when(authenticationProviderService.getAuthenticationChain()).thenReturn(Optional.of(chain));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> controller.clearAuthenticationProviderCacheByName("p1", user));
+      assertTrue(ex.getMessage().contains("no cache to clear"));
+      verify(authenticationProviderService, never()).clearAuthenticationProviderCache(anyInt());
+   }
+
+   @Test void clearAuthenticationCache_unknownName_throwsStructuredNotFound() {
+      stubProviderList();
+
+      assertThrows(ResponseStatusException.class,
+         () -> controller.clearAuthenticationProviderCacheByName("missing", user));
+   }
+
+   // -------------------------------------------------------------------------
+   // clearAuthorizationProviderCacheByName() -- mirrors the authentication-chain behavior
+   // -------------------------------------------------------------------------
+
+   @Test void clearAuthorizationCache_fileProvider_refusesLoud() throws Exception {
+      stubAuthzProviderList("z1");
+      AuthorizationChain chain = mock(AuthorizationChain.class);
+      AuthorizationProvider fileProvider = mock(AuthorizationProvider.class); // not CachableProvider
+      when(chain.getProviders()).thenReturn(List.of(fileProvider));
+      when(authorizationProviderService.getAuthorizationChain()).thenReturn(Optional.of(chain));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> controller.clearAuthorizationProviderCacheByName("z1", user));
+      assertTrue(ex.getMessage().contains("no cache to clear"));
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private void stubProviderList(String... names) {
+      SecurityProviderStatusList.Builder builder = SecurityProviderStatusList.builder();
+
+      for(String name : names) {
+         builder.addProviders(SecurityProviderStatus.builder()
+            .name(name).label(name).cacheEnabled(false).cacheAge(0).loading(false).build());
+      }
+
+      lenient().when(authenticationProviderService.getProviderListModel()).thenReturn(builder.build());
+   }
+
+   private void stubAuthzProviderList(String... names) {
+      SecurityProviderStatusList.Builder builder = SecurityProviderStatusList.builder();
+
+      for(String name : names) {
+         builder.addProviders(SecurityProviderStatus.builder()
+            .name(name).label(name).cacheEnabled(false).cacheAge(0).loading(false).build());
+      }
+
+      lenient().when(authorizationProviderService.getProviderListModel()).thenReturn(builder.build());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangePlanServiceTest.java
@@ -115,6 +115,77 @@ class ProviderChangePlanServiceTest {
    }
 
    // -------------------------------------------------------------------------
+   // duplicate verb (bug 76602)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveDuplicateAuthenticationAutoGeneratesCopyName() throws Exception {
+      stubProviderList(authenticationProviderService, List.of("p1"));
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(fileModel("p1"));
+
+      ResolvedPlan plan = service.resolve(request("dup", List.of(duplicateAuth("p1", null))), user);
+
+      PlanChange change = plan.changes().get(0);
+      assertNull(change.currentValue());
+      assertTrue(change.proposedValue().contains("name=Copy of p1;"));
+   }
+
+   @Test void resolveDuplicateAuthenticationWithExplicitNewNameUsesIt() throws Exception {
+      stubProviderList(authenticationProviderService, List.of("p1"));
+      when(authenticationProviderService.getAuthenticationProvider("p1")).thenReturn(fileModel("p1"));
+
+      ResolvedPlan plan = service.resolve(request("dup", List.of(duplicateAuth("p1", "p1-clone"))), user);
+
+      assertTrue(plan.changes().get(0).proposedValue().contains("name=p1-clone;"));
+   }
+
+   @Test void resolveDuplicateAuthenticationExplicitNewNameCollidesThrows() {
+      stubProviderList(authenticationProviderService, List.of("p1", "p2"));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("dup", List.of(duplicateAuth("p1", "p2"))), user));
+      assertTrue(ex.getMessage().contains("newName"));
+   }
+
+   @Test void resolveDuplicateAuthenticationSourceNotFoundThrows() {
+      stubProviderList(authenticationProviderService, List.of());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("dup", List.of(duplicateAuth("missing", null))), user));
+      assertTrue(ex.getMessage().contains("not found"));
+   }
+
+   @Test void resolveDuplicateRejectsProviderType() {
+      stubProviderList(authenticationProviderService, List.of("p1"));
+      ProviderChangeRequest change = duplicateAuth("p1", null);
+      change.setProviderType("FILE");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("dup", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("providerType"));
+   }
+
+   @Test void resolveDuplicateRejectsSpec() {
+      stubProviderList(authenticationProviderService, List.of("p1"));
+      ProviderChangeRequest change = duplicateAuth("p1", null);
+      change.setSpec(ldapSpec());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("dup", List.of(change)), user));
+      assertTrue(ex.getMessage().contains("spec"));
+   }
+
+   @Test void resolveDuplicateAuthorizationAlsoSupported() throws Exception {
+      stubProviderList(authorizationProviderService, List.of("p1"));
+      when(authorizationProviderService.getAuthorizationProvider("p1")).thenReturn(authzFileModel("p1"));
+      ProviderChangeRequest change = duplicateAuth("p1", null);
+      change.setChain("authorization");
+
+      ResolvedPlan plan = service.resolve(request("dup", List.of(change)), user);
+
+      assertTrue(plan.changes().get(0).proposedValue().contains("name=Copy of p1;"));
+   }
+
+   // -------------------------------------------------------------------------
    // providerType/chain cross-validation (section 11)
    // -------------------------------------------------------------------------
 
@@ -572,6 +643,15 @@ class ProviderChangePlanServiceTest {
       change.setChain(chain.label());
       change.setName(name);
       change.setProviderType("FILE");
+      return change;
+   }
+
+   private static ProviderChangeRequest duplicateAuth(String name, String newName) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("duplicate");
+      change.setChain("authentication");
+      change.setName(name);
+      change.setNewName(newName);
       return change;
    }
 

--- a/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/providers/ProviderChangesetApplyServiceTest.java
@@ -151,6 +151,57 @@ class ProviderChangesetApplyServiceTest {
    }
 
    // -------------------------------------------------------------------------
+   // duplicate verb (bug 76602)
+   // -------------------------------------------------------------------------
+
+   @Test void appliesADuplicateAuthenticationProviderAutoNamedAndReportsApplied() throws Exception {
+      seedHealthyAuthentication("p1");
+
+      var result = service.apply(applyRequest("duplicate p1", duplicateAuth("p1", null)), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertTrue(authChainNames.contains("p1"));
+      assertTrue(authChainNames.contains("Copy of p1"));
+      assertEquals("Copy of p1", authModels.get("Copy of p1").providerName());
+   }
+
+   @Test void appliesADuplicateAuthenticationProviderWithExplicitNewName() throws Exception {
+      seedHealthyAuthentication("p1");
+
+      var result = service.apply(
+         applyRequest("duplicate p1", duplicateAuth("p1", "p1-clone")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertTrue(authChainNames.contains("p1-clone"));
+   }
+
+   @Test void appliesADuplicateAuthorizationProvider() throws Exception {
+      authzChainNames.add("z1");
+      authzModels.put("z1", AuthorizationProviderModel.builder()
+         .providerName("z1").providerType(SecurityProviderType.FILE).build());
+
+      var result = service.apply(applyRequest("duplicate z1", duplicateAuthz("z1", null)), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertTrue(authzChainNames.contains("Copy of z1"));
+   }
+
+   @Test void rollbackOfADuplicateRemovesTheCopyNotTheSource() throws Exception {
+      seedHealthyAuthentication("p1");
+      // Second change's own add succeeds but its post-add verification throws -- same genuine
+      // unknown-state shape the other rollback tests in this file use to force a rollback.
+      doThrow(new RuntimeException("boom"))
+         .when(authenticationProviderService).getAuthenticationProvider(eq("boom"));
+
+      var result = service.apply(applyRequest("duplicate p1 then create boom",
+         duplicateAuth("p1", null), createFile(ProviderChain.AUTHENTICATION, "boom")), user);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertTrue(authChainNames.contains("p1")); // source untouched
+      assertFalse(authChainNames.contains("Copy of p1")); // copy rolled back
+   }
+
+   // -------------------------------------------------------------------------
    // throw mid-apply -> rollback / rollback-failed (section 6, "fails by throwing")
    // -------------------------------------------------------------------------
 
@@ -519,6 +570,24 @@ class ProviderChangesetApplyServiceTest {
       change.setChain(chain.label());
       change.setName(name);
       change.setProviderType("FILE");
+      return change;
+   }
+
+   private static ProviderChangeRequest duplicateAuth(String name, String newName) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("duplicate");
+      change.setChain("authentication");
+      change.setName(name);
+      change.setNewName(newName);
+      return change;
+   }
+
+   private static ProviderChangeRequest duplicateAuthz(String name, String newName) {
+      ProviderChangeRequest change = new ProviderChangeRequest();
+      change.setVerb("duplicate");
+      change.setChain("authorization");
+      change.setName(name);
+      change.setNewName(newName);
       return change;
    }
 


### PR DESCRIPTION
## Summary

Redmine #76602: the wiz-plugin-admin "Providers" tool surface had no coverage for four StyleBI Enterprise Manager UI actions — Test Connection, Show Users/Groups/Roles, Duplicate Provider, Clear Security Cache. All four already exist as EM UI actions backed by `AuthenticationProviderService`/`AuthorizationProviderService` methods; the gap was purely missing `AdminProviderController` endpoints (no new backend capability needed).

- **Test connection** — `GET /api/wiz/v1/admin/providers/authentication/{name}/test-connection`. Authentication chain only (no authorization-chain equivalent exists). Resolves the model via `authenticationProviderService.getAuthenticationProvider(name)`, which already forces `oldName := name` on the returned model (`AuthenticationProviderService.java:119`) — this is what makes `replacePlaceholderWithPassword` resolve the REAL stored credential server-side. There is no caller-supplied model parameter at all, so a masked placeholder password can never reach `testConnection` literally.
- **Directory listing** — `GET /api/wiz/v1/admin/providers/authentication/{name}/directory/{kind}` (`kind`: users/groups/roles). Same placeholder-safety shape as test-connection. Authentication chain only.
- **Duplicate** — new `verb: "duplicate"` in the existing `ProviderChangeRequest`/`ProviderChangePlanService`/`ProviderChangesetApplyService` plan+apply+rollback machinery, on BOTH chains. Reuses `Util.getCopyName`/`getNextCopyName` — the same naming algorithm `AuthenticationProviderController.copyAuthenticationProvider`/`AuthorizationProviderController.copyAuthorizationProviderCache` already use — rather than reimplementing it. Accepts an optional explicit `newName` (a colliding explicit name is refused loud). Unlike `create`, is NOT restricted to FILE/LDAP providerType, since it copies an existing, already-licensed provider rather than spinning up a fresh, unvetted one. A duplicate's own rollback deletes the copy by its resolved name; the source is never touched (reuses the existing `Undo.createdAuthentication`/`createdAuthorization` kind, no new rollback path needed).
- **Clear cache by name** — `POST /api/wiz/v1/admin/providers/{authentication,authorization}/{name}/clear-cache`. The underlying `clearAuthenticationProviderCache`/`clearAuthorizationProviderCache` are index-only; this resolves name→index via `ProviderChangesetApplyService.indexOfName` (promoted from `private` to package-visible, not duplicated). A provider whose type does not enable caching (most notably FILE) is refused loud with a field-named error rather than silently reporting success for `CachableProvider.clearCache()`'s own no-op default.

## Test plan

- [x] `AdminProviderControllerTest` (new file) — happy paths for all 4 new endpoints, the oldName/placeholder-forcing behavior, FILE-provider refuse-loud for clear-cache, kind-dispatch validation for directory listing.
- [x] `ProviderChangePlanServiceTest` — duplicate verb resolution: auto-generated copy name, explicit `newName`, collision refusal, source-not-found, providerType/spec rejection, works on both chains.
- [x] `ProviderChangesetApplyServiceTest` — duplicate apply (both chains, auto/explicit name) and rollback (copy removed, source untouched).
- [x] Ran `./mvnw -pl core -Dtest=AdminProviderControllerTest,ProviderChangePlanServiceTest,ProviderChangesetApplyServiceTest test` — all pass (68 tests in this targeted run, 0 failures).

## Cross-repo dependency

This PR's new endpoints are called by new tools in the companion `stylebi-wiz` PR (`fix/76602-provider-admin-actions` → `main`). That PR's `test_auth_provider_connection`/`list_auth_provider_directory_entries`/`clear_provider_cache` tools and the `duplicate` verb will 404 until THIS PR merges. Link: (stylebi-wiz PR to be added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)