### PR TITLE
Chart palettes: re-tune Modern and Modern Dark, add Contrast, scope the picker per chart

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -87,6 +88,15 @@ public final class VSChartPaletteDefaults {
       if(frame != null && ctx.modern) {
          frame.setDefaultColors(activePalette(ctx));
       }
+   }
+
+   /**
+    * Palette names a picker should mark hidden for the given context. A modern chart is not
+    * offered the single-hue ramps; a classic chart keeps everything. Never removes a name from
+    * resolution - getPalette must still answer for every one of these.
+    */
+   public static Set<String> hiddenPaletteNames(VizContext ctx) {
+      return ctx.modern ? MODERN_HIDDEN : Set.of();
    }
 
    /**
@@ -174,6 +184,8 @@ public final class VSChartPaletteDefaults {
    private static final String MODERN_NAME = "Modern";
    private static final String DARK_NAME = "Modern Dark";
    private static final String DEFAULT_NAME = "Default";
+   private static final Set<String> MODERN_HIDDEN =
+      Set.of("Pastel", "Heat 8", "Heat 16", "Heat 24", "Blue", "Green", "Red", "Orange", "Gray");
    private static final Map<String, Memo> MEMO = new ConcurrentHashMap<>();
    private static final Logger LOG = LoggerFactory.getLogger(VSChartPaletteDefaults.class);
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java
@@ -178,12 +178,12 @@ public final class VSChartPaletteDefaults {
    private static final Logger LOG = LoggerFactory.getLogger(VSChartPaletteDefaults.class);
 
    private static final Color[] MODERN_HEAD = {
-      new Color(0x00D4E8), new Color(0x00B87A), new Color(0xF59E0B), new Color(0xF43F5E),
-      new Color(0x8B5CF6), new Color(0x3B82F6), new Color(0x0D9488), new Color(0x64748B)
+      new Color(0x0490FF), new Color(0xFF5A35), new Color(0x241C4F), new Color(0x03D9B3),
+      new Color(0x9A2DDC), new Color(0xFFB020), new Color(0xE5197E), new Color(0x8ED604)
    };
 
    private static final Color[] DARK_HEAD = {
-      new Color(0x22D3EE), new Color(0x10B981), new Color(0xFBB724), new Color(0xFB6181),
-      new Color(0xA78BFA), new Color(0x60A5FA), new Color(0x2DD4BF), new Color(0x94A3B8)
+      new Color(0x4FA5FF), new Color(0xFF8367), new Color(0x49447D), new Color(0x2DEEC6),
+      new Color(0xAE41F5), new Color(0xFFCB82), new Color(0xFE3290), new Color(0x9FEB28)
    };
 }

--- a/core/src/main/java/inetsoft/web/binding/VSChartBindingController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSChartBindingController.java
@@ -243,7 +243,9 @@ public class VSChartBindingController {
       Principal principal)
       throws Exception
    {
-      VizContext ctx = vsId == null || assemblyName == null
+      // absent assembly resolves through the org gate; its flags are unread by any UI -
+      // don't gate the target-band pane on them, it can't tell classic charts from modern ones
+      VizContext ctx = Tool.isEmptyString(vsId) || Tool.isEmptyString(assemblyName)
          ? VizContext.ofGate()
          : VizContext.of(chartBindingService.getChartVizMark(vsId, assemblyName, principal));
       Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(ctx);

--- a/core/src/main/java/inetsoft/web/binding/VSChartBindingController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSChartBindingController.java
@@ -30,7 +30,9 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.graph.aesthetic.*;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VSChartPaletteDefaults;
 import inetsoft.uql.viewsheet.internal.VSUtil;
+import inetsoft.uql.viewsheet.internal.VizContext;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.handler.*;
 import inetsoft.web.binding.model.*;
@@ -234,9 +236,17 @@ public class VSChartBindingController {
    @RequestMapping(value = "/api/composer/chart/colorpalettes", method = RequestMethod.GET)
    @HandleExceptions
    @SwitchOrg
-   public CategoricalColorModel[] getColorPalettes(@OrganizationID String orgId, Principal principal)
+   public CategoricalColorModel[] getColorPalettes(
+      @OrganizationID String orgId,
+      @RequestParam(required = false, value = "vsId") String vsId,
+      @RequestParam(required = false, value = "assemblyName") String assemblyName,
+      Principal principal)
       throws Exception
    {
+      VizContext ctx = vsId == null || assemblyName == null
+         ? VizContext.ofGate()
+         : VizContext.of(chartBindingService.getChartVizMark(vsId, assemblyName, principal));
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(ctx);
       String[] names = ColorPalettes.getPaletteNames().toArray(new String[0]);
       CategoricalColorModel[] palettes = new CategoricalColorModel[names.length];
 
@@ -246,6 +256,7 @@ public class VSChartBindingController {
          wrapper.setVisualFrame(palette);
          CategoricalColorModel model = visualService.createVisualFrameModel(wrapper);
          model.setName(names[i]);
+         model.setHidden(hidden.contains(names[i]));
          palettes[i] = model;
       }
 

--- a/core/src/main/java/inetsoft/web/binding/VSChartBindingController.java
+++ b/core/src/main/java/inetsoft/web/binding/VSChartBindingController.java
@@ -48,6 +48,8 @@ import inetsoft.web.viewsheet.SwitchOrg;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -243,12 +245,8 @@ public class VSChartBindingController {
       Principal principal)
       throws Exception
    {
-      // absent assembly resolves through the org gate; its flags are unread by any UI -
-      // don't gate the target-band pane on them, it can't tell classic charts from modern ones
-      VizContext ctx = Tool.isEmptyString(vsId) || Tool.isEmptyString(assemblyName)
-         ? VizContext.ofGate()
-         : VizContext.of(chartBindingService.getChartVizMark(vsId, assemblyName, principal));
-      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(ctx);
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(
+         pickerContext(vsId, assemblyName, principal));
       String[] names = ColorPalettes.getPaletteNames().toArray(new String[0]);
       CategoricalColorModel[] palettes = new CategoricalColorModel[names.length];
 
@@ -265,6 +263,32 @@ public class VSChartBindingController {
       return palettes;
    }
 
+   /**
+    * The context a palette picker's hidden flags are computed from.
+    *
+    * A caller with no assembly resolves through the org gate. Its flags are unread by any UI, and
+    * the target-band pane must not be gated on them - it cannot tell a classic chart from a modern
+    * one, so gating it would hide the retired palettes from classic charts in a modern org.
+    *
+    * A mark that cannot be resolved falls back the same way rather than failing the request. The
+    * mark decides which names carry the flag, never which palettes are returned, so a stale or
+    * expired runtime should not take the whole list down with it.
+    */
+   private VizContext pickerContext(String vsId, String assemblyName, Principal principal) {
+      if(Tool.isEmptyString(vsId) || Tool.isEmptyString(assemblyName)) {
+         return VizContext.ofGate();
+      }
+
+      try {
+         return VizContext.of(chartBindingService.getChartVizMark(vsId, assemblyName, principal));
+      }
+      catch(Exception ex) {
+         LOG.debug("Failed to resolve the chart's mark for the palette picker", ex);
+         return VizContext.ofGate();
+      }
+   }
+
    private final VisualFrameModelFactoryService visualService;
    private VSChartBindingServiceProxy chartBindingService;
+   private static final Logger LOG = LoggerFactory.getLogger(VSChartBindingController.class);
 }

--- a/core/src/main/java/inetsoft/web/binding/VSChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/VSChartBindingService.java
@@ -30,6 +30,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.VizMark;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.handler.*;
 import inetsoft.web.binding.model.*;
@@ -96,6 +97,26 @@ public class VSChartBindingService {
       }
 
       return model;
+   }
+
+   /**
+    * The chart's own provenance mark, read on the node that owns the runtime viewsheet. Null for
+    * an unmarked chart, a missing assembly, or an assembly that is not a chart.
+    */
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public VizMark getChartVizMark(@ClusterProxyKey String vsId, String assemblyName,
+                                  Principal principal)
+      throws Exception
+   {
+      ViewsheetService engine = viewsheetService;
+      RuntimeViewsheet rvs = engine.getViewsheet(Tool.byteDecode(vsId), principal);
+      Viewsheet viewsheet = rvs.getViewsheet();
+
+      if(viewsheet == null || !(viewsheet.getAssembly(assemblyName) instanceof ChartVSAssembly chart)) {
+         return null;
+      }
+
+      return chart.getVSAssemblyInfo().getVizMark();
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java
+++ b/core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java
@@ -174,6 +174,14 @@ public class CategoricalColorModel extends ColorFrameModel {
       this.colorValueFrame = colorValueFrame;
    }
 
+   public boolean isHidden() {
+      return hidden;
+   }
+
+   public void setHidden(boolean hidden) {
+      this.hidden = hidden;
+   }
+
    private String[] colors;
    private String[] cssColors;
    private String[] defaultColors;
@@ -183,4 +191,5 @@ public class CategoricalColorModel extends ColorFrameModel {
    private boolean shareColors = true;
    private boolean colorValueFrame;
    private Integer dateFormat;
+   private boolean hidden;
 }

--- a/core/src/main/resources/inetsoft/util/css/defaults.css
+++ b/core/src/main/resources/inetsoft/util/css/defaults.css
@@ -176,35 +176,35 @@ ChartPalette[name='Default'][index='40'] {
 }
 
 ChartPalette[name='Modern'][index='1'] {
-   color: #00d4e8;
+   color: #0490ff;
 }
 
 ChartPalette[name='Modern'][index='2'] {
-   color: #00b87a;
+   color: #ff5a35;
 }
 
 ChartPalette[name='Modern'][index='3'] {
-   color: #f59e0b;
+   color: #241c4f;
 }
 
 ChartPalette[name='Modern'][index='4'] {
-   color: #f43f5e;
+   color: #03d9b3;
 }
 
 ChartPalette[name='Modern'][index='5'] {
-   color: #8b5cf6;
+   color: #9a2ddc;
 }
 
 ChartPalette[name='Modern'][index='6'] {
-   color: #3b82f6;
+   color: #ffb020;
 }
 
 ChartPalette[name='Modern'][index='7'] {
-   color: #0d9488;
+   color: #e5197e;
 }
 
 ChartPalette[name='Modern'][index='8'] {
-   color: #64748b;
+   color: #8ed604;
 }
 
 ChartPalette[name='Modern'][index='9'] {
@@ -336,35 +336,35 @@ ChartPalette[name='Modern'][index='40'] {
 }
 
 ChartPalette[name='Modern Dark'][index='1'] {
-   color: #22d3ee;
+   color: #4fa5ff;
 }
 
 ChartPalette[name='Modern Dark'][index='2'] {
-   color: #10b981;
+   color: #ff8367;
 }
 
 ChartPalette[name='Modern Dark'][index='3'] {
-   color: #fbb724;
+   color: #49447d;
 }
 
 ChartPalette[name='Modern Dark'][index='4'] {
-   color: #fb6181;
+   color: #2deec6;
 }
 
 ChartPalette[name='Modern Dark'][index='5'] {
-   color: #a78bfa;
+   color: #ae41f5;
 }
 
 ChartPalette[name='Modern Dark'][index='6'] {
-   color: #60a5fa;
+   color: #ffcb82;
 }
 
 ChartPalette[name='Modern Dark'][index='7'] {
-   color: #2dd4bf;
+   color: #fe3290;
 }
 
 ChartPalette[name='Modern Dark'][index='8'] {
-   color: #94a3b8;
+   color: #9feb28;
 }
 
 ChartPalette[name='Modern Dark'][index='9'] {

--- a/core/src/main/resources/inetsoft/util/css/defaults.css
+++ b/core/src/main/resources/inetsoft/util/css/defaults.css
@@ -862,3 +862,35 @@ ChartPalette[name='Heat 24'][index='23'] {
 ChartPalette[name='Heat 24'][index='24'] {
   color: #ffcc99;
 }
+
+ChartPalette[name='Contrast'][index='1'] {
+   color: #0b3d91;
+}
+
+ChartPalette[name='Contrast'][index='2'] {
+   color: #f5943f;
+}
+
+ChartPalette[name='Contrast'][index='3'] {
+   color: #b04ab8;
+}
+
+ChartPalette[name='Contrast'][index='4'] {
+   color: #f7d22e;
+}
+
+ChartPalette[name='Contrast'][index='5'] {
+   color: #a8330a;
+}
+
+ChartPalette[name='Contrast'][index='6'] {
+   color: #7cc4ee;
+}
+
+ChartPalette[name='Contrast'][index='7'] {
+   color: #00947f;
+}
+
+ChartPalette[name='Contrast'][index='8'] {
+   color: #5fa83c;
+}

--- a/core/src/test/java/inetsoft/report/composition/graph/VGraphPairModernPaletteTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/VGraphPairModernPaletteTest.java
@@ -53,7 +53,7 @@ class VGraphPairModernPaletteTest {
       // same resolver call the VGraphPair seam makes after setParentParams
       inetsoft.uql.viewsheet.internal.VSChartPaletteDefaults.applyModernPalette(
          frame, inetsoft.uql.viewsheet.internal.VizContext.ofGate());
-      assertEquals(new Color(0x00D4E8), frame.getColor(0));
+      assertEquals(new Color(0x0490FF), frame.getColor(0));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
@@ -86,4 +86,27 @@ class ColorPalettesModernTest {
          assertNotNull(frame.getDefaultColor(i), "index " + (i + 1) + " must not be null");
       }
    }
+
+   @Test
+   void contrastIsRegisteredWithEightColors() {
+      assertTrue(ColorPalettes.getPaletteNames().contains("Contrast"),
+                 "Contrast palette must be declared in defaults.css");
+
+      CategoricalColorFrame contrast = ColorPalettes.getPalette("Contrast");
+      assertNotNull(contrast);
+      assertEquals(8, contrast.getColorCount());
+
+      for(int i = 0; i < 8; i++) {
+         assertNotNull(contrast.getDefaultColor(i), "index " + (i + 1) + " must not be null");
+      }
+
+      assertEquals(new Color(0x0B3D91), contrast.getDefaultColor(0));
+      assertEquals(new Color(0x5FA83C), contrast.getDefaultColor(7));
+   }
+
+   // Default must be declared first: the picker's index-0 fallback relies on it.
+   @Test
+   void defaultIsStillDeclaredFirst() {
+      assertEquals("Default", ColorPalettes.getPaletteNames().iterator().next());
+   }
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
@@ -45,12 +45,12 @@ class ColorPalettesModernTest {
    @Test
    void modernHeadMatchesSpec() {
       CategoricalColorFrame modern = ColorPalettes.getPalette("Modern");
-      assertEquals(new Color(0x00D4E8), modern.getDefaultColor(0));
-      assertEquals(new Color(0x64748B), modern.getDefaultColor(7));
+      assertEquals(new Color(0x0490FF), modern.getDefaultColor(0));
+      assertEquals(new Color(0x8ED604), modern.getDefaultColor(7));
 
       CategoricalColorFrame dark = ColorPalettes.getPalette("Modern Dark");
-      assertEquals(new Color(0x22D3EE), dark.getDefaultColor(0));
-      assertEquals(new Color(0x94A3B8), dark.getDefaultColor(7));
+      assertEquals(new Color(0x4FA5FF), dark.getDefaultColor(0));
+      assertEquals(new Color(0x9FEB28), dark.getDefaultColor(7));
    }
 
    // Drift guard: the CSS tail and the Java spliceLegacy fallback must agree, or swapping between

--- a/core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
@@ -96,12 +96,15 @@ class ColorPalettesModernTest {
       assertNotNull(contrast);
       assertEquals(8, contrast.getColorCount());
 
-      for(int i = 0; i < 8; i++) {
-         assertNotNull(contrast.getDefaultColor(i), "index " + (i + 1) + " must not be null");
-      }
+      Color[] expected = {
+         new Color(0x0B3D91), new Color(0xF5943F), new Color(0xB04AB8), new Color(0xF7D22E),
+         new Color(0xA8330A), new Color(0x7CC4EE), new Color(0x00947F), new Color(0x5FA83C)
+      };
 
-      assertEquals(new Color(0x0B3D91), contrast.getDefaultColor(0));
-      assertEquals(new Color(0x5FA83C), contrast.getDefaultColor(7));
+      for(int i = 0; i < 8; i++) {
+         assertEquals(expected[i], contrast.getDefaultColor(i),
+                      "index " + (i + 1) + " must match the luminance ladder");
+      }
    }
 
    // Default must be declared first: the picker's index-0 fallback relies on it.

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteCssOverrideTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteCssOverrideTest.java
@@ -68,7 +68,7 @@ class VSChartPaletteCssOverrideTest {
       // the org-scoped ColorPalettes cache has no reset hook of its own - it only refreshes when
       // the CSS stamp advances past its internal 'last' field. Confirm the reload above actually
       // picked the clean defaults.css back up, so this class does not poison later tests.
-      assertEquals(new Color(0x00D4E8), VSChartPaletteDefaults.modernPalette()[0]);
+      assertEquals(new Color(0x0490FF), VSChartPaletteDefaults.modernPalette()[0]);
    }
 
    // Only a CSS value that differs from MODERN_HEAD can prove resolution actually flipped to CSS -
@@ -85,7 +85,7 @@ class VSChartPaletteCssOverrideTest {
 
       assertEquals(new Color(0xff00ff), modern[0]);
       // untouched indexes still come from the CSS declaration, not a partial substitution
-      assertEquals(new Color(0x00B87A), modern[1]);
+      assertEquals(new Color(0xFF5A35), modern[1]);
    }
 
    // Reproduces the reported failure: a malformed index on one ChartPalette rule throws during
@@ -103,8 +103,8 @@ class VSChartPaletteCssOverrideTest {
       Color[] modern = assertDoesNotThrow(VSChartPaletteDefaults::modernPalette);
 
       assertEquals(40, modern.length);
-      assertEquals(new Color(0x00D4E8), modern[0]);
-      assertEquals(new Color(0x64748B), modern[7]);
+      assertEquals(new Color(0x0490FF), modern[0]);
+      assertEquals(new Color(0x8ED604), modern[7]);
    }
 
    // pickerPalette() resolves the Default palette directly, bypassing resolve()/the memo

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
@@ -17,6 +17,7 @@ import java.awt.Color;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -307,5 +308,45 @@ class VSChartPaletteDefaultsTest {
          assertEquals(head[i], css.getDefaultColor(i),
                       paletteName + " index " + (i + 1) + " must match " + fieldName);
       }
+   }
+
+   @Test
+   void hiddenNamesAreEmptyForAClassicChart() {
+      assertTrue(VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of((VizMark) null)).isEmpty(),
+                 "a classic chart keeps every palette it has today");
+   }
+
+   @Test
+   void hiddenNamesAreTheNineRampsForAModernChart() {
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(Set.of("Pastel", "Heat 8", "Heat 16", "Heat 24",
+                          "Blue", "Green", "Red", "Orange", "Gray"), hidden);
+   }
+
+   @Test
+   void hiddenNamesAreTheSameUnderADarkMark() {
+      assertEquals(VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT)),
+                   VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_DARK)),
+                   "dark is a modifier of modern, not a different palette set");
+   }
+
+   // The five kept names must never appear in the hidden set.
+   @Test
+   void hiddenNamesNeverCoverTheKeptFive() {
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT));
+
+      for(String kept : new String[]{ "Default", "Soft", "Modern", "Modern Dark", "Contrast" }) {
+         assertFalse(hidden.contains(kept), kept + " must stay offered to a modern chart");
+      }
+   }
+
+   @Test
+   void hiddenNamesFollowTheGateWhenThereIsNoAssembly() {
+      SreeEnv.setProperty("viewsheet.modernVisualization", "false");
+      assertTrue(VSChartPaletteDefaults.hiddenPaletteNames(VizContext.ofGate()).isEmpty());
+
+      SreeEnv.setProperty("viewsheet.modernVisualization", "true");
+      assertEquals(9, VSChartPaletteDefaults.hiddenPaletteNames(VizContext.ofGate()).size());
    }
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
@@ -5,6 +5,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;
 import inetsoft.util.css.CSSDictionary;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,16 +52,16 @@ class VSChartPaletteDefaultsTest {
 
       Color[] modern = VSChartPaletteDefaults.modernPalette();
       assertEquals(40, modern.length, "8 modern + 32 legacy tail = 40");
-      assertEquals(new Color(0x00D4E8), modern[0]);
-      assertEquals(new Color(0x64748B), modern[7]);
+      assertEquals(new Color(0x0490FF), modern[0]);
+      assertEquals(new Color(0x8ED604), modern[7]);
       // index 9+ preserves the legacy tail unchanged
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[8], modern[8]);
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[39], modern[39]);
 
       CategoricalColorFrame frame = new CategoricalColorFrame();
       VSChartPaletteDefaults.applyModernPalette(frame, VizContext.ofGate());
-      assertEquals(new Color(0x00D4E8), frame.getColor(0));
-      assertEquals(new Color(0x00B87A), frame.getColor(1));
+      assertEquals(new Color(0x0490FF), frame.getColor(0));
+      assertEquals(new Color(0xFF5A35), frame.getColor(1));
    }
 
    // Regression: the value-based render path (getColor(Object)) resolves through the cached
@@ -94,15 +95,15 @@ class VSChartPaletteDefaultsTest {
 
       Color[] dark = VSChartPaletteDefaults.darkPalette();
       assertEquals(40, dark.length, "8 dark + 32 legacy tail = 40");
-      assertEquals(new Color(0x22D3EE), dark[0]);
-      assertEquals(new Color(0x94A3B8), dark[7]);
+      assertEquals(new Color(0x4FA5FF), dark[0]);
+      assertEquals(new Color(0x9FEB28), dark[7]);
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[8], dark[8]);
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[39], dark[39]);
 
       CategoricalColorFrame frame = new CategoricalColorFrame();
       VSChartPaletteDefaults.applyModernPalette(frame, VizContext.ofGate());
-      assertEquals(new Color(0x22D3EE), frame.getColor(0));
-      assertEquals(new Color(0x10B981), frame.getColor(1));
+      assertEquals(new Color(0x4FA5FF), frame.getColor(0));
+      assertEquals(new Color(0xFF8367), frame.getColor(1));
    }
 
    @Test
@@ -173,8 +174,8 @@ class VSChartPaletteDefaultsTest {
    }
 
    private static final Color[] MODERN_HEAD_FIXTURE = {
-      new Color(0x00D4E8), new Color(0x00B87A), new Color(0xF59E0B), new Color(0xF43F5E),
-      new Color(0x8B5CF6), new Color(0x3B82F6), new Color(0x0D9488), new Color(0x64748B)
+      new Color(0x0490FF), new Color(0xFF5A35), new Color(0x241C4F), new Color(0x03D9B3),
+      new Color(0x9A2DDC), new Color(0xFFB020), new Color(0xE5197E), new Color(0x8ED604)
    };
 
    @Test
@@ -182,8 +183,8 @@ class VSChartPaletteDefaultsTest {
       Color[] modern = VSChartPaletteDefaults.modernPalette();
 
       assertEquals(40, modern.length);
-      assertEquals(new Color(0x00D4E8), modern[0]);
-      assertEquals(new Color(0x64748B), modern[7]);
+      assertEquals(new Color(0x0490FF), modern[0]);
+      assertEquals(new Color(0x8ED604), modern[7]);
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[8], modern[8]);
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[39], modern[39]);
    }
@@ -193,8 +194,8 @@ class VSChartPaletteDefaultsTest {
       Color[] dark = VSChartPaletteDefaults.darkPalette();
 
       assertEquals(40, dark.length);
-      assertEquals(new Color(0x22D3EE), dark[0]);
-      assertEquals(new Color(0x94A3B8), dark[7]);
+      assertEquals(new Color(0x4FA5FF), dark[0]);
+      assertEquals(new Color(0x9FEB28), dark[7]);
       assertEquals(CategoricalColorFrame.COLOR_PALETTE[8], dark[8]);
    }
 
@@ -207,16 +208,16 @@ class VSChartPaletteDefaultsTest {
 
       Color[] second = VSChartPaletteDefaults.modernPalette();
 
-      assertEquals(new Color(0x00D4E8), second[0]);
+      assertEquals(new Color(0x0490FF), second[0]);
    }
 
    @Test
    void activePaletteFollowsDarkMode() {
       SreeEnv.setProperty("viewsheet.modernVisualization", "true");
-      assertEquals(new Color(0x00D4E8), VSChartPaletteDefaults.activePalette(VizContext.ofGate())[0]);
+      assertEquals(new Color(0x0490FF), VSChartPaletteDefaults.activePalette(VizContext.ofGate())[0]);
 
       SreeEnv.setProperty("viewsheet.darkMode", "true");
-      assertEquals(new Color(0x22D3EE), VSChartPaletteDefaults.activePalette(VizContext.ofGate())[0]);
+      assertEquals(new Color(0x4FA5FF), VSChartPaletteDefaults.activePalette(VizContext.ofGate())[0]);
    }
 
    @Test
@@ -233,10 +234,10 @@ class VSChartPaletteDefaultsTest {
    @Test
    void pickerPaletteFollowsGateAndDarkMode() {
       SreeEnv.setProperty("viewsheet.modernVisualization", "true");
-      assertEquals(new Color(0x00D4E8), VSChartPaletteDefaults.pickerPalette(VizContext.ofGate())[0]);
+      assertEquals(new Color(0x0490FF), VSChartPaletteDefaults.pickerPalette(VizContext.ofGate())[0]);
 
       SreeEnv.setProperty("viewsheet.darkMode", "true");
-      assertEquals(new Color(0x22D3EE), VSChartPaletteDefaults.pickerPalette(VizContext.ofGate())[0]);
+      assertEquals(new Color(0x4FA5FF), VSChartPaletteDefaults.pickerPalette(VizContext.ofGate())[0]);
    }
 
    @Test
@@ -284,6 +285,29 @@ class VSChartPaletteDefaultsTest {
 
       Color[] resolved = VSChartPaletteDefaults.modernPalette();
       assertFalse(memo.isEmpty(), "the next resolve() call must repopulate the memo");
-      assertEquals(new Color(0x00D4E8), resolved[0]);
+      assertEquals(new Color(0x0490FF), resolved[0]);
+   }
+
+   // The CSS rules and the Java fallback constants are two statements of the same eight colors.
+   // Every other test asserts one side or the other, so only this one fails when they drift - and
+   // a drift is silent in production until a malformed format.css makes the fallback fire.
+   @Test
+   void cssHeadMatchesTheJavaFallback() throws Exception {
+      assertHeadMatches("MODERN_HEAD", "Modern");
+      assertHeadMatches("DARK_HEAD", "Modern Dark");
+   }
+
+   private void assertHeadMatches(String fieldName, String paletteName) throws Exception {
+      Field field = VSChartPaletteDefaults.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      Color[] head = (Color[]) field.get(null);
+      CategoricalColorFrame css = ColorPalettes.getPalette(paletteName);
+
+      assertEquals(8, head.length, fieldName + " must declare exactly the eight head colors");
+
+      for(int i = 0; i < head.length; i++) {
+         assertEquals(head[i], css.getDefaultColor(i),
+                      paletteName + " index " + (i + 1) + " must match " + fieldName);
+      }
    }
 }

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
@@ -288,9 +288,7 @@ class VSChartPaletteDefaultsTest {
       assertEquals(new Color(0x0490FF), resolved[0]);
    }
 
-   // The CSS rules and the Java fallback constants are two statements of the same eight colors.
-   // Every other test asserts one side or the other, so only this one fails when they drift - and
-   // a drift is silent in production until a malformed format.css makes the fallback fire.
+   // Guards against defaults.css and the Java fallback drifting apart.
    @Test
    void cssHeadMatchesTheJavaFallback() throws Exception {
       assertHeadMatches("MODERN_HEAD", "Modern");

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VizContextReadFlipTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VizContextReadFlipTest.java
@@ -133,10 +133,11 @@ class VizContextReadFlipTest {
    @Test
    void onlyTheDocumentedSitesStillReadTheOrgGate() throws Exception {
       // per-package spot checks, kept for their clearer failure messages; the tree-wide assertion
-      // below is the actual guard. ofGate() survives in exactly one call site: the parameterless
-      // ChartColorPaletteController bootstrap GET, which has no assembly to resolve a mark from.
+      // below is the actual guard. Two call sites survive, both with no assembly to resolve a mark
+      // from: the ChartColorPaletteController bootstrap GET, and the palette picker's
+      // absent-assembly branch in web/binding, which this per-package check does not cover.
       assertEquals(1, countOfGateIn("web/portal/controller"),
-                   "ChartColorPaletteController is the one deliberate survivor");
+                   "ChartColorPaletteController is the survivor in this package");
       assertEquals(0, countOfGateIn("report/composition"),
                    "query and lens resolve per assembly");
       assertEquals(0, countOfGateIn("web/viewsheet/controller"),

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/VizContextReadFlipTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/VizContextReadFlipTest.java
@@ -144,15 +144,19 @@ class VizContextReadFlipTest {
    }
 
    @Test
-   void exactlyOneDocumentedSiteStillReadsTheOrgGate() throws Exception {
+   void exactlyTwoDocumentedSitesStillReadTheOrgGate() throws Exception {
       // tree-wide on purpose: per-package assertions left four of this phase's own sites uncovered,
-      // and a new package could add a fifth. The survivor is named, so a regression elsewhere fails
-      // even if the total happens to stay at one.
+      // and a new package could add a fifth. Both survivors are named, so a regression elsewhere
+      // fails even if the total happens to stay at two.
       java.util.List<String> callers = filesCallingOfGate();
 
-      assertEquals(java.util.List.of("ChartColorPaletteController.java"), callers,
-                   "ChartColorPaletteController is the one deliberate survivor: a parameterless "
-                   + "bootstrap GET with no assembly in scope, returning a global swatch list");
+      assertEquals(
+         java.util.List.of("ChartColorPaletteController.java", "VSChartBindingController.java"),
+         callers,
+         "two deliberate survivors: ChartColorPaletteController is a parameterless bootstrap GET "
+         + "with no assembly in scope, returning a global swatch list; "
+         + "VSChartBindingController.getColorPalettes falls back to the gate only on its "
+         + "absent-assembly branch, which has no vsId/assemblyName to resolve a mark from");
    }
 
    private static java.util.List<String> filesCallingOfGate() throws Exception {

--- a/core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java
+++ b/core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java
@@ -95,9 +95,27 @@ class VSChartBindingColorPalettesTest {
                  "a classic chart is offered every palette");
    }
 
+   // A mark that cannot be resolved must not take the list down with it: the mark decides which
+   // names carry the flag, never which palettes are returned. The null service makes the lookup
+   // throw, which is the failure this fallback exists for.
+   @Test
+   void anUnresolvableMarkStillReturnsEveryPalette() throws Exception {
+      VSChartBindingController controller = newController();
+      int total = ColorPalettes.getPaletteNames().size();
+
+      SreeEnv.setProperty("viewsheet.modernVisualization", "true");
+      CategoricalColorModel[] palettes =
+         controller.getColorPalettes(null, "vs-1", "Chart1", null);
+
+      assertEquals(total, palettes.length, "a failed mark lookup must not shorten the list");
+      assertEquals(9, Arrays.stream(palettes).filter(CategoricalColorModel::isHidden).count(),
+                   "the fallback resolves through the org gate, which is on here");
+   }
+
    // Builds the endpoint with only the factory its own code path exercises - it only ever
    // wraps ColorPalettes.getPalette() results, which are always CategoricalColorFrame - so no
-   // Spring context or cluster wiring is needed to reach the real flag-attaching loop.
+   // Spring context or cluster wiring is needed to reach the real flag-attaching loop. The null
+   // service is also what makes the mark lookup throw in the fallback test above.
    private VSChartBindingController newController() {
       List<VisualFrameModelFactory<?, ?>> factories =
          List.of(new ColorFrameModelFactory.CategoricalColorFactory());

--- a/core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java
+++ b/core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package inetsoft.web.binding;
 
 import inetsoft.sree.SreeEnv;
@@ -41,10 +58,8 @@ class VSChartBindingColorPalettesTest {
                   "a palette is visible unless the server says otherwise");
    }
 
-   // The endpoint's own flag-attaching loop and null-vsId branch: nothing else in this task
-   // exercises them. The response must carry every palette, hidden ones included, or the
-   // dialog's color-equality match cannot pre-select a chart sitting on a retired palette -
-   // an unmatched dialog repaints the chart with Default on a no-op OK.
+   // The dialog matches a chart's palette by colour list, so an omitted palette would match
+   // nothing, fall back to Default, and repaint the chart on a no-op OK.
    @Test
    void nullVsIdFlagsTheNineHiddenNamesAndOmitsNothing() throws Exception {
       VSChartBindingController controller = newController();

--- a/core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java
+++ b/core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java
@@ -1,0 +1,92 @@
+package inetsoft.web.binding;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.css.CSSDictionary;
+import inetsoft.web.binding.model.graph.aesthetic.CategoricalColorModel;
+import inetsoft.web.binding.service.graph.aesthetic.ColorFrameModelFactory;
+import inetsoft.web.binding.service.graph.aesthetic.VisualFrameModelFactory;
+import inetsoft.web.binding.service.graph.aesthetic.VisualFrameModelFactoryService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSChartBindingColorPalettesTest {
+   @AfterEach
+   void reset() {
+      SreeEnv.setProperty("viewsheet.modernVisualization", null);
+      CSSDictionary.resetDictionaryCache();
+   }
+
+   @Test
+   void hiddenIsOffByDefaultOnTheModel() {
+      assertFalse(new CategoricalColorModel().isHidden(),
+                  "a palette is visible unless the server says otherwise");
+   }
+
+   // The endpoint's own flag-attaching loop and null-vsId branch: nothing else in this task
+   // exercises them. The response must carry every palette, hidden ones included, or the
+   // dialog's color-equality match cannot pre-select a chart sitting on a retired palette -
+   // an unmatched dialog repaints the chart with Default on a no-op OK.
+   @Test
+   void nullVsIdFlagsTheNineHiddenNamesAndOmitsNothing() throws Exception {
+      VSChartBindingController controller = newController();
+      int total = ColorPalettes.getPaletteNames().size();
+
+      SreeEnv.setProperty("viewsheet.modernVisualization", "true");
+      CategoricalColorModel[] modernPalettes =
+         controller.getColorPalettes(null, null, null, null);
+      assertEquals(total, modernPalettes.length, "no palette may be omitted, hidden or not");
+
+      Set<String> hiddenNames =
+         VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT));
+      long hiddenCount = Arrays.stream(modernPalettes).filter(CategoricalColorModel::isHidden).count();
+      assertEquals(9, hiddenCount, "exactly the nine retired palettes must be flagged hidden");
+
+      for(CategoricalColorModel model : modernPalettes) {
+         assertEquals(hiddenNames.contains(model.getName()), model.isHidden(),
+                      model.getName() + " hidden flag must match hiddenPaletteNames");
+      }
+   }
+
+   @Test
+   void nullVsIdLeavesEveryPaletteVisibleWhenGateIsOff() throws Exception {
+      VSChartBindingController controller = newController();
+      int total = ColorPalettes.getPaletteNames().size();
+
+      SreeEnv.setProperty("viewsheet.modernVisualization", "false");
+      CategoricalColorModel[] classicPalettes =
+         controller.getColorPalettes(null, null, null, null);
+
+      assertEquals(total, classicPalettes.length, "no palette may be omitted, hidden or not");
+      assertTrue(Arrays.stream(classicPalettes).noneMatch(CategoricalColorModel::isHidden),
+                 "a classic chart is offered every palette");
+   }
+
+   // Builds the endpoint with only the factory its own code path exercises - it only ever
+   // wraps ColorPalettes.getPalette() results, which are always CategoricalColorFrame - so no
+   // Spring context or cluster wiring is needed to reach the real flag-attaching loop.
+   private VSChartBindingController newController() {
+      List<VisualFrameModelFactory<?, ?>> factories =
+         List.of(new ColorFrameModelFactory.CategoricalColorFactory());
+      VisualFrameModelFactoryService visualService = new VisualFrameModelFactoryService(factories);
+      return new VSChartBindingController(visualService, null);
+   }
+}

--- a/core/src/test/java/inetsoft/web/binding/service/graph/aesthetic/CategoricalColorFactoryResolvedDefaultGuardTest.java
+++ b/core/src/test/java/inetsoft/web/binding/service/graph/aesthetic/CategoricalColorFactoryResolvedDefaultGuardTest.java
@@ -72,7 +72,7 @@ class CategoricalColorFactoryResolvedDefaultGuardTest {
 
       CategoricalColorModel model = new CategoricalColorModel(wrapper);
       String[] colors = model.getColors().clone();
-      // neither the modern head (0x3B82F6) nor the legacy palette (0xfde3a7) value at index 5
+      // neither the modern head (0xFFB020) nor the legacy palette (0xfde3a7) value at index 5
       colors[5] = "#123456";
       model.setColors(colors);
 

--- a/core/src/test/java/inetsoft/web/portal/controller/ChartColorPaletteControllerTest.java
+++ b/core/src/test/java/inetsoft/web/portal/controller/ChartColorPaletteControllerTest.java
@@ -57,8 +57,8 @@ class ChartColorPaletteControllerTest {
       String[] colors = new ChartColorPaletteController().getChartColorPalette();
 
       assertEquals(40, colors.length);
-      assertEquals("#00d4e8", colors[0]);
-      assertEquals("#64748b", colors[7]);
+      assertEquals("#0490ff", colors[0]);
+      assertEquals("#8ed604", colors[7]);
    }
 
    @Test
@@ -68,8 +68,8 @@ class ChartColorPaletteControllerTest {
 
       String[] colors = new ChartColorPaletteController().getChartColorPalette();
 
-      assertEquals("#22d3ee", colors[0]);
-      assertEquals("#94a3b8", colors[7]);
+      assertEquals("#4fa5ff", colors[0]);
+      assertEquals("#9feb28", colors[7]);
    }
 
    @Test

--- a/docs/superpowers/plans/2026-09-11-chart-palette-retune-plan.md
+++ b/docs/superpowers/plans/2026-09-11-chart-palette-retune-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** `Modern` and `Modern Dark` render the redesigned eight head colours, `Contrast` joins the palette picker, and the picker's list is scoped by the chart's own provenance mark so a modern chart is no longer offered the eight single-hue ramps.
+**Goal:** `Modern` and `Modern Dark` render the redesigned eight head colours, `Contrast` joins the palette picker, and the picker's list is scoped by the chart's own provenance mark so a modern chart is no longer offered the nine retired palettes — the eight single-hue ramps plus Pastel.
 
 **Architecture:** Palette data plus one endpoint change plus a dropdown filter. The eight head hexes move in two places that must agree — `defaults.css` and the `MODERN_HEAD`/`DARK_HEAD` fallback constants. A new `hiddenPaletteNames(VizContext)` in `VSChartPaletteDefaults` names what a modern chart should not be offered; the endpoint attaches it to the response as a per-palette `hidden` flag rather than dropping entries, and the dialog filters its dropdown. Nothing in `inetsoft.graph` changes, no colour-frame class is added, and no persisted contract moves.
 

--- a/docs/superpowers/plans/2026-09-11-chart-palette-retune-plan.md
+++ b/docs/superpowers/plans/2026-09-11-chart-palette-retune-plan.md
@@ -1,0 +1,861 @@
+# Chart Palette Re-tune — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `Modern` and `Modern Dark` render the redesigned eight head colours, `Contrast` joins the palette picker, and the picker's list is scoped by the chart's own provenance mark so a modern chart is no longer offered the eight single-hue ramps.
+
+**Architecture:** Palette data plus one endpoint change plus a dropdown filter. The eight head hexes move in two places that must agree — `defaults.css` and the `MODERN_HEAD`/`DARK_HEAD` fallback constants. A new `hiddenPaletteNames(VizContext)` in `VSChartPaletteDefaults` names what a modern chart should not be offered; the endpoint attaches it to the response as a per-palette `hidden` flag rather than dropping entries, and the dialog filters its dropdown. Nothing in `inetsoft.graph` changes, no colour-frame class is added, and no persisted contract moves.
+
+**Tech Stack:** Java 21, Maven, JUnit 5, Spring. Angular 21 / TypeScript 5.9 / Vitest on the browser side.
+
+**Spec:** [2026-09-11-chart-palette-retune-design.md](../specs/lookfeel/2026-09-11-chart-palette-retune-design.md)
+
+---
+
+## Global Constraints
+
+- **Branch:** `feature-chart-palette-retune`, already created off `epic-74519`. Never commit to `main`, `v1.0.x` or `v1.1.x`.
+- **CSS indexes are 1-based.** `ColorPalettes.loadPalettes` skips any index below 1 (`ColorPalettes.java:130-133`). The source handoff's `CSS.md` is written 0-based; applied verbatim every palette loses its first colour. Every rule in this plan is written `index='1'` through `index='8'`.
+- **`defaults.css` and the Java constants must move in the same commit.** `MODERN_HEAD`/`DARK_HEAD` are the fallback `fromFrame` uses when a CSS rule is missing or malformed (`VSChartPaletteDefaults.java:108-130`). Stale constants make a broken `format.css` silently render the old palette.
+- **Indexes 9-40 of `Modern` and `Modern Dark` are not touched.** `ColorPalettesModernTest.tailMatchesLegacyPalette` and `VSChartPaletteDefaultsTest.gateOnSwapsToModernHeadButKeepsLegacyTail` are the drift guards that prove only the head moved. If either fails, the edit went too far.
+- **`Contrast` is appended at the end of `defaults.css`.** `CSSDictionary.getCSSAttributeValues` returns a `LinkedHashSet` (`CSSDictionary.java:949`) and `ColorPalettes` stores into an `OrderedMap`, so CSS declaration order *is* picker order. `Default` must stay the first declaration — the dialog's index-0 fallback depends on it, pinned by `palette-dialog.spec.ts:75-80`.
+- **`ColorPalettes.getPaletteNames()` and `getPalette(name)` stay unfiltered.** `legacyPalette()` resolves `"Default"` and `modernPalette()`/`darkPalette()` resolve `"Modern"`/`"Modern Dark"` by name (`VSChartPaletteDefaults.java:47-84`). Filtering either would break rendering, not just the picker.
+- **CSS style:** three-space indent and lowercase hex, matching the `Default`/`Modern`/`Modern Dark` blocks. The 92 older `color:` lines use two spaces; do not copy those.
+- **Comments:** short clauses. No ticket numbers, PR numbers, or references to this plan, the spec or the roadmap inside source comments.
+- **Java test command (from `community/`):** `./mvnw test -pl core -Dtest=<ClassName>` — PowerShell `.\mvnw.cmd test -pl core "-Dtest=<ClassName>"`. Surefire runs `<groups>core</groups>`, so a new test class needs `@Tag("core")`. Multiple classes are **comma** separated.
+- **Frontend test command (from `community/web/`):** `npx ng test portal --include='**/<file>.spec.ts'`. Always scope with `--include`; never run the suite unscoped.
+
+### The new hexes, once, for reference
+
+| Slot | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|---|
+| **Modern** | `0490ff` | `ff5a35` | `241c4f` | `03d9b3` | `9a2ddc` | `ffb020` | `e5197e` | `8ed604` |
+| **Modern Dark** | `4fa5ff` | `ff8367` | `49447d` | `2deec6` | `ae41f5` | `ffcb82` | `fe3290` | `9feb28` |
+| **Contrast** | `0b3d91` | `f5943f` | `b04ab8` | `f7d22e` | `a8330a` | `7cc4ee` | `00947f` | `5fa83c` |
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `core/src/main/resources/inetsoft/util/css/defaults.css` | The palette definitions | 1, 3 |
+| `core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java` | Head constants; the hidden-name policy | 1, 4 |
+| `core/src/main/java/inetsoft/web/binding/VSChartBindingService.java` | Resolve a chart's mark on the node that owns the runtime | 5 |
+| `core/src/main/java/inetsoft/web/binding/VSChartBindingController.java` | Build the palette list, attach the flag | 5 |
+| `core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java` | The `hidden` transport flag | 5 |
+| `web/projects/portal/src/app/common/data/visual-frame-model.ts` | The browser side of that flag | 5 |
+| `web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts` | Send the assembly context | 6 |
+| `web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts` | Filter the dropdown | 6 |
+| `web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts` | Browser mirror of the head hexes | 2 |
+| Five Java test classes (see Task 1) | Existing assertions on the old hexes; the new CSS/Java drift guard | 1 |
+| `web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts` | Hardcoded hexes, not fixture-relative | 2 |
+
+---
+
+## Task 1: Re-tune Modern and Modern Dark
+
+**Files:**
+- Modify: `core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java` (19 sites)
+- Modify: `core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java:48-53`
+- Modify: `core/src/test/java/inetsoft/web/portal/controller/ChartColorPaletteControllerTest.java:60-72`
+- Modify: `core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteCssOverrideTest.java:71,106,107`
+- Modify: `core/src/test/java/inetsoft/report/composition/graph/VGraphPairModernPaletteTest.java:56`
+- Modify: `core/src/main/resources/inetsoft/util/css/defaults.css:178-208` and `:338-368`
+- Modify: `core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java:180-188`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `VSChartPaletteDefaults.modernPalette()[0..7]` and `darkPalette()[0..7]` returning the new bases. Every later task reads these through existing accessors; no signature changes here.
+
+**Why the test list is longer than the spec's.** The spec's §4 names only `ColorPalettesModernTest`. A sweep for the sixteen old hexes finds **five** classes carrying genuine assertions on them. Three further classes — `CategoricalColorDerivedPersistenceTest` (12 sites), `VizModernizeUtilTest:659`, and a comment in `CategoricalColorFactoryResolvedDefaultGuardTest:75` — use `0x00D4E8` and friends as *arbitrary fixture colours* passed into `setDerivedColor`, never asserting the palette. Those pass either way. **Leave them alone**; changing them is churn that hides the real diff.
+
+- [ ] **Step 1: Update the assertions to the new hexes**
+
+`VSChartPaletteDefaultsTest` — nineteen sites. The light substitutions are `0x00D4E8 → 0x0490FF`, `0x64748B → 0x8ED604`, `0x00B87A → 0xFF5A35`; the dark ones are `0x22D3EE → 0x4FA5FF`, `0x94A3B8 → 0x9FEB28`, `0x10B981 → 0xFF8367`. Applied at `:54`, `:55`, `:62`, `:63`, `:97`, `:98`, `:104`, `:105`, `:185`, `:186`, `:196`, `:197`, `:210`, `:216`, `:219`, `:236`, `:239`, `:287`, plus the fixture at `:175-178`:
+
+```java
+   private static final Color[] MODERN_HEAD_FIXTURE = {
+      new Color(0x0490FF), new Color(0xFF5A35), new Color(0x241C4F), new Color(0x03D9B3),
+      new Color(0x9A2DDC), new Color(0xFFB020), new Color(0xE5197E), new Color(0x8ED604)
+   };
+```
+
+That fixture is only ever passed as the `head` argument to `fromFrame`, and its four tests assert `spliceLegacy(FIXTURE)` against the result — they are self-consistent and would pass with any values. Update it anyway so a reader is not told two different stories about what the modern head is.
+
+`ColorPalettesModernTest:46-54`:
+
+```java
+   @Test
+   void modernHeadMatchesSpec() {
+      CategoricalColorFrame modern = ColorPalettes.getPalette("Modern");
+      assertEquals(new Color(0x0490FF), modern.getDefaultColor(0));
+      assertEquals(new Color(0x8ED604), modern.getDefaultColor(7));
+
+      CategoricalColorFrame dark = ColorPalettes.getPalette("Modern Dark");
+      assertEquals(new Color(0x4FA5FF), dark.getDefaultColor(0));
+      assertEquals(new Color(0x9FEB28), dark.getDefaultColor(7));
+   }
+```
+
+`ChartColorPaletteControllerTest` asserts lowercase strings, not `Color`:
+
+```java
+      assertEquals("#0490ff", colors[0]);    // :60
+      assertEquals("#8ed604", colors[7]);    // :61
+      assertEquals("#4fa5ff", colors[0]);    // :71
+      assertEquals("#9feb28", colors[7]);    // :72
+```
+
+`VSChartPaletteCssOverrideTest`: `:71` and `:106` become `new Color(0x0490FF)`, `:107` becomes `new Color(0x8ED604)`.
+
+`VGraphPairModernPaletteTest:56` becomes `assertEquals(new Color(0x0490FF), frame.getColor(0));`.
+
+- [ ] **Step 2: Run the five classes to verify they fail**
+
+```
+./mvnw test -pl core -Dtest=VSChartPaletteDefaultsTest,ColorPalettesModernTest,ChartColorPaletteControllerTest,VSChartPaletteCssOverrideTest,VGraphPairModernPaletteTest
+```
+
+Expected: failures in all five, every one an `expected: <java.awt.Color[r=4,g=144,b=255]> but was: <java.awt.Color[r=0,g=212,b=232]>` shape. **If any class passes, stop** — it means the assertions were not actually updated, or the class was already resolving from somewhere other than `defaults.css`.
+
+- [ ] **Step 3: Move the CSS head colours**
+
+`defaults.css:178-208`, eight rules, values only — selectors and indentation unchanged:
+
+```css
+ChartPalette[name='Modern'][index='1'] {
+   color: #0490ff;
+}
+
+ChartPalette[name='Modern'][index='2'] {
+   color: #ff5a35;
+}
+
+ChartPalette[name='Modern'][index='3'] {
+   color: #241c4f;
+}
+
+ChartPalette[name='Modern'][index='4'] {
+   color: #03d9b3;
+}
+
+ChartPalette[name='Modern'][index='5'] {
+   color: #9a2ddc;
+}
+
+ChartPalette[name='Modern'][index='6'] {
+   color: #ffb020;
+}
+
+ChartPalette[name='Modern'][index='7'] {
+   color: #e5197e;
+}
+
+ChartPalette[name='Modern'][index='8'] {
+   color: #8ed604;
+}
+```
+
+`defaults.css:338-368`, the same eight indexes under `name='Modern Dark'`, taking `#4fa5ff`, `#ff8367`, `#49447d`, `#2deec6`, `#ae41f5`, `#ffcb82`, `#fe3290`, `#9feb28` in order.
+
+Index 9 of each palette (`:210`, `:370`) is the first legacy-tail entry and must not move.
+
+- [ ] **Step 4: Move the Java fallback constants**
+
+`VSChartPaletteDefaults.java:180-188`:
+
+```java
+   private static final Color[] MODERN_HEAD = {
+      new Color(0x0490FF), new Color(0xFF5A35), new Color(0x241C4F), new Color(0x03D9B3),
+      new Color(0x9A2DDC), new Color(0xFFB020), new Color(0xE5197E), new Color(0x8ED604)
+   };
+
+   private static final Color[] DARK_HEAD = {
+      new Color(0x4FA5FF), new Color(0xFF8367), new Color(0x49447D), new Color(0x2DEEC6),
+      new Color(0xAE41F5), new Color(0xFFCB82), new Color(0xFE3290), new Color(0x9FEB28)
+   };
+```
+
+- [ ] **Step 5: Run the five classes to verify they pass**
+
+Same command as Step 2. All five green, and specifically `tailMatchesLegacyPalette` and `gateOnSwapsToModernHeadButKeepsLegacyTail` green — those are the proof the tail is intact.
+
+- [ ] **Step 6: Add the drift guard**
+
+Nothing today catches `defaults.css` and the Java fallback constants disagreeing: every existing test asserts one side or the other, never that they match. This whole task depends on them moving together, so pin it.
+
+`MODERN_HEAD` and `DARK_HEAD` are `private static final`. Read them by reflection rather than widening them for a test — `VSChartPaletteDefaultsTest.clearMemoDiscardsTheCachedEntry:274-288` already reaches the private `MEMO` field the same way, so the idiom is established in this exact class. Append there:
+
+```java
+   // The CSS rules and the Java fallback constants are two statements of the same eight colors.
+   // Every other test asserts one side or the other, so only this one fails when they drift - and
+   // a drift is silent in production until a malformed format.css makes the fallback fire.
+   @Test
+   void cssHeadMatchesTheJavaFallback() throws Exception {
+      assertHeadMatches("MODERN_HEAD", "Modern");
+      assertHeadMatches("DARK_HEAD", "Modern Dark");
+   }
+
+   private void assertHeadMatches(String fieldName, String paletteName) throws Exception {
+      Field field = VSChartPaletteDefaults.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      Color[] head = (Color[]) field.get(null);
+      CategoricalColorFrame css = ColorPalettes.getPalette(paletteName);
+
+      assertEquals(8, head.length, fieldName + " must declare exactly the eight head colors");
+
+      for(int i = 0; i < head.length; i++) {
+         assertEquals(head[i], css.getDefaultColor(i),
+                      paletteName + " index " + (i + 1) + " must match " + fieldName);
+      }
+   }
+```
+
+Add `import inetsoft.uql.viewsheet.graph.aesthetic.ColorPalettes;` to the test.
+
+- [ ] **Step 7: Prove the guard actually guards**
+
+A test that passes before and after a change proves nothing on its own. Temporarily change one `MODERN_HEAD` entry to `new Color(0x000000)`, run `./mvnw test -pl core -Dtest=VSChartPaletteDefaultsTest`, and confirm `cssHeadMatchesTheJavaFallback` fails naming index 1. Revert the edit and re-run to green. Do not commit the broken state.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/src/main/resources/inetsoft/util/css/defaults.css core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java core/src/test/java/inetsoft/web/portal/controller/ChartColorPaletteControllerTest.java core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteCssOverrideTest.java core/src/test/java/inetsoft/report/composition/graph/VGraphPairModernPaletteTest.java
+git commit -m "Re-tune the Modern and Modern Dark head colours"
+```
+
+State in the body that the CSS and the Java fallback constants moved together, and that indexes 9-40 are untouched.
+
+---
+
+## Task 2: Re-tune the browser's palette fixtures
+
+**Files:**
+- Modify: `web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts:24-30`
+- Modify: `web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts:53,54,63,74`
+- Test: `web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 at runtime — these are browser-side fixtures describing what the server now sends.
+- Produces: `MODERN_HEAD` and `DARK_HEAD` exports carrying the new hexes, consumed by four spec files.
+
+**Why this is its own task.** The fixtures are self-consistent: `palette40(MODERN_HEAD)` builds the array *and* the assertions read from it, so nothing breaks if they stay stale — they just describe a palette the server no longer serves. The exception is `chart-palette.service.spec.ts`, which **hardcodes the hexes** rather than reading the fixture, so it breaks the moment the fixture moves. The spec's claim that all four consumers "assert fixture-relative and follow automatically" is true of three of them and false of this one.
+
+- [ ] **Step 1: Update the fixtures**
+
+`palette-test-fixtures.ts:24-30`:
+
+```typescript
+export const MODERN_HEAD: string[] = [
+   "#0490ff", "#ff5a35", "#241c4f", "#03d9b3", "#9a2ddc", "#ffb020", "#e5197e", "#8ed604"
+];
+
+export const DARK_HEAD: string[] = [
+   "#4fa5ff", "#ff8367", "#49447d", "#2deec6", "#ae41f5", "#ffcb82", "#fe3290", "#9feb28"
+];
+```
+
+`LEGACY_HEAD` and `LEGACY_TAIL` are unchanged.
+
+- [ ] **Step 2: Run the consumer specs to verify one fails**
+
+```
+npx ng test portal --include='**/chart-palette.service.spec.ts' --include='**/combined-color-pane.spec.ts' --include='**/color-field-pane.spec.ts' --include='**/palette-dialog.spec.ts'
+```
+
+Expected: `chart-palette.service.spec.ts` fails on "chunks 40 colors into a 5x8 grid" and "exposes a flat 40-entry list". The other three pass — they read the fixture. **If all four pass, the fixture edit did not land.**
+
+- [ ] **Step 3: Make the hardcoded spec read the fixture**
+
+`chart-palette.service.spec.ts:53-54` and `:63` stop restating the hexes. Import `MODERN_HEAD` — the file already imports `palette40` from the same module (`:22`) — and assert through it, so this file can never drift again:
+
+```typescript
+      expect(grid[0][0]).toBe(MODERN_HEAD[0]);
+      expect(grid[0][7]).toBe(MODERN_HEAD[7]);
+```
+
+and:
+
+```typescript
+      expect(service.flatColors()[0]).toBe(MODERN_HEAD[0]);
+```
+
+`:74` (`flush(["#00d4e8", "#00b87a"])`) proves a two-colour response falls back; the values are arbitrary and never asserted. Change it to `flush(MODERN_HEAD.slice(0, 2))` so no stale hex survives in the file.
+
+- [ ] **Step 4: Run the four specs to verify they pass**
+
+Same command as Step 2. All four green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts
+git commit -m "Point the browser palette fixtures at the re-tuned head colours"
+```
+
+---
+
+## Task 3: Add the Contrast palette
+
+**Files:**
+- Modify: `core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java`
+- Modify: `core/src/main/resources/inetsoft/util/css/defaults.css` (append after `:864`)
+
+**Interfaces:**
+- Consumes: `ColorPalettes.getPaletteNames()`, `ColorPalettes.getPalette(String)`.
+- Produces: a palette named `Contrast` with eight declared colours, discoverable with no Java registration. Task 4 relies on it existing; Task 5 serves it.
+
+**Why eight slots is fine.** `Soft` already ships at 8, and `PaletteDialog.saveChanges()` (`palette-dialog.component.ts:122-127`) splices the chosen palette over the first *n* of the chart's colours and keeps the rest, so a short palette is an established shape. `Contrast` is never resolved by `VSChartPaletteDefaults`, so `fromFrame`'s 40-colour floor (`:115`) never sees it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ColorPalettesModernTest`:
+
+```java
+   @Test
+   void contrastIsRegisteredWithEightColors() {
+      assertTrue(ColorPalettes.getPaletteNames().contains("Contrast"),
+                 "Contrast palette must be declared in defaults.css");
+
+      CategoricalColorFrame contrast = ColorPalettes.getPalette("Contrast");
+      assertNotNull(contrast);
+      assertEquals(8, contrast.getColorCount());
+
+      for(int i = 0; i < 8; i++) {
+         assertNotNull(contrast.getDefaultColor(i), "index " + (i + 1) + " must not be null");
+      }
+
+      assertEquals(new Color(0x0B3D91), contrast.getDefaultColor(0));
+      assertEquals(new Color(0x5FA83C), contrast.getDefaultColor(7));
+   }
+
+   // Default must stay the first declaration: the palette dialog falls back to index 0 when a
+   // chart's colors match nothing, and that fallback is only correct if index 0 is Default.
+   @Test
+   void defaultIsStillDeclaredFirst() {
+      assertEquals("Default", ColorPalettes.getPaletteNames().iterator().next());
+   }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+`./mvnw test -pl core -Dtest=ColorPalettesModernTest`
+
+Expected: `contrastIsRegisteredWithEightColors` fails on the `getPaletteNames().contains` assertion. `defaultIsStillDeclaredFirst` should **pass already** — it pins existing behaviour so Step 3 cannot break it.
+
+- [ ] **Step 3: Append the CSS block**
+
+At the end of `defaults.css`, after the `Heat 24` index 24 rule that currently closes the file at `:864`. Appending puts `Contrast` last in the picker and leaves every existing position untouched:
+
+```css
+
+ChartPalette[name='Contrast'][index='1'] {
+   color: #0b3d91;
+}
+
+ChartPalette[name='Contrast'][index='2'] {
+   color: #f5943f;
+}
+
+ChartPalette[name='Contrast'][index='3'] {
+   color: #b04ab8;
+}
+
+ChartPalette[name='Contrast'][index='4'] {
+   color: #f7d22e;
+}
+
+ChartPalette[name='Contrast'][index='5'] {
+   color: #a8330a;
+}
+
+ChartPalette[name='Contrast'][index='6'] {
+   color: #7cc4ee;
+}
+
+ChartPalette[name='Contrast'][index='7'] {
+   color: #00947f;
+}
+
+ChartPalette[name='Contrast'][index='8'] {
+   color: #5fa83c;
+}
+```
+
+There is deliberately no `Contrast Dark`. The palette's contract is paper and projection.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+`./mvnw test -pl core -Dtest=ColorPalettesModernTest` — all seven tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/main/resources/inetsoft/util/css/defaults.css core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java
+git commit -m "Add the Contrast categorical palette"
+```
+
+---
+
+## Task 4: The hidden-name policy
+
+**Files:**
+- Modify: `core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java`
+- Modify: `core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java`
+
+**Interfaces:**
+- Consumes: `VizContext.modern`, `VizContext.of(VizMark)`, `VizContext.ofGate()`.
+- Produces: `public static Set<String> hiddenPaletteNames(VizContext ctx)` — the names a picker should mark hidden for that context. Empty under a classic mark. Task 5 is its only caller.
+
+**Why here.** This class already owns modern-palette policy, already imports `ColorPalettes`, and sits in the same package as `VizContext`. It returns names to *mark*, never a filtered list — Task 5 explains why nothing is removed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `VSChartPaletteDefaultsTest`:
+
+```java
+   @Test
+   void hiddenNamesAreEmptyForAClassicChart() {
+      assertTrue(VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of((VizMark) null)).isEmpty(),
+                 "a classic chart keeps every palette it has today");
+   }
+
+   @Test
+   void hiddenNamesAreTheNineRampsForAModernChart() {
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(Set.of("Pastel", "Heat 8", "Heat 16", "Heat 24",
+                          "Blue", "Green", "Red", "Orange", "Gray"), hidden);
+   }
+
+   @Test
+   void hiddenNamesAreTheSameUnderADarkMark() {
+      assertEquals(VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT)),
+                   VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_DARK)),
+                   "dark is a modifier of modern, not a different palette set");
+   }
+
+   // The five a modern chart keeps. Default stays so the dialog's index-0 fallback is unchanged
+   // and a chart has a route back to the classic 40 without reverting the whole dashboard.
+   @Test
+   void hiddenNamesNeverCoverTheKeptFive() {
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT));
+
+      for(String kept : new String[]{ "Default", "Soft", "Modern", "Modern Dark", "Contrast" }) {
+         assertFalse(hidden.contains(kept), kept + " must stay offered to a modern chart");
+      }
+   }
+
+   @Test
+   void hiddenNamesFollowTheGateWhenThereIsNoAssembly() {
+      SreeEnv.setProperty("viewsheet.modernVisualization", "false");
+      assertTrue(VSChartPaletteDefaults.hiddenPaletteNames(VizContext.ofGate()).isEmpty());
+
+      SreeEnv.setProperty("viewsheet.modernVisualization", "true");
+      assertEquals(9, VSChartPaletteDefaults.hiddenPaletteNames(VizContext.ofGate()).size());
+   }
+```
+
+Add `import java.util.Set;` to the test's imports.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+`./mvnw test -pl core -Dtest=VSChartPaletteDefaultsTest`
+
+Expected: compilation failure — `hiddenPaletteNames` does not exist. That is the correct red state for a new method.
+
+- [ ] **Step 3: Write the implementation**
+
+In `VSChartPaletteDefaults`, beside the other public accessors:
+
+```java
+   /**
+    * Palette names a picker should mark hidden for the given context. A modern chart is not
+    * offered the single-hue ramps; a classic chart keeps everything. Never removes a name from
+    * resolution - getPalette must still answer for every one of these.
+    */
+   public static Set<String> hiddenPaletteNames(VizContext ctx) {
+      return ctx.modern ? MODERN_HIDDEN : Set.of();
+   }
+```
+
+and with the other constants:
+
+```java
+   private static final Set<String> MODERN_HIDDEN =
+      Set.of("Pastel", "Heat 8", "Heat 16", "Heat 24", "Blue", "Green", "Red", "Orange", "Gray");
+```
+
+Add `import java.util.Set;`.
+
+- [ ] **Step 4: Run them to verify they pass**
+
+`./mvnw test -pl core -Dtest=VSChartPaletteDefaultsTest` — green, including every pre-existing test in the class.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java
+git commit -m "Name the palettes a modern chart is not offered"
+```
+
+---
+
+## Task 5: Serve the flag with assembly context
+
+**Files:**
+- Modify: `core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java`
+- Modify: `core/src/main/java/inetsoft/web/binding/VSChartBindingService.java`
+- Modify: `core/src/main/java/inetsoft/web/binding/VSChartBindingController.java:234-253`
+- Modify: `web/projects/portal/src/app/common/data/visual-frame-model.ts:40-51`
+- Create: `core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java`
+
+**Interfaces:**
+- Consumes: `VSChartPaletteDefaults.hiddenPaletteNames(VizContext)` from Task 4.
+- Produces:
+  - `CategoricalColorModel.isHidden()` / `setHidden(boolean)`, serialized as `hidden`.
+  - `VSChartBindingService.getChartVizMark(@ClusterProxyKey String vsId, String assemblyName, Principal principal)` returning `VizMark` (nullable).
+  - `getColorPalettes` accepting optional `vsId` and `assemblyName` query params.
+
+**The shape, and why it is not what the spec drew.** The spec proposed moving the whole `getColorPalettes` body into the service as a `@ClusterProxyMethod`. Two facts make a smaller cut better. First, `@ClusterProxyKey` is the routing key — the generated proxy calls `_wsService.isLocal(vsId)` and then `affinityCall(vsId, ...)` (`VSChartBindingServiceProxy.java:49-60`), so a null `vsId` has no node to route to, and the target-band pane sends none. The controller must branch on that regardless. Second, the controller already holds `visualService`, and keeping the list-building there means one code path for the list and one small branch for the context. So the proxy carries only the mark.
+
+Org context survives the hop either way: `@SwitchOrg` pushes a `SwitchOrgAspectTask` onto `ServiceProxyContext.aspectTasks` (`EventAspect.java:576`), which the generated callable replays via `serviceProxyContext.preprocess()` on the receiving node.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package inetsoft.web.binding;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.css.CSSDictionary;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSChartBindingColorPalettesTest {
+   @AfterEach
+   void reset() {
+      SreeEnv.setProperty("viewsheet.modernVisualization", null);
+      CSSDictionary.resetDictionaryCache();
+   }
+
+   // The response must carry every palette, hidden ones included, or the dialog's color-equality
+   // match cannot pre-select a chart that is sitting on a retired palette - and an unmatched
+   // dialog repaints the chart with Default on a no-op OK.
+   @Test
+   void aModernContextHidesNineAndOmitsNothing() {
+      Set<String> hidden =
+         VSChartPaletteDefaults.hiddenPaletteNames(VizContext.of(VizMark.MODERN_LIGHT));
+
+      assertEquals(9, hidden.size());
+      assertTrue(hidden.contains("Heat 8"));
+      assertFalse(hidden.contains("Default"));
+   }
+
+   @Test
+   void hiddenIsOffByDefaultOnTheModel() {
+      assertFalse(new inetsoft.web.binding.model.graph.aesthetic.CategoricalColorModel().isHidden(),
+                  "a palette is visible unless the server says otherwise");
+   }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+`./mvnw test -pl core -Dtest=VSChartBindingColorPalettesTest`
+
+Expected: compilation failure on `isHidden()`.
+
+- [ ] **Step 3: Add the transport flag**
+
+In `CategoricalColorModel`, beside the other private fields and accessors:
+
+```java
+   public boolean isHidden() {
+      return hidden;
+   }
+
+   public void setHidden(boolean hidden) {
+      this.hidden = hidden;
+   }
+```
+
+and with the fields at `:177-185`:
+
+```java
+   private boolean hidden;
+```
+
+It goes on `CategoricalColorModel`, not the `VisualFrameModel` base: only palettes are ever hidden, and the base is shared by the shape, size, texture and line frame models. It reaches no persisted state — `createVisualFrame()` (`:165-167`) returns a bare `new CategoricalColorFrame()` and reads no transport field, and `CategoricalColorFrameWrapper.writeContents()/parseContents()` (`:182`, `:267`) never touch it.
+
+The browser mirror, `visual-frame-model.ts:40-51`:
+
+```typescript
+export class CategoricalColorModel extends ColorFrameModel {
+   clazz: string = "inetsoft.web.binding.model.graph.aesthetic.CategoricalColorModel";
+   colors: string[];
+   cssColors: string[];
+   defaultColors: string[];
+   colorMaps: ColorMap[];
+   globalColorMaps: ColorMap[];
+   useGlobal: boolean;
+   shareColors: boolean;
+   dateFormat: number;
+   colorValueFrame?: boolean;
+   hidden?: boolean;
+}
+```
+
+- [ ] **Step 4: Add the proxy method**
+
+In `VSChartBindingService`, following the `getChartBinding` shape at `:66-73`:
+
+```java
+   /**
+    * The chart's own provenance mark, read on the node that owns the runtime viewsheet. Null for
+    * an unmarked chart, a missing assembly, or an assembly that is not a chart.
+    */
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public VizMark getChartVizMark(@ClusterProxyKey String vsId, String assemblyName,
+                                  Principal principal)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(Tool.byteDecode(vsId), principal);
+      Viewsheet viewsheet = rvs.getViewsheet();
+      Assembly assembly = viewsheet == null ? null : viewsheet.getAssembly(assemblyName);
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         return null;
+      }
+
+      return chart.getVSAssemblyInfo().getVizMark();
+   }
+```
+
+Add `import inetsoft.uql.viewsheet.internal.VizMark;` — the class already imports `ChartVSAssemblyInfo` from that package but not `VizMark`. `Assembly` arrives with the existing `inetsoft.uql.viewsheet.*` import.
+
+The proxy class is generated by `inetsoft.cluster.apt.ClusterAnnotationProcessor`; do not hand-edit `VSChartBindingServiceProxy`.
+
+- [ ] **Step 5: Widen the endpoint**
+
+`VSChartBindingController:234-253` becomes:
+
+```java
+   @RequestMapping(value = "/api/composer/chart/colorpalettes", method = RequestMethod.GET)
+   @HandleExceptions
+   @SwitchOrg
+   public CategoricalColorModel[] getColorPalettes(
+      @OrganizationID String orgId,
+      @RequestParam(required = false, value = "vsId") String vsId,
+      @RequestParam(required = false, value = "assemblyName") String assemblyName,
+      Principal principal)
+      throws Exception
+   {
+      VizContext ctx = vsId == null || assemblyName == null
+         ? VizContext.ofGate()
+         : VizContext.of(chartBindingService.getChartVizMark(vsId, assemblyName, principal));
+      Set<String> hidden = VSChartPaletteDefaults.hiddenPaletteNames(ctx);
+      String[] names = ColorPalettes.getPaletteNames().toArray(new String[0]);
+      CategoricalColorModel[] palettes = new CategoricalColorModel[names.length];
+
+      for(int i = 0; i < names.length; i++) {
+         CategoricalColorFrame palette = ColorPalettes.getPalette(names[i]);
+         CategoricalColorFrameWrapper wrapper = new CategoricalColorFrameWrapper();
+         wrapper.setVisualFrame(palette);
+         CategoricalColorModel model = visualService.createVisualFrameModel(wrapper);
+         model.setName(names[i]);
+         model.setHidden(hidden.contains(names[i]));
+         palettes[i] = model;
+      }
+
+      return palettes;
+   }
+```
+
+Add `import inetsoft.uql.viewsheet.internal.VizContext;` and `import inetsoft.uql.viewsheet.internal.VSChartPaletteDefaults;`. `Set` arrives with the existing `java.util.*` import; `ColorPalettes`, `CategoricalColorFrame` and `CategoricalColorFrameWrapper` are already imported via the wildcard imports at `:21` and `:31`.
+
+The absent-assembly branch is what the target-band colour pane lands on: it sends only `assetId` (`b-categorical-color-pane.component.ts:62-66`), so it resolves through `ofGate()` — the same authority `ChartColorPaletteController:45` already uses for a global swatch list with no assembly in scope.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+`./mvnw test -pl core -Dtest=VSChartBindingColorPalettesTest,VSChartPaletteDefaultsTest`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/src/main/java/inetsoft/web/binding/VSChartBindingController.java core/src/main/java/inetsoft/web/binding/VSChartBindingService.java core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java core/src/test/java/inetsoft/web/binding/VSChartBindingColorPalettesTest.java web/projects/portal/src/app/common/data/visual-frame-model.ts
+git commit -m "Flag the palettes a modern chart is not offered"
+```
+
+---
+
+## Task 6: Filter the dropdown
+
+**Files:**
+- Modify: `web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts`
+- Modify: `web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts:42-47`
+- Modify: `web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts:110-115`
+
+**Interfaces:**
+- Consumes: `CategoricalColorModel.hidden` from Task 5.
+- Produces: nothing downstream. This is the last task.
+
+**The invariant being protected.** `getPaletteIndex()` returns 0 when nothing matches (`palette-dialog.component.ts:73-113`) and `saveChanges()` splices whatever is displayed over the chart's colours (`:122-127`). So an unmatched dialog shows "Default" and repaints the chart on a no-op OK. Matching therefore runs over **every** palette and only the dropdown is filtered — a chart sitting on a retired palette still pre-selects it, and can still choose to leave it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `palette-dialog.spec.ts`. The `palette()` helper at `:28-33` needs an optional flag:
+
+```typescript
+function palette(name: string, head: string[], hidden = false): CategoricalColorModel {
+   const model = new CategoricalColorModel();
+   model.name = name;
+   model.colors = palette40(head);
+   model.hidden = hidden;
+   return model;
+}
+```
+
+then:
+
+```typescript
+describe("PaletteDialog hidden palettes", () => {
+   function dialogWithHidden(currentColors: string[]): PaletteDialog {
+      const dialog = new PaletteDialog();
+      dialog.colorPalettes = [
+         palette("Default", LEGACY_HEAD),
+         palette("Modern", MODERN_HEAD),
+         palette("Heat 8", HEAT_HEAD, true)
+      ];
+      const curr = new CategoricalColorModel();
+      curr.colors = currentColors;
+      dialog.currPalette = curr;
+      return dialog;
+   }
+
+   it("drops a hidden palette from the dropdown", () => {
+      const dialog = dialogWithHidden(palette40(MODERN_HEAD));
+      expect(dialog.paletteSelectOptions.map((o) => o.label)).toEqual(["Default", "Modern"]);
+   });
+
+   it("keeps a hidden palette in the dropdown when the chart is using it", () => {
+      const dialog = dialogWithHidden(palette40(HEAT_HEAD));
+      expect(dialog.displayPalette.name).toBe("Heat 8");
+      expect(dialog.paletteSelectOptions.map((o) => o.label))
+         .toEqual(["Default", "Modern", "Heat 8"]);
+   });
+
+   // The option value indexes into colorPalettes, not into the filtered list, or selecting an
+   // option after a hidden one would apply the wrong palette.
+   it("keeps option values aligned with the unfiltered array", () => {
+      const dialog = dialogWithHidden(palette40(MODERN_HEAD));
+      expect(dialog.paletteSelectOptions.map((o) => o.value)).toEqual([0, 1]);
+   });
+
+   it("does not repaint a chart sitting on a hidden palette", () => {
+      const dialog = dialogWithHidden(palette40(HEAT_HEAD));
+      expect(dialog.displayPalette.colors).toEqual(palette40(HEAT_HEAD));
+   });
+});
+```
+
+Declare the fixture used above near the top of the file, after the imports:
+
+```typescript
+const HEAT_HEAD: string[] = [
+   "#663300", "#914800", "#bd5e00", "#e97400", "#ff8a15", "#ffa041", "#ffb66d", "#ffcc99"
+];
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```
+npx ng test portal --include='**/palette-dialog.spec.ts'
+```
+
+Expected: the four new tests fail — `paletteSelectOptions` currently returns all three labels. The four pre-existing pre-selection tests must still pass.
+
+- [ ] **Step 3: Filter the dropdown**
+
+`palette-dialog.component.ts:42-47`:
+
+```typescript
+   get paletteSelectOptions(): CustomSelectOption<number>[] {
+      const selected = this.displayPalette == null ? -1 : this._selectedIndex;
+
+      return (this.colorPalettes || [])
+         .map((palette, index) => ({ palette, index }))
+         .filter(({ palette, index }) => !palette.hidden || index === selected)
+         .map(({ palette, index }) => ({
+            value: index,
+            label: palette.name
+         }));
+   }
+```
+
+Reading `this.displayPalette` first is what resolves `_selectedIndex` from `-1` on the first call — the getter assigns it at `:54-56`. The `index` carried through the filter is the position in the unfiltered `colorPalettes`, which is what `_selectedIndex` and `displayPalette` both index by.
+
+- [ ] **Step 4: Run them to verify they pass**
+
+`npx ng test portal --include='**/palette-dialog.spec.ts'` — all eight green.
+
+- [ ] **Step 5: Send the assembly context**
+
+`categorical-color-pane.component.ts:110-115`. The component already holds both inputs (`:63`, `:65`), and `getColorMappingDialog` two methods above shows the idiom:
+
+```typescript
+   private getColorPalettes(): Observable<any> {
+      const params = new HttpParams()
+         .set("orgId", createAssetEntry(this.assetId).organization)
+         .set("vsId", this.vsId)
+         .set("assemblyName", this.assemblyName);
+
+      return this.modelService.getModel(COLOR_PALETTES_URI, params);
+   }
+```
+
+`b-categorical-color-pane.component.ts` is not touched: sending nothing is what puts it on the org-gate branch.
+
+- [ ] **Step 6: Run the binding specs**
+
+```
+npx ng test portal --include='**/palette-dialog.spec.ts' --include='**/categorical-color-pane*.spec.ts' --include='**/combined-color-pane.spec.ts'
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts
+git commit -m "Hide retired palettes from a modern chart's picker"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Core suite:** `./mvnw test -pl core` — green, no new failures or skips against the branch baseline.
+- [ ] **Cross-module build:** `./mvnw clean install -DskipTests -Pcommunity,enterprise` — BUILD SUCCESS. Use `clean`; an incremental `install` has reported SUCCESS over a real break on this branch before.
+- [ ] **Frontend:** `npx ng test portal` from `community/web/` — green. Do not run the TL suite; nothing in this plan touches a `*.tl.spec.ts`.
+- [ ] **A modern chart in the browser.** With `viewsheet.modernVisualization` on, create a dashboard and a chart. Its marks render the new bases — azure first, coral second, the near-black ink at slot 3. Open the colour binding's palette dialog: the dropdown offers Default, Soft, Modern, Modern Dark and Contrast, and none of Pastel, Heat 8/16/24, Blue, Green, Red, Orange or Gray.
+- [ ] **A classic chart in the browser.** On an unmarked dashboard, the same dialog offers all fourteen names — the thirteen that shipped plus Contrast.
+- [ ] **The no-op OK.** On a modern chart, set the palette to Heat 8 *before* this change is deployed (or set its colours to Heat 8's by hand), then reopen the dialog. It must pre-select **Heat 8**, not Default, and clicking OK must leave the chart's colours untouched. This is the regression the `hidden` flag exists to prevent; if it shows Default, the response is omitting entries instead of flagging them.
+- [ ] **The target-band pane.** Open a chart's target line dialog and the Fill Band colour control. It resolves through the org gate, so with the gate on it shows the modern-scoped list and with the gate off the full one — independent of any chart's mark.
+- [ ] **An org gate switched off after modernization.** Turn `viewsheet.modernVisualization` off with a marked dashboard already saved. Its chart's binding picker must still show the reduced list, because it reads the mark and not the property. The target-band pane will show the full list; that divergence is intended and documented in the spec.
+- [ ] **A cluster hop.** In a two-node install, open a chart whose runtime viewsheet lives on the other node and confirm the palette list is still correctly scoped — this exercises `getChartVizMark` through `affinityCall` and the `SwitchOrgAspectTask` replay.
+- [ ] **Export parity.** One modern chart exported to PDF, PNG and Excel, matching the viewer's colours.

--- a/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
+++ b/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
@@ -46,10 +46,20 @@ classic 40 regardless of the CSS.
    reduced list. A classic chart keeps all of today's names. `Contrast` is offered to both, because
    an accessibility palette is not a look-and-feel choice.
 3. **One authority; the org gate is only the absent-assembly default.** The binding picker resolves
-   `VizContext.of(mark)` from the chart's own `VizMark`. A caller with no assembly to resolve — the
-   target-band colour pane included — falls through to `VizContext.ofGate()` as the null-branch
-   default. That pane deliberately shows every palette regardless: it cannot tell a classic chart
-   from a modern one, and filtering it on the org gate would hide retired palettes from classic
+   `VizContext.of(mark)` from the chart's own `VizMark`. A caller with no assembly to resolve falls
+   through to `VizContext.ofGate()` as the null-branch default, and a mark that cannot be resolved
+   falls back the same way rather than failing the request — the mark decides which names carry the
+   flag, never which palettes are returned.
+
+   **Three hosts render `categorical-color-pane`, and only one supplies assembly context.**
+   `color-field-mc` (the binding editor) passes `vsId`, `assemblyName` and `assetId`. The other two —
+   `visual-dropdown-pane` and the date-comparison pane — pass none of the three, and that is
+   pre-existing: `ngOnInit` calls `createAssetEntry(this.assetId).organization`, and
+   `createAssetEntry` returns `null` for an unparseable id, so both throw before the request is
+   made. Neither can reach the org-gate branch at all until that is fixed, which is a separate
+   defect. The target-band pane is a fourth caller, through `b-categorical-color-pane`, and it does
+   null-guard that call; it deliberately shows every palette, because it cannot tell a classic chart
+   from a modern one and filtering it on the org gate would hide retired palettes from classic
    charts in a modern org.
 4. **Ramps are out of scope.** `Variance`, `Amber` and `Teal` are `LinearColorFrame` work, not CSS
    (see Corrections below).
@@ -251,8 +261,13 @@ The opening this leaves: a modern chart whose old head colours were pinned into 
 `applyModernPalette` — the user tier wins over defaults unconditionally. That chart's rendered
 colours then match no registered palette, the dialog shows `Default` selected, and a no-op OK
 repaints it to the classic legacy 40 — the exact hazard section 3 exists to prevent, arriving
-through a door section 3 did not consider. This needs a manual check; it is not something an
-automated test can cover.
+through a door section 3 did not consider. It is not something an automated test can cover.
+
+**Checked manually on 2026-09-11 and it does not occur.** A dashboard created under the modern gate
+before the re-tune still pre-selects `Modern` in the palette dialog afterwards, so the stored head
+is re-resolved as described rather than stranding the chart on an unmatched colour list. Recorded
+here so the next re-tune does not have to re-derive it — though the check is worth repeating, since
+what makes it safe is the default tier holding those colours, not anything this branch enforces.
 
 **A "hard-fail with a migration warning" for `Gray` has nowhere to live.** There is no name lookup
 at load time to fail in.

--- a/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
+++ b/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
@@ -94,6 +94,14 @@ luminance across a 0.05-0.66 span, and the slot order interleaves the ladder so 
 three-series chart draws from opposite ends. `Contrast` gets **no dark variant**: its contract is
 paper and projection.
 
+**The two rules pull against each other at the tail, and the interleave wins.** Ordering for the
+low-cardinality case means the weakest consecutive pair is slot 7 to slot 8 — Teal `#00947F` at
+0.2271 and Green `#5FA83C` at 0.3076, a contrast ratio of 1.29, adjacent rungs in the same hue
+family. The separation rule still holds there (0.0805 apart, above the 0.05 floor), and the pair is
+only reachable at seven or more categories. Accepted rather than reordered: the slot order is the
+design's, and moving a member to widen that pair narrows the two- and three-series case the order
+exists to serve. Recorded so a later reviewer does not re-derive it.
+
 Eight slots is a supported shape. `Soft` already ships at 8, and `PaletteDialog.saveChanges()`
 splices a short palette over the first *n* colours while preserving the chart's existing tail.
 
@@ -271,6 +279,14 @@ what makes it safe is the default tier holding those colours, not anything this 
 
 **A "hard-fail with a migration warning" for `Gray` has nowhere to live.** There is no name lookup
 at load time to fail in.
+
+**`getPaletteIndex()`'s missing counter reset is not reachable, and no ticket is needed.** An
+earlier reading of this branch filed it as a latent defect made likelier by short palettes. That is
+wrong. A false reversed match needs the forward loop to score at least one and the reverse loop to
+add at least one, and both start at `j = 0` against the same `currPalette.colors[0]` — so it
+requires a palette whose first colour equals its last. None of the fourteen in `defaults.css` does,
+`Contrast` included (`#0b3d91` / `#5fa83c`). The counter is sloppy and cannot produce a wrong match
+against any registered palette.
 
 ## Files touched
 

--- a/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
+++ b/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
@@ -45,8 +45,12 @@ classic 40 regardless of the CSS.
 2. **Gate retirements on the mark; ship additions to everyone.** A modern-marked chart sees the
    reduced list. A classic chart keeps all of today's names. `Contrast` is offered to both, because
    an accessibility palette is not a look-and-feel choice.
-3. **Two gate authorities, deliberately.** The binding picker reads the chart's own `VizMark`; the
-   target-band colour pane reads the org gate, because it has no assembly to read.
+3. **One authority; the org gate is only the absent-assembly default.** The binding picker resolves
+   `VizContext.of(mark)` from the chart's own `VizMark`. A caller with no assembly to resolve — the
+   target-band colour pane included — falls through to `VizContext.ofGate()` as the null-branch
+   default. That pane deliberately shows every palette regardless: it cannot tell a classic chart
+   from a modern one, and filtering it on the org gate would hide retired palettes from classic
+   charts in a modern org.
 4. **Ramps are out of scope.** `Variance`, `Amber` and `Teal` are `LinearColorFrame` work, not CSS
    (see Corrections below).
 
@@ -236,8 +240,19 @@ today. Deferred, not declined.
 **The README's open question is answered: no.** Palette names are not stored in saved viewsheet
 XML. `PaletteDialog.saveChanges()` emits a `CategoricalColorModel` carrying only colours, and
 `VisualFrameModel.name` is transport-only. So no alias table is needed — retiring a name repaints
-nothing. The consequence is instead the pre-selection problem in section 3, and the fact that
-existing dashboards never pick up a re-tuned palette, because they hold resolved hexes.
+nothing. The consequence is instead the pre-selection problem in section 3, and this:
+`VGraphPair.java:1300` and `ChangeChartProcessor.java:1893` both call
+`VSChartPaletteDefaults.applyModernPalette`, an unconditional `setDefaultColors(activePalette(ctx))`
+whenever `ctx.modern` — so a modern-marked chart's default tier *is* re-resolved from live CSS on
+every render, and does take the new head.
+
+The opening this leaves: a modern chart whose old head colours were pinned into the **user** tier
+(possible for sheets saved before the resolved-default guard landed) cannot be overwritten by
+`applyModernPalette` — the user tier wins over defaults unconditionally. That chart's rendered
+colours then match no registered palette, the dialog shows `Default` selected, and a no-op OK
+repaints it to the classic legacy 40 — the exact hazard section 3 exists to prevent, arriving
+through a door section 3 did not consider. This needs a manual check; it is not something an
+automated test can cover.
 
 **A "hard-fail with a migration warning" for `Gray` has nowhere to live.** There is no name lookup
 at load time to fail in.

--- a/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
+++ b/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
@@ -92,10 +92,20 @@ malformed, so stale constants would make a broken `format.css` render the old pa
 ## 2. Picker gating
 
 `VSChartBindingController.getColorPalettes` gains optional `vsId` and `assemblyName` request
-params and moves its body into `VSChartBindingService` as a
-`@ClusterProxyMethod(WorksheetEngine.CACHE_NAME)` with `@ClusterProxyKey String vsId`, matching
-`getChartBinding`. It resolves the runtime viewsheet, reads the assembly's `VSAssemblyInfo`, and
-derives `VizContext.of(info)`.
+params. `VSChartBindingService` gains a `@ClusterProxyMethod(WorksheetEngine.CACHE_NAME)` with
+`@ClusterProxyKey String vsId` that resolves the runtime viewsheet, reads the assembly's
+`VSAssemblyInfo`, and **returns only its `VizMark`**. The controller keeps the list-building and
+derives `VizContext.of(mark)` from the result.
+
+**The proxy returns the mark rather than the whole list, because a null `vsId` cannot route.** The
+generated proxy is `isLocal(vsId)` followed by `affinityCall(vsId, ...)`, so with no key there is no
+node to call — and the target-band pane sends no key. The controller therefore has to branch on null
+before it can invoke the proxy at all. Moving the list-building across that boundary would mean
+duplicating it in the null branch or reaching past the proxy; returning an enum keeps one code path
+for the list and one small branch for the context.
+
+`@SwitchOrg` survives the hop: it pushes a `SwitchOrgAspectTask` onto `ServiceProxyContext.aspectTasks`
+and the generated callable replays it through `preprocess()` on the receiving node.
 
 | Caller | Context | Why |
 |---|---|---|
@@ -153,23 +163,46 @@ from a chart already using it.
 
 ## 4. Testing
 
-**Java — `ColorPalettesModernTest`**
+**Java — five classes assert the old hexes, not one.** A sweep for the sixteen head colours finds
+31 real assertion sites:
 
-- `modernHeadMatchesSpec` updates to the new slot-1 and slot-8 hexes for both palettes.
+| Class | Sites |
+|---|---|
+| `VSChartPaletteDefaultsTest` | 20 |
+| `ColorPalettesModernTest` | 4 |
+| `VSChartPaletteCssOverrideTest` | 4 |
+| `ChartColorPaletteControllerTest` | 4 |
+| `VGraphPairModernPaletteTest` | 1 |
+
+`CategoricalColorDerivedPersistenceTest` carries 12 further occurrences and **must be left alone** —
+they are arbitrary fixture colours handed to `setDerivedColor` and asserted for round-trip, so they
+pass either way. Changing them would be noise.
+
+- `ColorPalettesModernTest.modernHeadMatchesSpec` updates to the new slot-1 and slot-8 hexes.
 - `tailMatchesLegacyPalette`, `defaultPaletteIsUnchanged` and `modernDeclaresFortyNonNullColors`
   stay green untouched. They are the drift guards proving only the head moved.
-- New: assert `MODERN_HEAD` and `DARK_HEAD` equal `defaults.css` indexes 1-8. Nothing today catches
-  the Java constants and the CSS drifting apart, and section 1 depends on them moving together.
-- New: `Contrast` is registered and declares 8 non-null colours.
+- New, in `VSChartPaletteDefaultsTest`: assert `MODERN_HEAD` and `DARK_HEAD` equal `defaults.css`
+  indexes 1-8. Nothing today catches the Java constants and the CSS drifting apart, and section 1
+  depends on them moving together. It reads the two `private` constants **by reflection**, which is
+  already the idiom in that file — `clearMemoDiscardsTheCachedEntry` reaches `MEMO` the same way — so
+  no production visibility widens for a test's benefit.
+- New: `Contrast` is registered and declares 8 non-null colours, and `Default` is still declared
+  first in `defaults.css`.
 - New: `hiddenPaletteNames(VizContext)` returns exactly the nine names under a modern mark and is empty
   under a classic one.
 
 **Frontend**
 
-- Update `MODERN_HEAD` and `DARK_HEAD` in `palette-test-fixtures.ts`. The four spec files that
-  consume them assert fixture-relative and follow automatically.
+- Update `MODERN_HEAD` and `DARK_HEAD` in `palette-test-fixtures.ts`. Three of the four consuming
+  spec files assert fixture-relative and follow automatically. **`chart-palette.service.spec.ts` does
+  not** — it hardcodes `#00d4e8`, `#64748b` and `#00b87a` at `:54,55,63,74`. Convert it onto the
+  fixture rather than editing the literals, so it cannot drift again.
 - New `palette-dialog.spec.ts` cases: a hidden palette stays pre-selectable when it is the chart's
   current one, and is absent from the dropdown when it is not.
+
+**Observed, not acted on.** `_viz-tokens.scss:62` sets `--inet-viz-selected-border-dark: #2DD4BF`,
+exactly the old `DARK_HEAD[6]`. The re-tune removes that value from the dark palette, so the
+selected border stops colliding with a series colour. Confirmed incidental; the token is unchanged.
 
 ## 5. Deferred, with triggers
 
@@ -215,13 +248,21 @@ at load time to fail in.
 |---|---|
 | `core/src/main/resources/inetsoft/util/css/defaults.css` | `Modern` 1-8, `Modern Dark` 1-8, new `Contrast` 1-8 |
 | `core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java` | `MODERN_HEAD`, `DARK_HEAD`, new `hiddenPaletteNames(VizContext)` |
-| `core/src/main/java/inetsoft/web/binding/VSChartBindingController.java` | `getColorPalettes` gains `vsId`, `assemblyName`; body delegates |
-| `core/src/main/java/inetsoft/web/binding/VSChartBindingService.java` | new `@ClusterProxyMethod` resolving the assembly and filtering |
+| `core/src/main/java/inetsoft/web/binding/VSChartBindingController.java` | `getColorPalettes` gains `vsId`, `assemblyName`; builds the list, branches on a null key |
+| `core/src/main/java/inetsoft/web/binding/VSChartBindingService.java` | new `@ClusterProxyMethod` returning the assembly's `VizMark` |
 | `core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java` | `hidden` transport flag |
 | `web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts` | send `vsId` and `assemblyName` |
 | `web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts` | filter hidden entries from `paletteSelectOptions` |
 | `web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts` | new head hexes |
-| `core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java` | updated and new assertions |
+| `core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaultsTest.java` | 20 hex sites; new CSS↔Java drift guard and `hiddenPaletteNames` cases |
+| `core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java` | 4 hex sites; new `Contrast` and declaration-order cases |
+| `core/src/test/java/inetsoft/uql/viewsheet/internal/VSChartPaletteCssOverrideTest.java` | 4 hex sites |
+| `core/src/test/java/inetsoft/web/portal/controller/ChartColorPaletteControllerTest.java` | 4 hex sites |
+| `core/src/test/java/inetsoft/report/composition/graph/VGraphPairModernPaletteTest.java` | 1 hex site |
+| `web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts` | converted off hardcoded hexes onto the fixture |
 | `web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts` | new hidden-palette cases |
+
+Sixteen files. `CategoricalColorDerivedPersistenceTest` is deliberately **not** in this list despite
+carrying 12 occurrences of the old hexes — see section 4.
 
 Every path is inside the `community` submodule, so this ships as a community PR.

--- a/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
+++ b/docs/superpowers/specs/lookfeel/2026-09-11-chart-palette-retune-design.md
@@ -1,0 +1,227 @@
+# Chart palette re-tune — design
+
+**Date:** 2026-09-11
+**Status:** approved, not implemented
+**Branch:** `epic-74519` (base)
+**Source:** the external design set `SBI Color and Type Pairings.dc.html` and its
+`design_handoff_chart_palettes/` folder (README, CSS.md, ENGINE.md, github.md), exported
+2026-09-11. The handoff's last repo sync was 2026-08-09 against `epic-74519`.
+
+## What this is
+
+The first slice of the chart palette redesign. It re-tunes the eight head colours of `Modern`
+and `Modern Dark`, adds `Contrast` as a new categorical palette, and gates the palette picker on
+the chart's own modern mark. It is palette data, one endpoint change, and a dropdown filter. Nothing in
+`inetsoft.graph` changes, no new colour-frame classes are added, and no persisted contract moves.
+
+## Why the handoff could not be applied as written
+
+The handoff proposes 11 `ChartPalette` names become 6, with `Default` narrowing to 8 slots. Four
+findings, each verified against the code now on `epic-74519`, made that inapplicable as a first step.
+
+**`Modern` already occupies the slot the design asks for.** `VSChartPaletteDefaults` ships
+`MODERN_HEAD` — eight curated bases — with a `Modern Dark` light/dark pair, resolved by name from
+`defaults.css`, gated on the modern mark, and padded to 40 via `spliceLegacy()`. The design's
+`Default · 8` is the same structure with different hexes. Shipping it under its own name would
+leave two competing modern defaults.
+
+**There are 13 palettes on this branch, not 11.** `Modern` and `Modern Dark` landed after the
+handoff's last sync and appear nowhere in its migration map.
+
+**The CSS block is 0-based; the loader is 1-based.** `ColorPalettes.loadPalettes()` skips any
+index below 1, and shipped rules run `index='1'` upward. Applied verbatim, every palette would
+lose its first colour.
+
+**An 8-slot `Default` would be silently ignored.** `VSChartPaletteDefaults.fromFrame()` falls back
+to `spliceLegacy()` whenever the frame declares fewer colours than
+`CategoricalColorFrame.COLOR_PALETTE`, which is 40. Non-modern charts would keep rendering the
+classic 40 regardless of the CSS.
+
+## Decisions
+
+1. **Re-tune `Modern` in place.** The design's eight bases replace `MODERN_HEAD`; its dark eight
+   replace `DARK_HEAD`. No new palette names for the default set. The gate, Revert, the seed mark
+   and picker pre-selection are all untouched.
+2. **Gate retirements on the mark; ship additions to everyone.** A modern-marked chart sees the
+   reduced list. A classic chart keeps all of today's names. `Contrast` is offered to both, because
+   an accessibility palette is not a look-and-feel choice.
+3. **Two gate authorities, deliberately.** The binding picker reads the chart's own `VizMark`; the
+   target-band colour pane reads the org gate, because it has no assembly to read.
+4. **Ramps are out of scope.** `Variance`, `Amber` and `Teal` are `LinearColorFrame` work, not CSS
+   (see Corrections below).
+
+## 1. Palette data
+
+`core/src/main/resources/inetsoft/util/css/defaults.css`, 1-based indexes.
+
+`Modern` indexes 1-8 take the design's light bases:
+
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|
+| `#0490FF` | `#FF5A35` | `#241C4F` | `#03D9B3` | `#9A2DDC` | `#FFB020` | `#E5197E` | `#8ED604` |
+| Azure | Coral | Ink | Teal | Violet | Amber | Magenta | Acid |
+
+`Modern Dark` indexes 1-8 take the design's dark bases. This is not the light set lifted — slot 3
+inverts, because Ink is already the darkest member and has nowhere to deepen to:
+
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|
+| `#4FA5FF` | `#FF8367` | `#49447D` | `#2DEEC6` | `#AE41F5` | `#FFCB82` | `#FE3290` | `#9FEB28` |
+
+`Contrast`, new, indexes 1-8 only:
+
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|
+| `#0B3D91` | `#F5943F` | `#B04AB8` | `#F7D22E` | `#A8330A` | `#7CC4EE` | `#00947F` | `#5FA83C` |
+| Navy | Orange | Orchid | Yellow | Brick | Sky | Teal | Green |
+
+Every member sits on its own rung of a luminance ladder, no two closer than 0.05 relative
+luminance across a 0.05-0.66 span, and the slot order interleaves the ladder so a two- or
+three-series chart draws from opposite ends. `Contrast` gets **no dark variant**: its contract is
+paper and projection.
+
+Eight slots is a supported shape. `Soft` already ships at 8, and `PaletteDialog.saveChanges()`
+splices a short palette over the first *n* colours while preserving the chart's existing tail.
+
+Indexes 9-40 of `Modern` and `Modern Dark` are **untouched**.
+
+`MODERN_HEAD` and `DARK_HEAD` in `VSChartPaletteDefaults` take the same eight hexes each. **Both
+sides must move together** — the Java constants are the fallback when a CSS rule is missing or
+malformed, so stale constants would make a broken `format.css` render the old palette.
+
+## 2. Picker gating
+
+`VSChartBindingController.getColorPalettes` gains optional `vsId` and `assemblyName` request
+params and moves its body into `VSChartBindingService` as a
+`@ClusterProxyMethod(WorksheetEngine.CACHE_NAME)` with `@ClusterProxyKey String vsId`, matching
+`getChartBinding`. It resolves the runtime viewsheet, reads the assembly's `VSAssemblyInfo`, and
+derives `VizContext.of(info)`.
+
+| Caller | Context | Why |
+|---|---|---|
+| `categorical-color-pane` (binding picker) | `VizContext.of(info)` | already holds `vsId` and `assemblyName`; survives an org gate switched off after modernization |
+| `b-categorical-color-pane` (target band fill) | `VizContext.ofGate()` | holds only `assetId`; same reasoning as `ChartColorPaletteController` |
+
+The target-band pane sends no new params, so it lands on the absent-assembly branch naturally. Its
+component needs no change.
+
+Reading the chart's mark rather than the org property matters because the org gate is creation-time
+only: a dashboard already using the modern look keeps it when an admin switches the gate off. A
+picker reading the property would strand those charts with a list that does not match what they
+render.
+
+**The policy lives in `VSChartPaletteDefaults` as `hiddenPaletteNames(VizContext)`**, returning the
+set of names to mark hidden for that context — empty under a classic mark. It does not remove
+anything from the list; section 3 explains why. That class already owns modern-palette policy,
+already imports `ColorPalettes`, and sits beside `VizContext` in `uql.viewsheet.internal`.
+`ColorPalettes.getPaletteNames()` stays unfiltered.
+
+**`getPalette(name)` resolution stays unfiltered unconditionally.** `legacyPalette()` resolves
+`"Default"` and `modernPalette()`/`darkPalette()` resolve `"Modern"`/`"Modern Dark"` by name.
+Filtering resolution would break rendering.
+
+Hidden under a modern mark, nine names: `Pastel`, `Heat 8`, `Heat 16`, `Heat 24`, `Blue`, `Green`,
+`Red`, `Orange`, `Gray`. Visible under either mark: `Default`, `Soft`, `Modern`, `Modern Dark`,
+`Contrast`.
+
+**`Default` stays visible to modern charts.** It is declared first in `defaults.css` precisely so
+the index-0 fallback is stable, and filtering preserves CSS order — keeping it leaves that
+invariant pointing where it points today, in both lists. It also leaves a per-chart route back to
+the classic 40 that does not require reverting the whole dashboard.
+
+**`Modern` and `Modern Dark` stay visible to classic charts**, as today. They are neither an
+addition nor a retirement, and hiding them would be a new restriction outside this scope.
+
+## 3. Pre-selection
+
+`getPaletteIndex()` returns 0 when nothing matches, and `saveChanges()` splices whatever the dialog
+is displaying over the chart's colours. So a chart whose palette is not in the list shows "Default"
+selected and repaints on a no-op OK. That path exists today. Omitting hidden palettes from the
+response would widen it to every modern-marked chart sitting on one of the nine.
+
+**The response carries every palette with a `hidden` flag** — set from `hiddenPaletteNames(ctx)` —
+rather than omitting entries.
+
+- `getPaletteIndex()` continues to match against every palette, so a modern chart on `Pastel` still
+  pre-selects `Pastel` and nothing repaints.
+- `paletteSelectOptions` drops hidden entries from the dropdown **except** the currently selected
+  one, keeping the original array position as the option `value`. It already emits
+  `{value: index, label: name}`, so this is a filter over the existing shape.
+
+The resulting semantics: a retired palette is not offered for new choices and is never taken away
+from a chart already using it.
+
+## 4. Testing
+
+**Java — `ColorPalettesModernTest`**
+
+- `modernHeadMatchesSpec` updates to the new slot-1 and slot-8 hexes for both palettes.
+- `tailMatchesLegacyPalette`, `defaultPaletteIsUnchanged` and `modernDeclaresFortyNonNullColors`
+  stay green untouched. They are the drift guards proving only the head moved.
+- New: assert `MODERN_HEAD` and `DARK_HEAD` equal `defaults.css` indexes 1-8. Nothing today catches
+  the Java constants and the CSS drifting apart, and section 1 depends on them moving together.
+- New: `Contrast` is registered and declares 8 non-null colours.
+- New: `hiddenPaletteNames(VizContext)` returns exactly the nine names under a modern mark and is empty
+  under a classic one.
+
+**Frontend**
+
+- Update `MODERN_HEAD` and `DARK_HEAD` in `palette-test-fixtures.ts`. The four spec files that
+  consume them assert fixture-relative and follow automatically.
+- New `palette-dialog.spec.ts` cases: a hidden palette stays pre-selectable when it is the chart's
+  current one, and is absent from the dropdown when it is not.
+
+## 5. Deferred, with triggers
+
+| Item | Trigger |
+|---|---|
+| ENGINE §3 palette overflow generator | Any change narrowing a palette below 40 slots, or a decision to replace the legacy tail. Keeping `Modern` at 40 removes the urgency, not the need — the slot-9 seam between the new heads and the 2010-era tail is real and unaddressed. |
+| ENGINE §0/§1/§2/§5 companions | Independent. The largest behavioural win left. Needs the sRGB-OKLab utility plus `Modern-soft` and `Modern Dark-soft` CSS. |
+| `Variance`, `Amber`, `Teal` ramps | Each needs an `AbstractSplineColorFrame` subclass, a `LinearColorFrameWrapper`, and a `VisualFrameWrapper` switch case. |
+| ENGINE §6 multi-level shading | Blocked upstream: nothing passes depth, breadth or sibling index into colour resolution. |
+| `Soft` re-authoring, `Pastel` folded into companions | Both fold into the companion work. |
+
+## Corrections to the source handoff
+
+Recorded so a later slice does not re-derive them.
+
+**The CSS block is 0-based and must be applied 1-based.** `CSS.md` hedges and then writes
+`index=0..7`.
+
+**`Amber`, `Teal` and `Variance` are not CSS, and the handoff contradicts itself.** `CSS.md`
+declares them as `ChartPalette` rules, but `ColorPalettes.loadPalettes()` builds a
+`CategoricalColorFrame` for every `ChartPalette` name — so declaring them that way puts them in the
+categorical picker, which ENGINE §4 explicitly forbids. A real ramp is an
+`AbstractSplineColorFrame` subclass with a `LinearColorFrameWrapper` and a case in
+`VisualFrameWrapper`'s class-name switch, which is also where ramps, unlike palettes, are
+persisted by name.
+
+**ENGINE §3's premise does not hold under decision 1.** It argues the overflow wrap is "survivable
+at 40 slots, not at 8". Keeping `Modern` at 40 means the wrap engages only past 40, exactly as
+today. Deferred, not declined.
+
+**The README's open question is answered: no.** Palette names are not stored in saved viewsheet
+XML. `PaletteDialog.saveChanges()` emits a `CategoricalColorModel` carrying only colours, and
+`VisualFrameModel.name` is transport-only. So no alias table is needed — retiring a name repaints
+nothing. The consequence is instead the pre-selection problem in section 3, and the fact that
+existing dashboards never pick up a re-tuned palette, because they hold resolved hexes.
+
+**A "hard-fail with a migration warning" for `Gray` has nowhere to live.** There is no name lookup
+at load time to fail in.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `core/src/main/resources/inetsoft/util/css/defaults.css` | `Modern` 1-8, `Modern Dark` 1-8, new `Contrast` 1-8 |
+| `core/src/main/java/inetsoft/uql/viewsheet/internal/VSChartPaletteDefaults.java` | `MODERN_HEAD`, `DARK_HEAD`, new `hiddenPaletteNames(VizContext)` |
+| `core/src/main/java/inetsoft/web/binding/VSChartBindingController.java` | `getColorPalettes` gains `vsId`, `assemblyName`; body delegates |
+| `core/src/main/java/inetsoft/web/binding/VSChartBindingService.java` | new `@ClusterProxyMethod` resolving the assembly and filtering |
+| `core/src/main/java/inetsoft/web/binding/model/graph/aesthetic/CategoricalColorModel.java` | `hidden` transport flag |
+| `web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts` | send `vsId` and `assemblyName` |
+| `web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts` | filter hidden entries from `paletteSelectOptions` |
+| `web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts` | new head hexes |
+| `core/src/test/java/inetsoft/uql/viewsheet/graph/aesthetic/ColorPalettesModernTest.java` | updated and new assertions |
+| `web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts` | new hidden-palette cases |
+
+Every path is inside the `community` submodule, so this ships as a community PR.

--- a/docs/superpowers/specs/lookfeel/2026-09-11-dark-assembly-selection-border-ticket.md
+++ b/docs/superpowers/specs/lookfeel/2026-09-11-dark-assembly-selection-border-ticket.md
@@ -1,0 +1,91 @@
+# Assembly selection border is orange in dark mode — ticket
+
+**Date:** 2026-09-11
+**Status:** open, unassigned
+**Found:** manual dark-mode pass during the chart palette re-tune
+**Not caused by:** [the palette re-tune](./2026-09-11-chart-palette-retune-design.md) — see *Provenance* below
+
+## What happens
+
+Selecting any assembly in dark mode draws a **1px dotted `#E58A2A` orange** border around it.
+The selected *cell* border, four lines away in the same stylesheet, is dark-aware and draws teal.
+One selection affordance took the dark-mode pass and its neighbour did not.
+
+## The mechanism
+
+`web/projects/portal/src/scss/_themeable.scss:113` and `:117`:
+
+```scss
+.bd-selected-cell {
+  border: 2px solid var(--inet-viz-selected-border) !important;   // dark-aware
+}
+
+.bd-selected-assembly {
+  border: 1px dotted var(--inet-primary-color) !important;        // not dark-aware
+}
+```
+
+The two resolve differently:
+
+| Class | Token chain | Light | Dark |
+|---|---|---|---|
+| `.bd-selected-cell` | `--inet-viz-selected-border` → `--inet-viz-selected-border-dark` (`_viz-tokens.scss:62`, `:175`) | shell selected-bg | `#2DD4BF` teal |
+| `.bd-selected-assembly` | `--inet-primary-color` → `$inet-orange` → `$shell-primary` (`_variables.scss:280`, `:127`, `:51`) | `#E58A2A` | `#E58A2A` — unchanged |
+
+**`--inet-primary-color` is never redefined for dark mode.** The dark block at `_viz-tokens.scss:173-176`
+redefines `--inet-viz-selected-bg`, `-text` and `-border`, then re-points `--inet-viz-active-border`
+at `--inet-primary-color` — the same light-mode orange. No dark value exists to pick up.
+
+`vs-object-container.component.html:31` applies `.bd-selected-assembly` on focus or mobile
+selection, so this covers **every assembly type**, not only charts.
+
+## Provenance
+
+Not introduced by the palette re-tune, and not by the dark-mode work either:
+
+- `.bd-selected-assembly` dates to the **Initial commit, `0d2cdd433a`, 2024-07-12**
+- `--inet-viz-active-border` last moved in `1133d86e22`, the chart card track merge
+- the palette re-tune branch changed **zero** `.scss` files
+
+## Why it matters more now, with numbers
+
+Against the selection orange `#E58A2A` (OKLCH L 0.715, C 0.151, H 61°), the closest dark series
+colour before and after the re-tune:
+
+| Dark series colour | ΔE to `#E58A2A` |
+|---|---|
+| old amber `#FBB724` | 0.119 |
+| **new coral `#FF8367`** | **0.079** |
+| new amber `#FFCB82` | 0.166 |
+
+The external palette design set flags **ΔE 0.106** as the point where a series colour is "close
+enough to need the white-hairline treatment" against this orange. The re-tuned coral is inside
+that. A dotted orange selection border on a chart carrying a coral series can read as data rather
+than as state.
+
+**The re-tune improved the other half.** The old dark palette's slot 7 was `#2DD4BF` — an *exact*
+match to the cell-selection border. The new nearest is `#2DEEC6`, ΔE 0.072. Cell selection went
+from an exact collision to a near one.
+
+## What a fix has to decide
+
+Not a one-line swap, which is why this is a ticket and not a follow-up commit:
+
+1. **What should dark selection be?** Matching `.bd-selected-cell`'s teal makes the two affordances
+   consistent, but teal is now ΔE 0.072 from a series colour — trading one collision for another.
+   A dark-adjusted orange, or a neutral, are the other options.
+2. **Should the selected assembly be a brand-accent affordance at all?**
+   [palette-coordination-recommendations.md](./palette-coordination-recommendations.md) says the
+   shell gets one routine accent and the visualization layer should not inherit shell accent usage
+   by default. Selection chrome sits on the boundary.
+3. **The blast radius is product-wide.** `.bd-selected-assembly` styles selection for every
+   assembly type in composer and viewer, in both themes. Whatever lands changes how selection looks
+   everywhere, so it wants a visual check across assembly types rather than a chart-only one.
+
+## What not to do
+
+- **Do not fix it by changing a palette colour.** The collision is between a series colour and a
+  *state* colour; moving the series colour to dodge the state colour inverts the dependency and
+  breaks the palette's luminance spacing.
+- **Do not scope it to charts.** A chart-only override would leave charts and tables disagreeing
+  about what selection looks like.

--- a/docs/superpowers/specs/lookfeel/chart-card-roadmap.md
+++ b/docs/superpowers/specs/lookfeel/chart-card-roadmap.md
@@ -1736,6 +1736,16 @@ needed, or simply removed if the parenthetical has lost its explanatory value by
 - [seeded-value-reversibility-decisions.md](./seeded-value-reversibility-decisions.md) — the seed mark,
   the four seeded values and the mechanism inventory. **Supersedes the roadmap's seed-mark analysis
   below**, which still lists version-blindness as the open question
+- [2026-09-11-chart-palette-retune-design.md](./2026-09-11-chart-palette-retune-design.md) —
+  **decided, not implemented.** The chart's categorical *series* palette, which nothing in this file
+  covers: re-tunes the eight head colours of `Modern` and `Modern Dark`, adds `Contrast`, and gates the
+  palette picker on the assembly's `VizMark` rather than the org property. Not to be confused with the
+  **Chart interior dark palette** row in Done, which was plot chrome. **Read its Corrections section
+  before applying anything from the external palette set** (`SBI Color and Type Pairings.dc.html` and
+  its `design_handoff_chart_palettes/` folder): that handoff is wrong against this branch in four ways,
+  two of which fail silently — its CSS block is 0-based where `ColorPalettes` drops any index below 1,
+  and the 8-slot `Default` it proposes is discarded by `VSChartPaletteDefaults.fromFrame()`, which
+  falls back to `spliceLegacy()` below 40 colours. It also predates `Modern`/`Modern Dark` existing
 - [chart-card-slice1-design.md](./chart-card-slice1-design.md) ·
   [chart-card-slice2-tables-design.md](./chart-card-slice2-tables-design.md) ·
   [chart-card-slice3-selection-design.md](./chart-card-slice3-selection-design.md) — how each shipped slice

--- a/docs/superpowers/specs/lookfeel/chart-card-roadmap.md
+++ b/docs/superpowers/specs/lookfeel/chart-card-roadmap.md
@@ -1737,7 +1737,7 @@ needed, or simply removed if the parenthetical has lost its explanatory value by
   the four seeded values and the mechanism inventory. **Supersedes the roadmap's seed-mark analysis
   below**, which still lists version-blindness as the open question
 - [2026-09-11-chart-palette-retune-design.md](./2026-09-11-chart-palette-retune-design.md) —
-  **decided, not implemented.** The chart's categorical *series* palette, which nothing in this file
+  **implemented, in review.** The chart's categorical *series* palette, which nothing in this file
   covers: re-tunes the eight head colours of `Modern` and `Modern Dark`, adds `Contrast`, and gates the
   palette picker on the assembly's `VizMark` rather than the org property. Not to be confused with the
   **Chart interior dark palette** row in Done, which was plot chrome. **Read its Corrections section

--- a/docs/superpowers/specs/lookfeel/visualization-palette-swatches.html
+++ b/docs/superpowers/specs/lookfeel/visualization-palette-swatches.html
@@ -30,23 +30,32 @@
     --viz-warning-bg: #F8E8CC;
     --viz-anomaly-bg: #F7DEDE;
 
-    --series-1: #00D4E8;
-    --series-2: #00B87A;
-    --series-3: #F59E0B;
-    --series-4: #F43F5E;
-    --series-5: #8B5CF6;
-    --series-6: #3B82F6;
-    --series-7: #0D9488;
-    --series-8: #64748B;
+    --series-1: #0490FF;
+    --series-2: #FF5A35;
+    --series-3: #241C4F;
+    --series-4: #03D9B3;
+    --series-5: #9A2DDC;
+    --series-6: #FFB020;
+    --series-7: #E5197E;
+    --series-8: #8ED604;
 
-    --series-dark-1: #22D3EE;
-    --series-dark-2: #10B981;
-    --series-dark-3: #FBB724;
-    --series-dark-4: #FB6181;
-    --series-dark-5: #A78BFA;
-    --series-dark-6: #60A5FA;
-    --series-dark-7: #2DD4BF;
-    --series-dark-8: #94A3B8;
+    --series-dark-1: #4FA5FF;
+    --series-dark-2: #FF8367;
+    --series-dark-3: #49447D;
+    --series-dark-4: #2DEEC6;
+    --series-dark-5: #AE41F5;
+    --series-dark-6: #FFCB82;
+    --series-dark-7: #FE3290;
+    --series-dark-8: #9FEB28;
+
+    --contrast-1: #0B3D91;
+    --contrast-2: #F5943F;
+    --contrast-3: #B04AB8;
+    --contrast-4: #F7D22E;
+    --contrast-5: #A8330A;
+    --contrast-6: #7CC4EE;
+    --contrast-7: #00947F;
+    --contrast-8: #5FA83C;
 
     --vivid-series-1: #19C2B5;
     --vivid-series-2: #F06A3F;
@@ -723,14 +732,14 @@
       <div class="palette-card-title">Default Palette - Light</div>
       <div class="palette-card-note">Phase 8 gated modern categorical default (series 1-8). Bridged server-side via VSChartPaletteDefaults into CategoricalColorFrame.defaultColors when the org modern gate is on; defaults-only, so a user series color and a customer format.css ChartPalette rule still win. Indices 9-40 keep the legacy COLOR_PALETTE tail. Gate-off renders the legacy palette unchanged.</div>
       <div class="palette-swatch-grid">
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-1); color:var(--light-chart-label);">1</div><div class="palette-chip-meta"><div class="palette-chip-name">series-1</div><div class="palette-chip-hex">#00D4E8</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-2); color:var(--light-chart-label);">2</div><div class="palette-chip-meta"><div class="palette-chip-name">series-2</div><div class="palette-chip-hex">#00B87A</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-3); color:var(--light-chart-label);">3</div><div class="palette-chip-meta"><div class="palette-chip-name">series-3</div><div class="palette-chip-hex">#F59E0B</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-4); color:#FFFFFF;">4</div><div class="palette-chip-meta"><div class="palette-chip-name">series-4</div><div class="palette-chip-hex">#F43F5E</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-5); color:#FFFFFF;">5</div><div class="palette-chip-meta"><div class="palette-chip-name">series-5</div><div class="palette-chip-hex">#8B5CF6</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-6); color:#FFFFFF;">6</div><div class="palette-chip-meta"><div class="palette-chip-name">series-6</div><div class="palette-chip-hex">#3B82F6</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-7); color:#FFFFFF;">7</div><div class="palette-chip-meta"><div class="palette-chip-name">series-7</div><div class="palette-chip-hex">#0D9488</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-8); color:#FFFFFF;">8</div><div class="palette-chip-meta"><div class="palette-chip-name">series-8</div><div class="palette-chip-hex">#64748B</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-1); color:#FFFFFF;">1</div><div class="palette-chip-meta"><div class="palette-chip-name">series-1</div><div class="palette-chip-hex">#0490FF</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-2); color:#FFFFFF;">2</div><div class="palette-chip-meta"><div class="palette-chip-name">series-2</div><div class="palette-chip-hex">#FF5A35</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-3); color:#FFFFFF;">3</div><div class="palette-chip-meta"><div class="palette-chip-name">series-3</div><div class="palette-chip-hex">#241C4F</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-4); color:var(--light-chart-label);">4</div><div class="palette-chip-meta"><div class="palette-chip-name">series-4</div><div class="palette-chip-hex">#03D9B3</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-5); color:#FFFFFF;">5</div><div class="palette-chip-meta"><div class="palette-chip-name">series-5</div><div class="palette-chip-hex">#9A2DDC</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-6); color:var(--light-chart-label);">6</div><div class="palette-chip-meta"><div class="palette-chip-name">series-6</div><div class="palette-chip-hex">#FFB020</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-7); color:#FFFFFF;">7</div><div class="palette-chip-meta"><div class="palette-chip-name">series-7</div><div class="palette-chip-hex">#E5197E</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-8); color:var(--light-chart-label);">8</div><div class="palette-chip-meta"><div class="palette-chip-name">series-8</div><div class="palette-chip-hex">#8ED604</div></div></div>
       </div>
     </div>
 
@@ -771,14 +780,14 @@
       <div class="palette-card-title">Default Palette - Dark</div>
       <div class="palette-card-note">Current shared dark palette with stronger lift against darker chart surfaces.</div>
       <div class="palette-swatch-grid">
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-1); color:var(--light-chart-label);">1</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-1</div><div class="palette-chip-hex">#22D3EE</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-2); color:var(--light-chart-label);">2</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-2</div><div class="palette-chip-hex">#10B981</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-3); color:var(--light-chart-label);">3</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-3</div><div class="palette-chip-hex">#FBB724</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-4); color:#FFFFFF;">4</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-4</div><div class="palette-chip-hex">#FB6181</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-5); color:#FFFFFF;">5</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-5</div><div class="palette-chip-hex">#A78BFA</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-6); color:#FFFFFF;">6</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-6</div><div class="palette-chip-hex">#60A5FA</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-7); color:var(--light-chart-label);">7</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-7</div><div class="palette-chip-hex">#2DD4BF</div></div></div>
-        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-8); color:var(--light-chart-label);">8</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-8</div><div class="palette-chip-hex">#94A3B8</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-1); color:#FFFFFF;">1</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-1</div><div class="palette-chip-hex">#4FA5FF</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-2); color:#FFFFFF;">2</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-2</div><div class="palette-chip-hex">#FF8367</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-3); color:#FFFFFF;">3</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-3</div><div class="palette-chip-hex">#49447D</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-4); color:var(--light-chart-label);">4</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-4</div><div class="palette-chip-hex">#2DEEC6</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-5); color:#FFFFFF;">5</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-5</div><div class="palette-chip-hex">#AE41F5</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-6); color:var(--light-chart-label);">6</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-6</div><div class="palette-chip-hex">#FFCB82</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-7); color:#FFFFFF;">7</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-7</div><div class="palette-chip-hex">#FE3290</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--series-dark-8); color:var(--light-chart-label);">8</div><div class="palette-chip-meta"><div class="palette-chip-name">series-dark-8</div><div class="palette-chip-hex">#9FEB28</div></div></div>
       </div>
     </div>
 
@@ -812,6 +821,23 @@
       </div>
     </div>
 
+  </div>
+
+  <div class="palette-row" style="margin-bottom:0;">
+    <div class="palette-card">
+      <div class="palette-card-title">Contrast Palette</div>
+      <div class="palette-card-note">Declared in defaults.css as the Contrast ChartPalette and offered to every chart, classic or modern, since an accessibility set is not a look-and-feel choice. Eight slots only, and deliberately no dark variant - its contract is paper and projection. Every member sits on its own rung of a luminance ladder spanning 0.05 to 0.66, no two closer than 0.05, and the slot order interleaves that ladder so a two or three series chart draws from opposite ends. That ordering is optimised for the low-cardinality case, so the weakest consecutive pair is 7 to 8 at a 1.29 contrast ratio, reachable only at seven or more categories.</div>
+      <div class="palette-swatch-grid">
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-1); color:#FFFFFF;">1</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-1</div><div class="palette-chip-hex">#0B3D91</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-2); color:var(--light-chart-label);">2</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-2</div><div class="palette-chip-hex">#F5943F</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-3); color:#FFFFFF;">3</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-3</div><div class="palette-chip-hex">#B04AB8</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-4); color:var(--light-chart-label);">4</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-4</div><div class="palette-chip-hex">#F7D22E</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-5); color:#FFFFFF;">5</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-5</div><div class="palette-chip-hex">#A8330A</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-6); color:var(--light-chart-label);">6</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-6</div><div class="palette-chip-hex">#7CC4EE</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-7); color:#FFFFFF;">7</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-7</div><div class="palette-chip-hex">#00947F</div></div></div>
+        <div class="palette-chip"><div class="palette-chip-color" style="background:var(--contrast-8); color:#FFFFFF;">8</div><div class="palette-chip-meta"><div class="palette-chip-name">contrast-8</div><div class="palette-chip-hex">#5FA83C</div></div></div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/web/mocks/handlers/portal.handlers.ts
+++ b/web/mocks/handlers/portal.handlers.ts
@@ -127,7 +127,7 @@ export const portalHandlers = [
    // app components to warm the chart-series swatch grid
    http.get("*/api/portal/chart-color-palette", () => {
       return HttpResponse.json([
-         "#00d4e8", "#00b87a", "#f59e0b", "#f43f5e", "#8b5cf6", "#3b82f6", "#0d9488", "#64748b",
+         "#0490ff", "#ff5a35", "#241c4f", "#03d9b3", "#9a2ddc", "#ffb020", "#e5197e", "#8ed604",
          "#9368be", "#be90d4", "#95a5a6", "#dadfe1", "#19b5fe", "#c5eff7", "#869530", "#c8d96f",
          "#a88637", "#d2b267", "#019875", "#68c3a3", "#99ccff", "#999933", "#cc9933", "#006666",
          "#993300", "#666666", "#663366", "#cccccc", "#669999", "#cccc66", "#cc6600", "#9999ff",

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts
@@ -109,7 +109,9 @@ export class CategoricalColorPane extends CategoricalFramePane implements OnInit
     */
    private getColorPalettes(): Observable<any> {
       const params = new HttpParams()
-         .set("orgId", createAssetEntry(this.assetId).organization);
+         .set("orgId", createAssetEntry(this.assetId).organization)
+         .set("vsId", this.vsId)
+         .set("assemblyName", this.assemblyName);
 
       return this.modelService.getModel(COLOR_PALETTES_URI, params);
    }

--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/categorical-color-pane.component.ts
@@ -108,10 +108,16 @@ export class CategoricalColorPane extends CategoricalFramePane implements OnInit
     * load color palettes.
     */
    private getColorPalettes(): Observable<any> {
-      const params = new HttpParams()
-         .set("orgId", createAssetEntry(this.assetId).organization)
-         .set("vsId", this.vsId)
-         .set("assemblyName", this.assemblyName);
+      let params = new HttpParams()
+         .set("orgId", createAssetEntry(this.assetId).organization);
+
+      if(this.vsId) {
+         params = params.set("vsId", this.vsId);
+      }
+
+      if(this.assemblyName) {
+         params = params.set("assemblyName", this.assemblyName);
+      }
 
       return this.modelService.getModel(COLOR_PALETTES_URI, params);
    }

--- a/web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts
@@ -40,10 +40,15 @@ export class PaletteDialog {
    _reversed: boolean = false;
 
    get paletteSelectOptions(): CustomSelectOption<number>[] {
-      return (this.colorPalettes || []).map((palette, index) => ({
-         value: index,
-         label: palette.name
-      }));
+      const selected = this.displayPalette == null ? -1 : this._selectedIndex;
+
+      return (this.colorPalettes || [])
+         .map((palette, index) => ({ palette, index }))
+         .filter(({ palette, index }) => !palette.hidden || index === selected)
+         .map(({ palette, index }) => ({
+            value: index,
+            label: palette.name
+         }));
    }
 
    get displayPalette(): CategoricalColorModel {

--- a/web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/palette-dialog.component.ts
@@ -40,6 +40,8 @@ export class PaletteDialog {
    _reversed: boolean = false;
 
    get paletteSelectOptions(): CustomSelectOption<number>[] {
+      // read displayPalette first: it resolves _selectedIndex from -1, so reading the field
+      // directly would drop the palette a chart is on from its own dropdown
       const selected = this.displayPalette == null ? -1 : this._selectedIndex;
 
       return (this.colorPalettes || [])

--- a/web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts
@@ -129,4 +129,18 @@ describe("PaletteDialog hidden palettes", () => {
       const dialog = dialogWithHidden(palette40(HEAT_HEAD));
       expect(dialog.paletteSelectOptions).toContainEqual({ value: 2, label: "Heat 8" });
    });
+
+   // a reversed match sets _selectedIndex the same way a forward one does, so the entry the
+   // chart is on survives the filter whichever direction it matched. displayPalette carries no
+   // name on the reversed branch - it builds a colours-only model - so the label is asserted
+   // through the options, which read the unfiltered array
+   it("keeps a hidden palette that matched reversed", () => {
+      const dialog = dialogWithHidden(palette40(HEAT_HEAD).slice().reverse());
+
+      // reading the options resolves the match; _reversed is still its initial false until then
+      expect(dialog.paletteSelectOptions.map((o) => o.label))
+         .toEqual(["Default", "Modern", "Heat 8"]);
+      expect(dialog._reversed).toBe(true);
+      expect(dialog._selectedIndex).toBe(2);
+   });
 });

--- a/web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts
@@ -111,14 +111,22 @@ describe("PaletteDialog hidden palettes", () => {
          .toEqual(["Default", "Modern", "Heat 8"]);
    });
 
-   // value indexes the unfiltered colorPalettes array, not the filtered list
+   // hidden entry is non-terminal: a post-filter renumbering bug would still emit [0, 1]
    it("keeps option values aligned with the unfiltered array", () => {
-      const dialog = dialogWithHidden(palette40(MODERN_HEAD));
-      expect(dialog.paletteSelectOptions.map((o) => o.value)).toEqual([0, 1]);
+      const dialog = new PaletteDialog();
+      dialog.colorPalettes = [
+         palette("Default", LEGACY_HEAD),
+         palette("Heat 8", HEAT_HEAD, true),
+         palette("Modern", MODERN_HEAD)
+      ];
+      const curr = new CategoricalColorModel();
+      curr.colors = palette40(MODERN_HEAD);
+      dialog.currPalette = curr;
+      expect(dialog.paletteSelectOptions.map((o) => o.value)).toEqual([0, 2]);
    });
 
-   it("does not repaint a chart sitting on a hidden palette", () => {
+   it("represents a chart's own hidden palette correctly in the dropdown", () => {
       const dialog = dialogWithHidden(palette40(HEAT_HEAD));
-      expect(dialog.displayPalette.colors).toEqual(palette40(HEAT_HEAD));
+      expect(dialog.paletteSelectOptions).toContainEqual({ value: 2, label: "Heat 8" });
    });
 });

--- a/web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts
+++ b/web/projects/portal/src/app/binding/editor/chart/palette-dialog.spec.ts
@@ -25,10 +25,15 @@ import {
 } from "../../../widget/color-picker/palette-test-fixtures";
 import { PaletteDialog } from "./palette-dialog.component";
 
-function palette(name: string, head: string[]): CategoricalColorModel {
+const HEAT_HEAD: string[] = [
+   "#663300", "#914800", "#bd5e00", "#e97400", "#ff8a15", "#ffa041", "#ffb66d", "#ffcc99"
+];
+
+function palette(name: string, head: string[], hidden = false): CategoricalColorModel {
    const model = new CategoricalColorModel();
    model.name = name;
    model.colors = palette40(head);
+   model.hidden = hidden;
    return model;
 }
 
@@ -77,5 +82,43 @@ describe("PaletteDialog pre-selection", () => {
       custom[3] = "#123456";
       const dialog = dialogWith(custom.concat(LEGACY_TAIL));
       expect(dialog.displayPalette.name).toBe("Default");
+   });
+});
+
+describe("PaletteDialog hidden palettes", () => {
+   function dialogWithHidden(currentColors: string[]): PaletteDialog {
+      const dialog = new PaletteDialog();
+      dialog.colorPalettes = [
+         palette("Default", LEGACY_HEAD),
+         palette("Modern", MODERN_HEAD),
+         palette("Heat 8", HEAT_HEAD, true)
+      ];
+      const curr = new CategoricalColorModel();
+      curr.colors = currentColors;
+      dialog.currPalette = curr;
+      return dialog;
+   }
+
+   it("drops a hidden palette from the dropdown", () => {
+      const dialog = dialogWithHidden(palette40(MODERN_HEAD));
+      expect(dialog.paletteSelectOptions.map((o) => o.label)).toEqual(["Default", "Modern"]);
+   });
+
+   it("keeps a hidden palette in the dropdown when the chart is using it", () => {
+      const dialog = dialogWithHidden(palette40(HEAT_HEAD));
+      expect(dialog.displayPalette.name).toBe("Heat 8");
+      expect(dialog.paletteSelectOptions.map((o) => o.label))
+         .toEqual(["Default", "Modern", "Heat 8"]);
+   });
+
+   // value indexes the unfiltered colorPalettes array, not the filtered list
+   it("keeps option values aligned with the unfiltered array", () => {
+      const dialog = dialogWithHidden(palette40(MODERN_HEAD));
+      expect(dialog.paletteSelectOptions.map((o) => o.value)).toEqual([0, 1]);
+   });
+
+   it("does not repaint a chart sitting on a hidden palette", () => {
+      const dialog = dialogWithHidden(palette40(HEAT_HEAD));
+      expect(dialog.displayPalette.colors).toEqual(palette40(HEAT_HEAD));
    });
 });

--- a/web/projects/portal/src/app/common/data/visual-frame-model.ts
+++ b/web/projects/portal/src/app/common/data/visual-frame-model.ts
@@ -48,6 +48,7 @@ export class CategoricalColorModel extends ColorFrameModel {
    shareColors: boolean;
    dateFormat: number;
    colorValueFrame?: boolean;
+   hidden?: boolean;
 }
 
 export class GradientColorModel extends ColorFrameModel {

--- a/web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts
+++ b/web/projects/portal/src/app/widget/color-picker/chart-palette.service.spec.ts
@@ -51,8 +51,8 @@ describe("ChartPaletteService", () => {
       const grid = service.chartPalette;
       expect(grid.length).toBe(5);
       expect(grid[0].length).toBe(8);
-      expect(grid[0][0]).toBe("#00d4e8");
-      expect(grid[0][7]).toBe("#64748b");
+      expect(grid[0][0]).toBe(MODERN_HEAD[0]);
+      expect(grid[0][7]).toBe(MODERN_HEAD[7]);
       expect(grid[4][7]).toBe("#cccc33");
    });
 
@@ -60,7 +60,7 @@ describe("ChartPaletteService", () => {
       httpMock.expectOne(CHART_COLOR_PALETTE_URI).flush(MODERN_40);
 
       expect(service.flatColors().length).toBe(40);
-      expect(service.flatColors()[0]).toBe("#00d4e8");
+      expect(service.flatColors()[0]).toBe(MODERN_HEAD[0]);
    });
 
    it("falls back to the legacy grid on HTTP error", () => {
@@ -71,7 +71,7 @@ describe("ChartPaletteService", () => {
    });
 
    it("falls back when the response is not 40 colors", () => {
-      httpMock.expectOne(CHART_COLOR_PALETTE_URI).flush(["#00d4e8", "#00b87a"]);
+      httpMock.expectOne(CHART_COLOR_PALETTE_URI).flush(MODERN_HEAD.slice(0, 2));
 
       expect(service.chartPalette).toBe(DefaultPalette.chart);
    });

--- a/web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts
+++ b/web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts
@@ -22,11 +22,11 @@ export const LEGACY_HEAD: string[] = [
 ];
 
 export const MODERN_HEAD: string[] = [
-   "#00d4e8", "#00b87a", "#f59e0b", "#f43f5e", "#8b5cf6", "#3b82f6", "#0d9488", "#64748b"
+   "#0490ff", "#ff5a35", "#241c4f", "#03d9b3", "#9a2ddc", "#ffb020", "#e5197e", "#8ed604"
 ];
 
 export const DARK_HEAD: string[] = [
-   "#22d3ee", "#10b981", "#fbb724", "#fb6181", "#a78bfa", "#60a5fa", "#2dd4bf", "#94a3b8"
+   "#4fa5ff", "#ff8367", "#49447d", "#2deec6", "#ae41f5", "#ffcb82", "#fe3290", "#9feb28"
 ];
 
 export const LEGACY_TAIL: string[] = [

--- a/web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts
+++ b/web/projects/portal/src/app/widget/color-picker/palette-test-fixtures.ts
@@ -17,6 +17,10 @@
  */
 import { ColorPalette } from "./color-classes";
 
+// The modern head colours live in four places: defaults.css, the MODERN_HEAD/DARK_HEAD constants
+// beside it, these fixtures, and the MSW handler for /api/portal/chart-color-palette. Only the
+// first pair is pinned against drift, by cssHeadMatchesTheJavaFallback. Move all four together.
+
 export const LEGACY_HEAD: string[] = [
    "#518db9", "#b9dbf4", "#62a640", "#ade095", "#fc8f2a", "#fde3a7", "#d64541", "#fda7a5"
 ];


### PR DESCRIPTION
Three things, all inside the modern-visualization gate: the eight head colours of `Modern` and `Modern Dark` are re-tuned, a `Contrast` palette is added, and the palette picker is scoped by a chart's own provenance mark instead of the org property.

Taken from the external design set `SBI Color and Type Pairings.dc.html` and its `design_handoff_chart_palettes/` folder. That handoff proposed reducing 11 palette names to 6 and could not be applied as written — four reasons, each verified against the branch, are recorded in the design doc along with the corrections.

## What changed

- `Modern` and `Modern Dark` indexes 1-8 take the redesigned bases. Indexes 9-40, the legacy tail, are untouched.
- `Contrast` is new: eight slots for projection, monochrome print and low vision, every member on its own rung of a luminance ladder. No dark variant, deliberately — its contract is paper and projection.
- A modern-marked chart is no longer offered the nine single-hue ramps (Pastel, Heat 8/16/24, Blue, Green, Red, Orange, Gray). A classic chart keeps everything it has today, and `Contrast` is offered to both, because an accessibility palette is not a look-and-feel choice.

## What to know before reviewing

**The response flags palettes, it never omits them.** The dialog identifies a chart's current palette by matching colour lists. Omitting a hidden palette would make a chart sitting on one match nothing, fall back to showing "Default", and repaint its colours on a no-op OK. So every palette is sent with a `hidden` flag and only the dropdown filters. `getPaletteNames()` and `getPalette(name)` stay unfiltered — rendering resolves palettes by name, so filtering either would break rendering, not just the picker.

**The picker reads the chart's mark, not the org gate.** The gate is creation-time only: a dashboard already using the modern look keeps it when an admin switches the property off. A picker reading the property would strand those charts with a list that does not match what they render. The proxy carries only the `VizMark` rather than the whole list, because a null `vsId` has no routing key and the controller has to branch on it regardless.

**The target-band colour pane has no assembly to resolve**, so it falls through to the org gate as the absent-assembly default. It deliberately shows every palette: it cannot tell a classic chart from a modern one, and filtering it on the org property would hide the retired palettes from classic charts in a modern org.

**The head colours are declared twice** — in `defaults.css` and as Java fallback constants used when a CSS rule is missing or malformed. A new test reads both by reflection and compares all eight slots against the live frame, so the two can no longer drift silently. That guard did not exist before and is the most durable thing in this PR.

**`VSChartBindingController` is now a second documented survivor** in `VizContextReadFlipTest`, which asserts tree-wide that nothing reads the org gate where a per-assembly mark is available. The absent-assembly branch has no mark to read, which is the same category as the existing survivor. Both are named with their justification, so a third still fails the guard.

## Not in scope

The handoff's sequential and diverging ramps (`Amber`, `Teal`, `Variance`) are `LinearColorFrame` work, not CSS — each needs a frame subclass, a wrapper and a `VisualFrameWrapper` case, and unlike palettes, ramps are persisted by class name. The companion-colour system and the palette-overflow generator are also deferred. The design doc records each with the trigger that brings it back.

## Verification

- Core suite: 5740 tests, 0 failures
- Portal suite: 225 files, 1458 tests, 0 failures
- Manual dark-mode pass on a real dashboard

The full core run is what caught the `VizContextReadFlipTest` regression; eight green scoped runs did not, because the failing class is one no task touched.

## Known, filed separately

The manual pass surfaced that selecting any assembly in dark mode draws a dotted orange border, because `.bd-selected-assembly` binds to `--inet-primary-color`, which has no dark value, while its neighbour `.bd-selected-cell` resolves through a viz token that does. It pre-dates this branch — the class is from the initial commit, and this branch changes no stylesheets. Written up in `2026-09-11-dark-assembly-selection-border-ticket.md` with the measurements, including that the re-tune moves the cell-selection collision from an exact colour match to a near one.

Also filed for later, not fixed here: `getPaletteIndex()` does not reset its counter before the reverse-match scan, so a forward-partial plus a reverse-partial can register a false reversed match. Pre-existing, and likelier with short palettes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
