### PR TITLE
fix(wiz): don't clobber paired-browser socket session on agent input writes

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -2808,8 +2808,15 @@ public class VSInputService {
 
       int hint;
 
-      rvs.setSocketSessionId(dispatcher.getSessionId());
-      rvs.setSocketUserName(dispatcher.getUserName());
+      // Only adopt the dispatcher's socket session when it actually has one (a real STOMP
+      // dispatcher from a native browser controller). A CapturingCommandDispatcher (used by the
+      // wiz agent's InputValueService) has no real session and would otherwise clobber the
+      // already-correct paired-browser session id, silently disabling
+      // SheetAgentBroadcastService's refresh broadcast for every agent-driven input change.
+      if(dispatcher.getSessionId() != null) {
+         rvs.setSocketSessionId(dispatcher.getSessionId());
+         rvs.setSocketUserName(dispatcher.getUserName());
+      }
 
       box.get().lockWrite();
 

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSInputServiceSocketSessionTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSInputServiceSocketSessionTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.service;
+
+/*
+ * Test strategy (VTB-009 / Redmine #76574)
+ *
+ * VSInputService.applySelection unconditionally overwrote rvs's paired-browser socket session
+ * identity with whatever CommandDispatcher happened to be in play. The wiz agent's
+ * InputValueService.setValue (the sole agent-side caller of singleApplySelection/
+ * multiApplySelection/applySelection, serving CheckBox/ComboBox/RadioButton/TextInput/Spinner)
+ * always runs under a CapturingCommandDispatcher, whose getSessionId() deterministically returns
+ * null (it wraps a synthetic, non-STOMP message with no simpSessionId header). That null then
+ * clobbered rvs's already-correct socket session id, so
+ * SheetAgentBroadcastService.broadcastRefresh's "sessionId == null" guard silently skipped the
+ * paired browser's refresh broadcast on every single agent-driven input write.
+ *
+ * The fix only adopts the dispatcher's session id/user name when the dispatcher actually has one,
+ * so a CapturingCommandDispatcher (or any dispatcher with no real session) leaves an
+ * already-recorded socket session alone, while a real STOMP dispatcher (every native browser
+ * controller: VSSliderController, VSSpinnerController, VSCheckBoxController, OnClickService,
+ * VSRadioButtonController, VSTextInputController) still updates it exactly as before.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] A dispatcher with no session id (CapturingCommandDispatcher's shape) must NOT overwrite an
+ *      already-recorded socket session id/user name on the runtime viewsheet.
+ * [G2] A dispatcher with a real session id (native STOMP controller's shape) still updates the
+ *      runtime viewsheet's socket session id/user name, unchanged from before the fix.
+ */
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class VSInputServiceSocketSessionTest {
+   // [G1]
+   @Test
+   void aSessionlessDispatcherDoesNotClobberAnAlreadyRecordedSocketSession() throws Exception {
+      RuntimeViewsheet rvs = newMockRuntimeViewsheet();
+      when(rvs.getSocketSessionId()).thenReturn("already-correct-session");
+      when(rvs.getSocketUserName()).thenReturn("already-correct-user");
+
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+      when(dispatcher.getSessionId()).thenReturn(null);
+
+      invokeApplySelection(rvs, dispatcher);
+
+      verify(rvs, never()).setSocketSessionId(any());
+      verify(rvs, never()).setSocketUserName(any());
+   }
+
+   // [G2]
+   @Test
+   void aRealDispatchersSessionStillUpdatesTheSocketSession() throws Exception {
+      RuntimeViewsheet rvs = newMockRuntimeViewsheet();
+
+      CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+      when(dispatcher.getSessionId()).thenReturn("real-stomp-session");
+      when(dispatcher.getUserName()).thenReturn("real-browser-user");
+
+      invokeApplySelection(rvs, dispatcher);
+
+      verify(rvs).setSocketSessionId("real-stomp-session");
+      verify(rvs).setSocketUserName("real-browser-user");
+   }
+
+   /** A viewsheet whose sandbox is present but which has no assembly named "Assembly1", so
+    *  applySelection0 takes its early "not an InputVSAssembly" return -- the socket-session
+    *  clobber under test happens before that point regardless of the outcome. */
+   private static RuntimeViewsheet newMockRuntimeViewsheet() {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(vs.getAssembly("Assembly1")).thenReturn(null);
+
+      return rvs;
+   }
+
+   private static void invokeApplySelection(RuntimeViewsheet rvs, CommandDispatcher dispatcher)
+      throws Exception
+   {
+      VSObjectService vsObjectService = mock(VSObjectService.class);
+      Principal principal = mock(Principal.class);
+      when(vsObjectService.getRuntimeViewsheet(eq("vs-1"), eq(principal))).thenReturn(rvs);
+
+      VSInputService service = new VSInputService(vsObjectService, null, null, null, null, null,
+                                                    null, null, null);
+
+      Method method = VSInputService.class.getDeclaredMethod(
+         "applySelection", String.class, String.class, Object.class, Principal.class,
+         CommandDispatcher.class);
+      method.setAccessible(true);
+      method.invoke(service, "vs-1", "Assembly1", "value", principal, dispatcher);
+   }
+}


### PR DESCRIPTION
## Summary

- Redmine #76574 (VTB-009): after any agent-driven `set_input_value` (checkbox/combo box/radio
  button/text input/spinner), the paired live browser Composer session never received a refresh
  broadcast — the user had to manually click StyleBI's own in-app "Refresh" menu command to see
  the change.
- Root cause: `VSInputService.applySelection` unconditionally overwrote the runtime viewsheet's
  socket session id/user name with whatever `CommandDispatcher` was in play. The wiz agent's
  `InputValueService.setValue` always runs under a `CapturingCommandDispatcher`, whose
  `getSessionId()` is deterministically `null` (it wraps a synthetic, non-STOMP message with no
  `simpSessionId` header). That `null` clobbered the already-correct paired-browser session id, so
  `SheetAgentBroadcastService.broadcastRefresh`'s `sessionId == null` guard silently skipped the
  broadcast on every single agent-driven input write, deterministically, not intermittently.
- Fix: only adopt the dispatcher's session id/user name when the dispatcher actually has one.
  Native STOMP controllers (`VSSliderController`, `VSSpinnerController`, `VSCheckBoxController`,
  `OnClickService`, `VSRadioButtonController`, `VSTextInputController`) always carry a real
  session id, so this is a no-op for the human-click path — verified by reading each controller's
  `@MessageMapping` dispatch.
- Scoped to `VSInputService.applySelection` only, per the diagnosis. The same
  unconditional-overwrite pattern also exists at `CoreLifecycleService`, `ComposerViewsheetService`,
  and `VSLifecycleControllerService` (viewsheet-open-style flows, not this per-edit refresh path) —
  intentionally left untouched; worth a separate audit if an "open viewsheet" agent tool is ever
  built that reaches them via a `CapturingCommandDispatcher`.

## Test plan

- [x] New regression test `core/src/test/java/inetsoft/web/viewsheet/service/VSInputServiceSocketSessionTest.java`:
  - Confirms a sessionless dispatcher (`CapturingCommandDispatcher`'s shape) does NOT overwrite an
    already-recorded socket session id/user name.
  - Confirms a real dispatcher (native STOMP controller's shape) still updates it, unchanged from
    before the fix.
  - Verified the test fails against the pre-fix code (temporarily reverted the fix, reran, saw the
    expected `NeverWantedButInvoked` failure) and passes with the fix restored.
- [x] `./mvnw test -pl core -Dtest=VSInputServiceSocketSessionTest,ViewsheetSessionServiceTest,VSInputTableBindingResolutionTest,VSComboBoxDateValueTest` — all pass, no regressions in the surrounding input-service/session tests.
- [ ] Live self-verification via `mcp__composer-chat__*` tools was not possible in this session — those MCP tools are not available here. Unit tests are the verified bar for this PR; a live re-check (confirming the "Pairing broadcast skipped" WARN no longer fires for `set_input_value`) is recommended before merge if a paired-browser session is available.

Not chased in this PR (logged as open follow-on candidates from the live-check record, not this
mechanism):
- A field-write-level intermittency question from an earlier, separate investigation (unreproduced
  in 8/8 trials, unrelated to this socket-session mechanism).
- A "lagged by one step" broadcast-healing observation (a later call's `applySocketSession`
  "only if not set" guard can heal the socket id, and something then surfaces a stale update) — not
  traced to a specific mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)