### PR TITLE
Bug #76615, don't NPE saving a viewsheet with a null runtime sheet ID

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ComposerViewsheetController.java
@@ -99,6 +99,11 @@ public class ComposerViewsheetController {
                                 CommandDispatcher dispatcher, @LinkUri String linkUri)
       throws Exception
    {
+      if(runtimeViewsheetRef.getRuntimeId() == null) {
+         LOG.warn("Attempted to save viewsheet without runtime ID");
+         return false;
+      }
+
       if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET,
                                                        "*", ResourceAction.ACCESS))
       {

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/ComposerViewsheetControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/ComposerViewsheetControllerTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.web.composer.ws.event.SaveSheetEvent;
+import inetsoft.web.viewsheet.model.RuntimeViewsheetRef;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class ComposerViewsheetControllerTest {
+   @BeforeEach
+   void setup() {
+      controller = new ComposerViewsheetController(
+         runtimeViewsheetRef, viewsheetService, composerViewsheetService, securityEngine);
+   }
+
+   // Bug #76615, saving without an attached runtime viewsheet must not NPE.
+   @Test
+   void saveViewsheetReturnsFalseWhenRuntimeIdIsNull() throws Exception {
+      when(runtimeViewsheetRef.getRuntimeId()).thenReturn(null);
+
+      boolean result = controller.saveViewsheet(new SaveSheetEvent(), principal, dispatcher, "/");
+
+      assertFalse(result);
+      verifyNoInteractions(composerViewsheetService, securityEngine);
+   }
+
+   @Mock private RuntimeViewsheetRef runtimeViewsheetRef;
+   @Mock private ViewsheetService viewsheetService;
+   @Mock private ComposerViewsheetServiceProxy composerViewsheetService;
+   @Mock private SecurityEngine securityEngine;
+   @Mock private Principal principal;
+   @Mock private CommandDispatcher dispatcher;
+   private ComposerViewsheetController controller;
+}


### PR DESCRIPTION
## Summary

Saving a viewsheet via Composer could occasionally throw an unhandled `NullPointerException` on the server instead of a graceful error, when the STOMP save request reached the server before a runtime sheet ID was attached to the session.

## Root Cause

`ComposerViewsheetController.saveViewsheet()` passed `runtimeViewsheetRef.getRuntimeId()` unchecked into `ComposerViewsheetServiceProxy.saveViewsheet()`. When that ID is `null`, the cluster proxy call chain (`WorksheetEngine.isLocal()` → `RuntimeSheetCache.getAffinityKey()`) builds `new AffinityKey<>(null, ...)`, which Ignite's `GridArgumentCheck.notNull()` rejects, surfacing as an unhandled NPE on a clustered deployment. `closeViewsheet()` in the same controller already guards against this exact scenario, but `saveViewsheet()` did not.

## Fix

Added the same null-runtime-ID guard used by `closeViewsheet()` to `saveViewsheet()`: log a warning and return `false` instead of proceeding with a null ID. `saveAndCloseViewsheet()` (which calls `saveViewsheet()` internally) correctly skips sending `CloseSheetCommand` when the save returns `false`.

## Test Plan

- Added `ComposerViewsheetControllerTest.saveViewsheetReturnsFalseWhenRuntimeIdIsNull()`, which verifies the null-ID path returns `false` and never reaches the downstream proxy/service.
- `./mvnw clean install -pl core -am -DskipTests` — build succeeds.
- `./mvnw test -pl core -Dtest=ComposerViewsheetControllerTest` — new test passes.

Fixes Redmine #76615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)