### PR TITLE
Bug #76573, force change detection after deferred column-width recalculation

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.ts
@@ -218,6 +218,9 @@ export class PreviewTableComponent implements OnDestroy, AfterViewChecked, After
                this.initColumnWidths();
                this.updateHorizontalDist();
                this.updateColumnRange();
+               // Bug #76573: see the matching comment in updateWidths() -- this deferred
+               // callback needs its own view check too.
+               this.changeRef.detectChanges();
             }
          });
       }
@@ -280,6 +283,9 @@ export class PreviewTableComponent implements OnDestroy, AfterViewChecked, After
             this.initColumnWidths();
             this.renderer.setProperty(this.previewContainer.nativeElement, "scrollLeft",
                this.scrollXPos);
+            // Bug #76573: see the matching comment in updateWidths() -- this deferred
+            // callback needs its own view check too.
+            this.changeRef.detectChanges();
          });
       }
    }
@@ -488,6 +494,14 @@ export class PreviewTableComponent implements OnDestroy, AfterViewChecked, After
 
       setTimeout(() => {
          this.updateColumnRange();
+
+         // Bug #76573: this callback runs outside any Angular-bound event, so nothing
+         // triggers a view check afterward when hosted inside the elements/viewer-element
+         // Angular Elements bundle -- columnIndexRange (computed above, and gating every
+         // header/body cell in the template) would stay applied-but-unrendered until an
+         // unrelated DOM event (e.g. scroll, which calls updateColumnRange() directly from
+         // a bound (scroll) handler and so gets a check for free) forced a repaint.
+         this.changeRef.detectChanges();
       }, 0);
    }
 


### PR DESCRIPTION
## Summary

The "Show Summary Data"/"Show Details" table in the chart mini-toolbar (`preview-table.component.ts`) stays blank when the viewer is hosted inside the elements/viewer-element Angular Elements web-component bundle — real data is bound into the DOM (confirmed via inspection: correct row/cell content present) but no cells are visible until an unrelated DOM event (e.g. a scroll) forces a repaint.

## Root Cause

`columnIndexRange` — the range that gates whether any header/body `<th>`/`<td>` cell renders at all in the template — is computed by `updateColumnRange()`, which is invoked from three places that all defer via a bare `setTimeout()` or `Promise.resolve().then()`:
- `updateWidths()`'s `setTimeout(..., 0)`
- the `tableData` setter's `Promise.resolve().then()` block
- the `colWidths` setter's `Promise.resolve().then()` block

These callbacks run outside any Angular-bound event/template binding, so nothing schedules a view check afterward once this component is hosted inside the elements/viewer-element bundle (`createApplication()` + `createCustomElement()`). The computed layout is correct, but the template never re-evaluates against it — until an unrelated bound DOM event (e.g. the container's `(scroll)` handler, which calls the same `updateColumnRange()` directly and gets a check "for free" as part of Angular's normal event-binding change detection) happens to trigger a repaint.

## Fix

Call `this.changeRef.detectChanges()` at the end of each of the three deferred callbacks, so the newly computed column layout is reflected in the view immediately rather than waiting on an unrelated event.

## Test Plan

- Reproduced live against the ticket's own `WebComponentCase.html` (built `elements.js`/`viewer-element.js`, uploaded to EM Data Space): before the fix, "Show Summary Data" opened a blank dialog reliably; data was confirmed present in the DOM (171 rows, ~29KB innerHTML) but with zero rendered cells until a scroll.
- After the fix: 10 consecutive open/close cycles across both charts on the same page rendered correctly immediately, no click/scroll needed.
- Existing `preview-table.component.*.tl.spec.ts` and `vs-preview-table.component.tl.spec.ts` suites: 97 tests, all passing.
- `eslint` clean on the changed file.

Fixes Redmine #76573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)