### PR TITLE
fix(76489): fall through to session-cookie auth on a stale JWT with an active session

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
+++ b/core/src/main/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilter.java
@@ -25,6 +25,7 @@ import com.nimbusds.jwt.SignedJWT;
 import inetsoft.sree.ClientInfo;
 import inetsoft.sree.RepletRepository;
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
 import inetsoft.sree.web.SessionLicenseServiceProvider;
 import inetsoft.util.*;
@@ -41,6 +42,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.security.KeyPair;
+import java.security.Principal;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.*;
@@ -117,6 +119,25 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
       }
       catch(WizAuthenticationException e) {
          LOG.warn("WIZ service authentication failed: {}", e.getMessage());
+
+         // The wiz_auth cookie's JWT is stale (expired, signature mismatch from a key
+         // rotation, etc.), but this browser may separately hold a still-valid StyleBI
+         // session (e.g. an ordinary interactive login) alongside the now-stale cookie.
+         // Hard-401'ing unconditionally here turns that into a permanent, silent hang for
+         // anything routed through this filter (bug #76489) even when a perfectly good
+         // session already exists. Falling through to let that session handle the request
+         // is only safe if its own principal is still a genuinely active user: this filter
+         // is InvalidateSessionFilter's ONLY gate for any isWizRequest()==true request --
+         // that filter skips its own stale/deactivated-user check entirely whenever
+         // isWizRequest() is true, trusting this filter to be authoritative (see
+         // AbstractSecurityFilter#isWizRequest's own doc comment). So the equivalent check
+         // must run HERE before falling through, or an already-deactivated user's stale
+         // session could ride through unauthenticated-but-unrejected.
+         if(hasValidActiveSession(httpRequest)) {
+            chain.doFilter(request, response);
+            return;
+         }
+
          sendUnauthorized(httpResponse, "Unauthorized");
          return;
       }
@@ -157,6 +178,35 @@ public class WizServiceAuthenticationFilter extends AbstractSecurityFilter {
     */
    private boolean isWizAuthEnabled() {
       return "true".equalsIgnoreCase(SreeEnv.getProperty(WIZ_AUTH_ENABLED_PROPERTY, "true"));
+   }
+
+   /**
+    * Mirrors {@link inetsoft.web.security.InvalidateSessionFilter}'s own active-user check --
+    * that filter skips it entirely for any {@code isWizRequest()} request, trusting this filter
+    * to be the sole gate (see this class's own doc comment and
+    * {@code AbstractSecurityFilter#isWizRequest}'s). When the JWT itself is invalid or expired,
+    * falling through to let an already-established StyleBI session handle the request is only
+    * safe if that session's own principal is still genuinely active -- otherwise a request from
+    * an already-deactivated or logged-out user could slip through with neither this filter's own
+    * JWT check nor InvalidateSessionFilter's (skipped) check ever having verified it.
+    *
+    * @return {@code true} if an existing session already carries a principal that is either a
+    *         genuinely active user, or security is disabled entirely (mirroring
+    *         InvalidateSessionFilter's own {@code isSecurityEnabled()} gate around its check).
+    */
+   private boolean hasValidActiveSession(HttpServletRequest request) {
+      Principal existing = SUtil.getPrincipal(request, false);
+
+      if(!(existing instanceof SRPrincipal)) {
+         return false;
+      }
+
+      if(!isSecurityEnabled()) {
+         return true;
+      }
+
+      SecurityEngine securityEngine = getSecurityEngine();
+      return securityEngine != null && securityEngine.isActiveUser((SRPrincipal) existing);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilterTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/security/WizServiceAuthenticationFilterTest.java
@@ -1,0 +1,252 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.security;
+
+import inetsoft.sree.RepletRepository;
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.*;
+import inetsoft.sree.web.SessionLicenseServiceProvider;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Bug 76489: a stale/invalid wiz_auth JWT (expiry, or an SSO signing-key rotation) used to
+ * hard-401 unconditionally, even when the browser separately held a still-valid StyleBI session
+ * -- turning any JWT staleness into a permanent, silent "Generating..." hang in the Composer's
+ * AI-agent pairing flow, since the client had nothing to recover from. These tests exercise the
+ * fallthrough this fix adds, and -- the load-bearing case -- that it does NOT reopen the
+ * stale/deactivated-session gap InvalidateSessionFilter's own isWizRequest() skip depends on this
+ * filter to guard.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class WizServiceAuthenticationFilterTest {
+
+   @Mock private SessionLicenseServiceProvider licenseProvider;
+   @Mock private AuthenticationService authService;
+   @Mock private FilterChain chain;
+
+   private MockedStatic<SreeEnv> sreeEnvMock;
+   private MockedStatic<SecurityEngine> securityEngineMock;
+   private SecurityEngine mockEngine;
+   private SecurityProvider mockProvider;
+   private WizServiceAuthenticationFilter filter;
+
+   @BeforeEach
+   void setUp() {
+      // isWizAuthEnabled() calls SreeEnv.getProperty(WIZ_AUTH_ENABLED_PROPERTY, "true"), which
+      // without a real Spring context throws ShutdownException via PropertiesEngine.getInstance()
+      // -> ConfigurationContext.getSpringBean(). Mock it to just return the caller's own default,
+      // same as every other security-filter test in this package (see AnonymousUserFilterTest).
+      sreeEnvMock = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
+      sreeEnvMock.when(() -> SreeEnv.getProperty(anyString(), anyString()))
+         .thenAnswer(invocation -> invocation.getArgument(1));
+
+      securityEngineMock = mockStatic(SecurityEngine.class, withSettings().strictness(Strictness.LENIENT));
+      mockEngine = mock(SecurityEngine.class, withSettings().lenient());
+      mockProvider = mock(SecurityProvider.class, withSettings().lenient());
+      when(mockEngine.getSecurityProvider()).thenReturn(mockProvider);
+      // Unstubbed default method -> Mockito does not invoke it; isVirtual() unstubbed -> false,
+      // so isSecurityEnabled() defaults to true, matching a standard (non-virtual) deployment.
+      // Same gotcha as InvalidateSessionFilterTest.
+      when(mockProvider.getAuthenticationProvider()).thenReturn(mockProvider);
+      securityEngineMock.when(SecurityEngine::getSecurity).thenReturn(mockEngine);
+
+      filter = new WizServiceAuthenticationFilter(licenseProvider, authService);
+
+      // @PostConstruct never fires on a plain "new" in a unit test, so ssoKeyPair starts null;
+      // validateTokenAndCreatePrincipal()'s lazy-load fallback then calls
+      // PasswordEncryption.newInstance(), which needs a real Spring context and throws
+      // ShutdownException -- masking the actual JWT-parse failure these tests mean to exercise
+      // under the generic catch(Exception) branch instead of catch(WizAuthenticationException).
+      // Set a real key pair directly so validateTokenAndCreatePrincipal reaches SignedJWT.parse()
+      // and fails there instead, for a genuine WizAuthenticationException.
+      try {
+         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+         generator.initialize(2048);
+         KeyPair keyPair = generator.generateKeyPair();
+         ReflectionTestUtils.setField(filter, "ssoKeyPair", keyPair);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvMock.close();
+      securityEngineMock.close();
+   }
+
+   // ── outer gates, unchanged behavior ───────────────────────────────────────
+
+   @Test
+   void doFilter_notWizRequest_skipsFilter_callsChain() throws Exception {
+      MockHttpServletRequest request = wizPathRequest();
+      request.setServletPath("/portal/dashboard"); // no wiz_auth cookie, not /api/wiz/**
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(request, response);
+      assertEquals(200, response.getStatus());
+   }
+
+   @Test
+   void doFilter_noAuthorizationHeader_fallsThroughForOtherFiltersToHandle() throws Exception {
+      MockHttpServletRequest request = wizPathRequest();
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(request, response);
+      assertEquals(200, response.getStatus());
+   }
+
+   // ── invalid JWT, no existing session to fall back to: still 401 (unchanged) ──
+
+   @Test
+   void doFilter_invalidJwt_noExistingSession_stays401_neverCallsChain() throws Exception {
+      MockHttpServletRequest request = wizPathRequest();
+      request.addHeader("Authorization", "Bearer not-a-real-jwt");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(401, response.getStatus());
+      verify(chain, never()).doFilter(any(), any());
+   }
+
+   // ── invalid JWT, existing session: the new fallthrough ────────────────────
+
+   @Test
+   void doFilter_invalidJwt_existingActiveSession_fallsThrough_neverSends401() throws Exception {
+      MockHttpServletRequest request = wizPathRequest();
+      request.addHeader("Authorization", "Bearer not-a-real-jwt");
+      SRPrincipal principal = activePrincipal();
+      request.getSession(true).setAttribute(RepletRepository.PRINCIPAL_COOKIE, principal);
+      when(mockEngine.isActiveUser(principal)).thenReturn(true);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(request, response);
+      assertEquals(200, response.getStatus());
+   }
+
+   @Test
+   void doFilter_invalidJwt_existingInactiveSession_stays401_neverCallsChain() throws Exception {
+      // The load-bearing case: InvalidateSessionFilter skips its OWN isActiveUser() check for
+      // any isWizRequest()==true request, trusting this filter to be the sole gate. A naive
+      // fallthrough (chain.doFilter() unconditionally on any invalid JWT) would let an
+      // already-deactivated user's stale session ride through with NEITHER filter's check ever
+      // having run. This proves that gap is NOT reopened: an inactive principal still 401s.
+      MockHttpServletRequest request = wizPathRequest();
+      request.addHeader("Authorization", "Bearer not-a-real-jwt");
+      SRPrincipal principal = activePrincipal();
+      request.getSession(true).setAttribute(RepletRepository.PRINCIPAL_COOKIE, principal);
+      when(mockEngine.isActiveUser(principal)).thenReturn(false);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(401, response.getStatus());
+      verify(chain, never()).doFilter(any(), any());
+   }
+
+   @Test
+   void doFilter_invalidJwt_sessionWithNoPrincipal_stays401() throws Exception {
+      MockHttpServletRequest request = wizPathRequest();
+      request.addHeader("Authorization", "Bearer not-a-real-jwt");
+      request.getSession(true); // session exists but carries no PRINCIPAL_COOKIE attribute
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals(401, response.getStatus());
+      verify(mockEngine, never()).isActiveUser(any());
+      verify(chain, never()).doFilter(any(), any());
+   }
+
+   @Test
+   void doFilter_invalidJwt_securityDisabled_existingSession_fallsThroughWithoutCheckingActiveUser()
+      throws Exception
+   {
+      when(mockProvider.isVirtual()).thenReturn(true); // isSecurityEnabled() -> false
+      MockHttpServletRequest request = wizPathRequest();
+      request.addHeader("Authorization", "Bearer not-a-real-jwt");
+      request.getSession(true).setAttribute(RepletRepository.PRINCIPAL_COOKIE, activePrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      verify(chain).doFilter(request, response);
+      assertEquals(200, response.getStatus());
+      verify(mockEngine, never()).isActiveUser(any());
+   }
+
+   @Test
+   void doFilter_invalidJwt_securityEngineUnavailable_stays401() throws Exception {
+      // getSecurityEngine() can return null (e.g. cluster shutdown) even when
+      // isSecurityEnabled() reported true a moment earlier -- same race
+      // InvalidateSessionFilterTest guards for its own doFilter(). Must not NPE, and must not
+      // treat "engine unavailable" as "fall through".
+      securityEngineMock.when(SecurityEngine::getSecurity).thenReturn(mockEngine, (SecurityEngine) null);
+      MockHttpServletRequest request = wizPathRequest();
+      request.addHeader("Authorization", "Bearer not-a-real-jwt");
+      request.getSession(true).setAttribute(RepletRepository.PRINCIPAL_COOKIE, activePrincipal());
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      assertDoesNotThrow(() -> filter.doFilter(request, response, chain));
+
+      assertEquals(401, response.getStatus());
+      verify(chain, never()).doFilter(any(), any());
+   }
+
+   // ── helpers ────────────────────────────────────────────────────────────────
+
+   private static MockHttpServletRequest wizPathRequest() {
+      MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/wiz/pairing/mint");
+      request.setServletPath("/api/wiz/pairing/mint");
+      return request;
+   }
+
+   private static SRPrincipal activePrincipal() {
+      SRPrincipal principal = mock(SRPrincipal.class, withSettings().lenient());
+      when(principal.getRoles()).thenReturn(new IdentityID[0]);
+      when(principal.getName()).thenReturn("alice" + IdentityID.KEY_DELIMITER + "default");
+      return principal;
+   }
+}


### PR DESCRIPTION
## Summary

Redmine #76489, Finding 3: `WizServiceAuthenticationFilter` hard-401'd unconditionally on any invalid/expired `wiz_auth` JWT (an SSO signing-key rotation, or ordinary token expiry) -- even when the browser separately held a still-valid StyleBI session. This turned any JWT staleness into a permanent, silent "Generating..." hang in the Composer's AI-agent pairing flow, since the client (fixed separately in stylebi#5046) had nothing to recover from -- there was no valid session to fall back to.

## Root cause and the security wrinkle

The obvious fix -- fall through to `chain.doFilter()` on an invalid JWT, mirroring the existing "no token provided" path -- would have reopened a real gap: `InvalidateSessionFilter` skips its own stale/deactivated-user check (`isActiveUser`) entirely for any `isWizRequest()==true` request (see that filter's own doc comment), trusting `WizServiceAuthenticationFilter` to be the sole authoritative gate for these requests. A naive fallthrough would let an already-deactivated user's stale session ride through with **neither** filter's check ever having run.

## Fix

`catch(WizAuthenticationException e)` now calls a new `hasValidActiveSession(request)`, which mirrors `InvalidateSessionFilter`'s own check (`SUtil.getPrincipal(request, false)` + `securityEngine.isActiveUser(...)`, same `isSecurityEnabled()` bypass) before falling through. An inactive/deactivated principal, no session, or no principal at all still 401 exactly as before -- only a genuinely still-active existing session is allowed to carry the request onward.

## Tests

`WizServiceAuthenticationFilterTest.java` (no test existed for this filter before this PR) -- 8 cases:
- 2 preserved-unchanged paths (not a wiz request, no Authorization header)
- the new fallthrough (active session)
- 4 cases proving the gap is **not** reopened (no session, no principal, inactive principal, security-engine-unavailable race)
- the security-disabled bypass

Full `inetsoft.web.security` + `inetsoft.web.wiz.security` package suite (14 test classes, 143 tests) run and green -- no regressions.

## Review notes

This touches authentication code. Findings 1 (nginx) and 2 (client-side hang, stylebi#5046) are already merged and live-verified against the running dev deployment; this PR is the third and final piece, and was explicitly called out by the original investigation as needing security review before anyone changed this filter's behavior -- please review the `hasValidActiveSession` design (mirroring, not bypassing, `InvalidateSessionFilter`'s own check) closely.

Full archive: `docs/teams/2026-09-07-bugs-76489-76490-env/` (stylebi-wiz repo), see STATUS.md's "Finding 3 fix" section.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>