### PR TITLE
fix(wiz): clear group-others flag when a ranking is cleared (#76574 VTB-006)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/DimensionSortRanking.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/DimensionSortRanking.java
@@ -120,6 +120,7 @@ public final class DimensionSortRanking {
          dimension.setRankingOption(String.valueOf(XCondition.NONE));
          dimension.setRankingN(null);
          dimension.setRankingCol(null);
+         dimension.setGroupOthers(false);
          return;
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/DimensionSortRankingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/DimensionSortRankingTest.java
@@ -173,12 +173,15 @@ class DimensionSortRankingTest {
    @Test
    void clearingRankingNeedsNothingElse() {
       BDimensionRefModel dimension = new BDimensionRefModel();
-      DimensionSortRanking.applyRanking(dimension, ranking("top", 5, "Sales"));
+      DimensionSortRanking.applyRanking(dimension,
+         new DimensionSortRanking.Ranking("top", 5, "Sales", true));
 
       DimensionSortRanking.applyRanking(dimension, ranking("none", null, null));
 
       assertNull(dimension.getRankingN());
       assertNull(dimension.getRankingCol());
+      assertFalse(dimension.isGroupOthers(),
+         "clearing the ranking must also clear the now-meaningless 'group others' flag");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -745,6 +745,30 @@ class TableBindingMutatorTest {
       assertEquals("Sales", model.getRows().get(0).getRankingCol());
    }
 
+   /**
+    * VTB-006: clearing a ranking must also clear the "group others" flag it carried, and that
+    * cleared flag must stick across a subsequent shelf resubmission (copyOf()'s job is only to
+    * preserve whatever the model currently holds, per VTB-004).
+    */
+   @Test
+   void clearingRankingClearsGroupOthersAcrossAShelfResubmission() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+      TableBindingMutator.setShelf(model, "aggregates",
+                                   List.of(new FieldRef("Sales", "measure", "sum", null, null)));
+      TableBindingMutator.setRanking(model, "rows", "Region", null,
+                                     new DimensionSortRanking.Ranking("top", 5, "Sales", true));
+
+      TableBindingMutator.setRanking(model, "rows", "Region", null,
+                                     new DimensionSortRanking.Ranking("none", null, null, null));
+
+      // The filed repro: resubmit the identical field list to the same shelf after the clear.
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      assertFalse(model.getRows().get(0).isGroupOthers(),
+         "a cleared ranking's 'group others' flag must not be copied forward by a shelf resubmission");
+   }
+
    @Test
    void addFieldPreservesSortOnAFieldThatStaysAtTheSamePosition() {
       CrosstabBindingModel model = new CrosstabBindingModel();


### PR DESCRIPTION
## Summary
- Redmine #76574 (VTB-006, batch 3/P3): `DimensionSortRanking.applyRanking()`'s `mode:"none"` branch reset `rankingOption`/`rankingN`/`rankingCol` but returned before reaching the `groupOthers` clear, which only lives in the top/bottom-ranking branch below the early return. `get_table_binding`'s `"others"` field therefore stayed stuck at whatever it was before the clear, forever, even though `"ranking"` correctly read `"none"`.
- This is presently reachable, not hypothetical: VTB-004's already-merged `TableBindingMutator.copyOf()` fix (`ref.setGroupOthers(previous.isGroupOthers())`) copies forward whatever `groupOthers` currently holds, so today a shelf resubmission after a ranking `mode:"none"` clear silently perpetuates a stale `others:true` via that already-merged code path.
- Fix: clear `groupOthers` unconditionally in the `mode:"none"` branch. Surveyed all ~35 call sites of `isGroupOthers()`/`setGroupOthers()`; none treat the flag as meaningful independent of an active ranking, so this is safe. `ChartBindingMutator.setRanking()` shares the exact same method/model, so this one fix covers both table and chart ranking clears.

## Changes
- `core/src/main/java/inetsoft/web/wiz/binding/DimensionSortRanking.java`: add `dimension.setGroupOthers(false);` to the `mode:"none"` branch of `applyRanking()`.
- `core/src/test/java/inetsoft/web/wiz/binding/DimensionSortRankingTest.java`: extend the existing `clearingRankingNeedsNothingElse()` test to set `groupOthers=true` before the clear and assert it reads `false` after.
- `core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java`: add `clearingRankingClearsGroupOthersAcrossAShelfResubmission()`, a compound regression test covering the presently-live VTB-004 interaction (rank with `others:true` -> clear via `mode:"none"` -> resubmit the shelf unchanged -> assert `groupOthers` still reads `false`).

## Test plan
- [x] Confirmed both new/extended assertions fail against the pre-fix code (`expected: <false> but was: <true>`), then pass after the one-line fix, via:
  `./mvnw -pl core -am -Dtest=DimensionSortRankingTest,TableBindingMutatorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `ChartBindingMutatorTest` (28 tests) re-run to confirm no regression on the shared chart-ranking path.

Not merging per this batch's process — holding for the user's explicit review/merge sign-off regardless of CI/review outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)