### PR TITLE
Bug #76560 follow-up: fix 0-row table height mismatch in ScrollableTableDirective

### DIFF
--- a/web/projects/portal/src/app/widget/scrollable-table/scrollable-table.directive.ts
+++ b/web/projects/portal/src/app/widget/scrollable-table/scrollable-table.directive.ts
@@ -51,6 +51,7 @@ export class ScrollableTableDirective implements AfterContentInit, AfterContentC
             headCells[i].style.width = `${thead.offsetWidth / headCells.length}px`;
          }
 
+         this.setBodyHeight();
          return;
       }
 
@@ -68,22 +69,7 @@ export class ScrollableTableDirective implements AfterContentInit, AfterContentC
          totalw += w;
       }
 
-      const tableStyle = window.getComputedStyle(table);
-
-      if(!tbody.style.height) {
-         let tableHeight: string;
-
-         if(tableStyle.maxHeight && tableStyle.maxHeight !== "none") {
-            tableHeight = tableStyle.maxHeight;
-         }
-         else {
-            tableHeight = tableStyle.height;
-         }
-
-         if(tableHeight) {
-            tbody.style.height = `calc(${tableHeight} - ${thead.offsetHeight}px)`;
-         }
-      }
+      this.setBodyHeight();
 
       const scroll = tbody.scrollHeight > table.offsetHeight - thead.offsetHeight;
       const bodyw = Math.min(tbody.offsetWidth, table.parentElement.offsetWidth);
@@ -100,6 +86,28 @@ export class ScrollableTableDirective implements AfterContentInit, AfterContentC
             ? `${colw + 16}px` : `${colw}px`;
          bodyCells[i].style.width = `${colw}px`;
          bodyCells[i].style.maxWidth = `${colw}px`;
+      }
+   }
+
+   private setBodyHeight(): void {
+      const table = this.element.nativeElement;
+      const thead = table.querySelector("thead");
+      const tbody = table.querySelector("tbody");
+
+      if(!tbody.style.height) {
+         const tableStyle = window.getComputedStyle(table);
+         let tableHeight: string;
+
+         if(tableStyle.maxHeight && tableStyle.maxHeight !== "none") {
+            tableHeight = tableStyle.maxHeight;
+         }
+         else {
+            tableHeight = tableStyle.height;
+         }
+
+         if(tableHeight) {
+            tbody.style.height = `calc(${tableHeight} - ${thead.offsetHeight}px)`;
+         }
       }
    }
 


### PR DESCRIPTION
## Summary

Follow-up to the already-merged fix for bug 76560 (PR #5159), found by a human tester (Sally Ma) while verifying it in the running app.

PR #5159 fixed `ScrollableTableDirective`'s dead `tbody.style.height == null` guard, so the height calculation now correctly runs when a table has at least one row, locking that table's body to the CSS `max-height` (50vh). However, `setColumnWidths()`'s early-return branch for tables with 0 rows skipped that height assignment entirely, so an empty table fell back to the CSS `min-height` (40vh) instead of matching a sibling non-empty table's 50vh — a visible height mismatch between two side-by-side lists (e.g. the Filters/Shared Filters lists in Dashboard Options when one is empty and the other isn't).

## Fix

Extracted the height calculation into a new `setBodyHeight()` method and call it from both the 0-row early-return branch and the main path, so both compute the height identically instead of one of them silently no-oping.

## Testing

`ng build portal --configuration development` succeeds clean.

Fixes https://173.220.179.100/issues/76560 (follow-up finding, ticket reopened after the original PR #5159 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)