### PR TITLE
fix(wiz): preserve dimension sort/ranking across a shelf rewrite (#76574 VTB-004)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -136,12 +136,19 @@ public final class TableBindingMutator {
       }
 
       switch(name) {
-         case "rows" -> ((CrosstabBindingModel) model).setRows(
-            dimensions(refs, rvs, source, refModelService));
-         case "cols" -> ((CrosstabBindingModel) model).setCols(
-            dimensions(refs, rvs, source, refModelService));
-         case "groups" -> ((TableBindingModel) model).setGroups(
-            dimensions(refs, rvs, source, refModelService));
+         case "rows", "cols", "groups" -> {
+            // Captured before the overwrite below, so an unchanged field at the same position
+            // keeps its sort/ranking instead of dimensions() building it a fresh default one --
+            // see dimensions()'s own note on why this is matched by position, not just column.
+            List<BDimensionRefModel> previous = dimensionsOf(model, name);
+            List<BDimensionRefModel> next = dimensions(refs, previous, rvs, source, refModelService);
+
+            switch(name) {
+               case "rows" -> ((CrosstabBindingModel) model).setRows(next);
+               case "cols" -> ((CrosstabBindingModel) model).setCols(next);
+               default -> ((TableBindingModel) model).setGroups(next);
+            }
+         }
          case "details" -> ((TableBindingModel) model).setDetails(details(refs));
          default -> model.setAggregates(aggregates(refs));
       }
@@ -424,17 +431,34 @@ public final class TableBindingMutator {
     * overload too.
     */
    private static List<BDimensionRefModel> dimensions(List<FieldRef> fields) {
-      return dimensions(fields, null, null, null);
+      return dimensions(fields, List.of(), null, null, null);
    }
 
-   private static List<BDimensionRefModel> dimensions(List<FieldRef> fields, RuntimeViewsheet rvs,
+   /**
+    * @param previous the shelf's own {@code BDimensionRefModel} list before this write, so a
+    *                 field that is unchanged keeps its sort/ranking instead of resetting to
+    *                 {@code BDimensionRefModel}'s class defaults on every write (VTB-004).
+    *                 Matched by <b>same absolute index + same column (case-insensitive) + same
+    *                 date level</b> -- the same position-keyed identity {@link #requireDimension}
+    *                 and {@code pruneOrphanedSuppression} already use to disambiguate a column
+    *                 bound twice on one shelf, not a content-only key. This deliberately does
+    *                 NOT survive an insert/remove of a different field earlier on the shelf
+    *                 shifting a later, untouched field's index -- that field's sort/ranking is
+    *                 not preserved in that case, which is accepted as this strategy's known
+    *                 boundary rather than a defect (see the regression test that documents it).
+    */
+   private static List<BDimensionRefModel> dimensions(List<FieldRef> fields,
+                                                       List<BDimensionRefModel> previous,
+                                                       RuntimeViewsheet rvs,
                                                        SourceInfo source,
                                                        DataRefModelFactoryService refModelService)
    {
       List<BDimensionRefModel> out = new ArrayList<>();
 
-      for(FieldRef field : fields) {
-         BDimensionRefModel ref = new BDimensionRefModel();
+      for(int i = 0; i < fields.size(); i++) {
+         FieldRef field = fields.get(i);
+         BDimensionRefModel match = i < previous.size() ? previous.get(i) : null;
+         BDimensionRefModel ref = matches(match, field) ? copyOf(match) : new BDimensionRefModel();
          ref.setName(field.column());
          ref.setColumnValue(field.column());
 
@@ -461,6 +485,43 @@ public final class TableBindingMutator {
       }
 
       return out;
+   }
+
+   /** Whether {@code previous} is the same occurrence of the same column as {@code field}. */
+   private static boolean matches(BDimensionRefModel previous, FieldRef field) {
+      if(previous == null || field.column() == null) {
+         return false;
+      }
+
+      String previousColumn = previous.getColumnValue() == null
+         ? previous.getName() : previous.getColumnValue();
+
+      if(previousColumn == null || !previousColumn.equalsIgnoreCase(field.column())) {
+         return false;
+      }
+
+      String previousLevel = previous.getDateLevel();
+      String incomingLevel = DateLevels.normalize(field.dateLevel());
+      boolean previousUnset = previousLevel == null || previousLevel.isBlank() ||
+         "-1".equals(previousLevel);
+      boolean incomingUnset = incomingLevel == null || "-1".equals(incomingLevel);
+
+      return previousUnset && incomingUnset || Objects.equals(previousLevel, incomingLevel);
+   }
+
+   /** A copy of {@code previous}'s sort/ranking, for a field matched at the same position. */
+   private static BDimensionRefModel copyOf(BDimensionRefModel previous) {
+      BDimensionRefModel ref = new BDimensionRefModel();
+      ref.setOrder(previous.getOrder());
+      ref.setSortByCol(previous.getSortByCol());
+      ref.setManualOrder(previous.getManualOrder() == null
+         ? null : new ArrayList<>(previous.getManualOrder()));
+      ref.setRankingOption(previous.getRankingOption());
+      ref.setRankingN(previous.getRankingN());
+      ref.setRankingCol(previous.getRankingCol());
+      ref.setGroupOthers(previous.isGroupOthers());
+      ref.setOthers(previous.isOthers());
+      return ref;
    }
 
    private static List<BAggregateRefModel> aggregates(List<FieldRef> fields) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -480,6 +480,16 @@ public final class TableBindingMutator {
 
             ref.setOrder(XConstants.SORT_SPECIFIC);
          }
+         else if((ref.getOrder() & XConstants.SORT_SPECIFIC) != 0 &&
+            (ref.getNamedGroupInfo() == null || ref.getNamedGroupInfo().getType() == 0) &&
+            (ref.getManualOrder() == null || ref.getManualOrder().isEmpty()))
+         {
+            // ref may have carried SORT_SPECIFIC forward from a matched previous ref (copyOf())
+            // whose named group this incoming field no longer supplies -- strip it so the model
+            // doesn't carry SORT_SPECIFIC with nothing backing it. Mirrors the same self-heal
+            // BDimensionRefModel.createDataRef() already applies at conversion time.
+            ref.setOrder(ref.getOrder() & ~XConstants.SORT_SPECIFIC);
+         }
 
          out.add(ref);
       }

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -714,6 +714,145 @@ class TableBindingMutatorTest {
       assertTrue(described.containsKey("Region"));
    }
 
+   // ── sort/ranking survives a shelf rewrite (VTB-004, Redmine #76574) ────────
+   //
+   // setShelf/dimensions() used to build a brand-new BDimensionRefModel for every field on
+   // every write, discarding order/rankingOpt/rankingN/rankingCol/manualOrder/groupOthers/
+   // namedOthers even for a field that did not change. The fix matches a new field to the
+   // shelf's own previous list by same absolute index + same column (case-insensitive) + same
+   // date level -- the same position-keyed identity requireDimension/pruneOrphanedSuppression
+   // already use to disambiguate a column bound twice, not a dateLevel-content key. See
+   // 03-fix.md for why that (strategy (a)) was chosen over matching by (column, dateLevel)
+   // alone (strategy (b)).
+
+   @Test
+   void resubmittingTheIdenticalFieldListPreservesSortAndRanking() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+      TableBindingMutator.setShelf(model, "aggregates",
+                                   List.of(new FieldRef("Sales", "measure", "sum", null, null)));
+      TableBindingMutator.setSort(model, "rows", "Region", null,
+                                  new DimensionSortRanking.Sort("desc", null, null));
+      TableBindingMutator.setRanking(model, "rows", "Region", null,
+                                     new DimensionSortRanking.Ranking("top", 5, "Sales", null));
+
+      // The filed repro: resubmit the identical field list to the same shelf.
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      assertEquals(XConstants.SORT_DESC, model.getRows().get(0).getOrder(),
+         "an unchanged field's sort must survive a shelf resubmission");
+      assertEquals("5", model.getRows().get(0).getRankingN());
+      assertEquals("Sales", model.getRows().get(0).getRankingCol());
+   }
+
+   @Test
+   void addFieldPreservesSortOnAFieldThatStaysAtTheSamePosition() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+      TableBindingMutator.setSort(model, "rows", "Region", null,
+                                  new DimensionSortRanking.Sort("desc", null, null));
+
+      TableBindingMutator.addField(model, "rows", dim("Year"), null); // appended after Region
+
+      assertEquals(XConstants.SORT_DESC, model.getRows().get(0).getOrder(),
+         "REGION stays at index 0, so appending YEAR after it must not reset its sort");
+   }
+
+   @Test
+   void removeFieldPreservesSortOnAFieldThatStaysAtTheSamePosition() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region"), dim("Category")));
+      TableBindingMutator.setSort(model, "rows", "Region", null,
+                                  new DimensionSortRanking.Sort("desc", null, null));
+
+      TableBindingMutator.removeField(model, "rows", "Category");
+
+      assertEquals(XConstants.SORT_DESC, model.getRows().get(0).getOrder(),
+         "REGION stays at index 0 after removing the later CATEGORY field, so its sort must " +
+         "survive");
+   }
+
+   @Test
+   void moveFieldPreservesSortOnAFieldThatStaysOnTheSameShelfAtTheSamePosition() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region"), dim("Category")));
+      TableBindingMutator.setSort(model, "rows", "Region", null,
+                                  new DimensionSortRanking.Sort("desc", null, null));
+
+      TableBindingMutator.moveField(model, "rows", "cols", "Category", null);
+
+      assertEquals(1, model.getRows().size());
+      assertEquals(XConstants.SORT_DESC, model.getRows().get(0).getOrder(),
+         "REGION stays at rows index 0, so moving CATEGORY off the shelf must not reset its " +
+         "sort");
+   }
+
+   @Test
+   void resubmittingADuplicateBoundColumnKeepsEachOccurrencesSortSeparate() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows",
+         List.of(dated("ORDER_DATE", "year"), dated("ORDER_DATE", "quarter")));
+      TableBindingMutator.setSort(model, "rows", "ORDER_DATE", 0,
+         new DimensionSortRanking.Sort("desc", null, null));
+      TableBindingMutator.setSort(model, "rows", "ORDER_DATE", 1,
+         new DimensionSortRanking.Sort("manual", null, List.of("Q1", "Q2", "Q3", "Q4")));
+
+      TableBindingMutator.setShelf(model, "rows",
+         List.of(dated("ORDER_DATE", "year"), dated("ORDER_DATE", "quarter")));
+
+      assertEquals(XConstants.SORT_DESC, model.getRows().get(0).getOrder(),
+         "the year occurrence's sort must not cross-contaminate with the quarter occurrence's");
+      assertEquals(XConstants.SORT_SPECIFIC, model.getRows().get(1).getOrder());
+      assertEquals(List.of("Q1", "Q2", "Q3", "Q4"), model.getRows().get(1).getManualOrder());
+   }
+
+   /**
+    * Documents strategy (a)'s accepted boundary, not a bug: matching is by absolute shelf
+    * index, not by following a field across an edit elsewhere on the shelf. Removing CATEGORY
+    * (index 0) shifts ORDER_DATE from index 1 to index 0, so the new index-0 field no longer
+    * matches "the same position" ORDER_DATE held, and its sort resets to default instead of
+    * surviving.
+    */
+   @Test
+   void removingAnEarlierFieldShiftsALaterFieldsIndexSoItsSortIsNotPreserved() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Category"), dim("ORDER_DATE")));
+      TableBindingMutator.setSort(model, "rows", "ORDER_DATE", null,
+         new DimensionSortRanking.Sort("desc", null, null));
+
+      TableBindingMutator.removeField(model, "rows", "Category");
+
+      assertEquals(1, model.getRows().size());
+      assertEquals(XConstants.SORT_ASC, model.getRows().get(0).getOrder(),
+         "ORDER_DATE shifted from index 1 to index 0, so strategy (a) does not preserve its " +
+         "sort across this edit -- accepted boundary, not a bug");
+   }
+
+   /**
+    * Refuter's edge case on 02-refute.md: {@code requireKnownMeasure} validation only runs from
+    * {@link TableBindingMutator#setSort}/{@link TableBindingMutator#setRanking}, never from
+    * {@code setShelf}/{@code dimensions()} -- so a preserved ranking reference can go stale if
+    * its aggregate is removed in a companion edit. Confirmed here that this does not throw or
+    * otherwise corrupt the model; it is a pre-existing gap in {@code requireKnownMeasure}'s
+    * coverage, out of scope for VTB-004's own fix (see 03-fix.md).
+    */
+   @Test
+   void removingTheReferencedAggregateLeavesAStaleRankingReferenceRatherThanBreaking() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+      TableBindingMutator.setShelf(model, "aggregates",
+         List.of(new FieldRef("Sales", "measure", "sum", null, null)));
+      TableBindingMutator.setRanking(model, "rows", "Region", null,
+         new DimensionSortRanking.Ranking("top", 5, "Sales", null));
+
+      TableBindingMutator.removeField(model, "aggregates", "Sales");
+
+      assertEquals("Sales", model.getRows().get(0).getRankingCol(),
+         "removing the referenced aggregate neither clears nor validates a preserved ranking " +
+         "reference -- it goes stale rather than erroring, a pre-existing gap noted for the " +
+         "record, not fixed here");
+   }
+
    // ── column labels (2d Phase 2) ────────────────────────────────────────────
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -807,6 +807,53 @@ class TableBindingMutatorTest {
    }
 
    /**
+    * PR #5178 review round 1 (Important): {@code copyOf()} carries {@code order} forward from
+    * the matched previous ref unconditionally, but the named-group reapply block below it only
+    * ever SETS {@code SORT_SPECIFIC} when the incoming field supplies {@code namedGroupValues}/
+    * {@code namedGroup} -- there was no path to clear it back off when the incoming field drops
+    * the group. A field previously bound to a named group, resubmitted at the same column/index
+    * without {@code namedGroupValues}/{@code namedGroup}, must not be left at
+    * {@code SORT_SPECIFIC} with no {@code namedGroupInfo} backing it. Mirrors the self-heal
+    * {@code BDimensionRefModel.createDataRef()} already applies at conversion time.
+    */
+   @Test
+   void resubmittingANamedGroupedFieldWithoutNamedGroupClearsSortSpecific() throws Exception {
+      Condition condition = mock(Condition.class);
+      when(condition.getOperation()).thenReturn(Condition.EQUAL_TO);
+      when(condition.getValues()).thenReturn(List.of("CA"));
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(new AttributeRef(null, "REGION"), condition, 0));
+      NamedGroupInfo namedGroupInfo = new NamedGroupInfo();
+      namedGroupInfo.setGroupCondition("West", conditionList);
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Coastal");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource()).thenReturn(QUERY1_SOURCE);
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+      when(ngAssembly.getNamedGroupInfo()).thenReturn(namedGroupInfo);
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[]{ ngAssembly });
+
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dimWithNamedGroup("REGION", "Coastal")),
+                                   rvsWithWorksheet(ws), QUERY1_SOURCE, refModelService());
+      assertEquals(XConstants.SORT_SPECIFIC, model.getRows().get(0).getOrder());
+
+      // Resubmit REGION at the same index WITHOUT namedGroupValues/namedGroup -- dropping it.
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("REGION")),
+                                   rvsWithWorksheet(ws), QUERY1_SOURCE, refModelService());
+
+      BDimensionRefModel dim = model.getRows().get(0);
+      assertEquals(0, dim.getOrder() & XConstants.SORT_SPECIFIC,
+         "order must not be left with the SORT_SPECIFIC bit set once the named group backing " +
+         "it is dropped");
+      assertNull(dim.getNamedGroupInfo(),
+         "namedGroupInfo is null here, so order being SORT_SPECIFIC would be inconsistent");
+   }
+
+   /**
     * Documents strategy (a)'s accepted boundary, not a bug: matching is by absolute shelf
     * index, not by following a field across an edit elsewhere on the shelf. Removing CATEGORY
     * (index 0) shifts ORDER_DATE from index 1 to index 0, so the new index-0 field no longer


### PR DESCRIPTION
## Summary
- `TableBindingMutator.setShelf` rebuilt a crosstab shelf's `rows`/`cols`/`groups` dimension list from scratch on every write (`set_table_fields`, `add_table_field`, `remove_table_field`, `move_table_field` all funnel through it), so a field's `order`/`sortByCol`/`rankingOpt`/`rankingN`/`rankingCol`/`manualOrder`/`groupOthers`/`namedOthers` reset to class defaults even when nothing about that field changed — including a plain resubmission of the identical field list (Redmine #76574 / VTB-004).
- Fix: match a new field to the shelf's own previous list by **same absolute index + same column (case-insensitive) + same date level**, and carry its sort/ranking forward when matched. This is strategy (a) from the diagnosis/refutation pair in `docs/teams/2026-09-11-bugs-vtb-p2/bug-76574-vtb004/` — chosen over the diagnosis's own initial recommendation of a content-keyed match, per the refuter's correction that `requireDimension`/`pruneOrphanedSuppression`/the plugin's own `set_field_sort` tool contract all key duplicate-column identity by absolute shelf position, not date-level content.
- Known, accepted boundary of this strategy (documented in a regression test, not silently accepted): an insert/remove of an *earlier* field on the same shelf shifts a *later*, untouched field's absolute index, and that field's sort/ranking is not preserved across the shift.
- Out of scope, noted only: the sibling `aggregates()` helper has the same "always build a fresh ref" shape for `calculateInfo` — flagged as a candidate follow-on, not fixed here.

## Test plan
- [x] `mvn -pl core test -Dtest=TableBindingMutatorTest` — 74 run (67 existing + 7 new), 0 failures
- [x] `mvn -pl core test -Dtest=TableBindingServiceTest,ChartBindingMutatorTest` — 29 / 28 run, 0 failures (regression check on adjacent tests exercising the same mutator)
- [x] `mvn -pl core test -Dtest=BindingAgentControllerTest` — 19 run, 0 failures
- [ ] Live plugin-tool round trip (`set_field_sort`/`set_field_ranking` → `get_table_binding` → `set_table_fields` resubmit → `get_table_binding`) — not performed; no live StyleBI/backend or `mcp__composer-chat__*` tools were reachable in the fixer's session. Flagging for reviewer/user to run if a live stack is available.

Full root-cause writeup, diff, and self-verification notes: `docs/teams/2026-09-11-bugs-vtb-p2/bug-76574-vtb004/03-fix.md` in the `stylebi-wiz` repo (this PR is in `stylebi`, the docs live in the sibling repo per this batch's workflow).

**Not merging** — holding for explicit review/sign-off per this batch's merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)