### PR TITLE
Fix bug 76609 AID-003: group-owned schedule tasks ignored on delete/rename

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java
@@ -1088,7 +1088,7 @@ public class ScheduleManager {
             continue;
          }
 
-         if(type == Identity.USER && identityID.equals(task.getOwner())) {
+         if((type == Identity.USER || type == Identity.GROUP) && identityID.equals(task.getOwner())) {
             i.remove();
             continue;
          }
@@ -1162,7 +1162,7 @@ public class ScheduleManager {
             continue;
          }
 
-         if(type == Identity.USER && identityID.equals(task.getOwner())) {
+         if((type == Identity.USER || type == Identity.GROUP) && identityID.equals(task.getOwner())) {
             ownedTasks.add(task.getName());
             continue;
          }
@@ -1202,7 +1202,7 @@ public class ScheduleManager {
             continue;
          }
 
-         if(type == Identity.USER && oname.equals(task.getOwner())) {
+         if((type == Identity.USER || type == Identity.GROUP) && oname.equals(task.getOwner())) {
             String oldTaskId = task.getTaskId();
             this.getOrgTaskMap(orgID).remove(getTaskIdentifier(oldTaskId, orgID));
             task.setOwner(id);

--- a/core/src/test/java/inetsoft/sree/schedule/ScheduleManagerTest.java
+++ b/core/src/test/java/inetsoft/sree/schedule/ScheduleManagerTest.java
@@ -70,6 +70,7 @@ public class ScheduleManagerTest {
 
    private IdentityID identityID_admin;
    private IdentityID identityID_tuser0;
+   private IdentityID identityID_tgroup0;
    private SRPrincipal admin;
    private SRPrincipal tuser0;
 
@@ -77,6 +78,7 @@ public class ScheduleManagerTest {
    void before() {
       identityID_admin = new IdentityID("admin", "host-org");
       identityID_tuser0 = new IdentityID("tuser0", "host-org");
+      identityID_tgroup0 = new IdentityID("tgroup0", "host-org");
       admin = new SRPrincipal(new IdentityID("admin", Organization.getDefaultOrganizationID()),
                               new IdentityID[] { new IdentityID("Administrator", null)},
                               new String[] {"g0"}, "host-org",
@@ -487,6 +489,71 @@ public class ScheduleManagerTest {
 
       // the read-only impact check must not delete the owned task
       assertNotNull(scheduleManager.getScheduleTask("tuser0~;~host-org:impact_owned"));
+   }
+
+   /**
+    * Regression test for Bug #76609 AID-003: getIdentityRemovalImpact() must report tasks owned
+    * by a GROUP the same way it reports tasks owned by a user -- ScheduleTask.getOwner() is a
+    * bare IdentityID with no type discriminator, so a group-owned task was previously never
+    * added to ownedTasks() because the guard hardcoded type == Identity.USER.
+    */
+   @Test
+   void getIdentityRemovalImpact_reportsGroupOwnedTasksWithoutMutating() throws Exception {
+      ScheduleTask owned = new ScheduleTask("impact_owned_by_group");
+      owned.setOwner(identityID_tgroup0);
+
+      scheduleManager.setScheduleTask("tgroup0~;~host-org:impact_owned_by_group", owned, admin);
+
+      EditableAuthenticationProvider provider = mock(EditableAuthenticationProvider.class);
+
+      ScheduleManager.IdentityTaskImpact impact =
+         scheduleManager.getIdentityRemovalImpact(new Group(identityID_tgroup0), provider);
+
+      assertTrue(impact.ownedTasks().contains("impact_owned_by_group"));
+
+      // the read-only impact check must not delete the owned task
+      assertNotNull(scheduleManager.getScheduleTask("tgroup0~;~host-org:impact_owned_by_group"));
+   }
+
+   /**
+    * Regression test for Bug #76609 AID-003: identityRemoved() must actually delete a task owned
+    * by a GROUP, not just leave it un-advised. Same guard defect as
+    * getIdentityRemovalImpact_reportsGroupOwnedTasksWithoutMutating above, but on the real
+    * delete-time code path.
+    */
+   @Test
+   void identityRemoved_removesGroupOwnedTask() throws Exception {
+      ScheduleTask owned = new ScheduleTask("removed_owned_by_group");
+      owned.setOwner(identityID_tgroup0);
+
+      scheduleManager.setScheduleTask("tgroup0~;~host-org:removed_owned_by_group", owned, admin);
+
+      EditableAuthenticationProvider provider = mock(EditableAuthenticationProvider.class);
+      Group group = new Group(identityID_tgroup0);
+      when(provider.getGroup(identityID_tgroup0)).thenReturn(group);
+
+      scheduleManager.identityRemoved(group, provider);
+
+      assertNull(scheduleManager.getScheduleTask("tgroup0~;~host-org:removed_owned_by_group"));
+   }
+
+   /**
+    * Regression test for Bug #76609 AID-003: identityRenamed() must update the owner of a task
+    * owned by a GROUP to the new group identity, mirroring checkIdentityRenamed's user-owned
+    * case. Same guard defect (type == Identity.USER hardcoded) on the rename-time code path.
+    */
+   @Test
+   void identityRenamed_updatesGroupOwnedTaskOwner() throws Exception {
+      ScheduleTask groupTask = new ScheduleTask("group_tk1");
+      groupTask.setOwner(identityID_tgroup0);
+
+      scheduleManager.setScheduleTask("tgroup0~;~host-org:group_tk1", groupTask, admin);
+
+      Group tgroup0_1 = new Group(new IdentityID("tgroup0_1", "host-org"));
+      scheduleManager.identityRenamed(identityID_tgroup0, tgroup0_1);
+
+      assertEquals("tgroup0_1~;~host-org",
+         scheduleManager.getScheduleTask("tgroup0_1~;~host-org:group_tk1").getOwner().convertToKey());
    }
 
    private ScheduleTask createScheduleTask(String taskName) {


### PR DESCRIPTION
## Root cause

`ScheduleManager.identityRemoved`, `getIdentityRemovalImpact`, and `identityRenamed` each
hardcoded a `type == Identity.USER` guard before matching against `ScheduleTask.getOwner()`.
`getOwner()` returns a bare `IdentityID` with no embedded type discriminator, and groups can own
schedule tasks the same way users do, so the hardcoded `Identity.USER` check silently excluded
every group-owned task from all three code paths:

- `getIdentityRemovalImpact` never reported a group-owned task in `ownedTasks()`, so
  `apply_identity_changes` (`verb: "delete"`, `unitType: "group"`) always returned `advisory: null`
  even when the group owned tasks.
- `identityRemoved` never deleted a group-owned task on a real group delete, leaving a dangling
  `owner` reference to the now-deleted group.
- `identityRenamed` never updated a group-owned task's `owner` on a group rename, leaving a
  dangling reference to the old (renamed-away) group name.

The sibling "execute as" branches in all three methods already compare against
`iden.getType()` (the actual type stored on the task's own execute-as identity) and were already
symmetric for user/group — only the `owner`-matching branches had the hardcoded `USER` guard.

## Fix

Widen all three guards from `type == Identity.USER` to
`(type == Identity.USER || type == Identity.GROUP)`, in
`core/src/main/java/inetsoft/sree/schedule/ScheduleManager.java`:
- line 1091 (`identityRemoved`)
- line 1165 (`getIdentityRemovalImpact`)
- line 1205 (`identityRenamed`)

No other lines touched. `task.getOwner()` has no type of its own, so widening the check is
sufficient and safe — role/organization delete never reach these methods through this call path
(confirmed by tracing `IdentityChangesetApplyService.applyDeleteRole`/
`applyDeleteOrganizationSafely`, both of which hardcode `advisory: null` without calling
`describeDeleteTaskImpacts` at all).

## Tests

Three new tests added to `core/src/test/java/inetsoft/sree/schedule/ScheduleManagerTest.java`,
mirroring the existing user-owned cases:
- `getIdentityRemovalImpact_reportsGroupOwnedTasksWithoutMutating`
- `identityRemoved_removesGroupOwnedTask`
- `identityRenamed_updatesGroupOwnedTaskOwner`

```
cd core && mvn test -Dtest=ScheduleManagerTest -q
```
`Tests run: 17, Failures: 0, Errors: 0, Skipped: 0` (14 pre-existing + 3 new, all passing).

Fixes Redmine #76609, AID-003 finding (AID-001/AID-002 on the same ticket already landed
separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)