### PR TITLE
Fix bug 76598: refuse deleting a non-removable schedule task before the owner-ADMIN precheck

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanService.java
@@ -193,6 +193,20 @@ public class ScheduleChangePlanService {
          throw new IllegalArgumentException(label + ".taskId: no task exists with id \"" + taskId + "\"");
       }
 
+      // Non-removable is a structural, permission-independent refusal -- the server marks a
+      // built-in/internal task (e.g. the 3 bundled maintenance tasks) or a synthesized data-cycle
+      // task as removable=false unconditionally, the same flag the EM task list's own Delete
+      // button is disabled on (Bug #76598). No caller, including the task's own owner or a Site
+      // Administrator, can delete it, so this must be checked and refused before -- and
+      // independently of -- the owner-ADMIN permission check below, which answers a different
+      // question ("do you have authority") than this one ("does this operation exist at all").
+      if(!existing.isRemovable()) {
+         throw new IllegalArgumentException(
+            label + ".taskId: \"" + taskId + "\" is a built-in/system task and cannot be deleted " +
+            "-- the server marks it non-removable for every caller regardless of permission, the " +
+            "same restriction the Enterprise Manager task list enforces by disabling Delete for it");
+      }
+
       // Inverse-permission preflight (spec §4): a delete's rollback is a re-create of the captured
       // task, which needs ADMIN over the owner (and executeAsID, if set) -- a strictly stronger
       // requirement than the DELETE this verb itself needs. Refuse now rather than mid-rollback.

--- a/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/schedule/ScheduleChangePlanServiceTest.java
@@ -250,6 +250,22 @@ class ScheduleChangePlanServiceTest {
       assertTrue(ex.getMessage().contains("no task exists"));
    }
 
+   // Bug #76598: a built-in/internal task (or a synthesized data-cycle task) is removable=false
+   // unconditionally -- the same flag that disables the Delete button in the EM task list -- and
+   // must be refused before the owner-ADMIN check even runs, since no caller (not even a Site
+   // Administrator, who bypasses that ADMIN check entirely) can delete it.
+   @Test void resolveDeleteThrowsWhenTaskIsNotRemovable() throws Exception {
+      inetsoft.sree.schedule.ScheduleTask task = sreeTask("__balance tasks__", "admin");
+      task.setRemovable(false);
+      when(scheduleManager.getScheduleTask("__balance tasks__")).thenReturn(task);
+      ScheduleChangePlanRequest req = request("task", List.of(deleteChange("__balance tasks__")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, user));
+      assertTrue(ex.getMessage().contains("cannot be deleted"));
+      verify(scheduleGateway, never()).hasOwnerAdminPermission(any(), any(), any());
+   }
+
    // A delete's rollback is a re-create -- requires ADMIN over the owner, strictly stronger than
    // the DELETE the verb itself needs (spec §4's asymmetric-gap finding).
    @Test void resolveDeleteThrowsWhenCallerLacksOwnerAdminPermissionForRollback() throws Exception {


### PR DESCRIPTION
## Summary
- `preview_schedule_task_changes`'s delete precheck only checked `hasOwnerAdminPermission`, so a task owned by an unresolvable pseudo-identity (`INETSOFT_SYSTEM` — the 3 built-in maintenance tasks, and synthesized data-cycle tasks) sailed through preview/apply as an ordinary delete for a Site Administrator caller. Root cause: the owner-ADMIN check is a no-op for Site Admins for ANY owner (`DefaultCheckPermissionStrategy`'s `isSiteAdmin` bypass returns `true` before any resource/identity resolution), so it was never actually capable of catching this case.
- The real EM task list already disables its own Delete button for these tasks via a separate, permission-independent flag: `ScheduleTask#removable` (set `false` at creation in `InternalScheduledTaskService`/`DataCycleManager`). `ScheduleChangePlanService#resolveDelete` never read it.
- Fix: check `existing.isRemovable()` first in `resolveDelete()` and refuse loud, naming the task, before the owner-ADMIN check runs. Deliberately keyed off the existing `removable` field rather than the owner identity, so it also covers data-cycle tasks and any future non-removable task type without hardcoding task names.

## Test plan
- [x] New unit test `resolveDeleteThrowsWhenTaskIsNotRemovable` in `ScheduleChangePlanServiceTest`
- [x] `ai/schedule` package (`ScheduleChangePlanServiceTest`, `AdminScheduleControllerTest`, `AdminScheduleGatewayTest`, `ScheduleChangesetApplyServiceTest`, `ScheduleXmlProjectionTest`) — 50/50 tests pass
- [x] Live-verified against a rebuilt local StyleBI instance through the plugin/admin `preview_schedule_task_changes` MCP tool: deleting `__balance tasks__` as Site Administrator `admin` is now refused with `"__balance tasks__" is a built-in/system task and cannot be deleted -- the server marks it non-removable for every caller regardless of permission, the same restriction the Enterprise Manager task list enforces by disabling Delete for it`

Redmine: #76598

🤖 Generated with [Claude Code](https://claude.com/claude-code)